### PR TITLE
Rename E2E scripts and CI labels for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: cargo audit
 
   test-core:
-    name: Test Suite (Core)
+    name: Unit & CLI Smoke
     needs: [check, changes]
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
@@ -314,22 +314,22 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - label: main-fqdn
-            script: run-main-lifecycle.sh
+          - label: local-default
+            script: run-local-lifecycle.sh
             resolution: fqdn-only-hosts
-            artifact: ci-main-fqdn
-          - label: main-hosts
-            script: run-main-lifecycle.sh
+            artifact: ci-local-default
+          - label: local-hosts
+            script: run-local-lifecycle.sh
             resolution: hosts-all
-            artifact: ci-main-hosts
-          - label: remote-fqdn
-            script: run-main-remote-lifecycle.sh
+            artifact: ci-local-hosts
+          - label: remote-default
+            script: run-remote-lifecycle.sh
             resolution: fqdn-only-hosts
-            artifact: ci-main-remote-fqdn
+            artifact: ci-remote-default
           - label: remote-hosts
-            script: run-main-remote-lifecycle.sh
+            script: run-remote-lifecycle.sh
             resolution: hosts-all
-            artifact: ci-main-remote-hosts
+            artifact: ci-remote-hosts
           - label: rotation
             script: run-rotation-recovery.sh
             resolution: ""

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ jobs; scripts under `preflight/extra/` are local-only checks not in CI.
 | Script | CI job |
 | --- | --- |
 | `./scripts/preflight/ci/check.sh` | `ci.yml` Quality Check |
-| `./scripts/preflight/ci/test-core.sh` | `ci.yml` Test Suite (Core) |
+| `./scripts/preflight/ci/test-core.sh` | `ci.yml` Unit & CLI Smoke |
 | `./scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` Docker E2E Matrix |
 | `./scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` Run Extended |
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -70,8 +70,8 @@ PR-critical Docker test set validates:
 
 Primary scripts:
 
-- `scripts/impl/run-main-lifecycle.sh`
-- `scripts/impl/run-main-remote-lifecycle.sh`
+- `scripts/impl/run-local-lifecycle.sh`
+- `scripts/impl/run-remote-lifecycle.sh`
 - `scripts/impl/run-rotation-recovery.sh`
 
 Extended workflow validates:
@@ -94,7 +94,7 @@ reproduction.
 
 Configuration:
 
-- Single machine baseline used by `scripts/impl/run-main-lifecycle.sh`
+- Single machine baseline used by `scripts/impl/run-local-lifecycle.sh`
 - `openbao`, `postgres`, `step-ca`, `bootroot-http01` run in Docker Compose
 - Services are added with `--delivery-mode local-file`
 - Service set in this scenario (2 services): `edge-proxy` (`daemon`),
@@ -181,7 +181,7 @@ Actual commands (script excerpt):
 
 ```bash
 # run in hosts-all mode
-RESOLUTION_MODE=hosts-all ./scripts/impl/run-main-lifecycle.sh
+RESOLUTION_MODE=hosts-all ./scripts/impl/run-local-lifecycle.sh
 
 # internal host-entry add/remove sequence
 echo "127.0.0.1 stepca.internal ${HOSTS_MARKER}" | sudo -n tee -a /etc/hosts
@@ -276,7 +276,7 @@ Actual commands (script excerpt):
 
 ```bash
 # run remote lifecycle in hosts-all mode
-RESOLUTION_MODE=hosts-all ./scripts/impl/run-main-remote-lifecycle.sh
+RESOLUTION_MODE=hosts-all ./scripts/impl/run-remote-lifecycle.sh
 
 # internal host-entry add/remove sequence
 echo "127.0.0.1 stepca.internal ${HOSTS_MARKER}" | sudo -n tee -a /etc/hosts
@@ -381,7 +381,7 @@ Or run individual scripts:
 | Script | CI job |
 | --- | --- |
 | `./scripts/preflight/ci/check.sh` | `ci.yml` Quality Check |
-| `./scripts/preflight/ci/test-core.sh` | `ci.yml` Test Suite (Core) |
+| `./scripts/preflight/ci/test-core.sh` | `ci.yml` Unit & CLI Smoke |
 | `./scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` Docker E2E Matrix |
 | `./scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` Run Extended |
 
@@ -467,7 +467,7 @@ Pass/fail rules:
 E2E scripts write step-progress events to `phases.log`.
 The examples below describe the JSON event format in that file.
 
-Main lifecycle scripts write:
+Lifecycle scripts write:
 
 ```json
 {"ts":"2026-02-17T04:49:01Z","phase":"infra-up","mode":"fqdn-only-hosts"}
@@ -498,10 +498,10 @@ For users/contributors debugging CI failures directly, it is useful.
 
 Typical PR-critical artifacts:
 
-- `tmp/e2e/ci-main-fqdn-<run-id>`
-- `tmp/e2e/ci-main-hosts-<run-id>`
-- `tmp/e2e/ci-main-remote-fqdn-<run-id>`
-- `tmp/e2e/ci-main-remote-hosts-<run-id>`
+- `tmp/e2e/ci-local-default-<run-id>`
+- `tmp/e2e/ci-local-hosts-<run-id>`
+- `tmp/e2e/ci-remote-default-<run-id>`
+- `tmp/e2e/ci-remote-hosts-<run-id>`
 - `tmp/e2e/ci-rotation-<run-id>`
 
 Typical extended artifact:

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -68,8 +68,8 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 
 주요 스크립트:
 
-- `scripts/impl/run-main-lifecycle.sh`
-- `scripts/impl/run-main-remote-lifecycle.sh`
+- `scripts/impl/run-local-lifecycle.sh`
+- `scripts/impl/run-remote-lifecycle.sh`
 - `scripts/impl/run-rotation-recovery.sh`
 
 확장 워크플로는 다음을 검증합니다.
@@ -91,7 +91,7 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 
 구성:
 
-- `scripts/impl/run-main-lifecycle.sh` 기반 단일 머신 시나리오
+- `scripts/impl/run-local-lifecycle.sh` 기반 단일 머신 시나리오
 - Docker Compose에서 `openbao`, `postgres`, `step-ca`, `bootroot-http01` 실행
 - 서비스는 `--delivery-mode local-file`로 추가
 - 이 시나리오의 서비스 구성(총 2개): `edge-proxy` (`daemon`), `web-app` (`docker`)
@@ -177,7 +177,7 @@ bootroot rotate --compose-file "$COMPOSE_FILE" \
 
 ```bash
 # hosts-all 모드로 실행
-RESOLUTION_MODE=hosts-all ./scripts/impl/run-main-lifecycle.sh
+RESOLUTION_MODE=hosts-all ./scripts/impl/run-local-lifecycle.sh
 
 # 내부적으로 /etc/hosts 추가/정리
 echo "127.0.0.1 stepca.internal ${HOSTS_MARKER}" | sudo -n tee -a /etc/hosts
@@ -272,7 +272,7 @@ bootroot rotate --yes responder-hmac
 
 ```bash
 # hosts-all 모드로 원격 전체 흐름 실행
-RESOLUTION_MODE=hosts-all ./scripts/impl/run-main-remote-lifecycle.sh
+RESOLUTION_MODE=hosts-all ./scripts/impl/run-remote-lifecycle.sh
 
 # 내부적으로 /etc/hosts 추가/정리
 echo "127.0.0.1 stepca.internal ${HOSTS_MARKER}" | sudo -n tee -a /etc/hosts
@@ -461,7 +461,7 @@ E2E에서 OpenBao 언실/런타임 인증 사용 방식:
 E2E 스크립트는 단계 진행 상태를 `phases.log` 파일로 남깁니다.
 아래는 그 파일에 기록되는 이벤트 JSON 형식입니다.
 
-로컬 전달 E2E 시나리오 스크립트는 다음 형식으로 기록합니다.
+라이프사이클 스크립트는 다음 형식으로 기록합니다.
 
 ```json
 {"ts":"2026-02-17T04:49:01Z","phase":"infra-up","mode":"fqdn-only-hosts"}
@@ -492,10 +492,10 @@ CI 실패를 직접 디버깅하는 사용자/기여자 관점에서는 유용�
 
 PR 필수 아티팩트 예시:
 
-- `tmp/e2e/ci-main-fqdn-<run-id>`
-- `tmp/e2e/ci-main-hosts-<run-id>`
-- `tmp/e2e/ci-main-remote-fqdn-<run-id>`
-- `tmp/e2e/ci-main-remote-hosts-<run-id>`
+- `tmp/e2e/ci-local-default-<run-id>`
+- `tmp/e2e/ci-local-hosts-<run-id>`
+- `tmp/e2e/ci-remote-default-<run-id>`
+- `tmp/e2e/ci-remote-hosts-<run-id>`
 - `tmp/e2e/ci-rotation-<run-id>`
 
 확장 아티팩트 예시:

--- a/scripts/impl/run-extended-suite.sh
+++ b/scripts/impl/run-extended-suite.sh
@@ -94,7 +94,7 @@ case_infra_lifecycle() {
   TIMEOUT_SECS="$TIMEOUT_SECS_LIFECYCLE" \
   BOOTROOT_BIN="$BOOTROOT_BIN" \
   BOOTROOT_REMOTE_BIN="$BOOTROOT_REMOTE_BIN" \
-  "$ROOT_DIR/scripts/impl/run-main-lifecycle.sh"
+  "$ROOT_DIR/scripts/impl/run-local-lifecycle.sh"
 }
 
 case_runner_cron() {

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-main-lifecycle-$(date +%s)}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-local-lifecycle-$(date +%s)}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/docker-compose.yml}"
 COMPOSE_TEST_FILE="${COMPOSE_TEST_FILE:-$ROOT_DIR/docker-compose.test.yml}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-$ARTIFACT_DIR/workspace}"
@@ -236,7 +236,7 @@ cleanup() {
 
 on_error() {
   local line="$1"
-  echo "run-main-lifecycle failed at phase=${CURRENT_PHASE} line=${line}" >&2
+  echo "run-local-lifecycle failed at phase=${CURRENT_PHASE} line=${line}" >&2
   echo "artifact dir: ${ARTIFACT_DIR}" >&2
   if [ -f "$RUN_LOG" ]; then
     echo "--- run.log (tail) ---" >&2

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-main-remote-lifecycle-$(date +%s)}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-remote-lifecycle-$(date +%s)}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/docker-compose.yml}"
 COMPOSE_TEST_FILE="${COMPOSE_TEST_FILE:-$ROOT_DIR/docker-compose.test.yml}"
 SECRETS_DIR="${SECRETS_DIR:-$ROOT_DIR/secrets}"
@@ -140,7 +140,7 @@ cleanup() {
 
 on_error() {
   local line="$1"
-  echo "run-main-remote-lifecycle failed at phase=${CURRENT_PHASE} line=${line}" >&2
+  echo "run-remote-lifecycle failed at phase=${CURRENT_PHASE} line=${line}" >&2
   echo "artifact dir: ${ARTIFACT_DIR}" >&2
   [ -f "$RUN_LOG" ] && tail -n 120 "$RUN_LOG" >&2 || true
   [ -f "$INIT_RAW_LOG" ] && tail -n 120 "$INIT_RAW_LOG" >&2 || true

--- a/scripts/preflight/ci/e2e-matrix.sh
+++ b/scripts/preflight/ci/e2e-matrix.sh
@@ -14,10 +14,10 @@ usage() {
 Usage: scripts/preflight/ci/e2e-matrix.sh [--skip-hosts-all] [--fresh-secrets]
 
 Runs the same Docker E2E matrix steps used in CI:
-1) main lifecycle (fqdn-only-hosts)
-2) main lifecycle (hosts-all)
-3) main remote lifecycle (fqdn-only-hosts)
-4) main remote lifecycle (hosts-all)
+1) local lifecycle (fqdn-only-hosts)
+2) local lifecycle (hosts-all)
+3) remote lifecycle (fqdn-only-hosts)
+4) remote lifecycle (hosts-all)
 5) rotation/recovery full matrix
 
 Options:
@@ -71,9 +71,9 @@ echo "[ci-local-e2e] run id: $RUN_ID"
 echo "[ci-local-e2e] building bootroot binaries"
 cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
-echo "[ci-local-e2e] run main lifecycle (fqdn-only-hosts)"
-ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-main-fqdn-${RUN_ID}" \
-PROJECT_NAME="bootroot-e2e-ci-main-fqdn-${RUN_ID}" \
+echo "[ci-local-e2e] run local lifecycle (fqdn-only-hosts)"
+ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-local-default-${RUN_ID}" \
+PROJECT_NAME="bootroot-e2e-ci-local-default-${RUN_ID}" \
 RESOLUTION_MODE="fqdn-only-hosts" \
 SECRETS_DIR="$ROOT_DIR/secrets" \
 TIMEOUT_SECS=120 \
@@ -82,12 +82,12 @@ INFRA_UP_DELAY_SECS=10 \
 BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
 BOOTROOT_REMOTE_BIN="$ROOT_DIR/target/debug/bootroot-remote" \
 BOOTROOT_AGENT_BIN="$ROOT_DIR/target/debug/bootroot-agent" \
-"$ROOT_DIR/scripts/impl/run-main-lifecycle.sh"
+"$ROOT_DIR/scripts/impl/run-local-lifecycle.sh"
 
 if [ "$SKIP_HOSTS_ALL" -eq 0 ]; then
-  echo "[ci-local-e2e] run main lifecycle (hosts-all)"
-  ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-main-hosts-${RUN_ID}" \
-  PROJECT_NAME="bootroot-e2e-ci-main-hosts-${RUN_ID}" \
+  echo "[ci-local-e2e] run local lifecycle (hosts-all)"
+  ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-local-hosts-${RUN_ID}" \
+  PROJECT_NAME="bootroot-e2e-ci-local-hosts-${RUN_ID}" \
   RESOLUTION_MODE="hosts-all" \
   SECRETS_DIR="$ROOT_DIR/secrets" \
   TIMEOUT_SECS=120 \
@@ -96,14 +96,14 @@ if [ "$SKIP_HOSTS_ALL" -eq 0 ]; then
   BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
   BOOTROOT_REMOTE_BIN="$ROOT_DIR/target/debug/bootroot-remote" \
   BOOTROOT_AGENT_BIN="$ROOT_DIR/target/debug/bootroot-agent" \
-  "$ROOT_DIR/scripts/impl/run-main-lifecycle.sh"
+  "$ROOT_DIR/scripts/impl/run-local-lifecycle.sh"
 else
-  echo "[ci-local-e2e] skip main lifecycle (hosts-all)"
+  echo "[ci-local-e2e] skip local lifecycle (hosts-all)"
 fi
 
-echo "[ci-local-e2e] run main remote lifecycle (fqdn-only-hosts)"
-ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-main-remote-fqdn-${RUN_ID}" \
-PROJECT_NAME="bootroot-e2e-ci-main-remote-fqdn-${RUN_ID}" \
+echo "[ci-local-e2e] run remote lifecycle (fqdn-only-hosts)"
+ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-remote-default-${RUN_ID}" \
+PROJECT_NAME="bootroot-e2e-ci-remote-default-${RUN_ID}" \
 RESOLUTION_MODE="fqdn-only-hosts" \
 SECRETS_DIR="$ROOT_DIR/secrets" \
 TIMEOUT_SECS=120 \
@@ -114,12 +114,12 @@ VERIFY_DELAY_SECS=5 \
 BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
 BOOTROOT_REMOTE_BIN="$ROOT_DIR/target/debug/bootroot-remote" \
 BOOTROOT_AGENT_BIN="$ROOT_DIR/target/debug/bootroot-agent" \
-"$ROOT_DIR/scripts/impl/run-main-remote-lifecycle.sh"
+"$ROOT_DIR/scripts/impl/run-remote-lifecycle.sh"
 
 if [ "$SKIP_HOSTS_ALL" -eq 0 ]; then
-  echo "[ci-local-e2e] run main remote lifecycle (hosts-all)"
-  ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-main-remote-hosts-${RUN_ID}" \
-  PROJECT_NAME="bootroot-e2e-ci-main-remote-hosts-${RUN_ID}" \
+  echo "[ci-local-e2e] run remote lifecycle (hosts-all)"
+  ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-remote-hosts-${RUN_ID}" \
+  PROJECT_NAME="bootroot-e2e-ci-remote-hosts-${RUN_ID}" \
   RESOLUTION_MODE="hosts-all" \
   SECRETS_DIR="$ROOT_DIR/secrets" \
   TIMEOUT_SECS=120 \
@@ -130,9 +130,9 @@ if [ "$SKIP_HOSTS_ALL" -eq 0 ]; then
   BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
   BOOTROOT_REMOTE_BIN="$ROOT_DIR/target/debug/bootroot-remote" \
   BOOTROOT_AGENT_BIN="$ROOT_DIR/target/debug/bootroot-agent" \
-  "$ROOT_DIR/scripts/impl/run-main-remote-lifecycle.sh"
+  "$ROOT_DIR/scripts/impl/run-remote-lifecycle.sh"
 else
-  echo "[ci-local-e2e] skip main remote lifecycle (hosts-all)"
+  echo "[ci-local-e2e] skip remote lifecycle (hosts-all)"
 fi
 
 echo "[ci-local-e2e] run rotation/recovery full matrix"
@@ -147,8 +147,8 @@ BOOTROOT_REMOTE_BIN="$ROOT_DIR/target/debug/bootroot-remote" \
 
 echo "[ci-local-e2e] done"
 echo "[ci-local-e2e] artifacts:"
-echo "  - $ROOT_DIR/tmp/e2e/ci-main-fqdn-${RUN_ID}"
-echo "  - $ROOT_DIR/tmp/e2e/ci-main-hosts-${RUN_ID}"
-echo "  - $ROOT_DIR/tmp/e2e/ci-main-remote-fqdn-${RUN_ID}"
-echo "  - $ROOT_DIR/tmp/e2e/ci-main-remote-hosts-${RUN_ID}"
+echo "  - $ROOT_DIR/tmp/e2e/ci-local-default-${RUN_ID}"
+echo "  - $ROOT_DIR/tmp/e2e/ci-local-hosts-${RUN_ID}"
+echo "  - $ROOT_DIR/tmp/e2e/ci-remote-default-${RUN_ID}"
+echo "  - $ROOT_DIR/tmp/e2e/ci-remote-hosts-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-rotation-${RUN_ID}"

--- a/tests/docker_e2e_local_lifecycle.rs
+++ b/tests/docker_e2e_local_lifecycle.rs
@@ -9,19 +9,19 @@ mod unix_integration {
     use anyhow::{Context, Result};
 
     fn run_mode(mode: &str) -> Result<PathBuf> {
-        let scenario_id = super::support::docker_harness::unique_scenario_id("main-lifecycle");
+        let scenario_id = super::support::docker_harness::unique_scenario_id("local-lifecycle");
         let artifact_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tmp")
             .join("e2e")
-            .join(format!("docker-main-lifecycle-{mode}-{scenario_id}"));
+            .join(format!("docker-local-lifecycle-{mode}-{scenario_id}"));
 
         let output = Command::new("bash")
             .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .arg(super::support::docker_harness::main_lifecycle_script_path())
+            .arg(super::support::docker_harness::local_lifecycle_script_path())
             .env("ARTIFACT_DIR", &artifact_dir)
             .env(
                 "PROJECT_NAME",
-                format!("bootroot-e2e-main-lifecycle-{mode}-{scenario_id}"),
+                format!("bootroot-e2e-local-lifecycle-{mode}-{scenario_id}"),
             )
             .env("RESOLUTION_MODE", mode)
             .env("TIMEOUT_SECS", "120")
@@ -29,11 +29,11 @@ mod unix_integration {
             .env("BOOTROOT_REMOTE_BIN", env!("CARGO_BIN_EXE_bootroot-remote"))
             .env("BOOTROOT_AGENT_BIN", env!("CARGO_BIN_EXE_bootroot-agent"))
             .output()
-            .with_context(|| "Failed to run docker main lifecycle script")?;
+            .with_context(|| "Failed to run docker local lifecycle script")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("main lifecycle script failed ({mode}): {stderr}");
+            anyhow::bail!("local lifecycle script failed ({mode}): {stderr}");
         }
 
         let phase_log = artifact_dir.join("phases.log");
@@ -67,7 +67,7 @@ mod unix_integration {
 
     #[test]
     #[ignore = "Requires local Docker and root-level hosts updates for hosts-all mode"]
-    fn docker_main_lifecycle_hosts_variants() -> Result<()> {
+    fn docker_local_lifecycle_hosts_variants() -> Result<()> {
         for mode in ["fqdn-only-hosts", "hosts-all"] {
             let artifact_dir = run_mode(mode)?;
             let manifest = std::fs::read_to_string(artifact_dir.join("manifest.json"))

--- a/tests/docker_e2e_remote_lifecycle.rs
+++ b/tests/docker_e2e_remote_lifecycle.rs
@@ -9,20 +9,19 @@ mod unix_integration {
     use anyhow::{Context, Result};
 
     fn run_mode(mode: &str) -> Result<PathBuf> {
-        let scenario_id =
-            super::support::docker_harness::unique_scenario_id("main-remote-lifecycle");
+        let scenario_id = super::support::docker_harness::unique_scenario_id("remote-lifecycle");
         let artifact_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tmp")
             .join("e2e")
-            .join(format!("docker-main-remote-lifecycle-{mode}-{scenario_id}"));
+            .join(format!("docker-remote-lifecycle-{mode}-{scenario_id}"));
 
         let output = Command::new("bash")
             .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .arg(super::support::docker_harness::main_remote_lifecycle_script_path())
+            .arg(super::support::docker_harness::remote_lifecycle_script_path())
             .env("ARTIFACT_DIR", &artifact_dir)
             .env(
                 "PROJECT_NAME",
-                format!("bootroot-e2e-main-remote-lifecycle-{mode}-{scenario_id}"),
+                format!("bootroot-e2e-remote-lifecycle-{mode}-{scenario_id}"),
             )
             .env("RESOLUTION_MODE", mode)
             .env("TIMEOUT_SECS", "120")
@@ -30,11 +29,11 @@ mod unix_integration {
             .env("BOOTROOT_REMOTE_BIN", env!("CARGO_BIN_EXE_bootroot-remote"))
             .env("BOOTROOT_AGENT_BIN", env!("CARGO_BIN_EXE_bootroot-agent"))
             .output()
-            .with_context(|| "Failed to run docker main remote lifecycle script")?;
+            .with_context(|| "Failed to run docker remote lifecycle script")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("main remote lifecycle script failed ({mode}): {stderr}");
+            anyhow::bail!("remote lifecycle script failed ({mode}): {stderr}");
         }
 
         let phase_log = artifact_dir.join("phases.log");
@@ -78,7 +77,7 @@ mod unix_integration {
 
     #[test]
     #[ignore = "Requires local Docker and root-level hosts updates for hosts-all mode"]
-    fn docker_main_remote_lifecycle_hosts_variants() -> Result<()> {
+    fn docker_remote_lifecycle_hosts_variants() -> Result<()> {
         for mode in ["fqdn-only-hosts", "hosts-all"] {
             let artifact_dir = run_mode(mode)?;
             let phase_log = std::fs::read_to_string(artifact_dir.join("phases.log"))

--- a/tests/support/docker_harness.rs
+++ b/tests/support/docker_harness.rs
@@ -23,18 +23,18 @@ pub(crate) fn baseline_script_path() -> PathBuf {
         .join("run-baseline.sh")
 }
 
-pub(crate) fn main_lifecycle_script_path() -> PathBuf {
+pub(crate) fn local_lifecycle_script_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("scripts")
         .join("impl")
-        .join("run-main-lifecycle.sh")
+        .join("run-local-lifecycle.sh")
 }
 
-pub(crate) fn main_remote_lifecycle_script_path() -> PathBuf {
+pub(crate) fn remote_lifecycle_script_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("scripts")
         .join("impl")
-        .join("run-main-remote-lifecycle.sh")
+        .join("run-remote-lifecycle.sh")
 }
 
 pub(crate) fn baseline_scenario_path(file_name: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- Rename `run-main-lifecycle.sh` → `run-local-lifecycle.sh` and `run-main-remote-lifecycle.sh` → `run-remote-lifecycle.sh` to better reflect delivery mode semantics (`local-file` vs `remote-bootstrap`)
- Update CI matrix labels: `main-fqdn` → `local-default`, `main-hosts` → `local-hosts`, `remote-fqdn` → `remote-default`, `remote-hosts` → `remote-hosts`
- Rename CI job `Test Suite (Core)` → `Unit & CLI Smoke` to better describe what the job actually runs
- Update all references across CI workflows, preflight scripts, Rust test code, and documentation (en/ko)

Closes #322

## Test plan

- [x] All 5 Docker E2E matrix jobs pass with updated labels (`local-default`, `local-hosts`, `remote-default`, `remote-hosts`, `rotation`)
- [x] `Unit & CLI Smoke` job passes
- [x] Quality Check passes (markdownlint, clippy, rustfmt)
- [x] No stale `run-main-*` or `ci-main-*` references remain