### PR TITLE
Add polling config and restart orchestration for OBA

### DIFF
--- a/scripts/e2e/docker/run-main-lifecycle.sh
+++ b/scripts/e2e/docker/run-main-lifecycle.sh
@@ -163,6 +163,8 @@ compose_down() {
 capture_artifacts() {
   docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
   docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+  docker logs bootroot-openbao-agent-stepca >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+  docker logs bootroot-openbao-agent-responder >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
 }
 
 cleanup_hosts() {

--- a/scripts/e2e/docker/run-main-remote-lifecycle.sh
+++ b/scripts/e2e/docker/run-main-remote-lifecycle.sh
@@ -108,6 +108,8 @@ compose_down() {
 capture_artifacts() {
   docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
   docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+  docker logs bootroot-openbao-agent-stepca >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+  docker logs bootroot-openbao-agent-responder >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
 }
 
 cleanup_hosts() {

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -36,7 +36,7 @@ use super::constants::{
     STEPCA_PASSWORD_TEMPLATE_NAME,
 };
 
-const STATIC_SECRET_RENDER_INTERVAL: &str = "5m";
+const STATIC_SECRET_RENDER_INTERVAL: &str = "30s";
 use super::paths::{
     OpenBaoAgentPaths, ResponderPaths, StepCaTemplatePaths, compose_has_openbao,
     compose_has_responder, resolve_openbao_agent_addr, resolve_responder_url, to_container_path,
@@ -2557,8 +2557,8 @@ services:
             "config should contain template_config block"
         );
         assert!(
-            config.contains("static_secret_render_interval = \"5m\""),
-            "config should set static_secret_render_interval to 5m"
+            config.contains("static_secret_render_interval = \"30s\""),
+            "config should set static_secret_render_interval to 30s"
         );
         assert!(
             config.contains("vault {"),

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -131,6 +131,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_secrets_dir_resolve_failed: "Failed to resolve secrets dir",
     error_parse_ca_json_failed: "Failed to parse ca.json",
     error_serialize_ca_json_failed: "Failed to serialize ca.json",
+    error_rendered_file_timeout: "Timed out waiting for OpenBao Agent to render {value}",
     error_ca_json_db_missing: "ca.json missing db.dataSource field",
     error_ca_cert_missing: "CA certificate not found: {value}",
     error_ca_cert_parse_failed: "Failed to parse CA certificate: {value}",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -131,6 +131,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_secrets_dir_resolve_failed: "secrets dir 확인 실패",
     error_parse_ca_json_failed: "ca.json 파싱 실패",
     error_serialize_ca_json_failed: "ca.json 직렬화 실패",
+    error_rendered_file_timeout: "OpenBao Agent가 {value}을(를) 렌더링하기를 기다리다 시간이 초과되었습니다",
     error_ca_json_db_missing: "ca.json에 db.dataSource 필드가 없습니다",
     error_ca_cert_missing: "CA 인증서 파일이 없습니다: {value}",
     error_ca_cert_parse_failed: "CA 인증서 파싱 실패: {value}",

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -163,6 +163,7 @@ pub(crate) struct Strings {
     pub(crate) error_docker_command_failed: &'static str,
     pub(crate) error_bootroot_agent_run_failed: &'static str,
     pub(crate) error_secrets_dir_resolve_failed: &'static str,
+    pub(crate) error_rendered_file_timeout: &'static str,
     pub(crate) error_parse_ca_json_failed: &'static str,
     pub(crate) error_serialize_ca_json_failed: &'static str,
     pub(crate) error_ca_json_db_missing: &'static str,
@@ -986,6 +987,13 @@ impl Messages {
 
     pub(crate) fn error_secrets_dir_resolve_failed(&self) -> &'static str {
         self.strings().error_secrets_dir_resolve_failed
+    }
+
+    pub(crate) fn error_rendered_file_timeout(&self, value: &str) -> String {
+        format_template(
+            self.strings().error_rendered_file_timeout,
+            &[("value", value)],
+        )
     }
 
     pub(crate) fn error_parse_ca_json_failed(&self) -> &'static str {


### PR DESCRIPTION
## Summary

- Add `template_config { static_secret_render_interval = "5m" }` to OpenBao Agent HCL so KV v2 static secrets are re-polled periodically
- Change rotation orchestration to: write KV → restart OBA container → poll rendered file → restart dependent service
- Remove dead helpers (`write_ca_json_dsn`, `build_responder_config`, `update_responder_hmac`) since OBA now handles file rendering
- Add `error_rendered_file_timeout` i18n message (EN/KO)

## Test plan

- [x] Unit tests for `wait_for_rendered_file` (immediate success + timeout)
- [x] Unit test for `template_config` block in HCL output
- [x] Integration test: OBA restart ordering before compose restart (stepca-password)
- [x] Integration test: OBA restart ordering before HUP reload (responder-hmac)
- [x] Integration test: AppRole auth + fake docker render simulation
- [x] E2E test: full rotation sequence with fake docker
- [ ] Docker E2E: `./tests/docker/run-e2e.sh main-lifecycle`
- [ ] Docker E2E: `./tests/docker/run-e2e.sh rotation-recovery`

Closes #301