### PR TITLE
Pre-create secrets dir before docker compose up

### DIFF
--- a/scripts/e2e/docker/run-baseline.sh
+++ b/scripts/e2e/docker/run-baseline.sh
@@ -62,6 +62,9 @@ ensure_prerequisites() {
 }
 
 compose_up() {
+  # Pre-create the secrets directory so Docker does not create it as root when
+  # bind-mounting ./secrets:/home/step for the step-ca service.
+  mkdir -p "$ROOT_DIR/secrets"
   docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" up -d $COMPOSE_SERVICES
 }
 

--- a/scripts/e2e/docker/run-harness-smoke.sh
+++ b/scripts/e2e/docker/run-harness-smoke.sh
@@ -64,6 +64,9 @@ ensure_bins() {
 }
 
 compose_up() {
+  # Pre-create the secrets directory so Docker does not create it as root when
+  # bind-mounting ./secrets:/home/step for the step-ca service.
+  mkdir -p "$ROOT_DIR/secrets"
   docker compose \
     -p "$PROJECT_NAME" \
     -f "$COMPOSE_FILE" \

--- a/scripts/e2e/docker/run-rotation-recovery.sh
+++ b/scripts/e2e/docker/run-rotation-recovery.sh
@@ -73,6 +73,9 @@ ensure_prerequisites() {
 }
 
 compose_up() {
+  # Pre-create the secrets directory so Docker does not create it as root when
+  # bind-mounting ./secrets:/home/step for the step-ca service.
+  mkdir -p "$ROOT_DIR/secrets"
   docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" up -d $COMPOSE_SERVICES
 }
 


### PR DESCRIPTION
Closes #313

## Summary

- `run-baseline.sh`, `run-rotation-recovery.sh`, `run-harness-smoke.sh` 세 스크립트의 `compose_up()` 함수에서 `docker compose up` 전에 `mkdir -p "$ROOT_DIR/secrets"` 호출 추가

## Root cause

`docker-compose.yml`의 step-ca 서비스에는 `./secrets:/home/step` 바인드 마운트가 있다. `./secrets`가 존재하지 않을 때 `docker compose up`을 실행하면 Docker 데몬(root로 실행 중)이 해당 디렉터리를 **root 소유**로 생성한다.

Extended E2E suite에서 `scale-contention` → `failure-recovery` → `runner-timer` → `runner-cron` 케이스가 순서대로 실행될 때 이 세 스크립트가 step-ca를 포함한 docker compose를 먼저 실행하고, 결과적으로 `secrets/`가 root 소유로 남는다 (step-ca는 config 없이 즉시 종료되지만 디렉터리는 남음).

이후 `infra-lifecycle` 케이스에서 `run-main-lifecycle.sh`의 `prepare_test_ca_materials`가 `chmod 700 "$SECRETS_DIR"`를 실행하면 runner가 해당 디렉터리를 소유하지 않아 `EPERM`으로 실패한다.

## Fix

각 스크립트의 `compose_up()` 안에서 Docker가 마운트 디렉터리를 생성하기 전에 runner가 직접 `mkdir -p "$ROOT_DIR/secrets"`를 실행한다. 디렉터리가 이미 존재하면 no-op이다.

## Test plan

- [ ] `scripts/e2e/docker/run-extended-suite.sh` 로컬 실행으로 infra-lifecycle 케이스 통과 확인
- [ ] CI E2E Extended workflow dispatch 실행으로 all cases pass 확인