### PR TITLE
Clarify daemon-only profiles and runtime settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ You can run the agent directly on your host machine.
    cargo run -- --config agent.toml
    ```
 
+   `agent.toml` is for daemon profiles only. Docker sidecars do not use
+   `agent.toml`; configure them via runtime arguments or environment variables.
+
    *(Note: You might need to handle TLS trust for `try-ca` manually or ignore
    cert errors if supported by flags)*
 

--- a/agent.toml.compose
+++ b/agent.toml.compose
@@ -1,4 +1,5 @@
 # Bootroot Agent Docker Compose Config (Multi-Profile)
+# This file is for daemon profiles only. Docker sidecars use runtime args/env.
 
 email = "admin@example.com"
 server = "https://bootroot-ca:9000/acme/acme/directory"

--- a/agent.toml.example
+++ b/agent.toml.example
@@ -1,5 +1,6 @@
 # Bootroot Agent Configuration Example (Multi-Profile)
 # Rename this file to agent.toml to use it.
+# This file is for daemon profiles only. Docker sidecars use runtime args/env.
 
 # Support email address for ACME registration
 email = "admin@example.com"

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -2,6 +2,8 @@
 
 bootroot-agent reads a TOML configuration file (default `agent.toml`).
 The full template lives in `agent.toml.example`.
+`agent.toml` is for daemon profiles only. Docker sidecars do not use
+`agent.toml`; configure them via runtime arguments or environment variables.
 
 ## bootroot CLI
 

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -2,6 +2,8 @@
 
 bootroot-agent는 TOML 설정 파일을 읽습니다(기본값: `agent.toml`).
 전체 템플릿은 `agent.toml.example`에 있습니다.
+`agent.toml`은 데몬 프로필 전용입니다. 도커 사이드카는 `agent.toml`을
+사용하지 않고 런타임 인자나 환경변수로 설정합니다.
 
 ## bootroot CLI
 

--- a/src/acme/flow.rs
+++ b/src/acme/flow.rs
@@ -16,7 +16,7 @@ fn contact_from_email(email: &str) -> String {
 
 fn build_csr_params(
     settings: &crate::config::Settings,
-    profile: &crate::config::ProfileSettings,
+    profile: &crate::config::DaemonProfileSettings,
 ) -> Result<rcgen::CertificateParams> {
     let primary_domain = crate::config::profile_domain(settings, profile);
     let mut params = rcgen::CertificateParams::default();
@@ -186,7 +186,7 @@ async fn wait_for_order_completion(
 ///
 pub async fn issue_certificate(
     settings: &crate::config::Settings,
-    profile: &crate::config::ProfileSettings,
+    profile: &crate::config::DaemonProfileSettings,
     eab_creds: Option<crate::eab::EabCredentials>,
 ) -> Result<()> {
     let mut client = AcmeClient::new(settings.server.clone(), &settings.acme)?;
@@ -288,8 +288,8 @@ mod tests {
         }
     }
 
-    fn test_profile() -> crate::config::ProfileSettings {
-        crate::config::ProfileSettings {
+    fn test_profile() -> crate::config::DaemonProfileSettings {
+        crate::config::DaemonProfileSettings {
             service_name: "edge-proxy".to_string(),
             instance_id: "001".to_string(),
             hostname: "edge-node-01".to_string(),
@@ -297,7 +297,7 @@ mod tests {
                 cert: PathBuf::from("certs/edge-proxy-a.pem"),
                 key: PathBuf::from("certs/edge-proxy-a.key"),
             },
-            daemon: crate::config::DaemonSettings::default(),
+            daemon: crate::config::DaemonRuntimeSettings::default(),
             retry: None,
             hooks: crate::config::HookSettings::default(),
             eab: None,

--- a/src/bin/bootroot-agent.rs
+++ b/src/bin/bootroot-agent.rs
@@ -77,8 +77,8 @@ mod tests {
     const TEST_BASE_SECS: u64 = 60;
     const TEST_SEED_NS: i128 = 123_456_789;
 
-    fn build_profile(cert_path: PathBuf) -> config::ProfileSettings {
-        config::ProfileSettings {
+    fn build_profile(cert_path: PathBuf) -> config::DaemonProfileSettings {
+        config::DaemonProfileSettings {
             service_name: "edge-proxy".to_string(),
             instance_id: "001".to_string(),
             hostname: "edge-node-01".to_string(),
@@ -86,7 +86,7 @@ mod tests {
                 cert: cert_path,
                 key: PathBuf::from(TEST_KEY_PATH),
             },
-            daemon: config::DaemonSettings {
+            daemon: config::DaemonRuntimeSettings {
                 check_interval: Duration::from_secs(60 * 60),
                 renew_before: Duration::from_secs(720 * 60 * 60),
                 check_jitter: Duration::from_secs(0),
@@ -97,7 +97,7 @@ mod tests {
         }
     }
 
-    fn build_settings(profiles: Vec<config::ProfileSettings>) -> config::Settings {
+    fn build_settings(profiles: Vec<config::DaemonProfileSettings>) -> config::Settings {
         config::Settings {
             email: "test@example.com".to_string(),
             server: "https://example.com/acme/directory".to_string(),
@@ -140,7 +140,7 @@ mod tests {
             kid: "profile".to_string(),
             hmac: "profile-hmac".to_string(),
         };
-        let profile = config::ProfileSettings {
+        let profile = config::DaemonProfileSettings {
             eab: Some(profile_eab),
             ..build_profile(PathBuf::from("unused.pem"))
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,11 +16,11 @@ pub struct Settings {
     #[serde(default)]
     pub scheduler: SchedulerSettings,
     #[serde(default)]
-    pub profiles: Vec<ProfileSettings>,
+    pub profiles: Vec<DaemonProfileSettings>,
 }
 
 #[must_use]
-pub fn profile_domain(settings: &Settings, profile: &ProfileSettings) -> String {
+pub fn profile_domain(settings: &Settings, profile: &DaemonProfileSettings) -> String {
     format!(
         "{}.{}.{}.{}",
         profile.instance_id, profile.service_name, profile.hostname, settings.domain
@@ -40,13 +40,13 @@ pub struct Eab {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct ProfileSettings {
+pub struct DaemonProfileSettings {
     pub service_name: String,
     pub instance_id: String,
     pub hostname: String,
     pub paths: Paths,
     #[serde(default)]
-    pub daemon: DaemonSettings,
+    pub daemon: DaemonRuntimeSettings,
     #[serde(default)]
     pub retry: Option<RetrySettings>,
     #[serde(default)]
@@ -55,7 +55,7 @@ pub struct ProfileSettings {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct DaemonSettings {
+pub struct DaemonRuntimeSettings {
     #[serde(default = "default_check_interval", with = "duration_serde")]
     pub check_interval: Duration,
     #[serde(default = "default_renew_before", with = "duration_serde")]
@@ -162,7 +162,7 @@ fn default_check_jitter() -> Duration {
     Duration::from_secs(DEFAULT_CHECK_JITTER_SECS)
 }
 
-impl Default for DaemonSettings {
+impl Default for DaemonRuntimeSettings {
     fn default() -> Self {
         Self {
             check_interval: default_check_interval(),
@@ -330,7 +330,7 @@ impl Settings {
         Ok(())
     }
 
-    fn validate_profile(profile: &ProfileSettings) -> Result<()> {
+    fn validate_profile(profile: &DaemonProfileSettings) -> Result<()> {
         if profile.service_name.trim().is_empty() {
             anyhow::bail!("profiles.service_name must not be empty");
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -53,7 +53,7 @@ pub async fn run_daemon(
 
 async fn run_profile_daemon(
     settings: Arc<config::Settings>,
-    profile: config::ProfileSettings,
+    profile: config::DaemonProfileSettings,
     default_eab: Option<eab::EabCredentials>,
     semaphore: Arc<Semaphore>,
     mut shutdown: watch::Receiver<bool>,
@@ -202,7 +202,7 @@ pub async fn run_oneshot(
 
 async fn run_profile_oneshot(
     settings: Arc<config::Settings>,
-    profile: config::ProfileSettings,
+    profile: config::DaemonProfileSettings,
     default_eab: Option<eab::EabCredentials>,
     semaphore: Arc<Semaphore>,
 ) -> anyhow::Result<()> {
@@ -244,7 +244,7 @@ async fn run_profile_oneshot(
 
 async fn issue_with_retry(
     settings: &config::Settings,
-    profile: &config::ProfileSettings,
+    profile: &config::DaemonProfileSettings,
     eab: Option<eab::EabCredentials>,
 ) -> anyhow::Result<()> {
     let backoff = select_retry_backoff(settings, profile);
@@ -258,7 +258,7 @@ async fn issue_with_retry(
 
 fn select_retry_backoff<'a>(
     settings: &'a config::Settings,
-    profile: &'a config::ProfileSettings,
+    profile: &'a config::DaemonProfileSettings,
 ) -> &'a [u64] {
     profile
         .retry
@@ -315,7 +315,7 @@ where
 /// # Errors
 /// Returns an error if the certificate cannot be parsed or read.
 pub async fn should_renew(
-    profile: &config::ProfileSettings,
+    profile: &config::DaemonProfileSettings,
     renew_before: Duration,
 ) -> anyhow::Result<bool> {
     let cert_bytes = match tokio::fs::read(&profile.paths.cert).await {
@@ -410,10 +410,12 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::config::{AcmeSettings, DaemonSettings, Paths, RetrySettings, SchedulerSettings};
+    use crate::config::{
+        AcmeSettings, DaemonRuntimeSettings, Paths, RetrySettings, SchedulerSettings,
+    };
 
-    fn build_profile() -> config::ProfileSettings {
-        config::ProfileSettings {
+    fn build_profile() -> config::DaemonProfileSettings {
+        config::DaemonProfileSettings {
             service_name: "edge-proxy".to_string(),
             instance_id: "001".to_string(),
             hostname: "edge-node-01".to_string(),
@@ -421,7 +423,7 @@ mod tests {
                 cert: PathBuf::from("unused.pem"),
                 key: PathBuf::from("unused.key"),
             },
-            daemon: DaemonSettings {
+            daemon: DaemonRuntimeSettings {
                 check_interval: Duration::from_secs(60 * 60),
                 renew_before: Duration::from_secs(720 * 60 * 60),
                 check_jitter: Duration::from_secs(0),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -2,7 +2,7 @@ use crate::{config, eab};
 
 /// Resolves the effective EAB credentials for a profile.
 pub fn resolve_profile_eab(
-    profile: &config::ProfileSettings,
+    profile: &config::DaemonProfileSettings,
     default_eab: Option<eab::EabCredentials>,
 ) -> Option<eab::EabCredentials> {
     profile.eab.as_ref().map(to_eab_credentials).or(default_eab)


### PR DESCRIPTION
- Rename ProfileSettings to DaemonProfileSettings and fold daemon settings into DaemonRuntimeSettings to avoid implying docker profiles.
- Document that agent.toml applies to daemon profiles only and that docker sidecars use runtime args or environment variables.

Closes #86