### PR TITLE
Extract shared trust writer and add conflict protection

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,4 +7,5 @@ pub(crate) mod openbao_unseal;
 pub(crate) mod rotate;
 pub(crate) mod service;
 pub(crate) mod status;
+pub(crate) mod trust;
 pub(crate) mod verify;

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -15,8 +15,8 @@ use crate::cli::prompt::Prompt;
 use crate::commands::guardrails::{ensure_postgres_localhost_binding, ensure_single_host_db_host};
 use crate::commands::infra::run_docker;
 use crate::commands::init::{
-    CA_TRUST_KEY, PATH_AGENT_EAB, PATH_CA_TRUST, PATH_RESPONDER_HMAC, PATH_STEPCA_DB,
-    PATH_STEPCA_PASSWORD, compute_ca_bundle_pem, compute_ca_fingerprints,
+    PATH_AGENT_EAB, PATH_RESPONDER_HMAC, PATH_STEPCA_DB, PATH_STEPCA_PASSWORD,
+    compute_ca_bundle_pem, compute_ca_fingerprints,
 };
 use crate::commands::openbao_auth::{authenticate_openbao_client, resolve_runtime_auth};
 use crate::i18n::Messages;
@@ -29,8 +29,6 @@ const SERVICE_SECRET_ID_KEY: &str = "secret_id";
 const SERVICE_EAB_KID_KEY: &str = "kid";
 const SERVICE_EAB_HMAC_KEY: &str = "hmac";
 const SERVICE_RESPONDER_HMAC_KEY: &str = "hmac";
-const CA_BUNDLE_PEM_KEY: &str = "ca_bundle_pem";
-const SERVICE_TRUST_KV_SUFFIX: &str = "trust";
 const OPENBAO_AGENT_STEPCA_CONTAINER: &str = "bootroot-openbao-agent-stepca";
 const OPENBAO_AGENT_RESPONDER_CONTAINER: &str = "bootroot-openbao-agent-responder";
 const RENDERED_FILE_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -83,6 +81,7 @@ struct RotateContext {
     compose_file: PathBuf,
     state: StateFile,
     paths: StatePaths,
+    state_dir: PathBuf,
 }
 
 pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result<()> {
@@ -112,6 +111,9 @@ pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result
         .clone()
         .unwrap_or_else(|| state.secrets_dir());
     let paths = StatePaths::new(secrets_dir.clone());
+    let state_dir = state_path
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
     let runtime_auth = resolve_runtime_auth(&args.runtime_auth, true, messages)?;
     let mut ctx = RotateContext {
         openbao_url,
@@ -119,6 +121,7 @@ pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result
         compose_file: args.compose.compose_file.clone(),
         state,
         paths,
+        state_dir,
     };
     let mut client = OpenBaoClient::new(&ctx.openbao_url)
         .with_context(|| messages.error_openbao_client_create_failed())?;
@@ -862,43 +865,36 @@ async fn rotate_trust_sync(
 ) -> Result<()> {
     confirm_action(messages.prompt_rotate_trust_sync(), auto_confirm, messages)?;
 
+    if crate::commands::trust::rotation_in_progress(&ctx.state_dir) {
+        eprintln!("{}", messages.warning_rotation_in_progress());
+        anyhow::bail!(messages.error_trust_sync_blocked_by_rotation());
+    }
+
     let secrets_dir = ctx.paths.secrets_dir();
     let fingerprints = compute_ca_fingerprints(secrets_dir, messages).await?;
     let ca_bundle_pem = compute_ca_bundle_pem(secrets_dir, messages).await?;
 
-    // Write global CA trust KV
-    client
-        .write_kv(
-            &ctx.kv_mount,
-            PATH_CA_TRUST,
-            serde_json::json!({ CA_TRUST_KEY: fingerprints, CA_BUNDLE_PEM_KEY: ca_bundle_pem }),
-        )
-        .await
-        .with_context(|| messages.error_openbao_kv_write_failed())?;
-
-    // Sync trust to each service KV
-    let service_names: Vec<String> = ctx
-        .state
-        .services
-        .values()
-        .map(|entry| entry.service_name.clone())
-        .collect();
-    for service_name in &service_names {
-        client
-            .write_kv(
-                &ctx.kv_mount,
-                &format!("{SERVICE_KV_BASE}/{service_name}/{SERVICE_TRUST_KV_SUFFIX}"),
-                serde_json::json!({ CA_TRUST_KEY: fingerprints, CA_BUNDLE_PEM_KEY: ca_bundle_pem }),
-            )
-            .await
-            .with_context(|| messages.error_openbao_kv_write_failed())?;
-    }
+    crate::commands::trust::write_trust_to_openbao(
+        client,
+        &ctx.kv_mount,
+        &ctx.state.services,
+        &fingerprints,
+        &ca_bundle_pem,
+        messages,
+    )
+    .await?;
 
     println!("{}", messages.rotate_summary_title());
     println!(
         "{}",
         messages.rotate_summary_trust_sync_global(&fingerprints.join(", "))
     );
+    let service_names: Vec<String> = ctx
+        .state
+        .services
+        .values()
+        .map(|entry| entry.service_name.clone())
+        .collect();
     for service_name in &service_names {
         println!(
             "{}",

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1289,16 +1289,27 @@ async fn write_service_kv_secrets(
         )
         .await
         .with_context(|| messages.error_openbao_kv_write_failed())?;
-    let mut trust_payload = serde_json::json!({
-        CA_TRUST_KEY: &material.trusted_ca_sha256,
-    });
     if let Some(bundle) = material.ca_bundle_pem.as_deref() {
-        trust_payload[SERVICE_CA_BUNDLE_PEM_KEY] = serde_json::Value::String(bundle.to_string());
+        crate::commands::trust::write_service_trust(
+            client,
+            kv_mount,
+            service_name,
+            &material.trusted_ca_sha256,
+            bundle,
+            messages,
+        )
+        .await?;
+    } else {
+        // Legacy fallback for installations before ca_bundle_pem was introduced.
+        client
+            .write_kv(
+                kv_mount,
+                &format!("{base}/trust"),
+                serde_json::json!({ CA_TRUST_KEY: &material.trusted_ca_sha256 }),
+            )
+            .await
+            .with_context(|| messages.error_openbao_kv_write_failed())?;
     }
-    client
-        .write_kv(kv_mount, &format!("{base}/trust"), trust_payload)
-        .await
-        .with_context(|| messages.error_openbao_kv_write_failed())?;
     Ok(())
 }
 

--- a/src/commands/trust.rs
+++ b/src/commands/trust.rs
@@ -1,0 +1,79 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use bootroot::openbao::OpenBaoClient;
+
+use crate::commands::init::{CA_TRUST_KEY, PATH_CA_TRUST};
+use crate::i18n::Messages;
+use crate::state::ServiceEntry;
+
+const CA_BUNDLE_PEM_KEY: &str = "ca_bundle_pem";
+const SERVICE_KV_BASE: &str = "bootroot/services";
+const SERVICE_TRUST_KV_SUFFIX: &str = "trust";
+const ROTATION_STATE_FILENAME: &str = "rotation-state.json";
+
+/// Writes trust payload (fingerprints and CA bundle PEM) to the `OpenBao`
+/// global CA path and all per-service trust paths.
+pub(crate) async fn write_trust_to_openbao(
+    client: &OpenBaoClient,
+    kv_mount: &str,
+    services: &BTreeMap<String, ServiceEntry>,
+    fingerprints: &[String],
+    ca_bundle_pem: &str,
+    messages: &Messages,
+) -> Result<()> {
+    client
+        .write_kv(
+            kv_mount,
+            PATH_CA_TRUST,
+            serde_json::json!({
+                CA_TRUST_KEY: fingerprints,
+                CA_BUNDLE_PEM_KEY: ca_bundle_pem,
+            }),
+        )
+        .await
+        .with_context(|| messages.error_openbao_kv_write_failed())?;
+
+    for entry in services.values() {
+        write_service_trust(
+            client,
+            kv_mount,
+            &entry.service_name,
+            fingerprints,
+            ca_bundle_pem,
+            messages,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Writes trust payload to a single service's trust path in `OpenBao`.
+pub(crate) async fn write_service_trust(
+    client: &OpenBaoClient,
+    kv_mount: &str,
+    service_name: &str,
+    fingerprints: &[String],
+    ca_bundle_pem: &str,
+    messages: &Messages,
+) -> Result<()> {
+    client
+        .write_kv(
+            kv_mount,
+            &format!("{SERVICE_KV_BASE}/{service_name}/{SERVICE_TRUST_KV_SUFFIX}"),
+            serde_json::json!({
+                CA_TRUST_KEY: fingerprints,
+                CA_BUNDLE_PEM_KEY: ca_bundle_pem,
+            }),
+        )
+        .await
+        .with_context(|| messages.error_openbao_kv_write_failed())
+}
+
+/// Returns `true` if `rotation-state.json` exists in the given directory,
+/// indicating that a CA key rotation is in progress.
+pub(crate) fn rotation_in_progress(state_dir: &Path) -> bool {
+    state_dir.join(ROTATION_STATE_FILENAME).exists()
+}

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -281,6 +281,8 @@ pub(super) static STRINGS: Strings = Strings {
     rotate_summary_force_reissue_deleted: "- {service_name}: cert/key deleted ({cert_path}, {key_path})",
     rotate_summary_force_reissue_local_signal: "- {service_name}: signaled bootroot-agent for renewal",
     rotate_summary_force_reissue_remote_hint: "- {service_name}: run `bootroot-remote bootstrap` on the service host to reissue",
+    warning_rotation_in_progress: "WARNING: rotation-state.json exists, indicating a CA key rotation is in progress.",
+    error_trust_sync_blocked_by_rotation: "trust-sync is blocked while CA key rotation is in progress; complete or abort the rotation first",
     summary_responder_check_ok: "- responder check: ok",
     summary_responder_check_skipped: "- responder check: skipped",
     summary_db_check_ok: "- db check: ok",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -281,6 +281,8 @@ pub(super) static STRINGS: Strings = Strings {
     rotate_summary_force_reissue_deleted: "- {service_name}: cert/key 삭제 ({cert_path}, {key_path})",
     rotate_summary_force_reissue_local_signal: "- {service_name}: 인증서 갱신을 위해 bootroot-agent에 시그널 전송",
     rotate_summary_force_reissue_remote_hint: "- {service_name}: 서비스 머신에서 `bootroot-remote bootstrap`을 실행하여 재발급하세요",
+    warning_rotation_in_progress: "경고: rotation-state.json이 존재합니다. CA 키 교체가 진행 중입니다.",
+    error_trust_sync_blocked_by_rotation: "CA 키 교체가 진행 중일 때 trust-sync가 차단됩니다. 먼저 교체를 완료하거나 중단하세요",
     summary_responder_check_ok: "- responder 점검: ok",
     summary_responder_check_skipped: "- responder 점검: 생략",
     summary_db_check_ok: "- DB 점검: ok",

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -315,6 +315,8 @@ pub(crate) struct Strings {
     pub(crate) rotate_summary_force_reissue_deleted: &'static str,
     pub(crate) rotate_summary_force_reissue_local_signal: &'static str,
     pub(crate) rotate_summary_force_reissue_remote_hint: &'static str,
+    pub(crate) warning_rotation_in_progress: &'static str,
+    pub(crate) error_trust_sync_blocked_by_rotation: &'static str,
     pub(crate) summary_responder_check_ok: &'static str,
     pub(crate) summary_responder_check_skipped: &'static str,
     pub(crate) summary_db_check_ok: &'static str,
@@ -1805,6 +1807,14 @@ impl Messages {
             self.strings().rotate_summary_force_reissue_remote_hint,
             &[("service_name", service_name)],
         )
+    }
+
+    pub(crate) fn warning_rotation_in_progress(&self) -> &'static str {
+        self.strings().warning_rotation_in_progress
+    }
+
+    pub(crate) fn error_trust_sync_blocked_by_rotation(&self) -> &'static str {
+        self.strings().error_trust_sync_blocked_by_rotation
     }
 
     pub(crate) fn summary_responder_check_ok(&self) -> &'static str {

--- a/tests/bootroot_rotate.rs
+++ b/tests/bootroot_rotate.rs
@@ -982,19 +982,21 @@ async fn test_rotate_trust_sync_writes_global_and_per_service() {
         .respond_with(ResponseTemplate::new(200))
         .mount(&openbao)
         .await;
-    Mock::given(method("POST"))
+    let global_mock = Mock::given(method("POST"))
         .and(path("/v1/secret/data/bootroot/ca"))
         .and(header("X-Vault-Token", support::ROOT_TOKEN))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-        .mount(&openbao)
+        .expect(1)
+        .mount_as_scoped(&openbao)
         .await;
-    Mock::given(method("POST"))
+    let service_mock = Mock::given(method("POST"))
         .and(path(format!(
             "/v1/secret/data/bootroot/services/{SERVICE_NAME}/trust"
         )))
         .and(header("X-Vault-Token", support::ROOT_TOKEN))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
-        .mount(&openbao)
+        .expect(1)
+        .mount_as_scoped(&openbao)
         .await;
 
     let output = Command::new(env!("CARGO_BIN_EXE_bootroot"))
@@ -1018,6 +1020,14 @@ async fn test_rotate_trust_sync_writes_global_and_per_service() {
         "stdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(stdout.contains("CA trust updated"));
+    assert!(
+        stdout.contains(SERVICE_NAME),
+        "stdout should mention the service name: {stdout}"
+    );
+
+    // Verify mock expectations: global and per-service writes each called exactly once.
+    drop(global_mock);
+    drop(service_mock);
 }
 
 #[cfg(unix)]
@@ -1544,4 +1554,57 @@ fn mock_pg_read_payload(stream: &mut std::net::TcpStream) -> Vec<u8> {
         return Vec::new();
     }
     payload
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_rotate_trust_sync_blocked_by_rotation_state() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let openbao = MockServer::start().await;
+
+    support::create_secrets_dir(temp_dir.path()).expect("create secrets dir");
+    prepare_app_state(
+        temp_dir.path(),
+        &openbao.uri(),
+        "daemon",
+        "remote-bootstrap",
+    )
+    .expect("prepare state");
+
+    // Simulate an in-progress CA key rotation.
+    fs::write(
+        temp_dir.path().join("rotation-state.json"),
+        r#"{"mode":"intermediate-only","phase":3}"#,
+    )
+    .expect("write rotation-state.json");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/sys/health"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&openbao)
+        .await;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "rotate",
+            "--openbao-url",
+            &openbao.uri(),
+            "--root-token",
+            support::ROOT_TOKEN,
+            "--yes",
+            "trust-sync",
+        ])
+        .output()
+        .expect("run rotate trust-sync");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "trust-sync should fail when rotation-state.json exists; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("rotation-state.json") || stderr.contains("trust-sync is blocked"),
+        "stderr should mention rotation conflict: {stderr}"
+    );
 }


### PR DESCRIPTION
## Summary

- Introduce `src/commands/trust.rs` with `write_trust_to_openbao` and `write_service_trust` as the single path for all trust KV writes to OpenBao.
- Refactor `rotate trust-sync` and `service add` to delegate trust writes to the shared module, eliminating duplicated logic that could drift.
- Add `rotation_in_progress` guard: when `rotation-state.json` exists, `trust-sync` prints a warning and aborts to prevent premature removal of transitional fingerprints during CA key rotation.
- Strengthen the existing trust-sync test with `expect(1)` mock call count verification and add a dedicated conflict detection test.

## Test plan

- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — passes
- [x] `cargo test` — all existing tests pass, including `test_rotate_trust_sync_writes_global_and_per_service`
- [x] New `test_rotate_trust_sync_blocked_by_rotation_state` passes
- [ ] CI `check` job
- [x] CI `test-core` job
- [x] CI `test-docker-e2e-matrix` job (trust-sync and service-add paths exercised)

Closes #328