### PR TITLE
Refactor daemon scheduler into module

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,448 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{Mutex, Semaphore, watch};
+use tracing::{error, info};
+
+use crate::{acme, config, eab, hooks};
+
+const DAEMON_CHECK_INTERVAL_KEY: &str = "daemon.check_interval";
+const DAEMON_RENEW_BEFORE_KEY: &str = "daemon.renew_before";
+const DAEMON_CHECK_JITTER_KEY: &str = "daemon.check_jitter";
+pub(crate) const MIN_DAEMON_CHECK_DELAY_NANOS: i128 = 1_000_000_000;
+
+pub(crate) async fn run_daemon(
+    settings: Arc<config::Settings>,
+    default_eab: Option<eab::EabCredentials>,
+    challenges: Arc<Mutex<HashMap<String, String>>>,
+) -> anyhow::Result<()> {
+    let max_concurrent = max_concurrent_issuances(&settings)?;
+    let semaphore = Arc::new(Semaphore::new(max_concurrent));
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    let shutdown_handle = tokio::spawn(async move {
+        if let Err(err) = wait_for_shutdown().await {
+            error!("Shutdown signal handler error: {err}");
+        }
+        let _ = shutdown_tx.send(true);
+    });
+
+    let mut handles = Vec::new();
+    for profile in settings.profiles.clone() {
+        let settings = Arc::clone(&settings);
+        let semaphore = Arc::clone(&semaphore);
+        let shutdown_rx = shutdown_rx.clone();
+        let challenges = challenges.clone();
+        let default_eab = default_eab.clone();
+
+        handles.push(tokio::spawn(async move {
+            run_profile_daemon(
+                settings,
+                profile,
+                default_eab,
+                challenges,
+                semaphore,
+                shutdown_rx,
+            )
+            .await
+        }));
+    }
+
+    let _ = shutdown_handle.await;
+    for handle in handles {
+        match handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => error!("Profile daemon exited with error: {err}"),
+            Err(err) => error!("Profile daemon task join error: {err}"),
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_profile_daemon(
+    settings: Arc<config::Settings>,
+    profile: config::ProfileSettings,
+    default_eab: Option<eab::EabCredentials>,
+    challenges: Arc<Mutex<HashMap<String, String>>>,
+    semaphore: Arc<Semaphore>,
+    mut shutdown: watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    let check_interval =
+        parse_duration_setting(&profile.daemon.check_interval, DAEMON_CHECK_INTERVAL_KEY)?;
+    let renew_before =
+        parse_duration_setting(&profile.daemon.renew_before, DAEMON_RENEW_BEFORE_KEY)?;
+    let check_jitter =
+        parse_duration_setting(&profile.daemon.check_jitter, DAEMON_CHECK_JITTER_KEY)?;
+    let uri_san = if profile.uri_san_enabled {
+        Some(build_spiffe_uri(&settings, &profile))
+    } else {
+        None
+    };
+
+    info!(
+        "Profile '{}' daemon enabled. check_interval={:?}, renew_before={:?}, check_jitter={:?}",
+        profile.name, check_interval, renew_before, check_jitter
+    );
+
+    let mut first_tick = true;
+    loop {
+        if *shutdown.borrow() {
+            info!(
+                "Shutdown signal received. Exiting profile '{}'.",
+                profile.name
+            );
+            break;
+        }
+
+        let delay = if first_tick {
+            first_tick = false;
+            Duration::from_secs(0)
+        } else {
+            jittered_delay(check_interval, check_jitter)
+        };
+
+        tokio::select! {
+            _ = shutdown.changed() => {
+                info!("Shutdown signal received. Exiting profile '{}'.", profile.name);
+                break;
+            }
+            () = tokio::time::sleep(delay) => {
+                tracing::debug!("Profile '{}' checking renewal status...", profile.name);
+                match should_renew(&profile, renew_before).await {
+                    Ok(true) => {
+                        info!("Profile '{}' renewal required. Starting ACME issuance...", profile.name);
+                        let _permit = semaphore.acquire().await?;
+                        let profile_eab = resolve_profile_eab(&profile, default_eab.clone());
+                        match issue_with_retry(
+                            &settings,
+                            &profile,
+                            profile_eab,
+                            challenges.clone(),
+                            uri_san.as_deref(),
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                if let Err(err) = hooks::run_post_renew_hooks(
+                                    &settings,
+                                    &profile,
+                                    hooks::HookStatus::Success,
+                                    None,
+                                )
+                                .await
+                                {
+                                    error!("Post-renew success hooks failed for '{}': {err}", profile.name);
+                                }
+                            }
+                            Err(err) => {
+                                error!("Profile '{}' renewal failed after retries: {err}", profile.name);
+                                if let Err(hook_err) = hooks::run_post_renew_hooks(
+                                    &settings,
+                                    &profile,
+                                    hooks::HookStatus::Failure,
+                                    Some(err.to_string()),
+                                )
+                                .await
+                                {
+                                    error!("Post-renew failure hooks failed for '{}': {hook_err}", profile.name);
+                                }
+                            }
+                        }
+                    }
+                    Ok(false) => {
+                        tracing::debug!("Profile '{}' certificate still valid.", profile.name);
+                    }
+                    Err(err) => {
+                        error!("Profile '{}' renewal check failed: {err}", profile.name);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn run_oneshot(
+    settings: Arc<config::Settings>,
+    default_eab: Option<eab::EabCredentials>,
+    challenges: Arc<Mutex<HashMap<String, String>>>,
+) -> anyhow::Result<()> {
+    let max_concurrent = max_concurrent_issuances(&settings)?;
+    let semaphore = Arc::new(Semaphore::new(max_concurrent));
+    let mut handles = Vec::new();
+
+    for profile in settings.profiles.clone() {
+        let settings = Arc::clone(&settings);
+        let challenges = challenges.clone();
+        let semaphore = Arc::clone(&semaphore);
+        let default_eab = default_eab.clone();
+
+        handles.push(tokio::spawn(async move {
+            run_profile_oneshot(settings, profile, default_eab, challenges, semaphore).await
+        }));
+    }
+
+    let mut first_error = None;
+    for handle in handles {
+        match handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                error!("Profile oneshot failed: {err}");
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+            Err(err) => {
+                error!("Profile oneshot task join error: {err}");
+                if first_error.is_none() {
+                    first_error = Some(anyhow::anyhow!("Profile task join error: {err}"));
+                }
+            }
+        }
+    }
+
+    if let Some(err) = first_error {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+async fn run_profile_oneshot(
+    settings: Arc<config::Settings>,
+    profile: config::ProfileSettings,
+    default_eab: Option<eab::EabCredentials>,
+    challenges: Arc<Mutex<HashMap<String, String>>>,
+    semaphore: Arc<Semaphore>,
+) -> anyhow::Result<()> {
+    let _permit = semaphore.acquire().await?;
+    let uri_san = if profile.uri_san_enabled {
+        Some(build_spiffe_uri(&settings, &profile))
+    } else {
+        None
+    };
+    let profile_eab = resolve_profile_eab(&profile, default_eab);
+
+    match acme::issue_certificate(
+        &settings,
+        &profile,
+        profile_eab,
+        challenges,
+        uri_san.as_deref(),
+    )
+    .await
+    {
+        Ok(()) => {
+            if let Err(err) =
+                hooks::run_post_renew_hooks(&settings, &profile, hooks::HookStatus::Success, None)
+                    .await
+            {
+                error!(
+                    "Post-renew success hooks failed for '{}': {err}",
+                    profile.name
+                );
+            }
+            Ok(())
+        }
+        Err(err) => {
+            if let Err(hook_err) = hooks::run_post_renew_hooks(
+                &settings,
+                &profile,
+                hooks::HookStatus::Failure,
+                Some(err.to_string()),
+            )
+            .await
+            {
+                error!(
+                    "Post-renew failure hooks failed for '{}': {hook_err}",
+                    profile.name
+                );
+            }
+            Err(err)
+        }
+    }
+}
+
+async fn issue_with_retry(
+    settings: &config::Settings,
+    profile: &config::ProfileSettings,
+    eab: Option<eab::EabCredentials>,
+    challenges: Arc<Mutex<HashMap<String, String>>>,
+    uri_san: Option<&str>,
+) -> anyhow::Result<()> {
+    let backoff = profile
+        .retry
+        .as_ref()
+        .map_or(settings.retry.backoff_secs.as_slice(), |retry| {
+            retry.backoff_secs.as_slice()
+        });
+    issue_with_retry_inner(
+        || acme::issue_certificate(settings, profile, eab.clone(), challenges.clone(), uri_san),
+        |duration| tokio::time::sleep(duration),
+        backoff,
+    )
+    .await
+}
+
+pub(crate) async fn issue_with_retry_inner<IssueFn, IssueFut, SleepFn, SleepFut>(
+    mut issue_fn: IssueFn,
+    mut sleep_fn: SleepFn,
+    delays: &[u64],
+) -> anyhow::Result<()>
+where
+    IssueFn: FnMut() -> IssueFut,
+    IssueFut: Future<Output = anyhow::Result<()>>,
+    SleepFn: FnMut(Duration) -> SleepFut,
+    SleepFut: Future<Output = ()>,
+{
+    if delays.is_empty() {
+        return issue_fn().await;
+    }
+
+    let mut last_err = None;
+    for (attempt, delay) in delays.iter().enumerate() {
+        match issue_fn().await {
+            Ok(()) => {
+                info!("Certificate issuance succeeded.");
+                return Ok(());
+            }
+            Err(err) => {
+                error!(
+                    "Certificate issuance failed (attempt {}): {err}",
+                    attempt + 1
+                );
+                last_err = Some(err);
+                if attempt + 1 < delays.len() {
+                    sleep_fn(Duration::from_secs(*delay)).await;
+                }
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("Certificate issuance failed")))
+}
+
+pub(crate) fn build_spiffe_uri(
+    settings: &config::Settings,
+    profile: &config::ProfileSettings,
+) -> String {
+    format!(
+        "spiffe://{}/{}/{}/{}",
+        settings.spiffe_trust_domain, profile.hostname, profile.daemon_name, profile.instance_id
+    )
+}
+
+pub(crate) fn resolve_profile_eab(
+    profile: &config::ProfileSettings,
+    default_eab: Option<eab::EabCredentials>,
+) -> Option<eab::EabCredentials> {
+    profile.eab.as_ref().map(to_eab_credentials).or(default_eab)
+}
+
+pub(crate) fn to_eab_credentials(eab: &config::Eab) -> eab::EabCredentials {
+    eab::EabCredentials {
+        kid: eab.kid.clone(),
+        hmac: eab.hmac.clone(),
+    }
+}
+
+pub(crate) fn max_concurrent_issuances(settings: &config::Settings) -> anyhow::Result<usize> {
+    usize::try_from(settings.scheduler.max_concurrent_issuances).map_err(|_| {
+        anyhow::anyhow!("scheduler.max_concurrent_issuances is too large for this platform")
+    })
+}
+
+pub(crate) async fn should_renew(
+    profile: &config::ProfileSettings,
+    renew_before: Duration,
+) -> anyhow::Result<bool> {
+    let cert_bytes = match tokio::fs::read(&profile.paths.cert).await {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            info!("Certificate file not found. Issuing a new certificate.");
+            return Ok(true);
+        }
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "Failed to read certificate file {}: {err}",
+                profile.paths.cert.display()
+            ));
+        }
+    };
+
+    let not_after = parse_cert_not_after(&cert_bytes)?;
+
+    let renew_before = time::Duration::try_from(renew_before)
+        .map_err(|_| anyhow::anyhow!("renew_before duration is too large"))?;
+    let now = time::OffsetDateTime::now_utc();
+    let renew_at = now + renew_before;
+
+    Ok(not_after <= renew_at)
+}
+
+pub(crate) fn parse_cert_not_after(cert_bytes: &[u8]) -> anyhow::Result<time::OffsetDateTime> {
+    let pem = x509_parser::pem::parse_x509_pem(cert_bytes)
+        .map_err(|e| anyhow::anyhow!("Failed to parse PEM certificate: {e}"))?
+        .1;
+    let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)
+        .map_err(|e| anyhow::anyhow!("Failed to parse X509 certificate: {e}"))?;
+    Ok(cert.validity().not_after.to_datetime())
+}
+
+pub(crate) fn parse_duration_setting(value: &str, label: &str) -> anyhow::Result<Duration> {
+    humantime::parse_duration(value)
+        .map_err(|e| anyhow::anyhow!("Invalid {label} value '{value}': {e}"))
+}
+
+fn jittered_delay(base: Duration, jitter: Duration) -> Duration {
+    let now_ns = time::OffsetDateTime::now_utc()
+        .unix_timestamp_nanos()
+        .max(0);
+    jittered_delay_with_seed(base, jitter, now_ns)
+}
+
+pub(crate) fn jittered_delay_with_seed(base: Duration, jitter: Duration, now_ns: i128) -> Duration {
+    let jitter_ns = i128::try_from(jitter.as_nanos()).unwrap_or(i128::MAX);
+    if jitter_ns == 0 {
+        return base;
+    }
+
+    let base_ns = i128::try_from(base.as_nanos()).unwrap_or(i128::MAX);
+    let span = jitter_ns.saturating_mul(2).saturating_add(1);
+    let offset = (now_ns % span) - jitter_ns;
+    let adjusted = (base_ns + offset).max(MIN_DAEMON_CHECK_DELAY_NANOS);
+    let adjusted = adjusted.min(i128::from(u64::MAX));
+    let adjusted = u64::try_from(adjusted).unwrap_or(u64::MAX);
+
+    Duration::from_nanos(adjusted)
+}
+
+async fn wait_for_shutdown() -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut term = signal(SignalKind::terminate())
+            .map_err(|e| anyhow::anyhow!("Failed to install SIGTERM handler: {e}"))?;
+
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                result.map_err(|e| anyhow::anyhow!("Failed to listen for Ctrl+C: {e}"))?;
+            }
+            _ = term.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to listen for Ctrl+C: {e}"))?;
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,16 @@
 use std::collections::HashMap;
-use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use clap::Parser;
-use tokio::sync::{Mutex, Semaphore, watch};
+use tokio::sync::Mutex;
 use tracing::{error, info};
 
 pub mod acme;
 pub mod config;
+pub mod daemon;
 pub mod eab;
 pub mod hooks;
-
-const DAEMON_CHECK_INTERVAL_KEY: &str = "daemon.check_interval";
-const DAEMON_RENEW_BEFORE_KEY: &str = "daemon.renew_before";
-const DAEMON_CHECK_JITTER_KEY: &str = "daemon.check_jitter";
-const MIN_DAEMON_CHECK_DELAY_NANOS: i128 = 1_000_000_000;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -74,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    let final_eab = cli_eab.or_else(|| settings.eab.as_ref().map(to_eab_credentials));
+    let final_eab = cli_eab.or_else(|| settings.eab.as_ref().map(daemon::to_eab_credentials));
 
     info!("Loaded {} profile(s).", settings.profiles.len());
     info!("CA URL: {}", settings.server);
@@ -93,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
 
     // 4. Run ACME Flow
     if args.oneshot {
-        match run_oneshot(Arc::clone(&settings), final_eab, challenges).await {
+        match daemon::run_oneshot(Arc::clone(&settings), final_eab, challenges).await {
             Ok(()) => info!("Successfully issued certificate!"),
             Err(e) => {
                 error!("Failed to issue certificate: {:?}", e);
@@ -101,438 +95,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     } else {
-        run_daemon(settings, final_eab, challenges).await?;
-    }
-
-    Ok(())
-}
-
-async fn run_daemon(
-    settings: Arc<config::Settings>,
-    default_eab: Option<eab::EabCredentials>,
-    challenges: Arc<Mutex<HashMap<String, String>>>,
-) -> anyhow::Result<()> {
-    let max_concurrent = max_concurrent_issuances(&settings)?;
-    let semaphore = Arc::new(Semaphore::new(max_concurrent));
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-
-    let shutdown_handle = tokio::spawn(async move {
-        if let Err(err) = wait_for_shutdown().await {
-            error!("Shutdown signal handler error: {err}");
-        }
-        let _ = shutdown_tx.send(true);
-    });
-
-    let mut handles = Vec::new();
-    for profile in settings.profiles.clone() {
-        let settings = Arc::clone(&settings);
-        let semaphore = Arc::clone(&semaphore);
-        let shutdown_rx = shutdown_rx.clone();
-        let challenges = challenges.clone();
-        let default_eab = default_eab.clone();
-
-        handles.push(tokio::spawn(async move {
-            run_profile_daemon(
-                settings,
-                profile,
-                default_eab,
-                challenges,
-                semaphore,
-                shutdown_rx,
-            )
-            .await
-        }));
-    }
-
-    let _ = shutdown_handle.await;
-    for handle in handles {
-        match handle.await {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => error!("Profile daemon exited with error: {err}"),
-            Err(err) => error!("Profile daemon task join error: {err}"),
-        }
-    }
-
-    Ok(())
-}
-
-async fn run_profile_daemon(
-    settings: Arc<config::Settings>,
-    profile: config::ProfileSettings,
-    default_eab: Option<eab::EabCredentials>,
-    challenges: Arc<Mutex<HashMap<String, String>>>,
-    semaphore: Arc<Semaphore>,
-    mut shutdown: watch::Receiver<bool>,
-) -> anyhow::Result<()> {
-    let check_interval =
-        parse_duration_setting(&profile.daemon.check_interval, DAEMON_CHECK_INTERVAL_KEY)?;
-    let renew_before =
-        parse_duration_setting(&profile.daemon.renew_before, DAEMON_RENEW_BEFORE_KEY)?;
-    let check_jitter =
-        parse_duration_setting(&profile.daemon.check_jitter, DAEMON_CHECK_JITTER_KEY)?;
-    let uri_san = if profile.uri_san_enabled {
-        Some(build_spiffe_uri(&settings, &profile))
-    } else {
-        None
-    };
-
-    info!(
-        "Profile '{}' daemon enabled. check_interval={:?}, renew_before={:?}, check_jitter={:?}",
-        profile.name, check_interval, renew_before, check_jitter
-    );
-
-    let mut first_tick = true;
-    loop {
-        if *shutdown.borrow() {
-            info!(
-                "Shutdown signal received. Exiting profile '{}'.",
-                profile.name
-            );
-            break;
-        }
-
-        let delay = if first_tick {
-            first_tick = false;
-            Duration::from_secs(0)
-        } else {
-            jittered_delay(check_interval, check_jitter)
-        };
-
-        tokio::select! {
-            _ = shutdown.changed() => {
-                info!("Shutdown signal received. Exiting profile '{}'.", profile.name);
-                break;
-            }
-            () = tokio::time::sleep(delay) => {
-                tracing::debug!("Profile '{}' checking renewal status...", profile.name);
-                match should_renew(&profile, renew_before).await {
-                    Ok(true) => {
-                        info!("Profile '{}' renewal required. Starting ACME issuance...", profile.name);
-                        let _permit = semaphore.acquire().await?;
-                        let profile_eab = resolve_profile_eab(&profile, default_eab.clone());
-                        match issue_with_retry(
-                            &settings,
-                            &profile,
-                            profile_eab,
-                            challenges.clone(),
-                            uri_san.as_deref(),
-                        )
-                        .await
-                        {
-                            Ok(()) => {
-                                if let Err(err) = hooks::run_post_renew_hooks(
-                                    &settings,
-                                    &profile,
-                                    hooks::HookStatus::Success,
-                                    None,
-                                )
-                                .await
-                                {
-                                    error!("Post-renew success hooks failed for '{}': {err}", profile.name);
-                                }
-                            }
-                            Err(err) => {
-                                error!("Profile '{}' renewal failed after retries: {err}", profile.name);
-                                if let Err(hook_err) = hooks::run_post_renew_hooks(
-                                    &settings,
-                                    &profile,
-                                    hooks::HookStatus::Failure,
-                                    Some(err.to_string()),
-                                )
-                                .await
-                                {
-                                    error!("Post-renew failure hooks failed for '{}': {hook_err}", profile.name);
-                                }
-                            }
-                        }
-                    }
-                    Ok(false) => {
-                        tracing::debug!("Profile '{}' certificate still valid.", profile.name);
-                    }
-                    Err(err) => {
-                        error!("Profile '{}' renewal check failed: {err}", profile.name);
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn run_oneshot(
-    settings: Arc<config::Settings>,
-    default_eab: Option<eab::EabCredentials>,
-    challenges: Arc<Mutex<HashMap<String, String>>>,
-) -> anyhow::Result<()> {
-    let max_concurrent = max_concurrent_issuances(&settings)?;
-    let semaphore = Arc::new(Semaphore::new(max_concurrent));
-    let mut handles = Vec::new();
-
-    for profile in settings.profiles.clone() {
-        let settings = Arc::clone(&settings);
-        let challenges = challenges.clone();
-        let semaphore = Arc::clone(&semaphore);
-        let default_eab = default_eab.clone();
-
-        handles.push(tokio::spawn(async move {
-            run_profile_oneshot(settings, profile, default_eab, challenges, semaphore).await
-        }));
-    }
-
-    let mut first_error = None;
-    for handle in handles {
-        match handle.await {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => {
-                error!("Profile oneshot failed: {err}");
-                if first_error.is_none() {
-                    first_error = Some(err);
-                }
-            }
-            Err(err) => {
-                error!("Profile oneshot task join error: {err}");
-                if first_error.is_none() {
-                    first_error = Some(anyhow::anyhow!("Profile task join error: {err}"));
-                }
-            }
-        }
-    }
-
-    if let Some(err) = first_error {
-        Err(err)
-    } else {
-        Ok(())
-    }
-}
-
-async fn run_profile_oneshot(
-    settings: Arc<config::Settings>,
-    profile: config::ProfileSettings,
-    default_eab: Option<eab::EabCredentials>,
-    challenges: Arc<Mutex<HashMap<String, String>>>,
-    semaphore: Arc<Semaphore>,
-) -> anyhow::Result<()> {
-    let _permit = semaphore.acquire().await?;
-    let uri_san = if profile.uri_san_enabled {
-        Some(build_spiffe_uri(&settings, &profile))
-    } else {
-        None
-    };
-    let profile_eab = resolve_profile_eab(&profile, default_eab);
-
-    match acme::issue_certificate(
-        &settings,
-        &profile,
-        profile_eab,
-        challenges,
-        uri_san.as_deref(),
-    )
-    .await
-    {
-        Ok(()) => {
-            if let Err(err) =
-                hooks::run_post_renew_hooks(&settings, &profile, hooks::HookStatus::Success, None)
-                    .await
-            {
-                error!(
-                    "Post-renew success hooks failed for '{}': {err}",
-                    profile.name
-                );
-            }
-            Ok(())
-        }
-        Err(err) => {
-            if let Err(hook_err) = hooks::run_post_renew_hooks(
-                &settings,
-                &profile,
-                hooks::HookStatus::Failure,
-                Some(err.to_string()),
-            )
-            .await
-            {
-                error!(
-                    "Post-renew failure hooks failed for '{}': {hook_err}",
-                    profile.name
-                );
-            }
-            Err(err)
-        }
-    }
-}
-
-async fn issue_with_retry(
-    settings: &config::Settings,
-    profile: &config::ProfileSettings,
-    eab: Option<eab::EabCredentials>,
-    challenges: Arc<Mutex<HashMap<String, String>>>,
-    uri_san: Option<&str>,
-) -> anyhow::Result<()> {
-    let backoff = profile
-        .retry
-        .as_ref()
-        .map_or(settings.retry.backoff_secs.as_slice(), |retry| {
-            retry.backoff_secs.as_slice()
-        });
-    issue_with_retry_inner(
-        || acme::issue_certificate(settings, profile, eab.clone(), challenges.clone(), uri_san),
-        |duration| tokio::time::sleep(duration),
-        backoff,
-    )
-    .await
-}
-
-async fn issue_with_retry_inner<IssueFn, IssueFut, SleepFn, SleepFut>(
-    mut issue_fn: IssueFn,
-    mut sleep_fn: SleepFn,
-    delays: &[u64],
-) -> anyhow::Result<()>
-where
-    IssueFn: FnMut() -> IssueFut,
-    IssueFut: Future<Output = anyhow::Result<()>>,
-    SleepFn: FnMut(Duration) -> SleepFut,
-    SleepFut: Future<Output = ()>,
-{
-    if delays.is_empty() {
-        return issue_fn().await;
-    }
-
-    let mut last_err = None;
-    for (attempt, delay) in delays.iter().enumerate() {
-        match issue_fn().await {
-            Ok(()) => {
-                info!("Certificate issuance succeeded.");
-                return Ok(());
-            }
-            Err(err) => {
-                error!(
-                    "Certificate issuance failed (attempt {}): {err}",
-                    attempt + 1
-                );
-                last_err = Some(err);
-                if attempt + 1 < delays.len() {
-                    sleep_fn(Duration::from_secs(*delay)).await;
-                }
-            }
-        }
-    }
-
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("Certificate issuance failed")))
-}
-
-fn build_spiffe_uri(settings: &config::Settings, profile: &config::ProfileSettings) -> String {
-    format!(
-        "spiffe://{}/{}/{}/{}",
-        settings.spiffe_trust_domain, profile.hostname, profile.daemon_name, profile.instance_id
-    )
-}
-
-fn resolve_profile_eab(
-    profile: &config::ProfileSettings,
-    default_eab: Option<eab::EabCredentials>,
-) -> Option<eab::EabCredentials> {
-    profile.eab.as_ref().map(to_eab_credentials).or(default_eab)
-}
-
-fn to_eab_credentials(eab: &config::Eab) -> eab::EabCredentials {
-    eab::EabCredentials {
-        kid: eab.kid.clone(),
-        hmac: eab.hmac.clone(),
-    }
-}
-
-fn max_concurrent_issuances(settings: &config::Settings) -> anyhow::Result<usize> {
-    usize::try_from(settings.scheduler.max_concurrent_issuances).map_err(|_| {
-        anyhow::anyhow!("scheduler.max_concurrent_issuances is too large for this platform")
-    })
-}
-
-async fn should_renew(
-    profile: &config::ProfileSettings,
-    renew_before: Duration,
-) -> anyhow::Result<bool> {
-    let cert_bytes = match tokio::fs::read(&profile.paths.cert).await {
-        Ok(bytes) => bytes,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            info!("Certificate file not found. Issuing a new certificate.");
-            return Ok(true);
-        }
-        Err(err) => {
-            return Err(anyhow::anyhow!(
-                "Failed to read certificate file {}: {err}",
-                profile.paths.cert.display()
-            ));
-        }
-    };
-
-    let not_after = parse_cert_not_after(&cert_bytes)?;
-
-    let renew_before = time::Duration::try_from(renew_before)
-        .map_err(|_| anyhow::anyhow!("renew_before duration is too large"))?;
-    let now = time::OffsetDateTime::now_utc();
-    let renew_at = now + renew_before;
-
-    Ok(not_after <= renew_at)
-}
-
-fn parse_cert_not_after(cert_bytes: &[u8]) -> anyhow::Result<time::OffsetDateTime> {
-    let pem = x509_parser::pem::parse_x509_pem(cert_bytes)
-        .map_err(|e| anyhow::anyhow!("Failed to parse PEM certificate: {e}"))?
-        .1;
-    let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)
-        .map_err(|e| anyhow::anyhow!("Failed to parse X509 certificate: {e}"))?;
-    Ok(cert.validity().not_after.to_datetime())
-}
-
-fn parse_duration_setting(value: &str, label: &str) -> anyhow::Result<Duration> {
-    humantime::parse_duration(value)
-        .map_err(|e| anyhow::anyhow!("Invalid {label} value '{value}': {e}"))
-}
-
-fn jittered_delay(base: Duration, jitter: Duration) -> Duration {
-    let now_ns = time::OffsetDateTime::now_utc()
-        .unix_timestamp_nanos()
-        .max(0);
-    jittered_delay_with_seed(base, jitter, now_ns)
-}
-
-fn jittered_delay_with_seed(base: Duration, jitter: Duration, now_ns: i128) -> Duration {
-    let jitter_ns = i128::try_from(jitter.as_nanos()).unwrap_or(i128::MAX);
-    if jitter_ns == 0 {
-        return base;
-    }
-
-    let base_ns = i128::try_from(base.as_nanos()).unwrap_or(i128::MAX);
-    let span = jitter_ns.saturating_mul(2).saturating_add(1);
-    let offset = (now_ns % span) - jitter_ns;
-    let adjusted = (base_ns + offset).max(MIN_DAEMON_CHECK_DELAY_NANOS);
-    let adjusted = adjusted.min(i128::from(u64::MAX));
-    let adjusted = u64::try_from(adjusted).unwrap_or(u64::MAX);
-
-    Duration::from_nanos(adjusted)
-}
-
-async fn wait_for_shutdown() -> anyhow::Result<()> {
-    #[cfg(unix)]
-    {
-        use tokio::signal::unix::{SignalKind, signal};
-
-        let mut term = signal(SignalKind::terminate())
-            .map_err(|e| anyhow::anyhow!("Failed to install SIGTERM handler: {e}"))?;
-
-        tokio::select! {
-            result = tokio::signal::ctrl_c() => {
-                result.map_err(|e| anyhow::anyhow!("Failed to listen for Ctrl+C: {e}"))?;
-            }
-            _ = term.recv() => {}
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        tokio::signal::ctrl_c()
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to listen for Ctrl+C: {e}"))?;
+        daemon::run_daemon(settings, final_eab, challenges).await?;
     }
 
     Ok(())
@@ -541,13 +104,15 @@ async fn wait_for_shutdown() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::sync::Mutex;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use rcgen::CertificateParams;
     use tempfile::tempdir;
     use time::OffsetDateTime;
 
-    use super::*;
+    use super::{config, daemon, eab};
 
     const TEST_DOMAIN: &str = "example.com";
     const TEST_KEY_PATH: &str = "unused.key";
@@ -618,13 +183,13 @@ mod tests {
 
     #[test]
     fn test_parse_duration_setting_valid() {
-        let duration = parse_duration_setting("15m", VALID_DURATION_LABEL).unwrap();
+        let duration = daemon::parse_duration_setting("15m", VALID_DURATION_LABEL).unwrap();
         assert_eq!(duration, Duration::from_secs(15 * 60));
     }
 
     #[test]
     fn test_parse_duration_setting_invalid() {
-        let err = parse_duration_setting("nope", VALID_DURATION_LABEL).unwrap_err();
+        let err = daemon::parse_duration_setting("nope", VALID_DURATION_LABEL).unwrap_err();
         assert!(
             err.to_string()
                 .contains("Invalid daemon.check_interval value")
@@ -636,7 +201,7 @@ mod tests {
         let profile = build_profile(PathBuf::from("unused.pem"));
         let settings = build_settings(vec![profile.clone()]);
 
-        let uri = build_spiffe_uri(&settings, &profile);
+        let uri = daemon::build_spiffe_uri(&settings, &profile);
 
         assert_eq!(uri, "spiffe://trusted.domain/edge-node-01/edge-proxy/001");
     }
@@ -657,7 +222,7 @@ mod tests {
             hmac: "default-hmac".to_string(),
         });
 
-        let resolved = resolve_profile_eab(&profile, default_eab).unwrap();
+        let resolved = daemon::resolve_profile_eab(&profile, default_eab).unwrap();
 
         assert_eq!(resolved.kid, "profile");
     }
@@ -671,7 +236,7 @@ mod tests {
             ..build_settings(vec![build_profile(PathBuf::from("unused.pem"))])
         };
 
-        let result = max_concurrent_issuances(&settings);
+        let result = daemon::max_concurrent_issuances(&settings);
 
         let max_usize_u64 = u64::try_from(usize::MAX).unwrap_or(u64::MAX);
         if max_usize_u64 == u64::MAX {
@@ -691,7 +256,7 @@ mod tests {
         let base = Duration::from_secs(TEST_BASE_SECS);
         let jitter = Duration::from_secs(0);
 
-        let delay = jittered_delay_with_seed(base, jitter, TEST_SEED_NS);
+        let delay = daemon::jittered_delay_with_seed(base, jitter, TEST_SEED_NS);
 
         assert_eq!(delay, base);
     }
@@ -700,7 +265,7 @@ mod tests {
     fn test_jittered_delay_bounds() {
         let base = Duration::from_secs(TEST_BASE_SECS);
         let jitter = Duration::from_secs(TEST_JITTER_SECS);
-        let delay = jittered_delay_with_seed(base, jitter, TEST_SEED_NS);
+        let delay = daemon::jittered_delay_with_seed(base, jitter, TEST_SEED_NS);
 
         let min = base.saturating_sub(jitter);
         let max = base + jitter;
@@ -713,9 +278,10 @@ mod tests {
     fn test_jittered_delay_minimum_floor() {
         let base = Duration::from_secs(2);
         let jitter = Duration::from_secs(10);
-        let delay = jittered_delay_with_seed(base, jitter, 0);
+        let delay = daemon::jittered_delay_with_seed(base, jitter, 0);
 
-        let min = Duration::from_nanos(u64::try_from(MIN_DAEMON_CHECK_DELAY_NANOS).unwrap());
+        let min =
+            Duration::from_nanos(u64::try_from(daemon::MIN_DAEMON_CHECK_DELAY_NANOS).unwrap());
         let max = base + jitter;
 
         assert!(delay >= min);
@@ -728,7 +294,7 @@ mod tests {
         let cert_path = dir.path().join("missing.pem");
         let profile = build_profile(cert_path);
 
-        let renew = should_renew(&profile, Duration::from_secs(60))
+        let renew = daemon::should_renew(&profile, Duration::from_secs(60))
             .await
             .unwrap();
 
@@ -744,7 +310,7 @@ mod tests {
         let not_after = OffsetDateTime::now_utc() + time::Duration::days(90);
         write_cert(&cert_path, not_after);
 
-        let renew = should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
+        let renew = daemon::should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
             .await
             .unwrap();
 
@@ -760,7 +326,7 @@ mod tests {
         let not_after = OffsetDateTime::now_utc() + time::Duration::days(1);
         write_cert(&cert_path, not_after);
 
-        let renew = should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
+        let renew = daemon::should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
             .await
             .unwrap();
 
@@ -774,7 +340,7 @@ mod tests {
         fs::write(&cert_path, "not a cert").unwrap();
         let profile = build_profile(cert_path);
 
-        let err = should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
+        let err = daemon::should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
             .await
             .unwrap_err();
 
@@ -789,7 +355,7 @@ mod tests {
         write_cert(&cert_path, not_after);
         let cert_bytes = fs::read(cert_path).unwrap();
 
-        let parsed = parse_cert_not_after(&cert_bytes).unwrap();
+        let parsed = daemon::parse_cert_not_after(&cert_bytes).unwrap();
 
         assert_eq!(parsed.unix_timestamp(), not_after.unix_timestamp());
     }
@@ -803,7 +369,9 @@ mod tests {
         let not_after = OffsetDateTime::now_utc() + time::Duration::days(90);
         write_cert(&cert_path, not_after);
 
-        let err = should_renew(&profile, Duration::MAX).await.unwrap_err();
+        let err = daemon::should_renew(&profile, Duration::MAX)
+            .await
+            .unwrap_err();
 
         assert!(
             err.to_string()
@@ -837,7 +405,7 @@ mod tests {
             }
         };
 
-        let ok = issue_with_retry_inner(issue_fn, sleep_fn, &TEST_DELAYS).await;
+        let ok = daemon::issue_with_retry_inner(issue_fn, sleep_fn, &TEST_DELAYS).await;
 
         assert!(ok.is_ok());
         assert_eq!(*attempts.lock().unwrap(), 3);
@@ -870,7 +438,7 @@ mod tests {
             }
         };
 
-        let ok = issue_with_retry_inner(issue_fn, sleep_fn, &TEST_DELAYS).await;
+        let ok = daemon::issue_with_retry_inner(issue_fn, sleep_fn, &TEST_DELAYS).await;
 
         assert!(ok.is_err());
         assert_eq!(*attempts.lock().unwrap(), 3);


### PR DESCRIPTION
Move scheduling, retry, and renewal helpers into daemon.rs to separate runtime orchestration from CLI setup. Update main tests to reference the daemon module utilities.

Closes #34