### PR TITLE
Deduplicate shared logic across modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls",
+ "toml_edit 0.22.27",
  "tracing",
  "tracing-subscriber",
  "wiremock",
@@ -1460,7 +1461,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -2255,10 +2256,16 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -2271,12 +2278,24 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -2289,6 +2308,12 @@ checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1"
 thiserror = "2"
 time = "0.3"
 tokio = { version = "1", features = ["fs", "macros", "process", "rt-multi-thread", "signal", "time"] }
+toml_edit = "0.22"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 x509-parser = "0.18"

--- a/src/bin/bootroot-remote.rs
+++ b/src/bin/bootroot-remote.rs
@@ -530,7 +530,7 @@ async fn apply_agent_config_updates(
     let agent_config = match fs::read_to_string(&args.agent_config_path).await {
         Ok(contents) => contents,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            render_agent_config_baseline(args, &profile_paths.cert_path, &profile_paths.key_path)
+            render_agent_config_baseline(args)
         }
         Err(err) => {
             let message = localized(
@@ -550,8 +550,33 @@ async fn apply_agent_config_updates(
             );
         }
     };
+    let acme_pairs = vec![("http_responder_hmac", pulled.responder_hmac.clone())];
+    let hmac_updated =
+        match bootroot::toml_util::upsert_section_keys(&agent_config, "acme", &acme_pairs) {
+            Ok(output) => output,
+            Err(err) => {
+                let msg = format!("agent config TOML parse error: {err}");
+                return (
+                    ApplyItemSummary::failed(msg.clone()),
+                    ApplyItemSummary::failed(msg),
+                );
+            }
+        };
+    let trust_pairs =
+        build_trust_updates(&pulled.trusted_ca_sha256, args.ca_bundle_path.as_deref());
+    let trust_updated =
+        match bootroot::toml_util::upsert_section_keys(&hmac_updated, "trust", &trust_pairs) {
+            Ok(output) => output,
+            Err(err) => {
+                let msg = format!("agent config TOML parse error: {err}");
+                return (
+                    ApplyItemSummary::failed(msg.clone()),
+                    ApplyItemSummary::failed(msg),
+                );
+            }
+        };
     let with_profile = upsert_managed_profile_block(
-        &agent_config,
+        &trust_updated,
         &args.service_name,
         &render_managed_profile_block(
             &args.service_name,
@@ -562,15 +587,9 @@ async fn apply_agent_config_updates(
         ),
     );
 
-    let acme_pairs = vec![("http_responder_hmac", pulled.responder_hmac.clone())];
-    let hmac_updated = upsert_toml_section_keys(&with_profile, "acme", &acme_pairs);
-    let trust_pairs =
-        build_trust_updates(&pulled.trusted_ca_sha256, args.ca_bundle_path.as_deref());
-    let trust_updated = upsert_toml_section_keys(&hmac_updated, "trust", &trust_pairs);
-
-    let responder_changed = hmac_updated != with_profile;
+    let responder_changed = hmac_updated != agent_config;
     let trust_changed = trust_updated != hmac_updated;
-    let profile_changed = with_profile != agent_config;
+    let profile_changed = with_profile != trust_updated;
 
     let mut responder_hmac_status = ApplyItemSummary::applied(if responder_changed {
         ApplyStatus::Applied
@@ -583,7 +602,7 @@ async fn apply_agent_config_updates(
         ApplyStatus::Unchanged
     });
 
-    if trust_updated != agent_config {
+    if with_profile != agent_config {
         if let Some(parent) = args.agent_config_path.parent()
             && let Err(err) = fs_util::ensure_secrets_dir(parent).await
         {
@@ -603,7 +622,7 @@ async fn apply_agent_config_updates(
                 ApplyItemSummary::failed(message),
             );
         }
-        if let Err(err) = fs::write(&args.agent_config_path, &trust_updated).await {
+        if let Err(err) = fs::write(&args.agent_config_path, &with_profile).await {
             let message = localized(
                 lang,
                 &format!(
@@ -644,7 +663,7 @@ async fn apply_agent_config_updates(
             return (responder_hmac_status, trust_sync_status);
         }
     }
-    if let Err(err) = write_openbao_agent_artifacts(args, &trust_updated, lang).await {
+    if let Err(err) = write_openbao_agent_artifacts(args, &with_profile, lang).await {
         let message = localized(
             lang,
             &format!("openbao agent setup failed: {err}"),
@@ -958,63 +977,6 @@ async fn write_eab_file(path: &Path, kid: &str, hmac: &str) -> Result<ApplyStatu
     write_secret_file(path, &payload).await
 }
 
-fn upsert_toml_section_keys(contents: &str, section: &str, pairs: &[(&str, String)]) -> String {
-    let mut output = String::new();
-    let mut section_found = false;
-    let mut in_section = false;
-    let mut seen_keys = std::collections::BTreeSet::new();
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if is_section_header(trimmed) {
-            if in_section {
-                output.push_str(&render_missing_keys(pairs, &seen_keys));
-            }
-            in_section = trimmed == format!("[{section}]");
-            if in_section {
-                section_found = true;
-                seen_keys.clear();
-            }
-            output.push_str(line);
-            output.push('\n');
-            continue;
-        }
-
-        if in_section
-            && let Some((key, indent)) = parse_key_line(line, pairs)
-            && let Some(value) = pairs
-                .iter()
-                .find(|(name, _)| *name == key)
-                .map(|(_, value)| value.as_str())
-        {
-            output.push_str(&format_key_line(&indent, key, value));
-            seen_keys.insert(key.to_string());
-            continue;
-        }
-
-        output.push_str(line);
-        output.push('\n');
-    }
-
-    if in_section {
-        output.push_str(&render_missing_keys(pairs, &seen_keys));
-    }
-
-    if !section_found {
-        if !output.ends_with('\n') {
-            output.push('\n');
-        }
-        output.push('[');
-        output.push_str(section);
-        output.push_str("]\n");
-        for (key, value) in pairs {
-            output.push_str(&format_key_line("", key, value));
-        }
-    }
-
-    output
-}
-
 struct ProfilePaths {
     cert_path: PathBuf,
     key_path: PathBuf,
@@ -1040,14 +1002,7 @@ fn resolve_profile_paths(args: &BootstrapArgs) -> ProfilePaths {
     }
 }
 
-fn render_agent_config_baseline(args: &BootstrapArgs, cert_path: &Path, key_path: &Path) -> String {
-    let profile_block = render_managed_profile_block(
-        &args.service_name,
-        &args.profile_instance_id,
-        &args.profile_hostname,
-        cert_path,
-        key_path,
-    );
+fn render_agent_config_baseline(args: &BootstrapArgs) -> String {
     format!(
         "email = \"{email}\"\n\
 server = \"{server}\"\n\
@@ -1061,8 +1016,7 @@ poll_interval_secs = 2\n\
 http_responder_url = \"{responder_url}\"\n\
 http_responder_hmac = \"\"\n\
 http_responder_timeout_secs = 5\n\
-http_responder_token_ttl_secs = 300\n\n\
-{profile_block}",
+http_responder_token_ttl_secs = 300\n",
         email = args.agent_email,
         server = args.agent_server,
         domain = args.agent_domain,
@@ -1130,10 +1084,14 @@ fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> St
          {{{{ .Data.data.hmac }}}}\
          {{{{ end }}}}"
     );
-    let acme_pairs = vec![("http_responder_hmac", hmac_template)];
-    let with_hmac = upsert_toml_section_keys(contents, "acme", &acme_pairs);
+    let with_hmac = replace_key_line_in_section(
+        contents,
+        "acme",
+        "http_responder_hmac",
+        &format!("http_responder_hmac = \"{hmac_template}\""),
+    );
 
-    let without_eab = remove_toml_sections(&with_hmac, &["eab", "profiles.eab"]);
+    let without_eab = remove_line_sections(&with_hmac, &["eab", "profiles.eab"]);
 
     let trust_template_line = format!(
         "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
@@ -1163,7 +1121,11 @@ fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> St
     result
 }
 
-fn remove_toml_sections(contents: &str, sections: &[&str]) -> String {
+/// Removes sections from pseudo-TOML content using line-based matching.
+///
+/// Used for Go template (ctmpl) files where the content is not valid
+/// TOML and cannot be parsed by `toml_edit`.
+fn remove_line_sections(contents: &str, sections: &[&str]) -> String {
     let mut output = String::new();
     let mut skip = false;
 
@@ -1323,41 +1285,6 @@ template {{
     )
 }
 
-fn parse_key_line<'a>(line: &'a str, pairs: &[(&'a str, String)]) -> Option<(&'a str, String)> {
-    for (key, _) in pairs {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with(&format!("{key} =")) || trimmed.starts_with(&format!("{key}=")) {
-            let indent = line
-                .chars()
-                .take_while(|ch| ch.is_whitespace())
-                .collect::<String>();
-            return Some((key, indent));
-        }
-    }
-    None
-}
-
-fn render_missing_keys(
-    pairs: &[(&str, String)],
-    seen_keys: &std::collections::BTreeSet<String>,
-) -> String {
-    let mut output = String::new();
-    for (key, value) in pairs {
-        if !seen_keys.contains(*key) {
-            output.push_str(&format_key_line("", key, value));
-        }
-    }
-    output
-}
-
-fn format_key_line(indent: &str, key: &str, value: &str) -> String {
-    if value.starts_with('[') {
-        format!("{indent}{key} = {value}\n")
-    } else {
-        format!("{indent}{key} = \"{value}\"\n")
-    }
-}
-
 fn is_section_header(value: &str) -> bool {
     value.starts_with('[') && value.ends_with(']')
 }
@@ -1454,19 +1381,24 @@ mod tests {
     #[test]
     fn test_upsert_toml_section_keys_updates_existing_section() {
         let input = "[acme]\nhttp_responder_hmac = \"old\"\n";
-        let output =
-            upsert_toml_section_keys(input, "acme", &[("http_responder_hmac", "new".to_string())]);
+        let output = bootroot::toml_util::upsert_section_keys(
+            input,
+            "acme",
+            &[("http_responder_hmac", "new".to_string())],
+        )
+        .unwrap();
         assert!(output.contains("http_responder_hmac = \"new\""));
     }
 
     #[test]
     fn test_upsert_toml_section_keys_adds_new_section() {
         let input = "[acme]\nhttp_responder_hmac = \"old\"\n";
-        let output = upsert_toml_section_keys(
+        let output = bootroot::toml_util::upsert_section_keys(
             input,
             "trust",
             &[("ca_bundle_path", "certs/ca.pem".to_string())],
-        );
+        )
+        .unwrap();
         assert!(output.contains("[trust]"));
         assert!(output.contains("ca_bundle_path = \"certs/ca.pem\""));
     }

--- a/src/commands/init/mod.rs
+++ b/src/commands/init/mod.rs
@@ -10,8 +10,9 @@ pub(crate) use constants::openbao_constants::{
 pub(crate) use constants::{
     CA_CERTS_DIR, CA_INTERMEDIATE_CERT_FILENAME, CA_ROOT_CERT_FILENAME, CA_TRUST_KEY,
     DEFAULT_COMPOSE_FILE, DEFAULT_KV_MOUNT, DEFAULT_OPENBAO_URL, DEFAULT_SECRETS_DIR,
-    DEFAULT_STEPCA_PROVISIONER, DEFAULT_STEPCA_URL,
+    DEFAULT_STEPCA_PROVISIONER, DEFAULT_STEPCA_URL, SECRET_BYTES,
 };
+pub(crate) use paths::to_container_path;
 pub(crate) use steps::{
     compute_ca_bundle_pem, compute_ca_fingerprints, read_ca_cert_fingerprint, run_init,
 };

--- a/src/commands/init/paths.rs
+++ b/src/commands/init/paths.rs
@@ -22,15 +22,22 @@ pub(crate) struct OpenBaoAgentPaths {
     pub(crate) compose_override_path: Option<PathBuf>,
 }
 
+/// Resolves a host path to its container-internal equivalent.
+///
+/// Strips the `secrets_dir` prefix and prepends `container_mount`.
 pub(crate) fn to_container_path(
     secrets_dir: &Path,
     path: &Path,
-    messages: &Messages,
+    container_mount: &str,
 ) -> Result<String> {
-    let relative = path
-        .strip_prefix(secrets_dir)
-        .with_context(|| messages.error_resolve_path_failed(&path.display().to_string()))?;
-    Ok(format!("/openbao/secrets/{}", relative.to_string_lossy()))
+    let relative = path.strip_prefix(secrets_dir).with_context(|| {
+        format!(
+            "path {} is not under secrets dir {}",
+            path.display(),
+            secrets_dir.display()
+        )
+    })?;
+    Ok(format!("{container_mount}/{}", relative.to_string_lossy()))
 }
 
 pub(crate) fn compose_has_responder(compose_file: &Path, messages: &Messages) -> Result<bool> {

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -449,28 +449,22 @@ async fn write_openbao_agent_files(
 
     let stepca_agent_config = stepca_dir.join(OPENBAO_AGENT_CONFIG_NAME);
     let responder_agent_config = responder_dir.join(OPENBAO_AGENT_CONFIG_NAME);
-    let password_template = to_container_path(
-        secrets_dir,
-        &stepca_templates.password_template_path,
-        messages,
-    )?;
-    let ca_json_template = to_container_path(
-        secrets_dir,
-        &stepca_templates.ca_json_template_path,
-        messages,
-    )?;
-    let responder_template = to_container_path(secrets_dir, responder_template, messages)?;
-    let password_output =
-        to_container_path(secrets_dir, &secrets_dir.join("password.txt"), messages)?;
+    let mount = "/openbao/secrets";
+    let password_template =
+        to_container_path(secrets_dir, &stepca_templates.password_template_path, mount)?;
+    let ca_json_template =
+        to_container_path(secrets_dir, &stepca_templates.ca_json_template_path, mount)?;
+    let responder_template = to_container_path(secrets_dir, responder_template, mount)?;
+    let password_output = to_container_path(secrets_dir, &secrets_dir.join("password.txt"), mount)?;
     let ca_json_output = to_container_path(
         secrets_dir,
         &secrets_dir.join("config").join("ca.json"),
-        messages,
+        mount,
     )?;
     let responder_output = to_container_path(
         secrets_dir,
         &secrets_dir.join("responder").join("responder.toml"),
-        messages,
+        mount,
     )?;
     let stepca_config = build_openbao_agent_config(
         openbao_addr,
@@ -1194,7 +1188,8 @@ fn resolve_secret(
         return Ok(value);
     }
     if auto_generate {
-        return generate_secret(messages);
+        return bootroot::utils::generate_secret(SECRET_BYTES)
+            .with_context(|| messages.error_generate_secret_failed());
     }
     prompt_text(&format!("{label}: "), messages)
 }
@@ -1493,7 +1488,8 @@ fn resolve_db_provision_inputs(args: &InitArgs, messages: &Messages) -> Result<D
     let db_password = if let Some(value) = args.db_password.clone() {
         value
     } else if args.auto_generate {
-        generate_secret(messages)?
+        bootroot::utils::generate_secret(SECRET_BYTES)
+            .with_context(|| messages.error_generate_secret_failed())?
     } else {
         prompt_text(&format!("{}: ", messages.prompt_db_password()), messages)?
     };
@@ -1559,18 +1555,6 @@ fn build_dsn_from_env() -> Option<String> {
     let port = env::var("POSTGRES_PORT").unwrap_or_else(|_| "5432".to_string());
     let dsn = format!("postgresql://{user}:{password}@{host}:{port}/{db}?sslmode=disable");
     Some(dsn)
-}
-
-fn generate_secret(messages: &Messages) -> Result<String> {
-    use base64::Engine as _;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use ring::rand::{SecureRandom, SystemRandom};
-
-    let mut buffer = vec![0u8; SECRET_BYTES];
-    let rng = SystemRandom::new();
-    rng.fill(&mut buffer)
-        .map_err(|_| anyhow::anyhow!(messages.error_generate_secret_failed()))?;
-    Ok(URL_SAFE_NO_PAD.encode(buffer))
 }
 
 fn build_policy_map(kv_mount: &str) -> BTreeMap<String, String> {

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -17,8 +17,8 @@ use crate::commands::guardrails::{ensure_postgres_localhost_binding, ensure_sing
 use crate::commands::infra::run_docker;
 use crate::commands::init::{
     CA_CERTS_DIR, CA_INTERMEDIATE_CERT_FILENAME, CA_ROOT_CERT_FILENAME, PATH_AGENT_EAB,
-    PATH_RESPONDER_HMAC, PATH_STEPCA_DB, PATH_STEPCA_PASSWORD, compute_ca_bundle_pem,
-    compute_ca_fingerprints, read_ca_cert_fingerprint,
+    PATH_RESPONDER_HMAC, PATH_STEPCA_DB, PATH_STEPCA_PASSWORD, SECRET_BYTES, compute_ca_bundle_pem,
+    compute_ca_fingerprints, read_ca_cert_fingerprint, to_container_path,
 };
 use crate::commands::openbao_auth::{authenticate_openbao_client, resolve_runtime_auth};
 use crate::commands::openbao_unseal::read_unseal_keys_from_file;
@@ -28,7 +28,6 @@ use crate::commands::trust::{
 };
 use crate::i18n::Messages;
 use crate::state::{DeliveryMode, DeployType, ServiceEntry, StateFile};
-const SECRET_BYTES: usize = 32;
 const OPENBAO_AGENT_CONTAINER_PREFIX: &str = "bootroot-openbao-agent";
 const ROLE_ID_FILENAME: &str = "role_id";
 const SERVICE_KV_BASE: &str = "bootroot/services";
@@ -218,7 +217,8 @@ async fn rotate_stepca_password(
 ) -> Result<()> {
     let new_password = match args.new_password.clone() {
         Some(value) => value,
-        None => generate_secret(messages)?,
+        None => bootroot::utils::generate_secret(SECRET_BYTES)
+            .with_context(|| messages.error_generate_secret_failed())?,
     };
     confirm_action(
         messages.prompt_rotate_stepca_password(),
@@ -323,7 +323,8 @@ async fn rotate_db(
     ensure_single_host_db_host(&admin.host, messages)?;
     let db_password = match args.password.clone() {
         Some(value) => value,
-        None => generate_secret(messages)?,
+        None => bootroot::utils::generate_secret(SECRET_BYTES)
+            .with_context(|| messages.error_generate_secret_failed())?,
     };
     let ca_json_path = ctx.paths.ca_json();
     let current_dsn = read_ca_json_dsn(&ca_json_path, messages)?;
@@ -397,7 +398,8 @@ async fn rotate_responder_hmac(
 
     let hmac = match args.hmac.clone() {
         Some(value) => value,
-        None => generate_secret(messages)?,
+        None => bootroot::utils::generate_secret(SECRET_BYTES)
+            .with_context(|| messages.error_generate_secret_failed())?,
     };
     client
         .write_kv(
@@ -859,11 +861,11 @@ fn change_stepca_passphrase(
         "step".to_string(),
         "crypto".to_string(),
         "change-pass".to_string(),
-        to_container_path(secrets_dir, key_path)?,
+        to_container_path(secrets_dir, key_path, "/home/step")?,
         "--password-file".to_string(),
-        to_container_path(secrets_dir, current_password)?,
+        to_container_path(secrets_dir, current_password, "/home/step")?,
         "--new-password-file".to_string(),
-        to_container_path(secrets_dir, new_password)?,
+        to_container_path(secrets_dir, new_password, "/home/step")?,
         "-f".to_string(),
     ];
     let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -940,25 +942,6 @@ async fn write_secret_file(path: &Path, contents: &str, messages: &Messages) -> 
         .with_context(|| messages.error_write_file_failed(&path.display().to_string()))?;
     fs_util::set_key_permissions(path).await?;
     Ok(())
-}
-
-fn generate_secret(messages: &Messages) -> Result<String> {
-    use base64::Engine as _;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use ring::rand::{SecureRandom, SystemRandom};
-
-    let mut buffer = vec![0u8; SECRET_BYTES];
-    let rng = SystemRandom::new();
-    rng.fill(&mut buffer)
-        .map_err(|_| anyhow::anyhow!(messages.error_generate_secret_failed()))?;
-    Ok(URL_SAFE_NO_PAD.encode(buffer))
-}
-
-fn to_container_path(secrets_dir: &Path, path: &Path) -> Result<String> {
-    let relative = path
-        .strip_prefix(secrets_dir)
-        .with_context(|| format!("Path {} is not under secrets dir", path.display()))?;
-    Ok(format!("/home/step/{}", relative.to_string_lossy()))
 }
 
 async fn write_secret_id_atomic(path: &Path, value: &str, messages: &Messages) -> Result<()> {

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -552,7 +552,7 @@ async fn apply_local_service_configs(
             .unwrap_or(Path::new("certs"))
             .join("ca-bundle.pem");
         let trust_updates = build_trust_updates(&material.trusted_ca_sha256, &ca_bundle_path);
-        next = upsert_toml_section_keys(&next, "trust", &trust_updates);
+        next = bootroot::toml_util::upsert_section_keys(&next, "trust", &trust_updates)?;
         if let Some(bundle_pem) = material.ca_bundle_pem.as_deref() {
             write_local_ca_bundle(&ca_bundle_path, bundle_pem, messages).await?;
         }
@@ -699,101 +699,8 @@ fn build_trust_updates(
     ]
 }
 
-fn upsert_toml_section_keys(contents: &str, section: &str, pairs: &[(&str, String)]) -> String {
-    let mut output = String::new();
-    let mut section_found = false;
-    let mut in_section = false;
-    let mut seen_keys = std::collections::BTreeSet::new();
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if is_section_header(trimmed) {
-            if in_section {
-                output.push_str(&render_missing_keys(pairs, &seen_keys));
-            }
-            in_section = trimmed == format!("[{section}]");
-            if in_section {
-                section_found = true;
-                seen_keys.clear();
-            }
-            output.push_str(line);
-            output.push('\n');
-            continue;
-        }
-
-        if in_section
-            && let Some((key, indent)) = parse_key_line(line, pairs)
-            && let Some(value) = pairs
-                .iter()
-                .find(|(name, _)| *name == key)
-                .map(|(_, value)| value.as_str())
-        {
-            output.push_str(&format_key_line(&indent, key, value));
-            seen_keys.insert(key.to_string());
-            continue;
-        }
-
-        output.push_str(line);
-        output.push('\n');
-    }
-
-    if in_section {
-        output.push_str(&render_missing_keys(pairs, &seen_keys));
-    }
-
-    if !section_found {
-        if !output.ends_with('\n') {
-            output.push('\n');
-        }
-        output.push('[');
-        output.push_str(section);
-        output.push_str("]\n");
-        for (key, value) in pairs {
-            output.push_str(&format_key_line("", key, value));
-        }
-    }
-
-    output
-}
-
 fn is_section_header(line: &str) -> bool {
     line.starts_with('[') && line.ends_with(']')
-}
-
-fn parse_key_line<'a>(line: &'a str, pairs: &[(&'a str, String)]) -> Option<(&'a str, String)> {
-    for (key, _) in pairs {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with(&format!("{key} =")) || trimmed.starts_with(&format!("{key}=")) {
-            let indent = line
-                .chars()
-                .take_while(|ch| ch.is_whitespace())
-                .collect::<String>();
-            return Some((key, indent));
-        }
-    }
-    None
-}
-
-fn format_key_line(indent: &str, key: &str, value: &str) -> String {
-    let rendered = if value.starts_with('[') {
-        value.to_string()
-    } else {
-        format!("\"{value}\"")
-    };
-    format!("{indent}{key} = {rendered}\n")
-}
-
-fn render_missing_keys(
-    pairs: &[(&str, String)],
-    seen_keys: &std::collections::BTreeSet<String>,
-) -> String {
-    let mut extra = String::new();
-    for (key, value) in pairs {
-        if !seen_keys.contains(*key) {
-            extra.push_str(&format_key_line("", key, value));
-        }
-    }
-    extra
 }
 
 fn render_openbao_agent_config(
@@ -852,10 +759,14 @@ fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> St
          {{{{ .Data.data.hmac }}}}\
          {{{{ end }}}}"
     );
-    let acme_pairs = vec![("http_responder_hmac", hmac_template)];
-    let with_hmac = upsert_toml_section_keys(contents, "acme", &acme_pairs);
+    let with_hmac = replace_key_line_in_section(
+        contents,
+        "acme",
+        "http_responder_hmac",
+        &format!("http_responder_hmac = \"{hmac_template}\""),
+    );
 
-    let without_eab = remove_toml_sections(&with_hmac, &["eab", "profiles.eab"]);
+    let without_eab = remove_line_sections(&with_hmac, &["eab", "profiles.eab"]);
 
     let trust_template_line = format!(
         "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
@@ -889,7 +800,11 @@ fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> St
     result
 }
 
-fn remove_toml_sections(contents: &str, sections: &[&str]) -> String {
+/// Removes sections from pseudo-TOML content using line-based matching.
+///
+/// Used for Go template (ctmpl) files where the content is not valid
+/// TOML and cannot be parsed by `toml_edit`.
+fn remove_line_sections(contents: &str, sections: &[&str]) -> String {
     let mut output = String::new();
     let mut skip = false;
 
@@ -903,9 +818,6 @@ fn remove_toml_sections(contents: &str, sections: &[&str]) -> String {
             }
         }
         if skip {
-            if trimmed.is_empty() {
-                continue;
-            }
             continue;
         }
         output.push_str(line);
@@ -1625,8 +1537,8 @@ mod tests {
             Path::new("certs/ca-bundle.pem"),
         );
         let original = "[acme]\nhttp_responder_hmac = \"old\"\n";
-        let once = upsert_toml_section_keys(original, "trust", &updates);
-        let twice = upsert_toml_section_keys(&once, "trust", &updates);
+        let once = bootroot::toml_util::upsert_section_keys(original, "trust", &updates).unwrap();
+        let twice = bootroot::toml_util::upsert_section_keys(&once, "trust", &updates).unwrap();
 
         assert_eq!(once, twice);
         assert!(once.contains("[trust]"));
@@ -1638,7 +1550,7 @@ mod tests {
     fn test_upsert_toml_section_keys_preserves_existing_unmanaged_lines() {
         let updates = vec![("ca_bundle_path", "certs/ca.pem".to_string())];
         let original = "[trust]\nextra = true\n";
-        let output = upsert_toml_section_keys(original, "trust", &updates);
+        let output = bootroot::toml_util::upsert_section_keys(original, "trust", &updates).unwrap();
 
         assert!(output.contains("extra = true"));
         assert!(output.contains("ca_bundle_path = \"certs/ca.pem\""));

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -494,14 +494,14 @@ async fn set_verify_certificates_true(
             )
         })?;
 
-    let updated = upsert_toml_section_keys(
+    let updated = crate::toml_util::upsert_section_keys(
         &current,
         TRUST_SECTION,
         &[(
             VERIFY_CERTIFICATES_KEY,
             VERIFY_CERTIFICATES_TRUE.to_string(),
         )],
-    );
+    )?;
     if updated != current {
         tokio::fs::write(config_path, updated)
             .await
@@ -535,102 +535,6 @@ async fn set_verify_certificates_true(
         config_path.display()
     );
     Ok(())
-}
-
-fn upsert_toml_section_keys(contents: &str, section: &str, pairs: &[(&str, String)]) -> String {
-    let mut output = String::new();
-    let mut section_found = false;
-    let mut in_section = false;
-    let mut seen_keys = std::collections::BTreeSet::new();
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if is_section_header(trimmed) {
-            if in_section {
-                output.push_str(&render_missing_keys(pairs, &seen_keys));
-            }
-            in_section = trimmed == format!("[{section}]");
-            if in_section {
-                section_found = true;
-                seen_keys.clear();
-            }
-            output.push_str(line);
-            output.push('\n');
-            continue;
-        }
-
-        if in_section
-            && let Some((key, indent)) = parse_key_line(line, pairs)
-            && let Some(value) = pairs
-                .iter()
-                .find(|(name, _)| *name == key)
-                .map(|(_, value)| value.as_str())
-        {
-            output.push_str(&format_key_line(&indent, key, value));
-            seen_keys.insert(key.to_string());
-            continue;
-        }
-
-        output.push_str(line);
-        output.push('\n');
-    }
-
-    if in_section {
-        output.push_str(&render_missing_keys(pairs, &seen_keys));
-    }
-
-    if !section_found {
-        if !output.ends_with('\n') {
-            output.push('\n');
-        }
-        output.push('[');
-        output.push_str(section);
-        output.push_str("]\n");
-        for (key, value) in pairs {
-            output.push_str(&format_key_line("", key, value));
-        }
-    }
-
-    output
-}
-
-fn parse_key_line<'a>(line: &'a str, pairs: &[(&'a str, String)]) -> Option<(&'a str, String)> {
-    for (key, _) in pairs {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with(&format!("{key} =")) || trimmed.starts_with(&format!("{key}=")) {
-            let indent = line
-                .chars()
-                .take_while(|ch| ch.is_whitespace())
-                .collect::<String>();
-            return Some((key, indent));
-        }
-    }
-    None
-}
-
-fn render_missing_keys(
-    pairs: &[(&str, String)],
-    seen_keys: &std::collections::BTreeSet<String>,
-) -> String {
-    let mut output = String::new();
-    for (key, value) in pairs {
-        if !seen_keys.contains(*key) {
-            output.push_str(&format_key_line("", key, value));
-        }
-    }
-    output
-}
-
-fn format_key_line(indent: &str, key: &str, value: &str) -> String {
-    if value.starts_with('[') || value == VERIFY_CERTIFICATES_TRUE {
-        format!("{indent}{key} = {value}\n")
-    } else {
-        format!("{indent}{key} = \"{value}\"\n")
-    }
-}
-
-fn is_section_header(value: &str) -> bool {
-    value.starts_with('[') && value.ends_with(']')
 }
 
 async fn wait_for_shutdown() -> anyhow::Result<()> {
@@ -743,28 +647,30 @@ mod tests {
     #[test]
     fn test_upsert_toml_section_keys_updates_existing_trust_flag() {
         let input = "[trust]\nverify_certificates = false\n";
-        let output = upsert_toml_section_keys(
+        let output = crate::toml_util::upsert_section_keys(
             input,
             TRUST_SECTION,
             &[(
                 VERIFY_CERTIFICATES_KEY,
                 VERIFY_CERTIFICATES_TRUE.to_string(),
             )],
-        );
+        )
+        .unwrap();
         assert!(output.contains("verify_certificates = true"));
     }
 
     #[test]
     fn test_upsert_toml_section_keys_adds_trust_section() {
         let input = "email = \"admin@example.com\"\n";
-        let output = upsert_toml_section_keys(
+        let output = crate::toml_util::upsert_section_keys(
             input,
             TRUST_SECTION,
             &[(
                 VERIFY_CERTIFICATES_KEY,
                 VERIFY_CERTIFICATES_TRUE.to_string(),
             )],
-        );
+        )
+        .unwrap();
         assert!(output.contains("[trust]"));
         assert!(output.contains("verify_certificates = true"));
     }
@@ -888,10 +794,10 @@ http_responder_hmac = "dev-hmac"
 
         let err = set_verify_certificates_true(&config_path, "test-profile")
             .await
-            .expect_err("must fail when config remains invalid");
+            .expect_err("must fail when config is malformed TOML");
         assert!(
-            err.to_string()
-                .contains("failed to reload hardening config")
+            err.to_string().contains("failed to parse TOML content"),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod fs_util;
 pub mod hooks;
 pub mod openbao;
 pub mod profile;
+pub mod toml_util;
 pub mod utils;
 
 pub use agent_args::Args;

--- a/src/toml_util.rs
+++ b/src/toml_util.rs
@@ -1,0 +1,153 @@
+use anyhow::{Context, Result};
+use toml_edit::{DocumentMut, Item, Value};
+
+/// Updates or inserts key-value pairs in a TOML section, preserving
+/// existing formatting and comments.
+///
+/// Each value string is interpreted as a TOML literal first (handling
+/// booleans and arrays), then falls back to a quoted string.
+///
+/// # Errors
+///
+/// Returns an error if `contents` is not valid TOML.
+pub fn upsert_section_keys(
+    contents: &str,
+    section: &str,
+    pairs: &[(&str, String)],
+) -> Result<String> {
+    let mut doc: DocumentMut = contents.parse().context("failed to parse TOML content")?;
+
+    if doc.get(section).is_none() {
+        doc[section] = Item::Table(toml_edit::Table::new());
+    }
+
+    if let Some(table) = doc[section].as_table_mut() {
+        for (key, raw) in pairs {
+            table[key] = Item::Value(parse_value(raw));
+        }
+    }
+
+    Ok(doc.to_string())
+}
+
+/// Removes one or more TOML sections by name.
+///
+/// Handles both top-level (`"eab"`) and dotted (`"profiles.eab"`)
+/// section names.
+///
+/// # Errors
+///
+/// Returns an error if `contents` is not valid TOML.
+pub fn remove_sections(contents: &str, sections: &[&str]) -> Result<String> {
+    let mut doc: DocumentMut = contents.parse().context("failed to parse TOML content")?;
+
+    for section in sections {
+        if let Some((parent, child)) = section.split_once('.') {
+            if let Some(table) = doc.get_mut(parent).and_then(Item::as_table_mut) {
+                table.remove(child);
+            }
+        } else {
+            doc.remove(section);
+        }
+    }
+
+    Ok(doc.to_string())
+}
+
+/// Parses a raw string as a typed TOML value.
+///
+/// Tries the TOML literal parser first to handle booleans (`true`,
+/// `false`) and arrays (`["a", "b"]`).  Falls back to a plain quoted
+/// string for everything else.
+fn parse_value(raw: &str) -> Value {
+    raw.parse::<Value>().unwrap_or_else(|_| Value::from(raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_updates_existing_key() {
+        let input = "[trust]\nverify_certificates = false\n";
+        let output =
+            upsert_section_keys(input, "trust", &[("verify_certificates", "true".into())]).unwrap();
+        assert!(output.contains("verify_certificates = true"), "{output}");
+    }
+
+    #[test]
+    fn upsert_adds_missing_section() {
+        let input = "email = \"admin@example.com\"\n";
+        let output =
+            upsert_section_keys(input, "trust", &[("verify_certificates", "true".into())]).unwrap();
+        assert!(output.contains("[trust]"), "{output}");
+        assert!(output.contains("verify_certificates = true"), "{output}");
+    }
+
+    #[test]
+    fn upsert_preserves_unmanaged_keys() {
+        let input = "[trust]\nextra = true\n";
+        let output =
+            upsert_section_keys(input, "trust", &[("ca_bundle_path", "certs/ca.pem".into())])
+                .unwrap();
+        assert!(output.contains("extra = true"), "{output}");
+        assert!(
+            output.contains("ca_bundle_path = \"certs/ca.pem\""),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let input = "email = \"admin@example.com\"\n";
+        let pairs = vec![("ca_bundle_path", "certs/ca.pem".into())];
+        let once = upsert_section_keys(input, "trust", &pairs).unwrap();
+        let twice = upsert_section_keys(&once, "trust", &pairs).unwrap();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn upsert_handles_array_value() {
+        let array = r#"["abc", "def"]"#;
+        let output =
+            upsert_section_keys("", "trust", &[("trusted_ca_sha256", array.into())]).unwrap();
+        assert!(
+            output.contains("trusted_ca_sha256 = [\"abc\", \"def\"]"),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn upsert_quotes_string_values() {
+        let output =
+            upsert_section_keys("", "acme", &[("http_responder_hmac", "my-secret".into())])
+                .unwrap();
+        assert!(
+            output.contains("http_responder_hmac = \"my-secret\""),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn upsert_rejects_malformed_toml() {
+        let input = "[broken\nkey = \"value\"\n";
+        let result = upsert_section_keys(input, "trust", &[("key", "val".into())]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn remove_top_level_section() {
+        let input = "[acme]\nurl = \"x\"\n\n[eab]\nkid = \"y\"\n";
+        let output = remove_sections(input, &["eab"]).unwrap();
+        assert!(output.contains("[acme]"), "{output}");
+        assert!(!output.contains("[eab]"), "{output}");
+    }
+
+    #[test]
+    fn remove_dotted_section() {
+        let input = "[profiles]\n\n[profiles.eab]\nkid = \"y\"\n";
+        let output = remove_sections(input, &["profiles.eab"]).unwrap();
+        assert!(output.contains("[profiles]"), "{output}");
+        assert!(!output.contains("kid"), "{output}");
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,26 @@
 use std::future::Future;
 use std::time::Duration;
 
+use anyhow::Result;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ring::rand::{SecureRandom, SystemRandom};
+
 pub const MIN_JITTER_DELAY_NANOS: i128 = 1_000_000_000;
+
+/// Generates a cryptographically secure random secret encoded as
+/// URL-safe base64 (no padding).
+///
+/// # Errors
+///
+/// Returns an error if the system random number generator fails.
+pub fn generate_secret(len: usize) -> Result<String> {
+    let mut buffer = vec![0u8; len];
+    let rng = SystemRandom::new();
+    rng.fill(&mut buffer)
+        .map_err(|_| anyhow::anyhow!("Failed to generate random secret"))?;
+    Ok(URL_SAFE_NO_PAD.encode(buffer))
+}
 
 /// Retries an operation using the provided backoff delays.
 ///


### PR DESCRIPTION
## Summary

Consolidates three categories of duplicated code as part of the pre-release refactoring plan (#343):

- **TOML helpers**: `upsert_toml_section_keys()` and `remove_toml_sections()` were copy-pasted across `daemon.rs`, `service.rs`, and `bootroot-remote.rs` (3 copies each). Replaced with a shared `toml_util` module backed by the `toml_edit` crate, which parses TOML into a document model and preserves formatting/comments. The ctmpl (Go template) builders keep line-based helpers since their intermediate output is intentionally not valid TOML.
- **`generate_secret()`**: Identical function in `init/steps.rs` and `rotate.rs` extracted to `utils.rs` with a length parameter.
- **`to_container_path()`**: Two copies with hardcoded mount prefixes (`/openbao/secrets/` vs `/home/step/`) unified into `init/paths.rs` with the mount prefix as a parameter.

Net result: **-76 lines** (322 added, 398 removed across 12 files).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all unit and integration tests pass, including:
  - `test_bootroot_remote_is_idempotent_on_second_run` (validates toml_edit idempotency)
  - `test_two_node_remote_bootstrap_happy_path` (E2E remote bootstrap flow)
  - `test_set_verify_certificates_true_fails_on_malformed_toml` (validates error propagation for invalid TOML)

Closes #344