### PR TITLE
Enable TLS verification during managed bootstrap

### DIFF
--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -336,6 +336,7 @@ fn build_trust_updates(
                 .join(", ")
         ),
     ));
+    updates.push(("verify_certificates", "true".to_string()));
     updates
 }
 

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -324,6 +324,7 @@ fn build_trust_updates(
     let mut updates = Vec::new();
     if let Some(path) = ca_bundle_path {
         updates.push(("ca_bundle_path", path.display().to_string()));
+        updates.push(("verify_certificates", "true".to_string()));
     }
     updates.push((
         TRUSTED_CA_KEY,
@@ -336,7 +337,6 @@ fn build_trust_updates(
                 .join(", ")
         ),
     ));
-    updates.push(("verify_certificates", "true".to_string()));
     updates
 }
 

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -40,7 +40,9 @@ pub(super) async fn apply_local_service_configs(
             .parent()
             .unwrap_or(Path::new("certs"))
             .join("ca-bundle.pem");
-        let trust_updates = build_trust_updates(&material.trusted_ca_sha256, &ca_bundle_path);
+        let has_bundle = material.ca_bundle_pem.is_some();
+        let trust_updates =
+            build_trust_updates(&material.trusted_ca_sha256, &ca_bundle_path, has_bundle);
         next = bootroot::toml_util::upsert_section_keys(&next, "trust", &trust_updates)?;
         if let Some(bundle_pem) = material.ca_bundle_pem.as_deref() {
             write_local_ca_bundle(&ca_bundle_path, bundle_pem, messages).await?;
@@ -171,8 +173,9 @@ fn upsert_managed_profile(contents: &str, service_name: &str, replacement: &str)
 fn build_trust_updates(
     fingerprints: &[String],
     ca_bundle_path: &Path,
+    has_bundle: bool,
 ) -> Vec<(&'static str, String)> {
-    vec![
+    let mut updates = vec![
         ("ca_bundle_path", ca_bundle_path.display().to_string()),
         (
             CA_TRUST_KEY,
@@ -185,8 +188,11 @@ fn build_trust_updates(
                     .join(", ")
             ),
         ),
-        ("verify_certificates", "true".to_string()),
-    ]
+    ];
+    if has_bundle {
+        updates.push(("verify_certificates", "true".to_string()));
+    }
+    updates
 }
 
 fn is_section_header(line: &str) -> bool {
@@ -361,6 +367,7 @@ mod tests {
         let updates = build_trust_updates(
             &["a".repeat(64), "b".repeat(64)],
             Path::new("certs/ca-bundle.pem"),
+            true,
         );
         let original = "[acme]\nhttp_responder_hmac = \"old\"\n";
         let once = bootroot::toml_util::upsert_section_keys(original, "trust", &updates).unwrap();

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -185,6 +185,7 @@ fn build_trust_updates(
                     .join(", ")
             ),
         ),
+        ("verify_certificates", "true".to_string()),
     ]
 }
 

--- a/tests/bootroot_remote.rs
+++ b/tests/bootroot_remote.rs
@@ -70,6 +70,10 @@ async fn test_bootroot_remote_applies_service_secrets() {
     assert!(agent_contents.contains("http_responder_hmac = \"responder-hmac-1\""));
     assert!(agent_contents.contains("ca_bundle_path = \""));
     assert!(agent_contents.contains("trusted_ca_sha256 = ["));
+    assert!(
+        agent_contents.contains("verify_certificates = true"),
+        "bootstrap should enable TLS verification:\n{agent_contents}"
+    );
     let bundle_contents = fs::read_to_string(&ca_bundle_path).expect("read ca bundle");
     assert_eq!(
         bundle_contents,

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -938,6 +938,10 @@ async fn test_app_add_includes_trust_snippet_when_present() {
     assert!(agent_contents.contains("[trust]"));
     assert!(agent_contents.contains("trusted_ca_sha256"));
     assert!(agent_contents.contains("ca_bundle_path = \""));
+    assert!(
+        agent_contents.contains("verify_certificates = true"),
+        "local config should enable TLS verification:\n{agent_contents}"
+    );
     let bundle_path = temp_dir.path().join("certs").join("ca-bundle.pem");
     let bundle_contents = fs::read_to_string(&bundle_path).expect("read ca bundle");
     assert!(bundle_contents.contains("BEGIN CERTIFICATE"));


### PR DESCRIPTION
## Summary

- Both `bootroot-remote` and `service add --local-file` bootstrap paths now set `verify_certificates = true` alongside `ca_bundle_path` and `trusted_ca_sha256`, so the agent enforces CA bundle and pin validation immediately instead of relying on post-issuance hardening.
- The default value in `src/config/defaults.rs` is `false`, which means without this change, trust material written during bootstrap was present but ignored at runtime.

## Test plan

- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` passes (including updated assertions in `bootroot_remote` and `bootroot_service` tests)
- [ ] CI: all jobs pass

Closes #412