### PR TITLE
Enable sccache for CI Rust builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: sccache
 
 jobs:
   check:
@@ -25,6 +26,9 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Check Rust Formatting
         run: cargo fmt -- --check --config group_imports=StdExternalCrate
@@ -70,6 +74,9 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       # --- Unit Testing ---
       - name: Run Unit Tests


### PR DESCRIPTION
Add sccache action and set RUSTC_WRAPPER so Rust compiles reuse cached artifacts across runs.

Closes #126