### PR TITLE
Clarify infra env prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,15 @@ The `bootroot-http01-responder` binary now lives under
 
 See `docs/en/cli.md` (EN) or `docs/ko/cli.md` (KO) for the full flow.
 
+Before `bootroot infra up`, set `POSTGRES_PASSWORD` in `.env` or export it in
+your shell. The full setup is documented in
+[`docs/en/installation.md`](docs/en/installation.md) and
+[`docs/ko/installation.md`](docs/ko/installation.md).
+
 Typical sequence:
 
 ```bash
+export POSTGRES_PASSWORD=step-pass
 bootroot infra up
 bootroot init
 bootroot service add

--- a/docs/en/cli-examples.md
+++ b/docs/en/cli-examples.md
@@ -9,6 +9,8 @@ environment may differ.
 - Docker/Docker Compose installed
 - Ports 80/443/8200/9000/5432/8080 available
 - Pull/build images for step-ca and bootroot-http01 if missing
+- Set `POSTGRES_PASSWORD` in `.env` or export it in your shell before
+  `bootroot infra up`
 
 Image prep example:
 
@@ -20,6 +22,14 @@ docker compose build step-ca bootroot-http01
 The Docker daemon should be configured to **start on reboot**. bootroot's
 containers use restart policies, but Docker itself must be managed by the OS
 (for example, via systemctl).
+
+Minimal env example:
+
+```bash
+export POSTGRES_PASSWORD=step-pass
+```
+
+For the full `.env` setup, see the [installation guide](installation.md).
 
 > Note: The example assumes OpenBao/PostgreSQL/HTTP-01 responder run on the
 > **same machine as step-ca**.

--- a/docs/ko/cli-examples.md
+++ b/docs/ko/cli-examples.md
@@ -9,6 +9,8 @@
 - Docker/Docker Compose 설치
 - 80/443/8200/9000/5432/8080 포트 사용 가능
 - step-ca/bootroot-http01 이미지가 로컬에 없으면 먼저 pull/build
+- `bootroot infra up` 전에 `.env` 또는 셸 환경 변수로
+  `POSTGRES_PASSWORD` 설정
 
 이미지 준비 예시:
 
@@ -20,6 +22,14 @@ docker compose build step-ca bootroot-http01
 Docker 데몬은 **재부팅 시 자동 시작**되도록 설정되어 있어야 합니다.
 bootroot가 제공하는 컨테이너들은 `restart` 정책으로 자동 재기동되지만,
 Docker 데몬 자체는 OS에서 systemctl 등으로 별도 관리해야 합니다.
+
+최소 환경 변수 예시:
+
+```bash
+export POSTGRES_PASSWORD=step-pass
+```
+
+전체 `.env` 설정은 [설치 가이드](installation.md)를 참고하세요.
 
 > 참고: 아래 예제는 **step-ca가 실행되는 동일 머신**에서
 > OpenBao/PostgreSQL/HTTP-01 리스폰더를 함께 기동하는 구성을 전제로 합니다.


### PR DESCRIPTION
## Summary
- add the `POSTGRES_PASSWORD` prerequisite to the README quick-start flow
- make the EN/KO CLI examples state the env setup before the first `bootroot infra up`
- link the short examples back to the installation guide for the full `.env` setup

## Testing
- `markdownlint-cli2 README.md docs/en/cli-examples.md docs/ko/cli-examples.md`
- `git diff --check`

Closes #421
