### PR TITLE
Add extended Docker E2E workflow for #249

### DIFF
--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -1,0 +1,99 @@
+name: E2E Extended
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 23:30 KST daily (UTC-based scheduler)
+    - cron: "30 14 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  decide-run:
+    name: Decide Extended Run
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide by event and main activity
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual dispatch" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch origin main --depth=200
+
+          TODAY_KST="$(TZ=Asia/Seoul date +%Y-%m-%d)"
+          COUNT="$(git log origin/main --since="${TODAY_KST} 00:00:00 +0900" --until="${TODAY_KST} 23:59:59 +0900" --pretty=oneline | wc -l | tr -d ' ')"
+
+          if [ "${COUNT}" -gt 0 ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=main commits detected on ${TODAY_KST} (KST): ${COUNT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no main commits on ${TODAY_KST} (KST)" >> "$GITHUB_OUTPUT"
+          fi
+
+  run-extended:
+    name: Run Extended Docker E2E
+    needs: [decide-run]
+    if: needs.decide-run.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build bootroot binaries
+        run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+
+      - name: Run extended Docker E2E suite
+        run: |
+          ARTIFACT_DIR="$(pwd)/tmp/e2e/extended-${GITHUB_RUN_ID}"
+          ARTIFACT_DIR="$ARTIFACT_DIR" \
+          PROJECT_PREFIX="bootroot-e2e-extended-${GITHUB_RUN_ID}" \
+          SCENARIO_FILE="$(pwd)/tests/e2e/docker_harness/scenarios/scenario-c-multi-node-uneven.json" \
+          BOOTROOT_BIN="$(pwd)/target/debug/bootroot" \
+          BOOTROOT_REMOTE_BIN="$(pwd)/target/debug/bootroot-remote" \
+          ./scripts/e2e/docker/run-extended-suite.sh || {
+            echo "extended suite failed"
+            [ -f "$ARTIFACT_DIR/extended-summary.json" ] && cat "$ARTIFACT_DIR/extended-summary.json" || true
+            [ -f "$ARTIFACT_DIR/phases.log" ] && cat "$ARTIFACT_DIR/phases.log" || true
+            find "$ARTIFACT_DIR" -name run.log -maxdepth 3 -print -exec tail -n 120 {} \; || true
+            exit 1
+          }
+
+      - name: Upload Extended E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extended-e2e-${{ github.run_id }}
+          path: tmp/e2e/extended-${{ github.run_id }}
+          if-no-files-found: warn
+
+  skip-note:
+    name: Skip Note
+    needs: [decide-run]
+    if: needs.decide-run.outputs.should_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print skip reason
+        run: |
+          echo "Skipped extended E2E: ${{ needs.decide-run.outputs.reason }}"

--- a/scripts/e2e/docker/run-extended-suite.sh
+++ b/scripts/e2e/docker/run-extended-suite.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+SCENARIO_FILE="${SCENARIO_FILE:-$ROOT_DIR/tests/e2e/docker_harness/scenarios/scenario-c-multi-node-uneven.json}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-extended-$(date +%s)}"
+PROJECT_PREFIX="${PROJECT_PREFIX:-bootroot-e2e-extended}"
+BOOTROOT_BIN="${BOOTROOT_BIN:-$ROOT_DIR/target/debug/bootroot}"
+BOOTROOT_REMOTE_BIN="${BOOTROOT_REMOTE_BIN:-$ROOT_DIR/target/debug/bootroot-remote}"
+MAX_CYCLES_SCALE="${MAX_CYCLES_SCALE:-8}"
+INTERVAL_SECS_SCALE="${INTERVAL_SECS_SCALE:-1}"
+TIMEOUT_SECS_SCALE="${TIMEOUT_SECS_SCALE:-90}"
+TIMEOUT_SECS_ROTATION="${TIMEOUT_SECS_ROTATION:-90}"
+TIMEOUT_SECS_RUNNER="${TIMEOUT_SECS_RUNNER:-45}"
+MAX_CYCLES_RUNNER="${MAX_CYCLES_RUNNER:-4}"
+INTERVAL_SECS_RUNNER="${INTERVAL_SECS_RUNNER:-1}"
+
+mkdir -p "$ARTIFACT_DIR"
+PHASE_LOG="$ARTIFACT_DIR/phases.log"
+SUMMARY_JSON="$ARTIFACT_DIR/extended-summary.json"
+: >"$PHASE_LOG"
+
+log_phase() {
+  local phase="$1"
+  local status="$2"
+  local now
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"ts":"%s","phase":"%s","status":"%s"}\n' "$now" "$phase" "$status" >>"$PHASE_LOG"
+}
+
+run_case() {
+  local case_id="$1"
+  shift
+  local case_dir="$ARTIFACT_DIR/$case_id"
+  local run_log="$case_dir/run.log"
+  mkdir -p "$case_dir"
+  log_phase "$case_id" "start"
+  if "$@" >"$run_log" 2>&1; then
+    log_phase "$case_id" "pass"
+    printf '{"case":"%s","status":"pass","artifact_dir":"%s"}\n' "$case_id" "$case_dir"
+    return 0
+  fi
+  log_phase "$case_id" "fail"
+  printf '{"case":"%s","status":"fail","artifact_dir":"%s"}\n' "$case_id" "$case_dir"
+  return 1
+}
+
+case_scale_contention() {
+  local case_dir="$ARTIFACT_DIR/scale-contention"
+  ARTIFACT_DIR="$case_dir" \
+  SCENARIO_FILE="$SCENARIO_FILE" \
+  PROJECT_NAME="${PROJECT_PREFIX}-scale-$$" \
+  MAX_CYCLES="$MAX_CYCLES_SCALE" \
+  INTERVAL_SECS="$INTERVAL_SECS_SCALE" \
+  TIMEOUT_SECS="$TIMEOUT_SECS_SCALE" \
+  BOOTROOT_BIN="$BOOTROOT_BIN" \
+  BOOTROOT_REMOTE_BIN="$BOOTROOT_REMOTE_BIN" \
+  "$ROOT_DIR/scripts/e2e/docker/run-baseline.sh"
+}
+
+case_failure_recovery() {
+  local case_dir="$ARTIFACT_DIR/failure-recovery"
+  ARTIFACT_DIR="$case_dir" \
+  SCENARIO_FILE="$SCENARIO_FILE" \
+  PROJECT_NAME="${PROJECT_PREFIX}-recovery-$$" \
+  TIMEOUT_SECS="$TIMEOUT_SECS_ROTATION" \
+  ROTATION_ITEMS="secret_id,eab,responder_hmac,trust_sync" \
+  BOOTROOT_BIN="$BOOTROOT_BIN" \
+  BOOTROOT_REMOTE_BIN="$BOOTROOT_REMOTE_BIN" \
+  "$ROOT_DIR/scripts/e2e/docker/run-rotation-recovery.sh"
+}
+
+case_runner_timer() {
+  local case_dir="$ARTIFACT_DIR/runner-timer"
+  ARTIFACT_DIR="$case_dir" \
+  PROJECT_NAME="${PROJECT_PREFIX}-timer-$$" \
+  SCENARIO_ID="extended-runner-timer" \
+  RUNNER_MODE="systemd-timer" \
+  TIMEOUT_SECS="$TIMEOUT_SECS_RUNNER" \
+  MAX_CYCLES="$MAX_CYCLES_RUNNER" \
+  INTERVAL_SECS="$INTERVAL_SECS_RUNNER" \
+  BOOTROOT_BIN="$BOOTROOT_BIN" \
+  BOOTROOT_REMOTE_BIN="$BOOTROOT_REMOTE_BIN" \
+  "$ROOT_DIR/scripts/e2e/docker/run-harness-smoke.sh"
+}
+
+case_runner_cron() {
+  local case_dir="$ARTIFACT_DIR/runner-cron"
+  ARTIFACT_DIR="$case_dir" \
+  PROJECT_NAME="${PROJECT_PREFIX}-cron-$$" \
+  SCENARIO_ID="extended-runner-cron" \
+  RUNNER_MODE="cron" \
+  TIMEOUT_SECS="$TIMEOUT_SECS_RUNNER" \
+  MAX_CYCLES="$MAX_CYCLES_RUNNER" \
+  INTERVAL_SECS="$INTERVAL_SECS_RUNNER" \
+  BOOTROOT_BIN="$BOOTROOT_BIN" \
+  BOOTROOT_REMOTE_BIN="$BOOTROOT_REMOTE_BIN" \
+  "$ROOT_DIR/scripts/e2e/docker/run-harness-smoke.sh"
+}
+
+main() {
+  local overall_status="pass"
+  local lines=()
+
+  if line="$(run_case "scale-contention" case_scale_contention)"; then
+    lines+=("$line")
+  else
+    lines+=("$line")
+    overall_status="fail"
+  fi
+
+  if line="$(run_case "failure-recovery" case_failure_recovery)"; then
+    lines+=("$line")
+  else
+    lines+=("$line")
+    overall_status="fail"
+  fi
+
+  if line="$(run_case "runner-timer" case_runner_timer)"; then
+    lines+=("$line")
+  else
+    lines+=("$line")
+    overall_status="fail"
+  fi
+
+  if line="$(run_case "runner-cron" case_runner_cron)"; then
+    lines+=("$line")
+  else
+    lines+=("$line")
+    overall_status="fail"
+  fi
+
+  {
+    printf '{\n'
+    printf '  "scenario_file": "%s",\n' "$SCENARIO_FILE"
+    printf '  "artifact_dir": "%s",\n' "$ARTIFACT_DIR"
+    printf '  "overall_status": "%s",\n' "$overall_status"
+    printf '  "cases": [\n'
+    local i
+    for i in "${!lines[@]}"; do
+      printf '    %s' "${lines[$i]}"
+      if [ "$i" -lt $((${#lines[@]} - 1)) ]; then
+        printf ','
+      fi
+      printf '\n'
+    done
+    printf '  ]\n'
+    printf '}\n'
+  } >"$SUMMARY_JSON"
+
+  if [ "$overall_status" != "pass" ]; then
+    echo "extended suite failed; see $SUMMARY_JSON"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/scripts/e2e/docker/run-harness-smoke.sh
+++ b/scripts/e2e/docker/run-harness-smoke.sh
@@ -11,6 +11,7 @@ INTERVAL_SECS="${INTERVAL_SECS:-1}"
 MAX_CYCLES="${MAX_CYCLES:-3}"
 TIMEOUT_SECS="${TIMEOUT_SECS:-30}"
 SERVICE_NAME="${SERVICE_NAME:-edge-proxy}"
+RUNNER_MODE="${RUNNER_MODE:-systemd-timer}"
 WORK_DIR="$ARTIFACT_DIR/service-node"
 RUNNER_TICKS_FILE="$ARTIFACT_DIR/runner-ticks.log"
 RUNNER_LOG="$ARTIFACT_DIR/runner.log"
@@ -225,6 +226,7 @@ main() {
   "scenario": "$SCENARIO_ID",
   "project": "$PROJECT_NAME",
   "artifact_dir": "$ARTIFACT_DIR",
+  "runner_mode": "$RUNNER_MODE",
   "topology": {
     "control_plane": 1,
     "service_nodes": 1,

--- a/tests/docker_e2e_extended_suite.rs
+++ b/tests/docker_e2e_extended_suite.rs
@@ -1,0 +1,62 @@
+#[cfg(unix)]
+mod support;
+
+#[cfg(unix)]
+mod unix_integration {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use anyhow::{Context, Result};
+
+    #[test]
+    #[ignore = "Requires local Docker for extended E2E suite validation"]
+    fn docker_extended_suite_scenario_c() -> Result<()> {
+        let scenario_id = super::support::docker_harness::unique_scenario_id("extended");
+        let artifact_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tmp")
+            .join("e2e")
+            .join(format!("docker-extended-{scenario_id}"));
+        let scenario_file = super::support::docker_harness::baseline_scenario_path(
+            "scenario-c-multi-node-uneven.json",
+        );
+
+        let output = Command::new("bash")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .arg(
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("scripts")
+                    .join("e2e")
+                    .join("docker")
+                    .join("run-extended-suite.sh"),
+            )
+            .env("SCENARIO_FILE", scenario_file)
+            .env("ARTIFACT_DIR", &artifact_dir)
+            .env(
+                "PROJECT_PREFIX",
+                format!("bootroot-e2e-extended-{scenario_id}"),
+            )
+            .env("BOOTROOT_BIN", env!("CARGO_BIN_EXE_bootroot"))
+            .env("BOOTROOT_REMOTE_BIN", env!("CARGO_BIN_EXE_bootroot-remote"))
+            .output()
+            .with_context(|| "Failed to run docker extended suite script")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("extended suite script failed: {stderr}");
+        }
+
+        let phase_log = artifact_dir.join("phases.log");
+        let summary = artifact_dir.join("extended-summary.json");
+        assert!(phase_log.exists());
+        assert!(summary.exists());
+
+        let phase_contents = std::fs::read_to_string(&phase_log)
+            .with_context(|| "Failed to read extended phases")?;
+        assert!(phase_contents.contains("\"phase\":\"scale-contention\""));
+        assert!(phase_contents.contains("\"phase\":\"failure-recovery\""));
+        assert!(phase_contents.contains("\"phase\":\"runner-timer\""));
+        assert!(phase_contents.contains("\"phase\":\"runner-cron\""));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Add scripts/e2e/docker/run-extended-suite.sh to run the extended reliability suite as separate cases: scale/contention, failure-recovery, and runner-mode parity (systemd-timer, cron).
- Add .github/workflows/e2e-extended.yml with workflow_dispatch, nightly schedule (UTC), run gating by same-day (KST) commit activity on main, and artifact upload for deterministic triage.
- Extend scripts/e2e/docker/run-harness-smoke.sh to persist runner_mode in the manifest for parity diagnostics.
- Add ignored integration test tests/docker_e2e_extended_suite.rs to validate the extended suite contract and artifact structure in Docker-enabled environments.

Closes #249