### PR TITLE
Unify Docker command build pattern

### DIFF
--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -19,15 +19,24 @@ pub(crate) fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Result<()
         0
     };
 
+    let compose_str = args.compose_file.to_string_lossy();
+    let svc_refs: Vec<&str> = args.services.iter().map(String::as_str).collect();
+
     if loaded_archives == 0 {
-        let pull_args = compose_pull_args(&args.compose_file, &args.services);
-        let pull_args_ref: Vec<&str> = pull_args.iter().map(String::as_str).collect();
-        run_docker(&pull_args_ref, "docker compose pull", messages)?;
+        let mut pull_args: Vec<&str> = vec![
+            "compose",
+            "-f",
+            &compose_str,
+            "pull",
+            "--ignore-pull-failures",
+        ];
+        pull_args.extend(&svc_refs);
+        run_docker(&pull_args, "docker compose pull", messages)?;
     }
 
-    let compose_args = compose_up_args(&args.compose_file, &args.services);
-    let compose_args_ref: Vec<&str> = compose_args.iter().map(String::as_str).collect();
-    run_docker(&compose_args_ref, "docker compose up", messages)?;
+    let mut up_args: Vec<&str> = vec!["compose", "-f", &compose_str, "up", "-d"];
+    up_args.extend(&svc_refs);
+    run_docker(&up_args, "docker compose up", messages)?;
 
     if let Some(path) = args.openbao_unseal_from_file.as_deref() {
         auto_unseal_openbao(path, &args.openbao_url, messages)?;
@@ -36,9 +45,13 @@ pub(crate) fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Result<()
     let readiness = collect_readiness(&args.compose_file, &args.services, messages)?;
 
     for entry in &readiness {
-        let update_args = docker_update_args(&args.restart_policy, &entry.container_id);
-        let update_args_ref: Vec<&str> = update_args.iter().map(String::as_str).collect();
-        run_docker(&update_args_ref, "docker update", messages)?;
+        let update_args = [
+            "update",
+            "--restart",
+            &*args.restart_policy,
+            &*entry.container_id,
+        ];
+        run_docker(&update_args, "docker update", messages)?;
     }
 
     print_readiness_summary(&readiness, messages);
@@ -246,39 +259,6 @@ fn is_image_archive(path: &Path) -> bool {
     name.to_ascii_lowercase().ends_with(".tar.gz")
 }
 
-fn compose_pull_args(compose_file: &Path, services: &[String]) -> Vec<String> {
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().to_string(),
-        "pull".to_string(),
-        "--ignore-pull-failures".to_string(),
-    ];
-    args.extend(services.iter().cloned());
-    args
-}
-
-fn compose_up_args(compose_file: &Path, services: &[String]) -> Vec<String> {
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().to_string(),
-        "up".to_string(),
-        "-d".to_string(),
-    ];
-    args.extend(services.iter().cloned());
-    args
-}
-
-fn docker_update_args(restart_policy: &str, container_id: &str) -> Vec<String> {
-    vec![
-        "update".to_string(),
-        "--restart".to_string(),
-        restart_policy.to_string(),
-        container_id.to_string(),
-    ]
-}
-
 pub(crate) fn run_docker(args: &[&str], context: &str, messages: &Messages) -> Result<()> {
     let status = ProcessCommand::new("docker")
         .args(args)
@@ -317,8 +297,6 @@ fn docker_output(args: &[&str], messages: &Messages) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::*;
 
     #[test]
@@ -331,50 +309,6 @@ mod tests {
         assert!(is_image_archive(Path::new("image.TAR.GZ")));
         assert!(!is_image_archive(Path::new("image.zip")));
         assert!(!is_image_archive(Path::new("image")));
-    }
-
-    #[test]
-    fn test_compose_up_args_includes_services() {
-        let compose_file = PathBuf::from("compose.yml");
-        let services = vec!["openbao".to_string(), "postgres".to_string()];
-        let args = compose_up_args(&compose_file, &services);
-        assert_eq!(
-            args,
-            vec![
-                "compose",
-                "-f",
-                "compose.yml",
-                "up",
-                "-d",
-                "openbao",
-                "postgres"
-            ]
-        );
-    }
-
-    #[test]
-    fn test_docker_update_args() {
-        let args = docker_update_args("always", "container123");
-        assert_eq!(args, vec!["update", "--restart", "always", "container123"]);
-    }
-
-    #[test]
-    fn test_compose_pull_args_includes_services() {
-        let compose_file = PathBuf::from("docker-compose.yml");
-        let services = vec!["openbao".to_string(), "postgres".to_string()];
-        let args = compose_pull_args(&compose_file, &services);
-        assert_eq!(
-            args,
-            vec![
-                "compose",
-                "-f",
-                "docker-compose.yml",
-                "pull",
-                "--ignore-pull-failures",
-                "openbao",
-                "postgres"
-            ]
-        );
     }
 
     #[test]

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -730,19 +730,20 @@ pub(super) fn apply_openbao_agent_compose_override(
     override_path: &Path,
     messages: &Messages,
 ) -> Result<()> {
+    let compose_str = compose_file.to_string_lossy();
+    let override_str = override_path.to_string_lossy();
     let args = [
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().to_string(),
-        "-f".to_string(),
-        override_path.to_string_lossy().to_string(),
-        "up".to_string(),
-        "-d".to_string(),
-        OPENBAO_AGENT_STEPCA_SERVICE.to_string(),
-        OPENBAO_AGENT_RESPONDER_SERVICE.to_string(),
+        "compose",
+        "-f",
+        &*compose_str,
+        "-f",
+        &*override_str,
+        "up",
+        "-d",
+        OPENBAO_AGENT_STEPCA_SERVICE,
+        OPENBAO_AGENT_RESPONDER_SERVICE,
     ];
-    let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
-    run_docker(&args_ref, "docker compose openbao agent override", messages)?;
+    run_docker(&args, "docker compose openbao agent override", messages)?;
     Ok(())
 }
 

--- a/src/commands/init/steps/responder_setup.rs
+++ b/src/commands/init/steps/responder_setup.rs
@@ -120,18 +120,19 @@ pub(super) fn apply_responder_compose_override(
     override_path: &Path,
     messages: &Messages,
 ) -> Result<()> {
+    let compose_str = compose_file.to_string_lossy();
+    let override_str = override_path.to_string_lossy();
     let args = [
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().to_string(),
-        "-f".to_string(),
-        override_path.to_string_lossy().to_string(),
-        "up".to_string(),
-        "-d".to_string(),
-        RESPONDER_SERVICE_NAME.to_string(),
+        "compose",
+        "-f",
+        &*compose_str,
+        "-f",
+        &*override_str,
+        "up",
+        "-d",
+        RESPONDER_SERVICE_NAME,
     ];
-    let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
-    run_docker(&args_ref, "docker compose responder override", messages)?;
+    run_docker(&args, "docker compose responder override", messages)?;
     Ok(())
 }
 

--- a/src/commands/init/steps/stepca_setup.rs
+++ b/src/commands/init/steps/stepca_setup.rs
@@ -152,32 +152,31 @@ pub(super) fn ensure_step_ca_initialized(
         .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
     let mount = format!("{}:/home/step", mount_root.display());
     let args = vec![
-        "run".to_string(),
-        "--user".to_string(),
-        "root".to_string(),
-        "--rm".to_string(),
-        "-v".to_string(),
-        mount,
-        "smallstep/step-ca".to_string(),
-        "step".to_string(),
-        "ca".to_string(),
-        "init".to_string(),
-        "--name".to_string(),
-        DEFAULT_CA_NAME.to_string(),
-        "--provisioner".to_string(),
-        DEFAULT_CA_PROVISIONER.to_string(),
-        "--dns".to_string(),
-        DEFAULT_CA_DNS.to_string(),
-        "--address".to_string(),
-        DEFAULT_CA_ADDRESS.to_string(),
-        "--password-file".to_string(),
-        "/home/step/password.txt".to_string(),
-        "--provisioner-password-file".to_string(),
-        "/home/step/password.txt".to_string(),
-        "--acme".to_string(),
+        "run",
+        "--user",
+        "root",
+        "--rm",
+        "-v",
+        &*mount,
+        "smallstep/step-ca",
+        "step",
+        "ca",
+        "init",
+        "--name",
+        DEFAULT_CA_NAME,
+        "--provisioner",
+        DEFAULT_CA_PROVISIONER,
+        "--dns",
+        DEFAULT_CA_DNS,
+        "--address",
+        DEFAULT_CA_ADDRESS,
+        "--password-file",
+        "/home/step/password.txt",
+        "--provisioner-password-file",
+        "/home/step/password.txt",
+        "--acme",
     ];
-    let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
-    run_docker(&args_ref, "docker step-ca init", messages)?;
+    run_docker(&args, "docker step-ca init", messages)?;
     Ok(StepCaInitResult::Initialized)
 }
 

--- a/src/commands/monitoring.rs
+++ b/src/commands/monitoring.rs
@@ -15,10 +15,21 @@ pub(crate) fn run_monitoring_up(args: &MonitoringUpArgs, messages: &Messages) ->
         println!("{}", messages.monitoring_up_already_running());
         return Ok(());
     }
-    let compose_args = compose_up_args(&args.compose_file, args.profile, &services);
-    let compose_args_ref: Vec<&str> = compose_args.iter().map(String::as_str).collect();
+    let compose_str = args.compose_file.to_string_lossy();
+    let profile_str = args.profile.to_string();
+    let svc_refs: Vec<&str> = services.iter().map(String::as_str).collect();
+    let mut up_args: Vec<&str> = vec![
+        "compose",
+        "-f",
+        &compose_str,
+        "--profile",
+        &profile_str,
+        "up",
+        "-d",
+    ];
+    up_args.extend(&svc_refs);
     run_docker_with_env(
-        &compose_args_ref,
+        &up_args,
         "docker compose up",
         messages,
         args.grafana_admin_password.as_deref(),
@@ -133,13 +144,32 @@ pub(crate) fn run_monitoring_down(args: &MonitoringDownArgs, messages: &Messages
 
     for profile in &profiles {
         let services = monitoring_services(*profile);
-        let stop_args = compose_stop_args(&args.compose_file, *profile, &services);
-        let stop_args_ref: Vec<&str> = stop_args.iter().map(String::as_str).collect();
-        run_docker(&stop_args_ref, "docker compose stop", messages)?;
+        let compose_str = args.compose_file.to_string_lossy();
+        let profile_str = profile.to_string();
+        let svc_refs: Vec<&str> = services.iter().map(String::as_str).collect();
 
-        let rm_args = compose_rm_args(&args.compose_file, *profile, &services);
-        let rm_args_ref: Vec<&str> = rm_args.iter().map(String::as_str).collect();
-        run_docker(&rm_args_ref, "docker compose rm", messages)?;
+        let mut stop_args: Vec<&str> = vec![
+            "compose",
+            "-f",
+            &compose_str,
+            "--profile",
+            &profile_str,
+            "stop",
+        ];
+        stop_args.extend(&svc_refs);
+        run_docker(&stop_args, "docker compose stop", messages)?;
+
+        let mut rm_args: Vec<&str> = vec![
+            "compose",
+            "-f",
+            &compose_str,
+            "--profile",
+            &profile_str,
+            "rm",
+            "-f",
+        ];
+        rm_args.extend(&svc_refs);
+        run_docker(&rm_args, "docker compose rm", messages)?;
     }
 
     if args.reset_grafana_admin_password {
@@ -304,24 +334,6 @@ fn ensure_all_healthy(readiness: &[ContainerReadiness], messages: &Messages) -> 
     } else {
         anyhow::bail!(messages.monitoring_unhealthy(&failures.join(", ")))
     }
-}
-
-fn compose_up_args(
-    compose_file: &Path,
-    profile: MonitoringProfile,
-    services: &[String],
-) -> Vec<String> {
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().to_string(),
-        "--profile".to_string(),
-        profile.to_string(),
-        "up".to_string(),
-        "-d".to_string(),
-    ];
-    args.extend(services.iter().cloned());
-    args
 }
 
 fn monitoring_already_running(
@@ -494,39 +506,4 @@ fn run_docker(args: &[&str], context: &str, messages: &Messages) -> Result<()> {
         anyhow::bail!(messages.error_command_failed_status(context, &status.to_string()));
     }
     Ok(())
-}
-
-fn compose_stop_args(
-    compose_file: &Path,
-    profile: MonitoringProfile,
-    services: &[String],
-) -> Vec<String> {
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().to_string(),
-        "--profile".to_string(),
-        profile.to_string(),
-        "stop".to_string(),
-    ];
-    args.extend(services.iter().cloned());
-    args
-}
-
-fn compose_rm_args(
-    compose_file: &Path,
-    profile: MonitoringProfile,
-    services: &[String],
-) -> Vec<String> {
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().to_string(),
-        "--profile".to_string(),
-        profile.to_string(),
-        "rm".to_string(),
-        "-f".to_string(),
-    ];
-    args.extend(services.iter().cloned());
-    args
 }

--- a/src/commands/rotate/stepca_password.rs
+++ b/src/commands/rotate/stepca_password.rs
@@ -101,26 +101,28 @@ pub(super) fn change_stepca_passphrase(
     let mount_root = fs::canonicalize(secrets_dir)
         .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
     let mount = format!("{}:/home/step", mount_root.display());
+    let key_container = to_container_path(secrets_dir, key_path, "/home/step")?;
+    let pwd_container = to_container_path(secrets_dir, current_password, "/home/step")?;
+    let new_pwd_container = to_container_path(secrets_dir, new_password, "/home/step")?;
     let args = vec![
-        "run".to_string(),
-        "--user".to_string(),
-        "root".to_string(),
-        "--rm".to_string(),
-        "-v".to_string(),
-        mount,
-        "smallstep/step-ca".to_string(),
-        "step".to_string(),
-        "crypto".to_string(),
-        "change-pass".to_string(),
-        to_container_path(secrets_dir, key_path, "/home/step")?,
-        "--password-file".to_string(),
-        to_container_path(secrets_dir, current_password, "/home/step")?,
-        "--new-password-file".to_string(),
-        to_container_path(secrets_dir, new_password, "/home/step")?,
-        "-f".to_string(),
+        "run",
+        "--user",
+        "root",
+        "--rm",
+        "-v",
+        &*mount,
+        "smallstep/step-ca",
+        "step",
+        "crypto",
+        "change-pass",
+        &*key_container,
+        "--password-file",
+        &*pwd_container,
+        "--new-password-file",
+        &*new_pwd_container,
+        "-f",
     ];
-    let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
-    run_docker(&args_ref, "docker step-ca change-pass", messages)?;
+    run_docker(&args, "docker step-ca change-pass", messages)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Replace `Vec<String>` → `Vec<&str>` conversions with direct `&str` slices at all `run_docker()` call sites
- Compute dynamic strings (mount paths, container paths, compose file paths) as local bindings, then reference them in the arg vec
- Inline and delete 6 single-use helper functions that only existed to build `Vec<String>`: `compose_pull_args`, `compose_up_args`, `docker_update_args` (infra.rs) and `compose_up_args`, `compose_stop_args`, `compose_rm_args` (monitoring.rs)
- 6 files changed, 128 insertions, 214 deletions

## Test plan

- [x] `cargo fmt -- --config group_imports=StdExternalCrate` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 333 passed, 0 failed
- [ ] CI: `check`, `test-core`, `test-docker-e2e-matrix`, `run-extended`

Closes #348
Refs #343