### PR TITLE
Add bootroot-remote i18n and CLI notation notes

### DIFF
--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -34,8 +34,10 @@ Primary commands:
   - Environment variable: `BOOTROOT_LANG`
 
 Notation rule: when an option includes `(environment variable: ...)`, that
-option supports environment-variable input. If that marker is absent, the
-option does not support environment-variable input.
+option supports environment-variable input. When an option includes
+`(default ...)`, a code-level default value is defined. If those markers are
+absent, the item either has no default (required/optional input) or does not
+support environment-variable input.
 
 ## bootroot CLI automation scope vs operator responsibilities
 
@@ -748,6 +750,8 @@ service state (`secret_id`/`eab`/`responder_hmac`/`trust`) stored in OpenBao on
 the step-ca machine to files on remote service machines via `pull/sync/ack`,
 updates local files such as `agent.toml`, and records results in `state.json`
 sync-status.
+`bootroot-remote` also supports the global `--lang` option
+(environment variable: `BOOTROOT_LANG`).
 
 ### `bootroot-remote pull`
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -31,7 +31,9 @@ CLI는 infra 기동/초기화/상태 점검과 서비스 온보딩, 발급 검�
   - 환경 변수: `BOOTROOT_LANG`
 
 표기 규칙: 옵션 설명에 `(환경 변수: ...)`가 있으면 해당 옵션이 환경 변수 입력을
-지원한다는 뜻입니다. 이 표기가 없으면 환경 변수 입력을 지원하지 않습니다.
+지원한다는 뜻입니다. 옵션 설명에 `(기본값 ...)`가 있으면 코드에 기본값이
+정의되어 있다는 뜻입니다. 위 표기가 없으면 해당 항목은 기본값이 없거나
+(필수/선택 입력) 환경 변수 입력을 지원하지 않습니다.
 
 ## bootroot CLI 자동 준비 범위와 운영자 책임
 
@@ -720,6 +722,7 @@ OpenBao KV: `bootroot/responder/hmac`
 OpenBao에 저장된 서비스 목표 상태(`secret_id`/`eab`/`responder_hmac`/`trust`)를
 원격 서비스 머신에서 `pull/sync/ack` 순서로 반영해 `agent.toml` 같은 로컬
 파일을 갱신하고, 결과를 `state.json`의 sync-status에 기록합니다.
+`bootroot-remote`도 공통 옵션 `--lang`(환경 변수 `BOOTROOT_LANG`)을 지원합니다.
 
 ### `bootroot-remote pull`
 


### PR DESCRIPTION
Implement #276 by adding language selection support to bootroot-remote via --lang and BOOTROOT_LANG, and localize user-facing pull/ack/sync messages while keeping JSON contracts stable. Add and update unit tests for language parsing and localized summary labels. Update ko/en CLI docs to state bootroot-remote language support and clarify option notation for env/default markers.

Closes #276