### PR TITLE
Clarify root token and unseal operations docs

### DIFF
--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -141,10 +141,16 @@ Input priority is **CLI flags > environment variables > prompts/defaults**.
 - `--auto-generate`: auto-generate secrets where possible
 - `--show-secrets`: show secrets in the summary
 - `--summary-json`: write init summary as machine-readable JSON
+  (it may include sensitive fields such as `root_token`)
 - `--root-token`: OpenBao root token (environment variable:
   `OPENBAO_ROOT_TOKEN`). Required for normal apply mode. Optional in preview
   mode (`--print-only`/`--dry-run`), but required if you want trust preview
   output.
+  When OpenBao is newly initialized in the current run, init can use the
+  generated token in its internal flow without manual token entry. For an
+  already-initialized OpenBao, you must provide a token via
+  `--root-token`/env/prompt. `bootroot` does not maintain a built-in
+  persistent root-token store.
 - `--unseal-key`: OpenBao unseal key (repeatable, environment variable: `OPENBAO_UNSEAL_KEYS`)
   You can pass the same option multiple times
   (for example: `--unseal-key k1 --unseal-key k2 --unseal-key k3`).
@@ -273,6 +279,8 @@ Checks infra status (including containers) and OpenBao KV/AppRole status.
 - `--kv-mount`: OpenBao KV v2 mount path (default `secret`)
 - `--root-token`: token for KV/AppRole checks
   (optional, environment variable: `OPENBAO_ROOT_TOKEN`)
+  Without a token, checks are limited to infra/container-level status and do
+  not include full KV/AppRole verification.
 
 ### Outputs
 

--- a/docs/en/concepts.md
+++ b/docs/en/concepts.md
@@ -149,6 +149,11 @@ like init/rotate.
 OpenBao is initialized with **unseal keys** and a **root token**. Unseal keys
 unlock the storage on startup, while the root token grants full administrative
 access.
+These serve different purposes: unseal is for storage unlock state transitions,
+while the root token is for privileged management actions (policy/AppRole/secret
+path administration). Bootroot does not provide a built-in persistent
+root-token store, so day-2 admin commands should inject the token from a
+secure store or environment file.
 
 #### Unseal keys custody
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -402,6 +402,8 @@ Lifecycle scripts consume `bootroot init --summary-json` output for automation.
 Do not parse human-readable summary lines for tokens/secrets.
 Local CLI scenario runs use the same rule and read `.root_token` from
 `--summary-json`.
+This is a **test/automation convenience rule**, not a production token custody
+policy.
 
 Minimum machine field used by E2E:
 
@@ -416,6 +418,8 @@ How E2E handles OpenBao unseal and token usage:
 - `root_token` is read from `init-summary.json`, stored in a shell variable
   (`OPENBAO_ROOT_TOKEN`), and passed to `service add`/`rotate` in the same run
   via `--root-token`
+- test scripts also avoid long-term token persistence; token use stays in
+  per-run shell context
 - Because summary JSON contains the token, treat the artifact as sensitive
   output in storage/retention workflows
 

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -121,6 +121,9 @@ Run `bootroot rotate ...` on a schedule (cron/systemd timer). Keep secrets out
 of command history; use environment files or secure stores.
 `bootroot rotate` commands require an OpenBao root token. Provide it via
 `--root-token` or `OPENBAO_ROOT_TOKEN` (otherwise you will be prompted).
+`bootroot` does not include a built-in persistent root-token store, so
+production setups should inject the token per run from a secure store or
+protected environment file.
 
 Example (cron):
 
@@ -209,6 +212,16 @@ Security notes:
 - summary JSON is primarily status/error metadata; still keep it out of broad
   shared logs and apply retention controls
 - limit service account access to service-specific paths only
+- treat `bootroot init --summary-json` output as sensitive because it may
+  include `root_token`
+
+## OpenBao restart/recovery checklist
+
+- If OpenBao is `sealed`, unseal it first with unseal keys.
+- After unseal, inject root token for token-required admin commands
+  (`service add`, `rotate`, and detailed `status` checks when needed).
+- Keep unseal and root-token steps separate in runbooks: unseal completion does
+  not remove root-token requirements for privileged operations.
 
 ## CA bundle (trust) operations
 

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -26,6 +26,28 @@ The most common cause is mixing flags across binaries.
 - Check whether OpenBao is still `sealed` and unseal if needed
 - Verify root token/AppRole credentials
 - Confirm KV v2 mount exists (default `secret`)
+- Unseal keys and root token have different roles:
+  - unseal keys: clear `sealed` state
+  - root token: privileged commands (`service add`, `rotate`, detailed status)
+
+### root token missing/invalid
+
+Symptoms:
+
+- `root token missing` or permission-related errors
+
+Checks:
+
+- Confirm the current command requires root token
+- Verify `--root-token`/`OPENBAO_ROOT_TOKEN` value and expiry
+- If this is a detailed status/trust preview flow, confirm mode-specific token
+  requirements
+
+Actions:
+
+- Re-inject token from a secure store or protected env file
+- Keep runbooks explicit that `bootroot` does not provide a built-in persistent
+  root-token store
 
 ### step-ca init / CA file failures
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -132,9 +132,14 @@ OpenBao 초기화/언실/정책/AppRole 구성, step-ca 초기화, 시크릿 등
 - `--auto-generate`: 비밀번호/HMAC 등을 자동 생성
 - `--show-secrets`: 요약 출력에 시크릿 표시
 - `--summary-json`: init 요약을 머신 파싱용 JSON 파일로 저장
+  (민감 필드 포함 가능: 예 `root_token`)
 - `--root-token`: OpenBao root token (환경 변수: `OPENBAO_ROOT_TOKEN`).
   기본 실행에서는 필수입니다. preview 모드(`--print-only`/`--dry-run`)에서는
   선택이며, trust 프리뷰를 보려면 지정해야 합니다.
+  현재 실행에서 OpenBao를 신규 초기화하는 경우에는 별도 수동 입력 없이
+  생성된 토큰을 내부 흐름에서 사용합니다. 반대로 이미 초기화된 OpenBao에
+  대해 재실행할 때는 `--root-token`/환경 변수/프롬프트로 토큰을 제공해야
+  합니다. `bootroot`는 root token 영구 저장소를 별도로 관리하지 않습니다.
 - `--unseal-key`: OpenBao unseal key (반복 가능, 환경 변수: `OPENBAO_UNSEAL_KEYS`)
   같은 옵션을 여러 번 전달할 수 있습니다
   (예: `--unseal-key k1 --unseal-key k2 --unseal-key k3`).
@@ -261,6 +266,8 @@ infra 상태(컨테이너 포함)와 OpenBao KV/AppRole 상태를 점검합니�
 - `--kv-mount`: OpenBao KV v2 마운트 경로 (기본값 `secret`)
 - `--root-token`: KV/AppRole 체크용 토큰
   (선택, 환경 변수: `OPENBAO_ROOT_TOKEN`)
+  토큰을 주지 않으면 infra/컨테이너 상태 중심으로 점검하고, KV/AppRole
+  상세 체크는 제한됩니다.
 
 ### 출력
 

--- a/docs/ko/concepts.md
+++ b/docs/ko/concepts.md
@@ -148,6 +148,10 @@ AppRole로 로그인해 시크릿을 파일로 렌더링합니다. 주요 흐름
 OpenBao는 **unseal keys**와 **root token**으로 초기화/접속합니다.
 unseal keys는 기동 시 스토리지를 해제하는 용도이고, root token은
 전체 관리자 권한을 부여합니다.
+이 둘은 용도가 다릅니다. 언실은 저장소 잠금 해제 동작이고, root token은
+정책/AppRole/시크릿 경로 관리 같은 관리자 작업 권한입니다.
+Bootroot는 root token 영구 저장소를 기본 제공하지 않으므로, 운영 중
+관리자 명령 실행 시에는 안전한 보관소/환경 파일에서 주입해야 합니다.
 
 #### unseal keys 보관
 

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -393,6 +393,8 @@ RUNNER_MODE=cron ./scripts/e2e/docker/run-harness-smoke.sh
 라이프사이클 스크립트는 `bootroot init --summary-json` 출력으로 자동화를
 수행합니다. 사람용 요약 텍스트를 파싱해 토큰/시크릿을 추출하지 않습니다.
 로컬 CLI 시나리오 실행도 같은 방식으로 `--summary-json`의 `.root_token`을 사용합니다.
+이 절차는 **테스트/자동화 편의용 규칙**이며, 운영 환경의 토큰 보관 정책을
+대체하지 않습니다.
 
 E2E가 사용하는 최소 머신 필드:
 
@@ -405,6 +407,8 @@ E2E에서 OpenBao 언실/토큰 사용 방식:
   (예: 프로세스/컨테이너 재시작, 수동 seal, 복구 절차)
 - `root_token`은 `init-summary.json`에서 읽어 셸 변수(`OPENBAO_ROOT_TOKEN`)로
   보관하고, 같은 실행 내 `service add`/`rotate` 등에 `--root-token`으로 전달
+- 테스트 스크립트도 root token을 장기 저장하지 않으며, 실행 컨텍스트 변수로만
+  전달해 사용
 - 요약 JSON 파일 자체에 토큰이 포함되므로 아티팩트 보관 시 민감정보로 취급
   해야 함
 

--- a/docs/ko/operations.md
+++ b/docs/ko/operations.md
@@ -113,6 +113,9 @@ bootroot monitoring status
 `bootroot rotate` 계열 명령은 OpenBao root token이 필요하며,
 `--root-token` 또는 `OPENBAO_ROOT_TOKEN`으로 전달할 수 있습니다
 (없으면 프롬프트 입력).
+`bootroot`는 root token 영구 저장소를 기본 제공하지 않으므로,
+운영 환경에서는 비밀관리 시스템 또는 보호된 환경 파일에서 매 실행 시
+토큰을 주입하는 방식을 사용하세요.
 
 예시(크론):
 
@@ -201,6 +204,16 @@ bootroot service sync-status \
 - summary JSON은 상태/오류 요약 중심이지만, 운영 로그에는 필요한 범위만 남기고
   장기 보관 정책을 분리하기
 - 서비스 계정 권한을 서비스별 경로로 최소화
+- `bootroot init --summary-json` 산출물은 `root_token`을 포함할 수 있으므로
+  민감 아티팩트로 취급하고 접근/보관 기간을 제한하기
+
+## OpenBao 재기동/복구 체크리스트
+
+- OpenBao가 `sealed` 상태면 먼저 unseal keys로 언실을 완료합니다.
+- 언실 완료 후, root token이 필요한 관리자 명령(`service add`, `rotate`,
+  필요 시 `status` 상세 체크)에 토큰을 주입합니다.
+- 언실(unseal)과 root token 주입은 별도 단계입니다. 언실이 끝났다고
+  root token 요구가 사라지지는 않습니다.
 
 ## CA 번들(trust) 운영
 

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -26,6 +26,27 @@
 - OpenBao가 `sealed` 상태인지 확인하고, 필요 시 unseal 후 재시도
 - root token/AppRole 자격증명이 유효한지 확인
 - KV v2 마운트(`secret` 기본값)가 실제로 존재하는지 확인
+- 언실 키와 root token은 역할이 다릅니다.
+  - 언실 키: `sealed` 해제
+  - root token: `service add`/`rotate`/상세 상태 점검 같은 관리자 명령 권한
+
+### root token 누락/인증 실패
+
+증상:
+
+- `root token 누락` 또는 `permission denied` 류 오류
+
+확인:
+
+- 현재 명령이 root token 필요 명령인지 확인
+- `--root-token`/`OPENBAO_ROOT_TOKEN` 전달값과 만료 여부 확인
+- 토큰이 필요한 상세 체크라면 preview/기본 실행 모드 조건을 함께 확인
+
+조치:
+
+- 안전한 저장소/환경 파일에서 토큰을 다시 주입
+- `bootroot`가 root token 영구 저장소를 기본 제공하지 않는다는 전제로
+  운영 절차를 구성
 
 ### step-ca 초기화/CA 파일 관련
 


### PR DESCRIPTION
Align ko/en manuals on root token and unseal key lifecycle across CLI, concepts, operations, troubleshooting, and CI/E2E pages. Document when tokens are required, that bootroot does not persist root tokens, and that init summary JSON may contain sensitive fields.

Closes #279