### PR TITLE
Add Python quality gates with ruff in CI and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
               - "scripts/**"
               - "Cargo.toml"
               - "Cargo.lock"
+              - "pyproject.toml"
               - "docker-compose.yml"
               - "Dockerfile*"
               - "responder.toml.example"
@@ -67,11 +68,25 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install Python Tools
+        run: python -m pip install --upgrade pip ruff mkdocs-material mkdocs-static-i18n
+
       - name: Check Rust Formatting
         run: cargo fmt -- --check --config group_imports=StdExternalCrate
 
       - name: Check Rust Lints (Clippy)
         run: cargo clippy --all-targets -- -D warnings
+
+      - name: Check Python Formatting
+        run: ruff format --check .
+
+      - name: Check Python Lints
+        run: ruff check .
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
@@ -85,9 +100,6 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v22
         with:
           globs: "**/*.md"
-
-      - name: Set up MkDocs
-        run: python3 -m pip install --upgrade pip mkdocs-material mkdocs-static-i18n
 
       - name: Build Docs
         run: mkdocs build --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ verify these locally before proposing any code. Breakdown:
 * **Linting (Rust)**: Must pass `cargo clippy --all-targets -- -D warnings`.
 * **Formatting**: Must pass `cargo fmt -- --check --config group_imports=StdExternalCrate`.
 * **Linting (Biome)**: Must pass `biome ci --error-on-warnings .`.
+* **Formatting (Python)**: Must pass `ruff format --check .`.
+* **Linting (Python)**: Must pass `ruff check .`.
 * **Security Audit**: Must pass `cargo audit` (check for vulnerable dependencies).
 * **Testing**: `cargo test` must pass all unit and integration tests.
 * **Linting (Docs/Misc)**:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ Command notes:
 - `mkdocs build`: builds static files into `site/`.
 - `./scripts/build-docs-pdf.sh en|ko`: builds PDF manuals.
 
+## Quality Checks
+
+Run quality gates locally before pushing:
+
+```bash
+cargo fmt -- --check --config group_imports=StdExternalCrate
+cargo clippy --all-targets -- -D warnings
+biome ci --error-on-warnings .
+markdownlint-cli2 "**/*.md" "#node_modules" "#target"
+ruff format --check .
+ruff check .
+cargo audit
+cargo test
+```
+
+If Python formatting/linting fails, auto-fix first:
+
+```bash
+ruff format .
+ruff check --fix .
+```
+
 Install scope:
 
 - If you use a per-repo virtualenv (`.venv`), you need to create it and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.ruff]
+target-version = "py314"
+line-length = 100
+exclude = [
+  ".git",
+  ".venv",
+  "target",
+  "site",
+  "secrets",
+  "tmp",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP"]

--- a/scripts/e2e/docker/generate-baseline-workspace.py
+++ b/scripts/e2e/docker/generate-baseline-workspace.py
@@ -20,16 +20,16 @@ def parse_args() -> argparse.Namespace:
 def build_agent_toml(service_name: str, hostname: str, instance_id: str) -> str:
     return (
         "[acme]\n"
-        "http_responder_hmac = \"seed-responder-hmac\"\n\n"
+        'http_responder_hmac = "seed-responder-hmac"\n\n'
         "[trust]\n"
-        "trusted_ca_sha256 = [\"" + ("0" * 64) + "\"]\n\n"
+        'trusted_ca_sha256 = ["' + ("0" * 64) + '"]\n\n'
         "[[profiles]]\n"
-        f"service_name = \"{service_name}\"\n"
-        f"instance_id = \"{instance_id}\"\n"
-        f"hostname = \"{hostname}\"\n\n"
+        f'service_name = "{service_name}"\n'
+        f'instance_id = "{instance_id}"\n'
+        f'hostname = "{hostname}"\n\n'
         "[profiles.paths]\n"
-        f"cert = \"certs/{service_name}.crt\"\n"
-        f"key = \"certs/{service_name}.key\"\n"
+        f'cert = "certs/{service_name}.crt"\n'
+        f'key = "certs/{service_name}.key"\n'
     )
 
 
@@ -114,7 +114,9 @@ def main() -> None:
             role_id_path.write_text(f"role-{service_name}\n", encoding="utf-8")
             secret_id_path.write_text(f"seed-secret-{service_name}\n", encoding="utf-8")
             eab_file_path.write_text(
-                json.dumps({"kid": f"seed-kid-{service_name}", "hmac": f"seed-hmac-{service_name}"}),
+                json.dumps(
+                    {"kid": f"seed-kid-{service_name}", "hmac": f"seed-hmac-{service_name}"}
+                ),
                 encoding="utf-8",
             )
             os.chmod(role_id_path, 0o600)

--- a/scripts/e2e/docker/mock-openbao-server.py
+++ b/scripts/e2e/docker/mock-openbao-server.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
+import hashlib
 import json
 import os
 import re
-import hashlib
 from http.server import BaseHTTPRequestHandler, HTTPServer
-
 
 PORT = int(os.environ.get("MOCK_OPENBAO_PORT", "18200"))
 TOKEN = "mock-client-token"
@@ -105,14 +104,14 @@ class Handler(BaseHTTPRequestHandler):
                 )
                 return
             if secret_kind == "trust":
-                fingerprint = hashlib.sha256(f"{service}-v{version}".encode("utf-8")).hexdigest()
+                fingerprint = hashlib.sha256(f"{service}-v{version}".encode()).hexdigest()
                 write_json(
                     self,
                     200,
                     {
                         "data": {
                             "data": {
-                            "trusted_ca_sha256": [fingerprint],
+                                "trusted_ca_sha256": [fingerprint],
                                 "ca_bundle_pem": (
                                     "-----BEGIN CERTIFICATE-----\n"
                                     f"SMOKE-{service}-v{version}\n"


### PR DESCRIPTION
Introduce repository-wide Python formatting/linting standards using ruff and enforce them in CI, docs, and agent guidelines.

- Add pyproject.toml with ruff configuration (target-version py314)
- Update AGENTS.md quality gates with Python format/lint checks
- Update README with local Python quality-check commands
- Extend CI quality-check job to install ruff and run:
  - ruff format --check .
  - ruff check .
- Apply ruff formatting/lint fixes to existing E2E Python scripts

Closes #253