### PR TITLE
Add bootroot-remote sync runner and schedules

### DIFF
--- a/scripts/bootroot-remote-sync.cron
+++ b/scripts/bootroot-remote-sync.cron
@@ -1,0 +1,3 @@
+# Example cron entry (every 5 minutes)
+# */5 * * * * root /usr/local/bin/bootroot-remote sync --openbao-url "$OPENBAO_URL" --kv-mount "$OPENBAO_KV_MOUNT" --service-name "$SERVICE_NAME" --role-id-path "$ROLE_ID_PATH" --secret-id-path "$SECRET_ID_PATH" --eab-file-path "$EAB_FILE_PATH" --agent-config-path "$AGENT_CONFIG_PATH" --ca-bundle-path "$CA_BUNDLE_PATH" --summary-json "$SUMMARY_JSON_PATH" --bootroot-bin "$BOOTROOT_BIN" --retry-attempts "$RETRY_ATTEMPTS" --retry-backoff-secs "$RETRY_BACKOFF_SECS" --retry-jitter-secs "$RETRY_JITTER_SECS"
+

--- a/scripts/bootroot-remote-sync.service
+++ b/scripts/bootroot-remote-sync.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=bootroot remote secret sync (pull + ack)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+EnvironmentFile=/etc/bootroot/remote-sync.env
+ExecStart=/usr/local/bin/bootroot-remote sync \
+  --openbao-url ${OPENBAO_URL} \
+  --kv-mount ${OPENBAO_KV_MOUNT} \
+  --service-name ${SERVICE_NAME} \
+  --role-id-path ${ROLE_ID_PATH} \
+  --secret-id-path ${SECRET_ID_PATH} \
+  --eab-file-path ${EAB_FILE_PATH} \
+  --agent-config-path ${AGENT_CONFIG_PATH} \
+  --ca-bundle-path ${CA_BUNDLE_PATH} \
+  --summary-json ${SUMMARY_JSON_PATH} \
+  --bootroot-bin ${BOOTROOT_BIN} \
+  --retry-attempts ${RETRY_ATTEMPTS} \
+  --retry-backoff-secs ${RETRY_BACKOFF_SECS} \
+  --retry-jitter-secs ${RETRY_JITTER_SECS}
+

--- a/scripts/bootroot-remote-sync.timer
+++ b/scripts/bootroot-remote-sync.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Periodic bootroot remote secret sync
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30
+Unit=bootroot-remote-sync.service
+
+[Install]
+WantedBy=timers.target
+

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -666,7 +666,7 @@ async fn write_remote_bootstrap_artifact(
 
     let remote_summary_path = format!("{}-remote-summary.json", resolved.service_name);
     let remote_run_command = format!(
-        "bootroot-remote pull --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --summary-json '{}' --output json",
+        "bootroot-remote sync --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --summary-json '{}' --output json",
         artifact.openbao_url,
         artifact.kv_mount,
         artifact.service_name,
@@ -744,7 +744,7 @@ async fn write_remote_bootstrap_artifact_file(
     fs_util::set_key_permissions(&artifact_path).await?;
     let remote_summary_path = format!("{service_name}-remote-summary.json");
     let remote_run_command = format!(
-        "bootroot-remote pull --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --summary-json '{}' --output json",
+        "bootroot-remote sync --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --ca-bundle-path '{}' --summary-json '{}' --output json",
         artifact.openbao_url,
         artifact.kv_mount,
         artifact.service_name,


### PR DESCRIPTION
Add `bootroot-remote sync` to execute pull+ack in one flow. Ensure ack is skipped when pull fails, and add retry/backoff with optional jitter for transient failures.

Update remote-bootstrap service-add snippets to use sync.

Add operational schedule templates for remote execution:
- systemd service and timer
- cron example

Expand integration tests for sync success and pull-failure paths, including ack invocation behavior.

Closes #226