### PR TITLE
Drop SPIFFE and switch to DNS SAN

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,9 +64,9 @@ There is no implicit trust between environments.
 
 Examples:
 
-- `spiffe://customer-a/giganto`
-- `spiffe://customer-a/aice-web-next`
-- `spiffe://company-prod/aimer-web`
+- `001.giganto.node-01.customer-a.internal`
+- `002.aice-web-next.node-01.customer-a.internal`
+- `001.aimer-web.node-02.company-prod.internal`
 
 ## 5. System Authentication Model
 

--- a/agent.toml.compose
+++ b/agent.toml.compose
@@ -2,7 +2,8 @@
 
 email = "admin@example.com"
 server = "https://bootroot-ca:9000/acme/acme/directory"
-spiffe_trust_domain = "trusted.domain"
+# Format: <instance_id>.<daemon_name>.<hostname>.<domain>
+domain = "trusted.domain"
 
 [scheduler]
 max_concurrent_issuances = 1
@@ -22,12 +23,9 @@ http_responder_token_ttl_secs = 300
 backoff_secs = [5, 10, 30]
 
 [[profiles]]
-name = "bootroot-agent"
 daemon_name = "bootroot-agent"
 instance_id = "001"
 hostname = "bootroot-agent"
-uri_san_enabled = false
-domains = ["bootroot-agent.com"]
 
 [profiles.paths]
 cert = "/app/certs/bootroot-agent.crt"

--- a/agent.toml.example
+++ b/agent.toml.example
@@ -8,8 +8,9 @@ email = "admin@example.com"
 # Default: https://localhost:9000/acme/acme/directory (Step CA)
 server = "https://localhost:9000/acme/acme/directory"
 
-# SPIFFE trust domain used for URI SANs
-spiffe_trust_domain = "trusted.domain"
+# Root domain used to auto-generate the DNS SAN
+# Format: <instance_id>.<daemon_name>.<hostname>.<domain>
+domain = "trusted.domain"
 
 # Scheduler settings
 [scheduler]
@@ -40,12 +41,9 @@ backoff_secs = [5, 10, 30]
 
 # Profiles (one per daemon instance)
 [[profiles]]
-name = "edge-proxy-a"
 daemon_name = "edge-proxy"
 instance_id = "001"
 hostname = "edge-node-01"
-uri_san_enabled = true
-domains = ["edge-proxy.internal"]
 
 [profiles.paths]
 # Path to save the certificate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     networks:
       default:
         aliases:
-          - bootroot-agent.com
+          - 001.bootroot-agent.bootroot-agent.trusted.domain
 
   bootroot-agent:
     build:

--- a/docs/en/concepts.md
+++ b/docs/en/concepts.md
@@ -5,7 +5,7 @@ This section gives you enough background to understand what you are operating.
 ## PKI and Certificates
 
 - A **Certificate Authority (CA)** signs certificates that bind a public key
-  to an identity (a hostname, service, or SPIFFE URI).
+  to an identity (a hostname or IP address).
 - A **certificate** contains identity fields (Subject, SANs), validity, and
   the CA signature.
 - A **private key** must be protected. It proves possession of the identity.
@@ -58,17 +58,7 @@ and HMAC key. bootroot-agent can load EAB from config or CLI.
 SANs are the identities inside the certificate. Common types:
 
 - **DNS**: `example.internal`
-- **URI**: `spiffe://trusted.domain/host/daemon/instance`
-
-## SPIFFE URI
-
-A SPIFFE URI provides workload identity. In this repo the URI format is:
-
-```text
-spiffe://<trust-domain>/<hostname>/<daemon-name>/<instance-id>
-```
-
-This keeps identities stable across renewals and supports multiple instances.
+- **IP**: `192.0.2.10`
 
 ## mTLS
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -10,7 +10,7 @@ The full template lives in `agent.toml.example`.
 ```toml
 email = "admin@example.com"
 server = "https://localhost:9000/acme/acme/directory"
-spiffe_trust_domain = "trusted.domain"
+domain = "trusted.domain"
 ```
 
 - `email`: ACME account contact email. The account is created automatically
@@ -29,9 +29,8 @@ spiffe_trust_domain = "trusted.domain"
     - Docker Compose: `https://bootroot-ca:9000/acme/acme/directory`
     - Host install (same host): `https://localhost:9000/acme/acme/directory`
     - Remote step-ca: `https://<step-ca-host>:9000/acme/<provisioner>/directory`
-- `spiffe_trust_domain`: the **trust domain** portion of the SPIFFE URI SAN.
-  For example, `spiffe_trust_domain = "trusted.domain"` yields
-  `spiffe://trusted.domain/<hostname>/<daemon-name>/<instance-id>`.
+- `domain`: root domain used to auto-generate the DNS SAN as
+  `instance_id.daemon_name.hostname.domain`.
 
 ### Scheduler
 
@@ -96,12 +95,9 @@ Each profile represents one daemon instance (one certificate identity).
 
 ```toml
 [[profiles]]
-name = "edge-proxy-a"
 daemon_name = "edge-proxy"
 instance_id = "001"
 hostname = "edge-node-01"
-uri_san_enabled = true
-domains = ["edge-proxy.internal"]
 
 [profiles.paths]
 cert = "certs/edge-proxy-a.pem"
@@ -113,15 +109,11 @@ renew_before = "720h"
 check_jitter = "0s"
 ```
 
-When `uri_san_enabled = true`, bootroot-agent automatically includes a URI
-like `spiffe://<trust-domain>/<hostname>/<daemon-name>/<instance-id>` in the
-certificate SAN list (no extra user input required). The `<trust-domain>`
-portion comes from the global `spiffe_trust_domain` setting.
-
-`domains` lists the DNS names you want in the certificate (DNS SAN). These
-names are also the targets for HTTP-01 validation, so they must resolve
-from step-ca to the HTTP-01 responder (for Compose, update the network alias;
-for host installs, update `/etc/hosts` or DNS).
+The DNS SAN is auto-generated as
+`<instance-id>.<daemon-name>.<hostname>.<domain>`. This name is also the
+target for HTTP-01 validation, so it must resolve from step-ca to the
+HTTP-01 responder IP (for Compose, update the network alias; for host installs,
+update `/etc/hosts` or DNS).
 
 #### Profile Retry Override
 

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -3,13 +3,13 @@
 ## Can I run multiple certificates on one machine?
 
 Yes. Define multiple `[[profiles]]` entries. Each profile issues its own
-certificate and can use distinct domains and paths.
+certificate and uses a distinct identity derived from
+`instance_id.daemon_name.hostname.domain`.
 
-## Can I use SPIFFE without DNS names?
+## Can I include URI SANs with ACME?
 
-Not today. ACME HTTP-01 requires `domains`, and those values are always added
-as DNS SANs. `uri_san_enabled = true` only adds a SPIFFE URI; it does not
-remove DNS SANs.
+No. ACME only supports DNS/IP identifiers, so URI SANs are rejected by
+step-ca in the ACME flow.
 
 ## Do I need EAB?
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -6,10 +6,12 @@ This section walks through a full end-to-end issuance using Docker Compose.
 
 - Docker and Docker Compose
 - Port 80 accessible to the HTTP-01 responder inside the compose network
-- `profiles[].domains` must resolve **from step-ca to the HTTP-01 responder**
+- The auto-generated DNS SAN must resolve **from step-ca to the HTTP-01 responder**
   - In Compose, `docker-compose.yml` gives `bootroot-http01` the
-    `bootroot-agent.com` network alias
-  - If you change the domain, update the alias or map it in step-ca `/etc/hosts`
+    `001.bootroot-agent.bootroot-agent.trusted.domain` network alias
+  - If you change `domain`, update the alias or map it in step-ca `/etc/hosts`
+  - Auto-generated scheme:
+    `<instance-id>.<daemon-name>.<hostname>.<domain>`
 
 ## Quick Start (Compose)
 
@@ -23,16 +25,17 @@ This section walks through a full end-to-end issuance using Docker Compose.
 
    ```bash
    docker logs -f bootroot-agent
-   # Expected: "Successfully issued certificate!"
    ```
+
+   Expected log: `Successfully issued certificate!`
 
 3. Confirm output files:
 
    ```bash
    ls -l certs/
-   # bootroot-agent.crt
-   # bootroot-agent.key
    ```
+
+   Expected files: `bootroot-agent.crt`, `bootroot-agent.key`
 
 ## What Just Happened
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -21,7 +21,7 @@ Components:
 
 ## Manual Map
 
-- **Concepts**: PKI, ACME, CSR, SAN, SPIFFE, and mTLS basics
+- **Concepts**: PKI, ACME, CSR, SAN, and mTLS basics
 - **Getting Started**: Quick Docker-based issuance flow
 - **Installation**: step-ca + PostgreSQL + bootroot-agent + responder setup
 - **Configuration**: `agent.toml`, profiles, hooks, retries, and EAB

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -20,7 +20,7 @@ Check your CLI flags. The current CLI supports:
 ## "Finalize failed: badCSR"
 
 This usually means the CSR SANs are not accepted by the CA policy.
-Check the step-ca provisioner policy and the requested domains.
+Check the step-ca provisioner policy and the requested DNS SAN.
 
 ## Certificate files not written
 

--- a/docs/ko/concepts.md
+++ b/docs/ko/concepts.md
@@ -4,7 +4,7 @@
 
 ## PKI와 인증서
 
-- **CA(인증기관)** 는 공개키와 신원을 묶어 서명합니다.
+- **CA(인증기관)** 는 공개키와 신원을 묶어 서명합니다(호스트명 또는 IP).
 - **인증서**는 신원 정보(SAN), 유효기간, CA 서명을 포함합니다.
 - **개인키**는 반드시 안전하게 보호되어야 합니다.
 
@@ -60,15 +60,7 @@ HTTP-01은 **도메인 소유 확인 절차**입니다. CA가 **토큰**을 발�
 인증서의 실제 신원 목록입니다. 예:
 
 - **DNS**: `example.internal`
-- **URI**: `spiffe://trusted.domain/host/daemon/instance`
-
-## SPIFFE URI
-
-워크로드 식별을 위한 URI 형식입니다. 이 repo의 기본 형식:
-
-```text
-spiffe://<trust-domain>/<hostname>/<daemon-name>/<instance-id>
-```
+- **IP**: `192.0.2.10`
 
 ## mTLS
 

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -10,7 +10,7 @@ bootroot-agent는 TOML 설정 파일을 읽습니다(기본값: `agent.toml`).
 ```toml
 email = "admin@example.com"
 server = "https://localhost:9000/acme/acme/directory"
-spiffe_trust_domain = "trusted.domain"
+domain = "trusted.domain"
 ```
 
 - `email`: ACME 계정 연락처 이메일입니다. bootroot-agent가 step-ca에
@@ -29,9 +29,8 @@ spiffe_trust_domain = "trusted.domain"
     - Docker Compose: `https://bootroot-ca:9000/acme/acme/directory`
     - 호스트 실행(동일 호스트): `https://localhost:9000/acme/acme/directory`
     - 원격 step-ca: `https://<step-ca-host>:9000/acme/<provisioner>/directory`
-- `spiffe_trust_domain`: SPIFFE URI SAN의 **trust domain** 부분입니다.
-  예를 들어 `spiffe_trust_domain = "trusted.domain"`이면 다음처럼 들어갑니다.
-  `spiffe://trusted.domain/<hostname>/<daemon-name>/<instance-id>`
+- `domain`: `instance_id.daemon_name.hostname.domain` 형식의 DNS SAN을
+  자동 생성할 때 사용하는 루트 도메인입니다.
 
 ### 스케줄러
 
@@ -96,12 +95,9 @@ CLI에서도 지정 가능합니다(`--eab-kid`, `--eab-hmac`, `--eab-file`).
 
 ```toml
 [[profiles]]
-name = "edge-proxy-a"
 daemon_name = "edge-proxy"
 instance_id = "001"
 hostname = "edge-node-01"
-uri_san_enabled = true
-domains = ["edge-proxy.internal"]
 
 [profiles.paths]
 cert = "certs/edge-proxy-a.pem"
@@ -113,14 +109,11 @@ renew_before = "720h"
 check_jitter = "0s"
 ```
 
-`uri_san_enabled = true`이면 bootroot-agent가 인증서 SAN에
-`spiffe://<trust-domain>/<hostname>/<daemon-name>/<instance-id>` 형식의 URI를
-**자동으로 포함**합니다(사용자 추가 입력 없음). 이때 `<trust-domain>`은
-전역 설정의 `spiffe_trust_domain` 값을 사용합니다.
-
-`domains`는 인증서에 포함할 DNS 이름(DNS SAN) 목록입니다. HTTP-01 검증도
-이 도메인으로 진행되므로, step-ca에서 해당 도메인이 HTTP-01 리스폰더로
-해석되어야 합니다(Compose는 네트워크 alias, 베어메탈은 `/etc/hosts`나 DNS).
+DNS SAN은 `<instance-id>.<daemon-name>.<hostname>.<domain>` 형식으로
+자동 생성됩니다. 이 이름은 HTTP-01 검증 대상이므로, step-ca에서
+HTTP-01 리스폰더 IP로 해석되어야 합니다(Compose는 네트워크 alias,
+베어메탈은 `/etc/hosts` 또는 DNS 설정).
+권장 형식: `<instance-id>.<daemon-name>.<hostname>.<domain>`.
 
 #### 프로필 재시도 재정의
 

--- a/docs/ko/faq.md
+++ b/docs/ko/faq.md
@@ -2,13 +2,13 @@
 
 ## 한 머신에서 여러 인증서를 발급할 수 있나요?
 
-가능합니다. `[[profiles]]`를 여러 개 정의하면 됩니다.
+가능합니다. `[[profiles]]`를 여러 개 정의하면 됩니다. 각 프로필은
+`instance_id.daemon_name.hostname.domain` 형식의 고유 신원을 가집니다.
 
-## SPIFFE URI만 사용해도 되나요?
+## ACME에서 URI SAN을 넣을 수 있나요?
 
-현재는 불가능합니다. ACME HTTP-01 발급을 사용하므로 `domains`가 필수이고,
-그 값이 DNS SAN에 항상 포함됩니다. `uri_san_enabled = true`는 SPIFFE URI를
-추가로 넣는 옵션일 뿐, DNS SAN을 제거하지는 않습니다.
+불가능합니다. ACME는 DNS/IP 식별자만 지원하므로, URI SAN이 포함된 CSR은
+step-ca가 거부합니다.
 
 ## EAB는 꼭 필요한가요?
 

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -6,10 +6,12 @@
 
 - Docker 및 Docker Compose
 - Compose 네트워크 내부에서 리스폰더의 포트 80 접근 가능
-- `profiles[].domains` 값이 step-ca에서 **HTTP-01 리스폰더로 해석**되어야 함
+- 자동 생성된 DNS SAN이 step-ca에서 **HTTP-01 리스폰더로 해석**되어야 함
   - Compose에서는 `docker-compose.yml`의 `bootroot-http01`이
-    `bootroot-agent.com` alias를 제공함
-  - 도메인을 바꾸면 alias를 함께 바꾸거나 step-ca의 `/etc/hosts`에 매핑 필요
+    `001.bootroot-agent.bootroot-agent.trusted.domain` alias를 제공함
+  - `domain` 값을 바꾸면 alias를 함께 바꾸거나 step-ca의 `/etc/hosts`에 매핑 필요
+  - 자동 생성 형식:
+    `<instance-id>.<daemon-name>.<hostname>.<domain>`
 
 ## 빠른 실행(Compose)
 
@@ -23,16 +25,17 @@
 
    ```bash
    docker logs -f bootroot-agent
-   # 기대: "Successfully issued certificate!"
    ```
+
+   기대 로그 예시: `Successfully issued certificate!`
 
 3. 발급 파일 확인:
 
    ```bash
    ls -l certs/
-   # bootroot-agent.crt
-   # bootroot-agent.key
    ```
+
+   기대 파일: `bootroot-agent.crt`, `bootroot-agent.key`
 
 ## 내부적으로 일어난 일
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -20,7 +20,7 @@ Environment)는 RFC 8555에서 정의된 표준 프로토콜입니다. step-ca�
 
 ## 매뉴얼 구성
 
-- **개념**: PKI, ACME, CSR, SAN, SPIFFE, mTLS 개요
+- **개념**: PKI, ACME, CSR, SAN, mTLS 개요
 - **빠른 시작**: Docker Compose 기반 첫 발급
 - **설치**: step-ca + PostgreSQL + bootroot-agent + 리스폰더 설치
 - **설정**: `agent.toml`, 프로필, 훅, 재시도, EAB

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -20,7 +20,7 @@
 ## "Finalize failed: badCSR"
 
 CSR에 포함된 SAN이 CA 정책에 맞지 않을 때 발생합니다.
-step-ca 프로비저너 정책과 요청 도메인을 확인하세요.
+step-ca 프로비저너 정책과 요청 DNS SAN을 확인하세요.
 
 ## 인증서 파일이 생성되지 않음
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,6 @@ mod tests {
 
     const TEST_DOMAIN: &str = "example.com";
     const TEST_KEY_PATH: &str = "unused.key";
-    const TEST_TRUST_DOMAIN: &str = "trusted.domain";
     const THIRTY_DAYS_SECS: u64 = 30 * 24 * 60 * 60;
     const TEST_DELAYS: [u64; 3] = [1, 2, 3];
     const TEST_JITTER_SECS: u64 = 10;
@@ -129,12 +128,9 @@ mod tests {
 
     fn build_profile(cert_path: PathBuf) -> config::ProfileSettings {
         config::ProfileSettings {
-            name: "edge-proxy-a".to_string(),
             daemon_name: "edge-proxy".to_string(),
             instance_id: "001".to_string(),
             hostname: "edge-node-01".to_string(),
-            uri_san_enabled: true,
-            domains: vec![TEST_DOMAIN.to_string()],
             paths: config::Paths {
                 cert: cert_path,
                 key: PathBuf::from(TEST_KEY_PATH),
@@ -154,7 +150,7 @@ mod tests {
         config::Settings {
             email: "test@example.com".to_string(),
             server: "https://example.com/acme/directory".to_string(),
-            spiffe_trust_domain: TEST_TRUST_DOMAIN.to_string(),
+            domain: TEST_DOMAIN.to_string(),
             eab: None,
             acme: config::AcmeSettings {
                 directory_fetch_attempts: 10,
@@ -185,16 +181,6 @@ mod tests {
         let key = rcgen::KeyPair::generate().unwrap();
         let cert = params.self_signed(&key).unwrap();
         fs::write(cert_path, cert.pem()).unwrap();
-    }
-
-    #[test]
-    fn test_build_spiffe_uri_formats_path() {
-        let profile = build_profile(PathBuf::from("unused.pem"));
-        let settings = build_settings(vec![profile.clone()]);
-
-        let uri = profile::build_spiffe_uri(&settings, &profile);
-
-        assert_eq!(uri, "spiffe://trusted.domain/edge-node-01/edge-proxy/001");
     }
 
     #[test]

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,19 +1,5 @@
 use crate::{config, eab};
 
-pub(crate) const SPIFFE_URI_FORMAT: &str =
-    "spiffe://{trust_domain}/{hostname}/{daemon_name}/{instance_id}";
-
-pub(crate) fn build_spiffe_uri(
-    settings: &config::Settings,
-    profile: &config::ProfileSettings,
-) -> String {
-    SPIFFE_URI_FORMAT
-        .replace("{trust_domain}", &settings.spiffe_trust_domain)
-        .replace("{hostname}", &profile.hostname)
-        .replace("{daemon_name}", &profile.daemon_name)
-        .replace("{instance_id}", &profile.instance_id)
-}
-
 pub(crate) fn resolve_profile_eab(
     profile: &config::ProfileSettings,
     default_eab: Option<eab::EabCredentials>,


### PR DESCRIPTION
- Remove SPIFFE URI SAN handling from CSR and issuance flow
- Default uri_san_enabled to false and update config expectations
- Align docs and configs with DNS SAN naming scheme

Closes #52