### PR TITLE
Expose Locale from library and retire CliLang

### DIFF
--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -7,7 +7,7 @@ use tokio::fs;
 use super::io::PulledSecrets;
 use super::summary::{ApplyItemSummary, ApplyStatus};
 use super::{
-    BootstrapArgs, CliLang, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
+    BootstrapArgs, Locale, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
     SERVICE_KV_BASE, TRUSTED_CA_KEY, localized,
 };
 
@@ -22,7 +22,7 @@ struct ProfilePaths {
 pub(super) async fn apply_agent_config_updates(
     args: &BootstrapArgs,
     pulled: &PulledSecrets,
-    lang: CliLang,
+    lang: Locale,
 ) -> (ApplyItemSummary, ApplyItemSummary) {
     let profile_paths = resolve_profile_paths(args);
     let agent_config = match fs::read_to_string(&args.agent_config_path).await {
@@ -398,7 +398,7 @@ fn replace_key_line_in_section(
 async fn write_openbao_agent_artifacts(
     args: &BootstrapArgs,
     agent_template: &str,
-    lang: CliLang,
+    lang: Locale,
 ) -> Result<()> {
     let secret_service_dir = args.secret_id_path.parent().ok_or_else(|| {
         anyhow::anyhow!(

--- a/src/bin/bootroot-remote/apply_secret_id.rs
+++ b/src/bin/bootroot-remote/apply_secret_id.rs
@@ -3,12 +3,12 @@ use bootroot::openbao::OpenBaoClient;
 
 use super::io::{read_required_string, read_secret_file, write_secret_file};
 use super::summary::{ApplyStatus, status_to_str};
-use super::{ApplySecretIdArgs, CliLang, OutputFormat, SECRET_ID_KEY, SERVICE_KV_BASE, localized};
+use super::{ApplySecretIdArgs, Locale, OutputFormat, SECRET_ID_KEY, SERVICE_KV_BASE, localized};
 
 // This function intentionally keeps all apply-secret-id logic in one place
 // so the single-value variant stays easy to audit and modify separately.
 #[allow(clippy::too_many_lines)]
-pub(super) async fn run_apply_secret_id(args: ApplySecretIdArgs, lang: CliLang) -> Result<i32> {
+pub(super) async fn run_apply_secret_id(args: ApplySecretIdArgs, lang: Locale) -> Result<i32> {
     if args.service_name.trim().is_empty() {
         anyhow::bail!(
             "{}",

--- a/src/bin/bootroot-remote/bootstrap.rs
+++ b/src/bin/bootroot-remote/bootstrap.rs
@@ -4,12 +4,12 @@ use bootroot::openbao::OpenBaoClient;
 use super::agent_config::apply_agent_config_updates;
 use super::io::{pull_secrets, read_secret_file, write_eab_file, write_secret_file};
 use super::summary::{ApplyItemSummary, ApplySummary, merge_apply_status, print_summary};
-use super::{BootstrapArgs, CA_BUNDLE_PEM_KEY, CliLang, localized};
+use super::{BootstrapArgs, CA_BUNDLE_PEM_KEY, Locale, localized};
 
 // This function intentionally keeps end-to-end bootstrap orchestration in one place
 // so status aggregation and exit-code semantics stay easy to audit.
 #[allow(clippy::too_many_lines)]
-pub(super) async fn run_bootstrap(args: BootstrapArgs, lang: CliLang) -> Result<i32> {
+pub(super) async fn run_bootstrap(args: BootstrapArgs, lang: Locale) -> Result<i32> {
     validate_bootstrap_args(&args, lang)?;
 
     let role_id = read_secret_file(&args.role_id_path, lang)
@@ -125,7 +125,7 @@ pub(super) async fn run_bootstrap(args: BootstrapArgs, lang: CliLang) -> Result<
     Ok(0)
 }
 
-fn validate_bootstrap_args(args: &BootstrapArgs, lang: CliLang) -> Result<()> {
+fn validate_bootstrap_args(args: &BootstrapArgs, lang: Locale) -> Result<()> {
     if args.service_name.trim().is_empty() {
         anyhow::bail!(
             "{}",

--- a/src/bin/bootroot-remote/io.rs
+++ b/src/bin/bootroot-remote/io.rs
@@ -5,9 +5,9 @@ use bootroot::fs_util;
 use tokio::fs;
 
 use super::summary::ApplyStatus;
-use super::{CA_BUNDLE_PEM_KEY, CliLang, TRUSTED_CA_KEY, localized};
+use super::{CA_BUNDLE_PEM_KEY, Locale, TRUSTED_CA_KEY, localized};
 
-pub(super) async fn read_secret_file(path: &Path, lang: CliLang) -> Result<String> {
+pub(super) async fn read_secret_file(path: &Path, lang: Locale) -> Result<String> {
     let value = fs::read_to_string(path).await?;
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -26,7 +26,7 @@ pub(super) async fn read_secret_file(path: &Path, lang: CliLang) -> Result<Strin
 pub(super) fn read_required_string(
     data: &serde_json::Value,
     keys: &[&str],
-    lang: CliLang,
+    lang: Locale,
 ) -> Result<String> {
     for key in keys {
         if let Some(value) = data.get(key).and_then(serde_json::Value::as_str) {
@@ -48,7 +48,7 @@ pub(super) fn read_required_string(
 
 pub(super) fn read_required_fingerprints(
     data: &serde_json::Value,
-    lang: CliLang,
+    lang: Locale,
 ) -> Result<Vec<String>> {
     let values = data
         .get(TRUSTED_CA_KEY)
@@ -145,7 +145,7 @@ pub(super) async fn pull_secrets(
     client: &bootroot::openbao::OpenBaoClient,
     mount: &str,
     service: &str,
-    lang: CliLang,
+    lang: Locale,
 ) -> Result<PulledSecrets> {
     let base = format!("{}/{service}", super::SERVICE_KV_BASE);
     let secret_id_data = client
@@ -222,7 +222,7 @@ mod tests {
             "trusted_ca_sha256": ["a".repeat(64), "b".repeat(64)]
         });
         let parsed =
-            read_required_fingerprints(&data, CliLang::En).expect("parse trust fingerprints");
+            read_required_fingerprints(&data, Locale::En).expect("parse trust fingerprints");
         assert_eq!(parsed.len(), 2);
     }
 }

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -7,6 +7,7 @@ mod summary;
 use std::path::PathBuf;
 
 use anyhow::Result;
+use bootroot::locale::Locale;
 use clap::{Parser, ValueEnum};
 
 const SERVICE_KV_BASE: &str = "bootroot/services";
@@ -38,40 +39,24 @@ struct Args {
     command: Command,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CliLang {
-    En,
-    Ko,
-}
-
-impl CliLang {
-    fn parse(input: &str) -> Result<Self> {
-        match input.trim().to_ascii_lowercase().as_str() {
-            "en" => Ok(Self::En),
-            "ko" => Ok(Self::Ko),
-            _ => anyhow::bail!("Unsupported language code '{input}'. Supported values: en, ko"),
-        }
+fn localized(lang: Locale, en: &str, ko: &str) -> String {
+    match lang {
+        Locale::En => en.to_string(),
+        Locale::Ko => ko.to_string(),
     }
 }
 
-fn localized(lang: CliLang, en: &str, ko: &str) -> String {
+fn summary_header(lang: Locale) -> &'static str {
     match lang {
-        CliLang::En => en.to_string(),
-        CliLang::Ko => ko.to_string(),
+        Locale::En => "bootroot-remote bootstrap summary",
+        Locale::Ko => "bootroot-remote 부트스트랩 요약",
     }
 }
 
-fn summary_header(lang: CliLang) -> &'static str {
+fn redacted_error_label(lang: Locale) -> &'static str {
     match lang {
-        CliLang::En => "bootroot-remote bootstrap summary",
-        CliLang::Ko => "bootroot-remote 부트스트랩 요약",
-    }
-}
-
-fn redacted_error_label(lang: CliLang) -> &'static str {
-    match lang {
-        CliLang::En => "error",
-        CliLang::Ko => "오류",
+        Locale::En => "error",
+        Locale::Ko => "오류",
     }
 }
 
@@ -190,7 +175,7 @@ enum OutputFormat {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
-    let lang = match CliLang::parse(&args.lang) {
+    let lang = match Locale::parse(&args.lang) {
         Ok(lang) => lang,
         Err(err) => {
             eprintln!("{err}");
@@ -216,7 +201,7 @@ async fn main() {
     }
 }
 
-async fn run(args: Args, lang: CliLang) -> Result<i32> {
+async fn run(args: Args, lang: Locale) -> Result<i32> {
     match args.command {
         Command::Bootstrap(args) => bootstrap::run_bootstrap(*args, lang).await,
         Command::ApplySecretId(args) => apply_secret_id::run_apply_secret_id(args, lang).await,
@@ -229,16 +214,16 @@ mod tests {
 
     #[test]
     fn cli_lang_parse_en_and_ko() {
-        assert_eq!(CliLang::parse("en").expect("parse en"), CliLang::En);
-        assert_eq!(CliLang::parse("ko").expect("parse ko"), CliLang::Ko);
-        assert_eq!(CliLang::parse("EN").expect("parse EN"), CliLang::En);
+        assert_eq!(Locale::parse("en").expect("parse en"), Locale::En);
+        assert_eq!(Locale::parse("ko").expect("parse ko"), Locale::Ko);
+        assert_eq!(Locale::parse("EN").expect("parse EN"), Locale::En);
     }
 
     #[test]
     fn cli_lang_parse_invalid_fails() {
-        let err = CliLang::parse("jp").expect_err("invalid lang should fail");
+        let err = Locale::parse("jp").expect_err("invalid lang should fail");
         assert!(
-            err.to_string().contains("Unsupported language code"),
+            err.to_string().contains("Unsupported language"),
             "unexpected error: {err}"
         );
     }
@@ -246,11 +231,11 @@ mod tests {
     #[test]
     fn summary_header_localization() {
         assert_eq!(
-            summary_header(CliLang::En),
+            summary_header(Locale::En),
             "bootroot-remote bootstrap summary"
         );
         assert_eq!(
-            summary_header(CliLang::Ko),
+            summary_header(Locale::Ko),
             "bootroot-remote 부트스트랩 요약"
         );
     }

--- a/src/bin/bootroot-remote/summary.rs
+++ b/src/bin/bootroot-remote/summary.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::Serialize;
 
-use super::{CliLang, redacted_error_label, summary_header};
+use super::{Locale, redacted_error_label, summary_header};
 
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -83,7 +83,7 @@ pub(super) fn status_to_str(status: ApplyStatus) -> &'static str {
     }
 }
 
-fn print_text_summary(summary: &ApplySummary, lang: CliLang) {
+fn print_text_summary(summary: &ApplySummary, lang: Locale) {
     println!("{}", summary_header(lang));
     println!("- secret_id: {}", status_to_str(summary.secret_id.status));
     print_optional_error("secret_id", summary.secret_id.error.as_deref(), lang);
@@ -102,7 +102,7 @@ fn print_text_summary(summary: &ApplySummary, lang: CliLang) {
     print_optional_error("trust_sync", summary.trust_sync.error.as_deref(), lang);
 }
 
-fn print_optional_error(name: &str, error: Option<&str>, lang: CliLang) {
+fn print_optional_error(name: &str, error: Option<&str>, lang: Locale) {
     if let Some(_value) = error {
         println!("  {}({name}): <redacted>", redacted_error_label(lang));
     }
@@ -111,7 +111,7 @@ fn print_optional_error(name: &str, error: Option<&str>, lang: CliLang) {
 pub(super) fn print_summary(
     summary: &ApplySummary,
     output: super::OutputFormat,
-    lang: CliLang,
+    lang: Locale,
 ) -> Result<()> {
     match output {
         super::OutputFormat::Text => {

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
+use bootroot::locale::Locale;
 
 pub(crate) mod en;
 pub(crate) mod ko;
@@ -364,27 +365,6 @@ pub(crate) struct Strings {
     pub(crate) next_steps_run_status: &'static str,
     pub(crate) next_steps_eab_issue: &'static str,
     pub(crate) next_steps_eab_hint: &'static str,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Locale {
-    En,
-    Ko,
-}
-
-impl Locale {
-    pub(crate) fn parse(input: &str) -> Result<Self> {
-        let normalized = input.trim().to_ascii_lowercase();
-        let base = normalized
-            .split('-')
-            .next()
-            .context("Missing language code")?;
-        match base {
-            "en" => Ok(Locale::En),
-            "ko" => Ok(Locale::Ko),
-            _ => anyhow::bail!("Unsupported language: {input}"),
-        }
-    }
 }
 
 pub(crate) struct Messages {
@@ -2115,25 +2095,6 @@ pub(crate) fn test_messages() -> Messages {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_locale_parse_en() {
-        assert_eq!(Locale::parse("en").unwrap(), Locale::En);
-        assert_eq!(Locale::parse("EN").unwrap(), Locale::En);
-        assert_eq!(Locale::parse("en-US").unwrap(), Locale::En);
-    }
-
-    #[test]
-    fn test_locale_parse_ko() {
-        assert_eq!(Locale::parse("ko").unwrap(), Locale::Ko);
-        assert_eq!(Locale::parse("ko-KR").unwrap(), Locale::Ko);
-    }
-
-    #[test]
-    fn test_locale_parse_invalid() {
-        let err = Locale::parse("fr").unwrap_err();
-        assert!(err.to_string().contains("Unsupported language"));
-    }
 
     #[test]
     fn readiness_entry_templates_identical_across_locales() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod db;
 pub mod eab;
 pub mod fs_util;
 pub mod hooks;
+pub mod locale;
 pub mod openbao;
 pub mod profile;
 pub mod tls;

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -1,0 +1,70 @@
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+
+/// Represents a supported display language.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Locale {
+    En,
+    Ko,
+}
+
+impl Locale {
+    /// Parses a locale string, accepting forms like `"en"`, `"en-US"`, `"ko"`, `"ko-KR"`.
+    ///
+    /// The comparison is case-insensitive and the region subtag is ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the language code is not supported.
+    pub fn parse(input: &str) -> Result<Self> {
+        let normalized = input.trim().to_ascii_lowercase();
+        let base = normalized
+            .split('-')
+            .next()
+            .context("Missing language code")?;
+        match base {
+            "en" => Ok(Locale::En),
+            "ko" => Ok(Locale::Ko),
+            _ => anyhow::bail!("Unsupported language: {input}"),
+        }
+    }
+}
+
+impl FromStr for Locale {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_en_variants() {
+        assert_eq!(Locale::parse("en").unwrap(), Locale::En);
+        assert_eq!(Locale::parse("EN").unwrap(), Locale::En);
+        assert_eq!(Locale::parse("en-US").unwrap(), Locale::En);
+    }
+
+    #[test]
+    fn parse_ko_variants() {
+        assert_eq!(Locale::parse("ko").unwrap(), Locale::Ko);
+        assert_eq!(Locale::parse("ko-KR").unwrap(), Locale::Ko);
+    }
+
+    #[test]
+    fn parse_invalid_returns_error() {
+        let err = Locale::parse("fr").unwrap_err();
+        assert!(err.to_string().contains("Unsupported language"));
+    }
+
+    #[test]
+    fn from_str_delegates_to_parse() {
+        assert_eq!("en".parse::<Locale>().unwrap(), Locale::En);
+        assert_eq!("ko".parse::<Locale>().unwrap(), Locale::Ko);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `bootroot::locale::Locale` to the library (`src/locale.rs`) with `parse()` and `FromStr` implementations that accept hyphenated codes like `"en-US"` and `"ko-KR"`.
- Remove the duplicate `Locale` definition from `src/i18n/mod.rs`; it now imports from the library.
- Replace `bootroot-remote`'s private `CliLang` enum with the shared `Locale` type across all sub-modules (`main.rs`, `agent_config.rs`, `io.rs`, `bootstrap.rs`, `apply_secret_id.rs`, `summary.rs`).

As a side effect, `bootroot-remote` now also accepts hyphenated locale codes (e.g. `--lang en-US`), consistent with the main binary.

Closes #378
Refs #369