### PR TITLE
Add bootroot-remote pull and ack workflow

### DIFF
--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -666,7 +666,7 @@ async fn write_remote_bootstrap_artifact(
 
     let remote_summary_path = format!("{}-remote-summary.json", resolved.service_name);
     let remote_run_command = format!(
-        "bootroot-remote --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --output json > {}",
+        "bootroot-remote pull --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --summary-json '{}' --output json",
         artifact.openbao_url,
         artifact.kv_mount,
         artifact.service_name,
@@ -678,7 +678,7 @@ async fn write_remote_bootstrap_artifact(
         remote_summary_path
     );
     let control_sync_command = format!(
-        "bootroot service sync-status --service-name '{}' --summary-json '{}'",
+        "bootroot-remote ack --service-name '{}' --summary-json '{}'",
         resolved.service_name, remote_summary_path
     );
     Ok(RemoteBootstrapResult {
@@ -744,7 +744,7 @@ async fn write_remote_bootstrap_artifact_file(
     fs_util::set_key_permissions(&artifact_path).await?;
     let remote_summary_path = format!("{service_name}-remote-summary.json");
     let remote_run_command = format!(
-        "bootroot-remote --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --output json > {}",
+        "bootroot-remote pull --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --summary-json '{}' --output json",
         artifact.openbao_url,
         artifact.kv_mount,
         artifact.service_name,
@@ -756,7 +756,7 @@ async fn write_remote_bootstrap_artifact_file(
         remote_summary_path
     );
     let control_sync_command = format!(
-        "bootroot service sync-status --service-name '{}' --summary-json '{}'",
+        "bootroot-remote ack --service-name '{}' --summary-json '{}'",
         artifact.service_name, remote_summary_path
     );
     Ok(RemoteBootstrapResult {


### PR DESCRIPTION
Split bootroot-remote into pull and ack subcommands. Keep pull behavior for secret fetch/apply and add
--summary-json output for later ingestion.

Add ack command to invoke bootroot service sync-status with service name and summary JSON.

Update remote-bootstrap service-add snippets to use: 1) bootroot-remote pull ... --summary-json ...
2) bootroot-remote ack --service-name ... --summary-json ...

Add integration test coverage for ack invocation flow.

Closes #224