### PR TITLE
Convert service sidecar ctmpl to dynamic KV-backed templates

### DIFF
--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1099,6 +1099,22 @@ fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str
     assert_eq!(hcl_mode, 0o600);
     assert_eq!(ctmpl_mode, 0o600);
     assert_eq!(token_mode, 0o600);
+
+    let ctmpl_contents = fs::read_to_string(&openbao_ctmpl).expect("read ctmpl");
+    assert!(
+        ctmpl_contents.contains("{{ with secret \"secret/data/bootroot/services/"),
+        "ctmpl should contain template directives"
+    );
+    assert!(
+        !ctmpl_contents.contains("test-responder-hmac"),
+        "ctmpl should not contain literal secret values"
+    );
+
+    let hcl_contents = fs::read_to_string(&openbao_hcl).expect("read agent.hcl");
+    assert!(
+        hcl_contents.contains("vault {"),
+        "agent.hcl should contain vault block"
+    );
 }
 
 fn write_cert_with_dns(

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -68,14 +68,31 @@ async fn test_same_host_local_file_happy_path() {
             .join("agent.hcl")
             .exists()
     );
+    let ctmpl_path = temp
+        .path()
+        .join("secrets")
+        .join("openbao")
+        .join("services")
+        .join(SERVICE_NAME)
+        .join("agent.toml.ctmpl");
+    assert!(ctmpl_path.exists());
+    let ctmpl_contents = fs::read_to_string(&ctmpl_path).expect("read ctmpl");
     assert!(
-        temp.path()
-            .join("secrets")
-            .join("openbao")
-            .join("services")
-            .join(SERVICE_NAME)
-            .join("agent.toml.ctmpl")
-            .exists()
+        ctmpl_contents.contains("{{ with secret \"secret/data/bootroot/services/"),
+        "ctmpl should contain template directives"
+    );
+
+    let hcl_path = temp
+        .path()
+        .join("secrets")
+        .join("openbao")
+        .join("services")
+        .join(SERVICE_NAME)
+        .join("agent.hcl");
+    let hcl_contents = fs::read_to_string(&hcl_path).expect("read agent.hcl");
+    assert!(
+        hcl_contents.contains("vault {"),
+        "agent.hcl should contain vault block"
     );
 
     write_service_cert(&files.cert_path, &files.key_path).expect("write cert");


### PR DESCRIPTION
## Summary

- Transform service `agent.toml.ctmpl` from static copies into dynamic Go templates with `{{ with secret }}` directives for `http_responder_hmac`, `trusted_ca_sha256` (via `toJSON`), and conditional EAB blocks
~~- Add `vault { address }` and `template_config { static_secret_render_interval = "30s" }` to `agent.hcl` so OpenBao Agent can connect and periodically re-render~~
- Write EAB KV unconditionally (empty strings when unconfigured) so template paths always exist

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] 5 new unit tests for `build_ctmpl_content` pass (`cargo test --bin bootroot -- service`)
- [x] `cargo test --test bootroot_service` — 17/17 pass (ctmpl + agent.hcl content assertions added)
- [x] `cargo test --test e2e_same_host_local_file` — 4/4 pass (ctmpl + agent.hcl content assertions added)
- [x] `cargo test --test bootroot_rotate` — 14/14 pass (no regressions)
- [ ] Docker E2E (`./tests/docker/run-e2e.sh main-lifecycle`, `remote-lifecycle`, `rotation-recovery`)

Closes #300