### PR TITLE
Close audit cleanup items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,12 +70,12 @@ before generating code.
 
 ## 2. Commit Messages
 
-* Title: max 50 characters, start with imperative verb (e.g., `Add`, `Fix`,
-  `Remove`)
+* Title: preferably under 50 characters, start with imperative verb
+  (e.g., `Add`, `Fix`, `Remove`)
 * Body: wrap at 72 characters, free-form, explain *why* not *what*
 * Separate title and body with a blank line
-* Reference issues with `Closes #N` or `Refs #N` in the body
-* **No Prefixes**: Do NOT use prefixes like `feat:`, `chore:`, `fix:`, etc.
+* Reference issues: use `Closes #N` to close an issue, or
+  `Part of #N` when the commit addresses part of an issue
 
 ## 3. Language
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,12 +70,12 @@ before generating code.
 
 ## 2. Commit Messages
 
-* Title: max 50 characters, start with imperative verb (e.g., `Add`, `Fix`,
-  `Remove`)
+* Title: preferably under 50 characters, start with imperative verb
+  (e.g., `Add`, `Fix`, `Remove`)
 * Body: wrap at 72 characters, free-form, explain *why* not *what*
 * Separate title and body with a blank line
-* Reference issues with `Closes #N` or `Refs #N` in the body
-* **No Prefixes**: Do NOT use prefixes like `feat:`, `chore:`, `fix:`, etc.
+* Reference issues: use `Closes #N` to close an issue, or
+  `Part of #N` when the commit addresses part of an issue
 
 ## 3. Language
 

--- a/src/bin/bootroot-agent.rs
+++ b/src/bin/bootroot-agent.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bootroot::{Args, config, daemon, eab, profile};
+use bootroot::{Args, config, eab, profile, run_daemon, run_oneshot};
 use clap::Parser;
 #[cfg(unix)]
 use tokio::signal::unix::{SignalKind, signal};
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
 
     if args.oneshot {
         let (settings, final_eab) = load_settings(&args).await?;
-        match daemon::run_oneshot(
+        match run_oneshot(
             Arc::new(settings),
             final_eab,
             args.config.clone(),
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
         };
         log_settings(&settings, final_eab.as_ref());
         let settings = Arc::new(settings);
-        let mut task = tokio::spawn(daemon::run_daemon(
+        let mut task = tokio::spawn(run_daemon(
             Arc::clone(&settings),
             final_eab,
             args.config.clone(),

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -263,34 +263,26 @@ pub(crate) fn print_service_info_summary(entry: &ServiceEntry, messages: &Messag
 }
 
 fn print_service_fields(entry: &ServiceEntry, messages: &Messages) {
+    let deploy_type = entry.deploy_type.to_string();
+    let delivery_mode = entry.delivery_mode.to_string();
     println!("{}", messages.service_summary_kind(&entry.service_name));
-    println!(
-        "{}",
-        messages.service_summary_deploy_type(entry.deploy_type.as_str())
-    );
+    println!("{}", messages.service_summary_deploy_type(&deploy_type));
     println!("{}", messages.service_summary_hostname(&entry.hostname));
     println!("{}", messages.service_summary_domain(&entry.domain));
-    println!(
-        "{}",
-        messages.service_summary_delivery_mode(entry.delivery_mode.as_str())
-    );
+    println!("{}", messages.service_summary_delivery_mode(&delivery_mode));
     if let Some(notes) = entry.notes.as_deref() {
         println!("{}", messages.service_summary_notes(notes));
     }
 }
 
 fn print_service_plan_fields(plan: &ServiceAddPlan<'_>, messages: &Messages) {
+    let deploy_type = plan.deploy_type.to_string();
+    let delivery_mode = plan.delivery_mode.to_string();
     println!("{}", messages.service_summary_kind(plan.service_name));
-    println!(
-        "{}",
-        messages.service_summary_deploy_type(plan.deploy_type.as_str())
-    );
+    println!("{}", messages.service_summary_deploy_type(&deploy_type));
     println!("{}", messages.service_summary_hostname(plan.hostname));
     println!("{}", messages.service_summary_domain(plan.domain));
-    println!(
-        "{}",
-        messages.service_summary_delivery_mode(plan.delivery_mode.as_str())
-    );
+    println!("{}", messages.service_summary_delivery_mode(&delivery_mode));
     if let Some(instance_id) = plan.instance_id {
         println!("{}", messages.service_summary_instance_id(instance_id));
     }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -107,7 +107,7 @@ fn load_service_statuses(messages: &Messages) -> Result<Vec<ServiceStatusEntry>>
     for entry in state.services.values() {
         service_statuses.push(ServiceStatusEntry {
             service_name: entry.service_name.clone(),
-            delivery_mode: entry.delivery_mode.as_str().to_string(),
+            delivery_mode: entry.delivery_mode.to_string(),
         });
     }
     Ok(service_statuses)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -24,7 +24,7 @@ struct HardeningPolicy {
 ///
 /// # Errors
 /// Returns an error if issuance or shutdown handling fails.
-pub async fn run_daemon(
+pub(crate) async fn run_daemon(
     settings: Arc<config::Settings>,
     default_eab: Option<eab::EabCredentials>,
     config_path: Option<PathBuf>,
@@ -132,7 +132,7 @@ async fn run_profile_daemon(
 ///
 /// # Errors
 /// Returns an error if any profile issuance fails.
-pub async fn run_oneshot(
+pub(crate) async fn run_oneshot(
     settings: Arc<config::Settings>,
     default_eab: Option<eab::EabCredentials>,
     config_path: Option<PathBuf>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
 pub mod acme;
 pub mod agent_args;
 pub mod config;
-pub mod daemon;
 pub mod db;
 pub mod eab;
 pub mod fs_util;
@@ -13,4 +15,32 @@ pub mod tls;
 pub mod toml_util;
 pub mod utils;
 
+mod daemon;
+
 pub use agent_args::Args;
+
+/// Runs the agent daemon loop for all profiles.
+///
+/// # Errors
+/// Returns an error if issuance or shutdown handling fails.
+pub async fn run_daemon(
+    settings: Arc<config::Settings>,
+    default_eab: Option<eab::EabCredentials>,
+    config_path: Option<PathBuf>,
+    insecure_mode: bool,
+) -> anyhow::Result<()> {
+    daemon::run_daemon(settings, default_eab, config_path, insecure_mode).await
+}
+
+/// Runs a single issuance pass for all profiles.
+///
+/// # Errors
+/// Returns an error if any profile issuance fails.
+pub async fn run_oneshot(
+    settings: Arc<config::Settings>,
+    default_eab: Option<eab::EabCredentials>,
+    config_path: Option<PathBuf>,
+    insecure_mode: bool,
+) -> anyhow::Result<()> {
+    daemon::run_oneshot(settings, default_eab, config_path, insecure_mode).await
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -77,13 +78,9 @@ pub(crate) enum DeliveryMode {
     RemoteBootstrap,
 }
 
-impl DeliveryMode {
-    #[must_use]
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::LocalFile => "local-file",
-            Self::RemoteBootstrap => "remote-bootstrap",
-        }
+impl fmt::Display for DeliveryMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_serde_string_value(self, formatter)
     }
 }
 
@@ -102,13 +99,19 @@ pub(crate) enum DeployType {
     Docker,
 }
 
-impl DeployType {
-    #[must_use]
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Daemon => "daemon",
-            Self::Docker => "docker",
-        }
+impl fmt::Display for DeployType {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_serde_string_value(self, formatter)
+    }
+}
+
+fn write_serde_string_value<T: Serialize>(
+    value: &T,
+    formatter: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
+    match serde_json::to_value(value).map_err(|_| fmt::Error)? {
+        serde_json::Value::String(name) => formatter.write_str(&name),
+        _ => Err(fmt::Error),
     }
 }
 
@@ -120,11 +123,11 @@ mod tests {
     fn delivery_mode_defaults_to_local_file() {
         let mode = DeliveryMode::default();
         assert_eq!(mode, DeliveryMode::LocalFile);
-        assert_eq!(mode.as_str(), "local-file");
+        assert_eq!(mode.to_string(), "local-file");
     }
 
     #[test]
-    fn deploy_type_as_str_matches_serde() {
+    fn deploy_type_display_matches_serde() {
         for variant in [DeployType::Daemon, DeployType::Docker] {
             let serialized = serde_json::to_value(variant)
                 .expect("serialize DeployType")
@@ -132,15 +135,15 @@ mod tests {
                 .expect("serde value is a string")
                 .to_string();
             assert_eq!(
-                variant.as_str(),
+                variant.to_string(),
                 serialized,
-                "as_str() and serde disagree for {variant:?}"
+                "Display and serde disagree for {variant:?}"
             );
         }
     }
 
     #[test]
-    fn delivery_mode_as_str_matches_serde() {
+    fn delivery_mode_display_matches_serde() {
         for variant in [DeliveryMode::LocalFile, DeliveryMode::RemoteBootstrap] {
             let serialized = serde_json::to_value(variant)
                 .expect("serialize DeliveryMode")
@@ -148,9 +151,9 @@ mod tests {
                 .expect("serde value is a string")
                 .to_string();
             assert_eq!(
-                variant.as_str(),
+                variant.to_string(),
                 serialized,
-                "as_str() and serde disagree for {variant:?}"
+                "Display and serde disagree for {variant:?}"
             );
         }
     }


### PR DESCRIPTION
## Summary
- move the daemon public boundary to the library root and keep src/daemon.rs internal
- derive deploy and delivery labels from serde serialization instead of duplicated enum string tables
- sync the repo-local commit message guidance in CLAUDE.md and AGENTS.md with the global files

## Testing
- cargo fmt --all -- --config group_imports=StdExternalCrate
- cargo test --lib --bin bootroot --bin bootroot-agent
- cargo clippy --all-targets -- -D warnings
- scripts/preflight/ci/check.sh

Closes #406