### PR TITLE
Harden hooks and retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Hook behavior notes:
 
 - `timeout_secs` defaults to 30 seconds.
 - `retry_backoff_secs` is optional; when set, hooks retry with the given delays.
+- `working_dir` is optional; when set, hooks run from that directory.
+- `max_output_bytes` caps stdout/stderr and logs when truncation happens.
 - `on_failure` controls whether failures stop or continue the hook chain.
 
 ### Configuration Schema
@@ -170,6 +172,7 @@ Defaults (if not provided):
 - `profiles[].daemon.renew_before`: `720h`
 - `profiles[].daemon.check_jitter`: `0s`
 - `profiles[].uri_san_enabled`: `true`
+- `profiles[].retry.backoff_secs`: `retry.backoff_secs` (fallback)
 - `profiles[].hooks.post_renew.*.timeout_secs`: `30`
 - `profiles[].hooks.post_renew.*.on_failure`: `continue`
 
@@ -188,9 +191,12 @@ Validation rules:
 - `profiles[].instance_id` is numeric
 - `profiles[].domains` is non-empty
 - `profiles[].paths.cert` and `profiles[].paths.key` are non-empty
+- `profiles[].retry.backoff_secs` values > 0 (when set)
 - `profiles[].hooks.post_renew.*.command` is non-empty
+- `profiles[].hooks.post_renew.*.working_dir` is non-empty (when set)
 - `profiles[].hooks.post_renew.*.timeout_secs` > 0
 - `profiles[].hooks.post_renew.*.retry_backoff_secs` values > 0
+- `profiles[].hooks.post_renew.*.max_output_bytes` > 0 (when set)
 
 ### Operational Guide
 

--- a/agent.toml.compose
+++ b/agent.toml.compose
@@ -34,3 +34,6 @@ key = "/app/certs/bootroot-agent.key"
 check_interval = "1h"
 renew_before = "720h"
 check_jitter = "0s"
+
+[profiles.retry]
+backoff_secs = [5, 10, 30]

--- a/agent.toml.example
+++ b/agent.toml.example
@@ -60,6 +60,10 @@ renew_before = "720h"
 # Randomize check interval by +/- jitter (0s disables)
 check_jitter = "0s"
 
+[profiles.retry]
+# Optional per-profile retry backoff override
+backoff_secs = [5, 10, 30]
+
 # Post-renewal hooks
 [profiles.hooks.post_renew]
 # Commands to run after a successful renewal
@@ -67,8 +71,10 @@ check_jitter = "0s"
 #   {
 #     command = "nginx"
 #     args = ["-s", "reload"]
+#     working_dir = "/etc/nginx"
 #     timeout_secs = 30
 #     retry_backoff_secs = [5, 10, 30]
+#     max_output_bytes = 4096
 #     on_failure = "continue"
 #   }
 # ]

--- a/src/acme/flow.rs
+++ b/src/acme/flow.rs
@@ -327,6 +327,7 @@ mod tests {
                 key: PathBuf::from("certs/edge-proxy-a.key"),
             },
             daemon: crate::config::DaemonSettings::default(),
+            retry: None,
             hooks: crate::config::HookSettings::default(),
             eab: None,
         };


### PR DESCRIPTION
- Add hook working_dir/output limits with validation and tests.
- Support per-profile retry overrides and update docs/examples.

Closes #31