### PR TITLE
Unify per-service KV sync for all delivery modes

### DIFF
--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -279,7 +279,7 @@ pub(super) static STRINGS: Strings = Strings {
     prompt_rotate_trust_sync: "Sync CA trust data to OpenBao and update services? [y/N]",
     prompt_rotate_force_reissue: "Delete certificates for {service_name} and trigger reissuance? [y/N]",
     rotate_summary_trust_sync_global: "- CA trust updated: {value}",
-    rotate_summary_trust_sync_remote: "- remote service trust synced: {value}",
+    rotate_summary_trust_sync_service: "- service trust synced: {value}",
     rotate_summary_force_reissue_deleted: "- {service_name}: cert/key deleted ({cert_path}, {key_path})",
     rotate_summary_force_reissue_local_signal: "- {service_name}: signaled bootroot-agent for renewal",
     rotate_summary_force_reissue_remote_hint: "- {service_name}: run `bootroot-remote bootstrap` on the service host to reissue",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -279,7 +279,7 @@ pub(super) static STRINGS: Strings = Strings {
     prompt_rotate_trust_sync: "CA trust 데이터를 OpenBao에 동기화하고 서비스를 갱신할까요? [y/N]",
     prompt_rotate_force_reissue: "{service_name} 인증서를 삭제하고 재발급을 시작할까요? [y/N]",
     rotate_summary_trust_sync_global: "- CA trust 갱신: {value}",
-    rotate_summary_trust_sync_remote: "- 원격 서비스 trust 동기화: {value}",
+    rotate_summary_trust_sync_service: "- 서비스 trust 동기화: {value}",
     rotate_summary_force_reissue_deleted: "- {service_name}: cert/key 삭제 ({cert_path}, {key_path})",
     rotate_summary_force_reissue_local_signal: "- {service_name}: 인증서 갱신을 위해 bootroot-agent에 시그널 전송",
     rotate_summary_force_reissue_remote_hint: "- {service_name}: 서비스 머신에서 `bootroot-remote bootstrap`을 실행하여 재발급하세요",

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -313,7 +313,7 @@ pub(crate) struct Strings {
     pub(crate) prompt_rotate_trust_sync: &'static str,
     pub(crate) prompt_rotate_force_reissue: &'static str,
     pub(crate) rotate_summary_trust_sync_global: &'static str,
-    pub(crate) rotate_summary_trust_sync_remote: &'static str,
+    pub(crate) rotate_summary_trust_sync_service: &'static str,
     pub(crate) rotate_summary_force_reissue_deleted: &'static str,
     pub(crate) rotate_summary_force_reissue_local_signal: &'static str,
     pub(crate) rotate_summary_force_reissue_remote_hint: &'static str,
@@ -1780,9 +1780,9 @@ impl Messages {
         )
     }
 
-    pub(crate) fn rotate_summary_trust_sync_remote(&self, value: &str) -> String {
+    pub(crate) fn rotate_summary_trust_sync_service(&self, value: &str) -> String {
         format_template(
-            self.strings().rotate_summary_trust_sync_remote,
+            self.strings().rotate_summary_trust_sync_service,
             &[("value", value)],
         )
     }

--- a/tests/bootroot_rotate.rs
+++ b/tests/bootroot_rotate.rs
@@ -748,6 +748,15 @@ async fn stub_openbao_for_eab_rotation(server: &MockServer) {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .mount(server)
         .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/v1/secret/data/bootroot/services/{SECONDARY_SERVICE_NAME}/eab"
+        )))
+        .and(header("X-Vault-Token", support::ROOT_TOKEN))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(server)
+        .await;
 }
 
 async fn stub_openbao_for_responder_hmac_rotation(server: &MockServer, hmac: &str) {


### PR DESCRIPTION
## Summary
- Remove `DeliveryMode::RemoteBootstrap` filter from per-service KV writes (`eab`, `http_responder_hmac`, `trust`) so `LocalFile` services also receive per-service KV data
- Keep `secret_id` KV write conditional on `RemoteBootstrap` only (LocalFile stores it in local files)
- Rename internal functions/types to reflect delivery-mode-agnostic semantics (`remote` → `service`)

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo test --test bootroot_rotate` — 14/14 passed
- [x] `cargo test --test bootroot_service` — 17/17 passed
- [x] E2E tests do not assert on changed output strings; no E2E changes needed

Closes #299