### PR TITLE
Fix incorrect command name in design philosophy docs

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -64,7 +64,7 @@ automatically.
    `role_id` (safe to store on disk) with a rotatable `secret_id` (sensitive).
    Rotating `secret_id` invalidates the running OpenBao Agent's credential, so
    the agent cannot rotate its own secret. The operator triggers rotation with
-   `bootroot rotate secret-id` and delivers the new value to the service
+   `bootroot rotate approle-secret-id` and delivers the new value to the service
    machine (Bootroot provides the delivery mechanism via `bootroot-remote
    apply-secret-id`).
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -56,7 +56,7 @@ step-ca 프로비저너 비밀번호, 데이터베이스 비밀번호 등)은 Op
    가능)와 회전 가능한 `secret_id`(민감)를 쌍으로 사용합니다. `secret_id`를
    회전하면 실행 중인 OpenBao Agent의 인증 정보가 무효화되므로, 에이전트가
    스스로 자신의 시크릿을 회전할 수 없습니다. 운영자가
-   `bootroot rotate secret-id`로 회전을 실행하고 `bootroot-remote
+   `bootroot rotate approle-secret-id`로 회전을 실행하고 `bootroot-remote
    apply-secret-id`로 서비스 머신에 새 값을 전달합니다.
 
 **AppRole 모델.**


### PR DESCRIPTION
## Summary

- Fix `bootroot rotate secret-id` → `bootroot rotate approle-secret-id` in both `docs/en/index.md` and `docs/ko/index.md`
- The correct name is already used in cli.md, cli-examples.md, and operations.md

## Test plan

- [ ] Verify the command name matches `src/cli/args.rs` (`approle-secret-id`)
- [ ] No code changes — cargo test/clippy not needed

Closes #289