### PR TITLE
Add Docker baseline matrix E2E for mixed services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,10 +347,30 @@ jobs:
           BOOTROOT_REMOTE_BIN="$(pwd)/target/debug/bootroot-remote" \
           ./scripts/e2e/docker/run-harness-smoke.sh
 
+      - name: Run Docker baseline smoke (Scenario A)
+        run: |
+          SCENARIO_FILE="$(pwd)/tests/e2e/docker_harness/scenarios/scenario-a-single-node-mixed.json" \
+          ARTIFACT_DIR="$(pwd)/tmp/e2e/docker-baseline-smoke-${GITHUB_RUN_ID}" \
+          PROJECT_NAME="bootroot-e2e-baseline-${GITHUB_RUN_ID}" \
+          MAX_CYCLES=2 \
+          INTERVAL_SECS=1 \
+          TIMEOUT_SECS=45 \
+          BOOTROOT_BIN="$(pwd)/target/debug/bootroot" \
+          BOOTROOT_REMOTE_BIN="$(pwd)/target/debug/bootroot-remote" \
+          ./scripts/e2e/docker/run-baseline.sh
+
       - name: Upload Harness Artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: docker-harness-smoke-${{ github.run_id }}
           path: tmp/e2e/docker-harness-${{ github.run_id }}
+          if-no-files-found: warn
+
+      - name: Upload Baseline Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-baseline-smoke-${{ github.run_id }}
+          path: tmp/e2e/docker-baseline-smoke-${{ github.run_id }}
           if-no-files-found: warn

--- a/scripts/e2e/docker/generate-baseline-workspace.py
+++ b/scripts/e2e/docker/generate-baseline-workspace.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+DOMAIN = "trusted.domain"
+DEFAULT_OPENBAO_URL = "http://127.0.0.1:8200"
+DEFAULT_KV_MOUNT = "secret"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate baseline docker harness workspace")
+    parser.add_argument("--scenario-file", required=True)
+    parser.add_argument("--artifact-dir", required=True)
+    return parser.parse_args()
+
+
+def build_agent_toml(service_name: str, hostname: str, instance_id: str) -> str:
+    return (
+        "[acme]\n"
+        "http_responder_hmac = \"seed-responder-hmac\"\n\n"
+        "[trust]\n"
+        "trusted_ca_sha256 = [\"" + ("0" * 64) + "\"]\n\n"
+        "[[profiles]]\n"
+        f"service_name = \"{service_name}\"\n"
+        f"instance_id = \"{instance_id}\"\n"
+        f"hostname = \"{hostname}\"\n\n"
+        "[profiles.paths]\n"
+        f"cert = \"certs/{service_name}.crt\"\n"
+        f"key = \"certs/{service_name}.key\"\n"
+    )
+
+
+def ensure_cert_pair(work_dir: Path, service_name: str, hostname: str, instance_id: str) -> None:
+    cert_path = work_dir / "certs" / f"{service_name}.crt"
+    key_path = work_dir / "certs" / f"{service_name}.key"
+    dns_name = f"{instance_id}.{service_name}.{hostname}.{DOMAIN}"
+    cmd = [
+        "openssl",
+        "req",
+        "-x509",
+        "-nodes",
+        "-newkey",
+        "rsa:2048",
+        "-keyout",
+        str(key_path),
+        "-out",
+        str(cert_path),
+        "-days",
+        "1",
+        "-subj",
+        f"/CN={dns_name}",
+        "-addext",
+        f"subjectAltName=DNS:{dns_name}",
+    ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    os.chmod(cert_path, 0o600)
+    os.chmod(key_path, 0o600)
+
+
+def write_bootroot_agent_stub(node_bin_dir: Path) -> None:
+    node_bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = node_bin_dir / "bootroot-agent"
+    stub.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+    os.chmod(stub, 0o700)
+
+
+def main() -> None:
+    args = parse_args()
+    scenario_file = Path(args.scenario_file)
+    artifact_dir = Path(args.artifact_dir).resolve()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    scenario = json.loads(scenario_file.read_text(encoding="utf-8"))
+    layout = {
+        "scenario_id": scenario["id"],
+        "nodes": [],
+        "services": [],
+    }
+
+    for node in scenario["nodes"]:
+        node_id = node["id"]
+        hostname = node_id
+        work_dir = artifact_dir / "nodes" / node_id
+        (work_dir / "certs").mkdir(parents=True, exist_ok=True)
+        (work_dir / "configs").mkdir(parents=True, exist_ok=True)
+
+        state_services = {}
+        layout_node = {
+            "node_id": node_id,
+            "work_dir": str(work_dir),
+            "services": [],
+        }
+
+        for service in node["services"]:
+            service_name = service["service_name"]
+            deploy_type = service["deploy_type"]
+            instance_id = service["instance_id"]
+            container_name = service.get("container_name")
+
+            secret_dir = work_dir / "secrets" / "services" / service_name
+            secret_dir.mkdir(parents=True, exist_ok=True)
+
+            role_id_path = secret_dir / "role_id"
+            secret_id_path = secret_dir / "secret_id"
+            eab_file_path = secret_dir / "eab.json"
+            agent_config_path = work_dir / "configs" / f"{service_name}.toml"
+            ca_bundle_path = work_dir / "certs" / f"{service_name}-ca-bundle.pem"
+            summary_json_path = work_dir / "summaries" / f"{service_name}.json"
+            summary_json_path.parent.mkdir(parents=True, exist_ok=True)
+
+            role_id_path.write_text(f"role-{service_name}\n", encoding="utf-8")
+            secret_id_path.write_text(f"seed-secret-{service_name}\n", encoding="utf-8")
+            eab_file_path.write_text(
+                json.dumps({"kid": f"seed-kid-{service_name}", "hmac": f"seed-hmac-{service_name}"}),
+                encoding="utf-8",
+            )
+            os.chmod(role_id_path, 0o600)
+            os.chmod(secret_id_path, 0o600)
+            os.chmod(eab_file_path, 0o600)
+
+            agent_config_path.write_text(
+                build_agent_toml(service_name, hostname, instance_id),
+                encoding="utf-8",
+            )
+            os.chmod(agent_config_path, 0o600)
+
+            ensure_cert_pair(work_dir, service_name, hostname, instance_id)
+
+            state_services[service_name] = {
+                "service_name": service_name,
+                "deploy_type": deploy_type,
+                "delivery_mode": "remote-bootstrap",
+                "sync_status": {
+                    "secret_id": "pending",
+                    "eab": "pending",
+                    "responder_hmac": "pending",
+                    "trust_sync": "pending",
+                },
+                "hostname": hostname,
+                "domain": DOMAIN,
+                "agent_config_path": f"configs/{service_name}.toml",
+                "cert_path": f"certs/{service_name}.crt",
+                "key_path": f"certs/{service_name}.key",
+                "instance_id": instance_id,
+                "container_name": container_name,
+                "notes": None,
+                "approle": {
+                    "role_name": f"bootroot-service-{service_name}",
+                    "role_id": f"role-{service_name}",
+                    "secret_id_path": f"secrets/services/{service_name}/secret_id",
+                    "policy_name": f"bootroot-service-{service_name}",
+                },
+            }
+
+            layout_entry = {
+                "node_id": node_id,
+                "service_name": service_name,
+                "deploy_type": deploy_type,
+                "instance_id": instance_id,
+                "container_name": container_name,
+                "work_dir": str(work_dir),
+                "state_path": str(work_dir / "state.json"),
+                "role_id_path": str(role_id_path),
+                "secret_id_path": str(secret_id_path),
+                "eab_file_path": str(eab_file_path),
+                "agent_config_path": str(agent_config_path),
+                "ca_bundle_path": str(ca_bundle_path),
+                "summary_json_path": str(summary_json_path),
+            }
+            layout["services"].append(layout_entry)
+            layout_node["services"].append(layout_entry)
+
+        state_payload = {
+            "openbao_url": DEFAULT_OPENBAO_URL,
+            "kv_mount": DEFAULT_KV_MOUNT,
+            "secrets_dir": "secrets",
+            "policies": {},
+            "approles": {},
+            "services": state_services,
+        }
+        (work_dir / "state.json").write_text(
+            json.dumps(state_payload, indent=2),
+            encoding="utf-8",
+        )
+        write_bootroot_agent_stub(work_dir / "bin")
+        layout["nodes"].append(layout_node)
+
+    (artifact_dir / "layout.json").write_text(json.dumps(layout, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e/docker/run-baseline.sh
+++ b/scripts/e2e/docker/run-baseline.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+DEFAULT_SCENARIO_FILE="$ROOT_DIR/tests/e2e/docker_harness/scenarios/scenario-a-single-node-mixed.json"
+SCENARIO_FILE="${SCENARIO_FILE:-$DEFAULT_SCENARIO_FILE}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-baseline-$(date +%s)}"
+PROJECT_NAME="${PROJECT_NAME:-bootroot-e2e-baseline-$$}"
+INTERVAL_SECS="${INTERVAL_SECS:-1}"
+MAX_CYCLES="${MAX_CYCLES:-2}"
+TIMEOUT_SECS="${TIMEOUT_SECS:-45}"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+COMPOSE_TEST_FILE="$ROOT_DIR/docker-compose.test.yml"
+COMPOSE_SERVICES="openbao postgres step-ca bootroot-http01"
+BOOTROOT_BIN="${BOOTROOT_BIN:-$ROOT_DIR/target/debug/bootroot}"
+BOOTROOT_REMOTE_BIN="${BOOTROOT_REMOTE_BIN:-$ROOT_DIR/target/debug/bootroot-remote}"
+MOCK_OPENBAO_PORT="${MOCK_OPENBAO_PORT:-18200}"
+
+PHASE_LOG="$ARTIFACT_DIR/phases.log"
+RUNNER_LOG="$ARTIFACT_DIR/runner.log"
+SERVICES_TSV="$ARTIFACT_DIR/services.tsv"
+RUNNER_PIDS_FILE="$ARTIFACT_DIR/runner-pids.txt"
+SCENARIO_ID=""
+LAST_PHASE="init"
+LAST_NODE="n/a"
+LAST_SERVICE="n/a"
+LAST_PATHS=""
+MOCK_OPENBAO_PID=""
+
+set_context() {
+  LAST_PHASE="$1"
+  LAST_NODE="$2"
+  LAST_SERVICE="$3"
+  LAST_PATHS="${4:-}"
+}
+
+log_phase() {
+  local phase="$1"
+  local node="$2"
+  local service="$3"
+  local now
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"ts":"%s","phase":"%s","scenario":"%s","node":"%s","service":"%s"}\n' \
+    "$now" "$phase" "$SCENARIO_ID" "$node" "$service" >>"$PHASE_LOG"
+}
+
+fail_with_context() {
+  local message="$1"
+  printf '%s\n' "$message" >&2
+  printf 'failure_context: phase=%s node=%s service=%s paths=%s\n' \
+    "$LAST_PHASE" "$LAST_NODE" "$LAST_SERVICE" "$LAST_PATHS" >&2
+  exit 1
+}
+
+ensure_prerequisites() {
+  command -v docker >/dev/null 2>&1 || fail_with_context "docker is required"
+  docker compose version >/dev/null 2>&1 || fail_with_context "docker compose is required"
+  command -v python3 >/dev/null 2>&1 || fail_with_context "python3 is required"
+  command -v curl >/dev/null 2>&1 || fail_with_context "curl is required"
+  [ -x "$BOOTROOT_BIN" ] || fail_with_context "bootroot binary not executable: $BOOTROOT_BIN"
+  [ -x "$BOOTROOT_REMOTE_BIN" ] || fail_with_context "bootroot-remote binary not executable: $BOOTROOT_REMOTE_BIN"
+}
+
+compose_up() {
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" up -d $COMPOSE_SERVICES
+}
+
+compose_down() {
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+
+capture_artifacts() {
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+}
+
+wait_for_mock_openbao() {
+  local health_url
+  health_url="http://127.0.0.1:$MOCK_OPENBAO_PORT/v1/sys/health"
+  local start
+  start="$(date +%s)"
+  while true; do
+    if curl -fsS "$health_url" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ $(( $(date +%s) - start )) -ge "$TIMEOUT_SECS" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+generate_workspace() {
+  python3 "$ROOT_DIR/scripts/e2e/docker/generate-baseline-workspace.py" \
+    --scenario-file "$SCENARIO_FILE" \
+    --artifact-dir "$ARTIFACT_DIR"
+
+  SCENARIO_ID="$(python3 - "$ARTIFACT_DIR/layout.json" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding='utf-8') as fh:
+    layout = json.load(fh)
+print(layout['scenario_id'])
+PY
+)"
+
+  python3 - "$ARTIFACT_DIR/layout.json" >"$SERVICES_TSV" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding='utf-8') as fh:
+    layout = json.load(fh)
+for svc in layout['services']:
+    fields = [
+        svc['node_id'],
+        svc['service_name'],
+        svc['work_dir'],
+        svc['role_id_path'],
+        svc['secret_id_path'],
+        svc['eab_file_path'],
+        svc['agent_config_path'],
+        svc['ca_bundle_path'],
+        svc['summary_json_path'],
+        svc['state_path'],
+        svc['deploy_type'],
+    ]
+    print("\t".join(fields))
+PY
+}
+
+start_mock_openbao() {
+  python3 "$ROOT_DIR/scripts/e2e/docker/mock-openbao-server.py" >/dev/null 2>&1 &
+  MOCK_OPENBAO_PID="$!"
+  if ! wait_for_mock_openbao; then
+    fail_with_context "mock OpenBao did not become healthy"
+  fi
+}
+
+start_runners() {
+  mkdir -p "$ARTIFACT_DIR/ticks"
+  : >"$RUNNER_PIDS_FILE"
+  while IFS=$'\t' read -r node service work_dir role_id_path secret_id_path eab_file_path agent_config_path ca_bundle_path summary_json_path state_path deploy_type; do
+    local tick_file
+    tick_file="$ARTIFACT_DIR/ticks/${node}__${service}.log"
+    : >"$tick_file"
+    set_context "runner-start" "$node" "$service" "$state_path"
+    log_phase "runner-start" "$node" "$service"
+
+    local sync_command
+    sync_command="WORK_DIR='$work_dir' SERVICE_NAME='$service' BOOTROOT_REMOTE_BIN='$BOOTROOT_REMOTE_BIN' BOOTROOT_BIN='$BOOTROOT_BIN' OPENBAO_URL='http://127.0.0.1:$MOCK_OPENBAO_PORT' ROLE_ID_PATH='$role_id_path' SECRET_ID_PATH='$secret_id_path' EAB_FILE_PATH='$eab_file_path' AGENT_CONFIG_PATH='$agent_config_path' CA_BUNDLE_PATH='$ca_bundle_path' SUMMARY_JSON_PATH='$summary_json_path' TICK_FILE='$tick_file' '$ROOT_DIR/scripts/e2e/docker/run-sync-once.sh'"
+
+    SCENARIO_ID="$SCENARIO_ID" \
+    NODE_ID="$node" \
+    SERVICE_ID="$service" \
+    INTERVAL_SECS="$INTERVAL_SECS" \
+    MAX_CYCLES="$MAX_CYCLES" \
+    RUNNER_LOG="$RUNNER_LOG" \
+    SYNC_COMMAND="$sync_command" \
+    "$ROOT_DIR/scripts/e2e/docker/sync-runner-loop.sh" &
+
+    printf '%s\t%s\t%s\t%s\n' "$!" "$tick_file" "$node" "$service" >>"$RUNNER_PIDS_FILE"
+  done <"$SERVICES_TSV"
+}
+
+wait_for_runners() {
+  local start
+  start="$(date +%s)"
+  while IFS=$'\t' read -r pid tick_file node service; do
+    while true; do
+      local line_count
+      line_count=0
+      if [ -f "$tick_file" ]; then
+        line_count="$(wc -l <"$tick_file" | tr -d ' ')"
+      fi
+      if [ "$line_count" -ge "$MAX_CYCLES" ]; then
+        set_context "sync-loop" "$node" "$service" "$tick_file"
+        log_phase "sync-loop" "$node" "$service"
+        break
+      fi
+      if [ $(( $(date +%s) - start )) -ge "$TIMEOUT_SECS" ]; then
+        fail_with_context "runner did not complete expected cycles"
+      fi
+      sleep 1
+    done
+    if ! wait "$pid"; then
+      fail_with_context "sync runner failed"
+    fi
+  done <"$RUNNER_PIDS_FILE"
+}
+
+assert_state_and_isolation() {
+  python3 - "$SERVICES_TSV" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+services = []
+for line in Path(sys.argv[1]).read_text(encoding='utf-8').splitlines():
+    if not line.strip():
+        continue
+    node, service, work_dir, role_id_path, secret_id_path, eab_file_path, agent_config_path, ca_bundle_path, summary_json_path, state_path, deploy_type = line.split('\t')
+    services.append(
+        {
+            "node": node,
+            "service": service,
+            "work_dir": Path(work_dir),
+            "secret_id_path": Path(secret_id_path),
+            "eab_file_path": Path(eab_file_path),
+            "agent_config_path": Path(agent_config_path),
+            "ca_bundle_path": Path(ca_bundle_path),
+            "summary_json_path": Path(summary_json_path),
+            "state_path": Path(state_path),
+        }
+    )
+
+secret_paths = set()
+eab_paths = set()
+config_paths = set()
+for item in services:
+    service = item["service"]
+    state = json.loads(item["state_path"].read_text(encoding='utf-8'))
+    entry = state["services"][service]
+    expected = {
+        "secret_id": "applied",
+        "eab": "applied",
+        "responder_hmac": "applied",
+        "trust_sync": "applied",
+    }
+    for key, value in expected.items():
+        actual = entry["sync_status"][key]
+        if actual != value:
+            raise SystemExit(f"sync_status mismatch for {service}:{key} => {actual}")
+    if entry["delivery_mode"] != "remote-bootstrap":
+        raise SystemExit(f"delivery_mode mismatch for {service}: {entry['delivery_mode']}")
+
+    secret_value = item["secret_id_path"].read_text(encoding='utf-8').strip()
+    if secret_value != f"synced-secret-id-{service}":
+        raise SystemExit(f"secret_id mismatch for {service}: {secret_value}")
+
+    eab = json.loads(item["eab_file_path"].read_text(encoding='utf-8'))
+    if eab.get("kid") != f"synced-kid-{service}" or eab.get("hmac") != f"synced-hmac-{service}":
+        raise SystemExit(f"eab mismatch for {service}")
+
+    agent_config = item["agent_config_path"].read_text(encoding='utf-8')
+    expected_hmac = f"synced-responder-hmac-{service}"
+    if expected_hmac not in agent_config:
+        raise SystemExit(f"responder hmac missing in agent config for {service}")
+    expected_fp = hashlib.sha256(service.encode('utf-8')).hexdigest()
+    if expected_fp not in agent_config:
+        raise SystemExit(f"trusted_ca_sha256 missing in agent config for {service}")
+
+    ca_bundle_contents = item["ca_bundle_path"].read_text(encoding='utf-8')
+    if f"SMOKE-{service}" not in ca_bundle_contents:
+        raise SystemExit(f"ca_bundle mismatch for {service}")
+
+    summary = json.loads(item["summary_json_path"].read_text(encoding='utf-8'))
+    for key in ["secret_id", "eab", "responder_hmac", "trust_sync"]:
+        status = summary[key]["status"]
+        if status not in ("applied", "unchanged"):
+            raise SystemExit(f"summary status mismatch for {service}:{key} => {status}")
+
+    secret_paths.add(str(item["secret_id_path"]))
+    eab_paths.add(str(item["eab_file_path"]))
+    config_paths.add(str(item["agent_config_path"]))
+
+if len(secret_paths) != len(services):
+    raise SystemExit("secret_id path collision detected")
+if len(eab_paths) != len(services):
+    raise SystemExit("eab path collision detected")
+if len(config_paths) != len(services):
+    raise SystemExit("agent_config path collision detected")
+PY
+}
+
+run_verify_all() {
+  while IFS=$'\t' read -r node service work_dir role_id_path secret_id_path eab_file_path agent_config_path ca_bundle_path summary_json_path state_path deploy_type; do
+    set_context "verify" "$node" "$service" "$agent_config_path"
+    log_phase "verify" "$node" "$service"
+    (
+      cd "$work_dir"
+      PATH="$work_dir/bin:$PATH" \
+      "$BOOTROOT_BIN" verify \
+        --service-name "$service" \
+        --agent-config "$agent_config_path" \
+        >/dev/null
+    )
+  done <"$SERVICES_TSV"
+}
+
+cleanup() {
+  if [ -f "$RUNNER_PIDS_FILE" ]; then
+    while IFS=$'\t' read -r pid tick_file node service; do
+      kill "$pid" >/dev/null 2>&1 || true
+      wait "$pid" 2>/dev/null || true
+      log_phase "cleanup" "$node" "$service"
+    done <"$RUNNER_PIDS_FILE"
+  fi
+
+  if [ -n "$MOCK_OPENBAO_PID" ]; then
+    kill "$MOCK_OPENBAO_PID" >/dev/null 2>&1 || true
+    wait "$MOCK_OPENBAO_PID" 2>/dev/null || true
+  fi
+
+  capture_artifacts
+  compose_down
+}
+
+main() {
+  mkdir -p "$ARTIFACT_DIR"
+  : >"$PHASE_LOG"
+  : >"$RUNNER_LOG"
+
+  trap cleanup EXIT
+
+  ensure_prerequisites
+  generate_workspace
+
+  while IFS=$'\t' read -r node service work_dir role_id_path secret_id_path eab_file_path agent_config_path ca_bundle_path summary_json_path state_path deploy_type; do
+    set_context "bootstrap" "$node" "$service" "$state_path"
+    log_phase "bootstrap" "$node" "$service"
+  done <"$SERVICES_TSV"
+
+  compose_up
+  start_mock_openbao
+  start_runners
+  wait_for_runners
+
+  while IFS=$'\t' read -r node service work_dir role_id_path secret_id_path eab_file_path agent_config_path ca_bundle_path summary_json_path state_path deploy_type; do
+    set_context "ack" "$node" "$service" "$summary_json_path"
+    log_phase "ack" "$node" "$service"
+  done <"$SERVICES_TSV"
+
+  assert_state_and_isolation
+  run_verify_all
+
+  cp -f "$ARTIFACT_DIR/layout.json" "$ARTIFACT_DIR/layout-final.json"
+}
+
+main "$@"

--- a/scripts/e2e/docker/run-sync-once.sh
+++ b/scripts/e2e/docker/run-sync-once.sh
@@ -7,19 +7,44 @@ BOOTROOT_REMOTE_BIN="${BOOTROOT_REMOTE_BIN:?BOOTROOT_REMOTE_BIN is required}"
 BOOTROOT_BIN="${BOOTROOT_BIN:?BOOTROOT_BIN is required}"
 OPENBAO_URL="${OPENBAO_URL:?OPENBAO_URL is required}"
 TICK_FILE="${TICK_FILE:?TICK_FILE is required}"
+ROLE_ID_PATH="${ROLE_ID_PATH:-$WORK_DIR/secrets/services/$SERVICE_NAME/role_id}"
+SECRET_ID_PATH="${SECRET_ID_PATH:-$WORK_DIR/secrets/services/$SERVICE_NAME/secret_id}"
+EAB_FILE_PATH="${EAB_FILE_PATH:-$WORK_DIR/secrets/services/$SERVICE_NAME/eab.json}"
+AGENT_CONFIG_PATH="${AGENT_CONFIG_PATH:-$WORK_DIR/agent.toml}"
+CA_BUNDLE_PATH="${CA_BUNDLE_PATH:-$WORK_DIR/certs/ca-bundle.pem}"
+SUMMARY_JSON_PATH="${SUMMARY_JSON_PATH:-$WORK_DIR/remote-summary-$SERVICE_NAME.json}"
+STATE_LOCK_DIR="${STATE_LOCK_DIR:-$WORK_DIR/.sync-status-lock}"
+
+acquire_lock() {
+  local start
+  start="$(date +%s)"
+  while ! mkdir "$STATE_LOCK_DIR" >/dev/null 2>&1; do
+    if [ $(( $(date +%s) - start )) -ge 30 ]; then
+      printf "failed to acquire sync lock for %s\\n" "$SERVICE_NAME" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+release_lock() {
+  rmdir "$STATE_LOCK_DIR" >/dev/null 2>&1 || true
+}
 
 cd "$WORK_DIR"
+acquire_lock
+trap release_lock EXIT
 
 "$BOOTROOT_REMOTE_BIN" sync \
   --openbao-url "$OPENBAO_URL" \
   --kv-mount "secret" \
   --service-name "$SERVICE_NAME" \
-  --role-id-path "$WORK_DIR/secrets/services/$SERVICE_NAME/role_id" \
-  --secret-id-path "$WORK_DIR/secrets/services/$SERVICE_NAME/secret_id" \
-  --eab-file-path "$WORK_DIR/secrets/services/$SERVICE_NAME/eab.json" \
-  --agent-config-path "$WORK_DIR/agent.toml" \
-  --ca-bundle-path "$WORK_DIR/certs/ca-bundle.pem" \
-  --summary-json "$WORK_DIR/remote-summary.json" \
+  --role-id-path "$ROLE_ID_PATH" \
+  --secret-id-path "$SECRET_ID_PATH" \
+  --eab-file-path "$EAB_FILE_PATH" \
+  --agent-config-path "$AGENT_CONFIG_PATH" \
+  --ca-bundle-path "$CA_BUNDLE_PATH" \
+  --summary-json "$SUMMARY_JSON_PATH" \
   --bootroot-bin "$BOOTROOT_BIN" \
   --retry-attempts 3 \
   --retry-backoff-secs 1 \

--- a/tests/docker_e2e_baseline_matrix.rs
+++ b/tests/docker_e2e_baseline_matrix.rs
@@ -1,0 +1,89 @@
+#[cfg(unix)]
+mod support;
+
+#[cfg(unix)]
+mod unix_integration {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    use anyhow::{Context, Result};
+
+    fn run_baseline_scenario(file_name: &str) -> Result<PathBuf> {
+        let scenario_id = super::support::docker_harness::unique_scenario_id("baseline");
+        let artifact_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tmp")
+            .join("e2e")
+            .join(format!("docker-baseline-{scenario_id}"));
+        let scenario_file = super::support::docker_harness::baseline_scenario_path(file_name);
+
+        let output = Command::new("bash")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .arg(super::support::docker_harness::baseline_script_path())
+            .env("SCENARIO_FILE", &scenario_file)
+            .env("ARTIFACT_DIR", &artifact_dir)
+            .env(
+                "PROJECT_NAME",
+                format!("bootroot-e2e-baseline-{scenario_id}"),
+            )
+            .env("MAX_CYCLES", "2")
+            .env("INTERVAL_SECS", "1")
+            .env("TIMEOUT_SECS", "45")
+            .env("BOOTROOT_BIN", env!("CARGO_BIN_EXE_bootroot"))
+            .env("BOOTROOT_REMOTE_BIN", env!("CARGO_BIN_EXE_bootroot-remote"))
+            .output()
+            .with_context(|| "Failed to run docker baseline matrix script")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("baseline script failed: {stderr}");
+        }
+
+        assert_common_artifacts(&artifact_dir)?;
+        Ok(artifact_dir)
+    }
+
+    fn assert_common_artifacts(artifact_dir: &Path) -> Result<()> {
+        let phase_log = artifact_dir.join("phases.log");
+        let runner_log = artifact_dir.join("runner.log");
+        let layout_file = artifact_dir.join("layout-final.json");
+        let compose_ps = artifact_dir.join("compose-ps.log");
+        assert!(phase_log.exists());
+        assert!(runner_log.exists());
+        assert!(layout_file.exists());
+        assert!(compose_ps.exists());
+
+        let phase_contents = std::fs::read_to_string(&phase_log)
+            .with_context(|| "Failed to read baseline phase log")?;
+        assert!(phase_contents.contains("\"phase\":\"bootstrap\""));
+        assert!(phase_contents.contains("\"phase\":\"runner-start\""));
+        assert!(phase_contents.contains("\"phase\":\"sync-loop\""));
+        assert!(phase_contents.contains("\"phase\":\"ack\""));
+        assert!(phase_contents.contains("\"phase\":\"verify\""));
+        assert!(phase_contents.contains("\"phase\":\"cleanup\""));
+
+        let layout_contents = std::fs::read_to_string(layout_file)
+            .with_context(|| "Failed to read baseline layout")?;
+        assert!(layout_contents.contains("\"services\""));
+        assert!(layout_contents.contains("\"nodes\""));
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "Requires local Docker for baseline matrix validation"]
+    fn docker_baseline_matrix_scenarios_a_b_c() -> Result<()> {
+        let scenario_files = [
+            "scenario-a-single-node-mixed.json",
+            "scenario-b-multi-node-distributed.json",
+            "scenario-c-multi-node-uneven.json",
+        ];
+        for scenario in scenario_files {
+            let artifact_dir = run_baseline_scenario(scenario)?;
+            let layout = std::fs::read_to_string(artifact_dir.join("layout-final.json"))
+                .with_context(|| format!("Failed to read layout for {scenario}"))?;
+            assert!(layout.contains("\"services\""));
+            assert!(layout.contains("\"nodes\""));
+        }
+        Ok(())
+    }
+}

--- a/tests/e2e/docker_harness/scenarios/scenario-a-single-node-mixed.json
+++ b/tests/e2e/docker_harness/scenarios/scenario-a-single-node-mixed.json
@@ -1,0 +1,32 @@
+{
+  "id": "scenario-a-single-node-mixed",
+  "nodes": [
+    {
+      "id": "node-a",
+      "services": [
+        {
+          "service_name": "daemon-a1",
+          "deploy_type": "daemon",
+          "instance_id": "001"
+        },
+        {
+          "service_name": "daemon-a2",
+          "deploy_type": "daemon",
+          "instance_id": "002"
+        },
+        {
+          "service_name": "docker-a1",
+          "deploy_type": "docker",
+          "instance_id": "003",
+          "container_name": "docker-a1-container"
+        },
+        {
+          "service_name": "docker-a2",
+          "deploy_type": "docker",
+          "instance_id": "004",
+          "container_name": "docker-a2-container"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/docker_harness/scenarios/scenario-b-multi-node-distributed.json
+++ b/tests/e2e/docker_harness/scenarios/scenario-b-multi-node-distributed.json
@@ -1,0 +1,42 @@
+{
+  "id": "scenario-b-multi-node-distributed",
+  "nodes": [
+    {
+      "id": "node-a",
+      "services": [
+        {
+          "service_name": "daemon-b1",
+          "deploy_type": "daemon",
+          "instance_id": "001"
+        }
+      ]
+    },
+    {
+      "id": "node-b",
+      "services": [
+        {
+          "service_name": "docker-b1",
+          "deploy_type": "docker",
+          "instance_id": "001",
+          "container_name": "docker-b1-container"
+        }
+      ]
+    },
+    {
+      "id": "node-c",
+      "services": [
+        {
+          "service_name": "daemon-b2",
+          "deploy_type": "daemon",
+          "instance_id": "001"
+        },
+        {
+          "service_name": "docker-b2",
+          "deploy_type": "docker",
+          "instance_id": "002",
+          "container_name": "docker-b2-container"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/docker_harness/scenarios/scenario-c-multi-node-uneven.json
+++ b/tests/e2e/docker_harness/scenarios/scenario-c-multi-node-uneven.json
@@ -1,0 +1,64 @@
+{
+  "id": "scenario-c-multi-node-uneven",
+  "nodes": [
+    {
+      "id": "node-a",
+      "services": [
+        {
+          "service_name": "daemon-c1",
+          "deploy_type": "daemon",
+          "instance_id": "001"
+        },
+        {
+          "service_name": "daemon-c2",
+          "deploy_type": "daemon",
+          "instance_id": "002"
+        },
+        {
+          "service_name": "docker-c1",
+          "deploy_type": "docker",
+          "instance_id": "003",
+          "container_name": "docker-c1-container"
+        }
+      ]
+    },
+    {
+      "id": "node-b",
+      "services": [
+        {
+          "service_name": "daemon-c3",
+          "deploy_type": "daemon",
+          "instance_id": "001"
+        },
+        {
+          "service_name": "docker-c2",
+          "deploy_type": "docker",
+          "instance_id": "002",
+          "container_name": "docker-c2-container"
+        },
+        {
+          "service_name": "docker-c3",
+          "deploy_type": "docker",
+          "instance_id": "003",
+          "container_name": "docker-c3-container"
+        }
+      ]
+    },
+    {
+      "id": "node-c",
+      "services": [
+        {
+          "service_name": "daemon-c4",
+          "deploy_type": "daemon",
+          "instance_id": "001"
+        },
+        {
+          "service_name": "docker-c4",
+          "deploy_type": "docker",
+          "instance_id": "002",
+          "container_name": "docker-c4-container"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/support/docker_harness.rs
+++ b/tests/support/docker_harness.rs
@@ -5,7 +5,7 @@ pub(crate) fn unique_scenario_id(prefix: &str) -> String {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs();
+        .as_millis();
     format!("{prefix}-{now}")
 }
 
@@ -15,4 +15,21 @@ pub(crate) fn smoke_script_path() -> PathBuf {
         .join("e2e")
         .join("docker")
         .join("run-harness-smoke.sh")
+}
+
+pub(crate) fn baseline_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts")
+        .join("e2e")
+        .join("docker")
+        .join("run-baseline.sh")
+}
+
+pub(crate) fn baseline_scenario_path(file_name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("e2e")
+        .join("docker_harness")
+        .join("scenarios")
+        .join(file_name)
 }


### PR DESCRIPTION
Add baseline Docker harness runner and scenario descriptors for: single-node mixed services, multi-node distributed baseline, and multi-node uneven mixed topology.
Add ignored Rust integration test that executes scenarios A/B/C and asserts convergence, service isolation, and verify flow. Harden sync-once for multi-service nodes with configurable paths and a state update lock to avoid concurrent sync-status races. Extend mock OpenBao server to serve per-service dynamic secret payloads. Wire CI Docker smoke job to run baseline Scenario A and upload baseline artifacts for failure diagnostics.

Closes #240