### PR TITLE
Orchestrate remote rotate sync transitions

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -57,6 +57,8 @@ pub(crate) struct ServiceEntry {
     pub(crate) delivery_mode: DeliveryMode,
     #[serde(default)]
     pub(crate) sync_status: ServiceSyncStatus,
+    #[serde(default)]
+    pub(crate) sync_metadata: ServiceSyncMetadata,
     pub(crate) hostname: String,
     pub(crate) domain: String,
     pub(crate) agent_config_path: PathBuf,
@@ -125,6 +127,24 @@ pub(crate) struct ServiceSyncStatus {
     pub(crate) trust_sync: SyncApplyStatus,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ServiceSyncMetadata {
+    #[serde(default)]
+    pub(crate) secret_id: SyncTiming,
+    #[serde(default)]
+    pub(crate) eab: SyncTiming,
+    #[serde(default)]
+    pub(crate) responder_hmac: SyncTiming,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+pub(crate) struct SyncTiming {
+    #[serde(default)]
+    pub(crate) started_at_unix: Option<i64>,
+    #[serde(default)]
+    pub(crate) expires_at_unix: Option<i64>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct ServiceRoleEntry {
     pub(crate) role_name: String,
@@ -158,5 +178,16 @@ mod tests {
         assert_eq!(status.eab, SyncApplyStatus::None);
         assert_eq!(status.responder_hmac, SyncApplyStatus::None);
         assert_eq!(status.trust_sync, SyncApplyStatus::None);
+    }
+
+    #[test]
+    fn sync_metadata_defaults_to_empty_timestamps() {
+        let metadata = ServiceSyncMetadata::default();
+        assert_eq!(metadata.secret_id.started_at_unix, None);
+        assert_eq!(metadata.secret_id.expires_at_unix, None);
+        assert_eq!(metadata.eab.started_at_unix, None);
+        assert_eq!(metadata.eab.expires_at_unix, None);
+        assert_eq!(metadata.responder_hmac.started_at_unix, None);
+        assert_eq!(metadata.responder_hmac.expires_at_unix, None);
     }
 }


### PR DESCRIPTION
- Implement remote-bootstrap sync lifecycle in rotate flows.
- Set pending with started/expires timestamps for secret_id, eab, and responder_hmac, and expire overdue pending states to expired.
- Update service sync-status ingest to clear rotation timing metadata when terminal states are reported.
- Keep local-file behavior stable and add unit/integration tests for pending, applied/failed ingest, and expiry transitions.

Closes #222