### PR TITLE
Share HTTP-01 HMAC helpers

### DIFF
--- a/src/acme/http01_protocol.rs
+++ b/src/acme/http01_protocol.rs
@@ -5,8 +5,71 @@
 //! names and payload format.  Keeping them in one place prevents silent
 //! protocol divergence.
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use ring::hmac;
+
 pub const HEADER_TIMESTAMP: &str = "x-bootroot-timestamp";
 pub const HEADER_SIGNATURE: &str = "x-bootroot-signature";
+
+/// Encapsulates HMAC signing and verification for HTTP-01 registration.
+#[derive(Clone)]
+pub struct Http01HmacSigner {
+    key: hmac::Key,
+}
+
+impl Http01HmacSigner {
+    /// Creates a signer for the shared HTTP-01 responder HMAC protocol.
+    #[must_use]
+    pub fn new(secret: &str) -> Self {
+        Self {
+            key: hmac::Key::new(hmac::HMAC_SHA256, secret.as_bytes()),
+        }
+    }
+
+    /// Signs a canonical HTTP-01 registration payload.
+    #[must_use]
+    pub fn sign_payload(&self, payload: &str) -> String {
+        let tag = hmac::sign(&self.key, payload.as_bytes());
+        STANDARD.encode(tag.as_ref())
+    }
+
+    /// Signs a full HTTP-01 registration request.
+    #[must_use]
+    pub fn sign_request(
+        &self,
+        timestamp: i64,
+        token: &str,
+        key_authorization: &str,
+        ttl_secs: u64,
+    ) -> String {
+        let payload = signature_payload(timestamp, token, key_authorization, ttl_secs);
+        self.sign_payload(&payload)
+    }
+
+    /// Verifies a canonical HTTP-01 registration payload.
+    #[must_use]
+    pub fn verify_payload(&self, signature: &str, payload: &str) -> bool {
+        let Ok(decoded) = STANDARD.decode(signature.as_bytes()) else {
+            return false;
+        };
+        hmac::verify(&self.key, payload.as_bytes(), &decoded).is_ok()
+    }
+
+    /// Verifies a full HTTP-01 registration request.
+    #[must_use]
+    pub fn verify_request(
+        &self,
+        signature: &str,
+        timestamp: i64,
+        token: &str,
+        key_authorization: &str,
+        ttl_secs: u64,
+    ) -> bool {
+        let payload = signature_payload(timestamp, token, key_authorization, ttl_secs);
+        self.verify_payload(signature, &payload)
+    }
+}
 
 /// Builds the canonical payload that is HMAC-signed for token registration.
 ///
@@ -33,14 +96,18 @@ mod tests {
 
     #[test]
     fn payload_round_trip_sign_verify() {
-        use base64::Engine;
-        use base64::engine::general_purpose::STANDARD;
-        use ring::hmac;
-
-        let key = hmac::Key::new(hmac::HMAC_SHA256, b"test-secret");
+        let signer = Http01HmacSigner::new("test-secret");
         let payload = signature_payload(123, "token", "key-auth", 60);
-        let sig = STANDARD.encode(hmac::sign(&key, payload.as_bytes()).as_ref());
-        let decoded = STANDARD.decode(sig.as_bytes()).expect("valid base64");
-        assert!(hmac::verify(&key, payload.as_bytes(), &decoded).is_ok());
+        let signature = signer.sign_payload(&payload);
+        assert!(signer.verify_payload(&signature, &payload));
+        assert!(!signer.verify_payload("invalid", &payload));
+    }
+
+    #[test]
+    fn request_round_trip_sign_verify() {
+        let signer = Http01HmacSigner::new("test-secret");
+        let signature = signer.sign_request(123, "token", "key-auth", 60);
+        assert!(signer.verify_request(&signature, 123, "token", "key-auth", 60));
+        assert!(!signer.verify_request(&signature, 124, "token", "key-auth", 60));
     }
 }

--- a/src/acme/responder_client.rs
+++ b/src/acme/responder_client.rs
@@ -1,12 +1,9 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
 use reqwest::Client;
-use ring::hmac;
 
-use super::http01_protocol::{HEADER_SIGNATURE, HEADER_TIMESTAMP, signature_payload};
+use super::http01_protocol::{HEADER_SIGNATURE, HEADER_TIMESTAMP, Http01HmacSigner};
 use crate::config::Settings;
 
 const DEFAULT_ADMIN_PATH: &str = "/admin/http01";
@@ -16,12 +13,6 @@ struct RegisterRequest<'a> {
     token: &'a str,
     key_authorization: &'a str,
     ttl_secs: u64,
-}
-
-fn sign_request(secret: &str, payload: &str) -> String {
-    let key = hmac::Key::new(hmac::HMAC_SHA256, secret.as_bytes());
-    let tag = hmac::sign(&key, payload.as_bytes());
-    STANDARD.encode(tag.as_ref())
 }
 
 /// Registers an HTTP-01 token with the responder.
@@ -70,8 +61,8 @@ pub async fn register_http01_token_with(
     let timestamp = i64::try_from(timestamp)
         .map_err(|_| anyhow::anyhow!("System time is too large for timestamp"))?;
 
-    let payload = signature_payload(timestamp, token, key_authorization, ttl_secs);
-    let signature = sign_request(hmac_secret, &payload);
+    let signer = Http01HmacSigner::new(hmac_secret);
+    let signature = signer.sign_request(timestamp, token, key_authorization, ttl_secs);
 
     let client = Client::builder()
         .timeout(Duration::from_secs(timeout_secs))
@@ -108,6 +99,7 @@ mod tests {
     use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 
     use super::*;
+    use crate::acme::http01_protocol::{Http01HmacSigner, signature_payload};
 
     #[derive(serde::Deserialize)]
     struct ReceivedRequest {
@@ -147,7 +139,7 @@ mod tests {
                 &body.key_authorization,
                 body.ttl_secs,
             );
-            let expected = sign_request(&self.secret, &payload);
+            let expected = Http01HmacSigner::new(&self.secret).sign_payload(&payload);
 
             let Ok(signature) = signature.to_str() else {
                 return ResponseTemplate::new(400).set_body_string("Invalid signature");

--- a/src/bin/bootroot-http01-responder/config.rs
+++ b/src/bin/bootroot-http01-responder/config.rs
@@ -4,9 +4,9 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use bootroot::acme::http01_protocol::Http01HmacSigner;
 use clap::Parser;
 use config::{Config, ConfigError, Environment, File};
-use ring::hmac;
 use serde::Deserialize;
 
 use super::state::ResponderState;
@@ -76,8 +76,8 @@ impl ResponderSettings {
         Ok(())
     }
 
-    pub(super) fn build_hmac_key(&self) -> hmac::Key {
-        hmac::Key::new(hmac::HMAC_SHA256, self.hmac_secret.as_bytes())
+    pub(super) fn build_hmac_signer(&self) -> Http01HmacSigner {
+        Http01HmacSigner::new(&self.hmac_secret)
     }
 }
 

--- a/src/bin/bootroot-http01-responder/signature.rs
+++ b/src/bin/bootroot-http01-responder/signature.rs
@@ -1,12 +1,8 @@
-//! Provides header parsing, timestamp checks, and HMAC verification helpers.
+//! Provides header parsing and timestamp checks for admin requests.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
-use bootroot::acme::http01_protocol::signature_payload;
 use poem::Request;
-use ring::hmac;
 
 pub(super) fn header_value(req: &Request, key: &str) -> Result<String, String> {
     req.headers()
@@ -27,38 +23,9 @@ pub(super) fn within_skew(timestamp: i64, max_skew_secs: u64) -> bool {
     (now - timestamp).unsigned_abs() <= max_skew_secs
 }
 
-pub(super) fn payload_for_request(
-    timestamp: i64,
-    token: &str,
-    key_authorization: &str,
-    ttl_secs: u64,
-) -> String {
-    signature_payload(timestamp, token, key_authorization, ttl_secs)
-}
-
-pub(super) fn verify_signature(key: &hmac::Key, signature: &str, payload: &str) -> bool {
-    let Ok(decoded) = STANDARD.decode(signature.as_bytes()) else {
-        return false;
-    };
-    hmac::verify(key, payload.as_bytes(), &decoded).is_ok()
-}
-
 #[cfg(test)]
 mod tests {
-    use base64::Engine;
-    use base64::engine::general_purpose::STANDARD;
-
     use super::*;
-
-    #[test]
-    fn test_signature_verification_round_trip() {
-        let key = hmac::Key::new(hmac::HMAC_SHA256, b"test-secret");
-        let payload = payload_for_request(123, "token", "key-auth", 60);
-        let signature = STANDARD.encode(hmac::sign(&key, payload.as_bytes()).as_ref());
-
-        assert!(verify_signature(&key, &signature, &payload));
-        assert!(!verify_signature(&key, "invalid", &payload));
-    }
 
     #[test]
     fn test_within_skew_rejects_out_of_range() {

--- a/src/bin/bootroot-http01-responder/state.rs
+++ b/src/bin/bootroot-http01-responder/state.rs
@@ -4,12 +4,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ring::hmac;
+use bootroot::acme::http01_protocol::Http01HmacSigner;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use super::config::ResponderSettings;
-use super::signature::{payload_for_request, verify_signature};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(super) struct RegisterRequest {
@@ -24,10 +23,9 @@ struct TokenEntry {
     expires_at: tokio::time::Instant,
 }
 
-#[derive(Debug)]
 pub(super) struct ResponderState {
     settings: RwLock<ResponderSettings>,
-    hmac_key: RwLock<hmac::Key>,
+    hmac_signer: RwLock<Http01HmacSigner>,
     tokens: RwLock<HashMap<String, TokenEntry>>,
 }
 
@@ -37,10 +35,10 @@ impl ResponderState {
     }
 
     fn new(settings: ResponderSettings) -> Self {
-        let hmac_key = settings.build_hmac_key();
+        let hmac_signer = settings.build_hmac_signer();
         Self {
             settings: RwLock::new(settings),
-            hmac_key: RwLock::new(hmac_key),
+            hmac_signer: RwLock::new(hmac_signer),
             tokens: RwLock::new(HashMap::new()),
         }
     }
@@ -66,14 +64,14 @@ impl ResponderState {
             let settings = self.settings.read().await;
             request.ttl_secs.unwrap_or(settings.token_ttl_secs)
         };
-        let payload = payload_for_request(
+        let signer = { self.hmac_signer.read().await.clone() };
+        if !signer.verify_request(
+            signature,
             timestamp,
             &request.token,
             &request.key_authorization,
             ttl_secs,
-        );
-        let key = { self.hmac_key.read().await.clone() };
-        if !verify_signature(&key, signature, &payload) {
+        ) {
             return Err("Invalid signature".to_string());
         }
 
@@ -98,14 +96,14 @@ impl ResponderState {
     }
 
     pub(super) async fn update_settings(&self, settings: ResponderSettings) {
-        let hmac_key = settings.build_hmac_key();
+        let hmac_signer = settings.build_hmac_signer();
         {
             let mut settings_lock = self.settings.write().await;
             *settings_lock = settings;
         }
         {
-            let mut key_lock = self.hmac_key.write().await;
-            *key_lock = hmac_key;
+            let mut signer_lock = self.hmac_signer.write().await;
+            *signer_lock = hmac_signer;
         }
     }
 
@@ -120,8 +118,7 @@ impl ResponderState {
 
 #[cfg(test)]
 mod tests {
-    use base64::Engine;
-    use base64::engine::general_purpose::STANDARD;
+    use bootroot::acme::http01_protocol::Http01HmacSigner;
 
     use super::*;
     use crate::config::{
@@ -191,9 +188,8 @@ mod tests {
             key_authorization: "token-2.key".to_string(),
             ttl_secs: Some(60),
         };
-        let payload = payload_for_request(123, &request.token, &request.key_authorization, 60);
-        let key = hmac::Key::new(hmac::HMAC_SHA256, b"test-secret");
-        let signature = STANDARD.encode(hmac::sign(&key, payload.as_bytes()).as_ref());
+        let signer = Http01HmacSigner::new("test-secret");
+        let signature = signer.sign_request(123, &request.token, &request.key_authorization, 60);
 
         state
             .register_request(123, &signature, request)

--- a/tests/bootroot_http01_responder.rs
+++ b/tests/bootroot_http01_responder.rs
@@ -5,11 +5,8 @@ use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
-use bootroot::acme::http01_protocol::{HEADER_SIGNATURE, HEADER_TIMESTAMP, signature_payload};
+use bootroot::acme::http01_protocol::{HEADER_SIGNATURE, HEADER_TIMESTAMP, Http01HmacSigner};
 use reqwest::StatusCode;
-use ring::hmac;
 use serde_json::json;
 use tempfile::tempdir;
 use tokio::time::sleep;
@@ -151,9 +148,8 @@ fn sign_request(
         .expect("System time must be after UNIX_EPOCH")
         .as_secs();
     let timestamp = i64::try_from(timestamp).expect("System time must fit in i64");
-    let payload = signature_payload(timestamp, token, key_authorization, ttl_secs);
-    let key = hmac::Key::new(hmac::HMAC_SHA256, secret.as_bytes());
-    let signature = STANDARD.encode(hmac::sign(&key, payload.as_bytes()).as_ref());
+    let signer = Http01HmacSigner::new(secret);
+    let signature = signer.sign_request(timestamp, token, key_authorization, ttl_secs);
     (timestamp, signature)
 }
 


### PR DESCRIPTION
## Summary
- centralize the remaining HTTP-01 HMAC signing and verification logic in `acme::http01_protocol`
- switch the responder client, responder binary, and responder integration test to the shared helper
- trim the responder-only signature module down to header and timestamp utilities

## Testing
- `cargo fmt --all -- --config group_imports=StdExternalCrate`
- `cargo test --lib`
- `cargo test --bin bootroot-http01-responder`
- `cargo test --test bootroot_http01_responder`
- `cargo clippy --all-targets -- -D warnings`
- `scripts/preflight/ci/check.sh`
- `scripts/preflight/ci/test-core.sh` (`cargo test --all-targets` completed, but the script still exits on this machine during the final `step ca init` because `step` cannot open `/dev/tty`)

Closes #405
