### PR TITLE
Render local service CA bundles from OpenBao

### DIFF
--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -25,6 +25,7 @@ pub(super) const SERVICE_SECRET_ID_FILENAME: &str = "secret_id";
 pub(super) const OPENBAO_SERVICE_CONFIG_DIR: &str = "openbao/services";
 pub(super) const OPENBAO_AGENT_CONFIG_FILENAME: &str = "agent.hcl";
 pub(super) const OPENBAO_AGENT_TEMPLATE_FILENAME: &str = "agent.toml.ctmpl";
+pub(super) const OPENBAO_AGENT_CA_BUNDLE_TEMPLATE_FILENAME: &str = "ca-bundle.pem.ctmpl";
 pub(super) const OPENBAO_AGENT_TOKEN_FILENAME: &str = "token";
 pub(super) const REMOTE_BOOTSTRAP_DIR: &str = "remote-bootstrap/services";
 pub(super) const REMOTE_BOOTSTRAP_FILENAME: &str = "bootstrap.json";

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -7,8 +7,9 @@ use tokio::fs;
 use super::resolve::ResolvedServiceAdd;
 use super::{
     CaTrustMaterial, LocalApplyResult, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
-    OPENBAO_AGENT_CONFIG_FILENAME, OPENBAO_AGENT_TEMPLATE_FILENAME, OPENBAO_AGENT_TOKEN_FILENAME,
-    OPENBAO_SERVICE_CONFIG_DIR, SERVICE_ROLE_ID_FILENAME,
+    OPENBAO_AGENT_CA_BUNDLE_TEMPLATE_FILENAME, OPENBAO_AGENT_CONFIG_FILENAME,
+    OPENBAO_AGENT_TEMPLATE_FILENAME, OPENBAO_AGENT_TOKEN_FILENAME, OPENBAO_SERVICE_CONFIG_DIR,
+    SERVICE_ROLE_ID_FILENAME,
 };
 use crate::commands::constants::{CA_TRUST_KEY, SERVICE_KV_BASE};
 use crate::i18n::Messages;
@@ -23,6 +24,11 @@ pub(super) async fn apply_local_service_configs(
     messages: &Messages,
 ) -> Result<LocalApplyResult> {
     let profile = render_managed_profile_block(resolved);
+    let ca_bundle_path = resolved
+        .cert_path
+        .parent()
+        .unwrap_or(Path::new("certs"))
+        .join("ca-bundle.pem");
     let current = if resolved.agent_config.exists() {
         fs::read_to_string(&resolved.agent_config)
             .await
@@ -35,11 +41,6 @@ pub(super) async fn apply_local_service_configs(
     let with_profile = upsert_managed_profile(&current, &resolved.service_name, &profile);
     let mut next = with_profile;
     if let Some(material) = ca_trust_material {
-        let ca_bundle_path = resolved
-            .cert_path
-            .parent()
-            .unwrap_or(Path::new("certs"))
-            .join("ca-bundle.pem");
         let trust_updates = build_trust_updates(&material.trusted_ca_sha256, &ca_bundle_path);
         next = bootroot::toml_util::upsert_section_keys(&next, "trust", &trust_updates)?;
         if let Some(bundle_pem) = material.ca_bundle_pem.as_deref() {
@@ -64,6 +65,24 @@ pub(super) async fn apply_local_service_configs(
         .await
         .with_context(|| messages.error_write_file_failed(&template_path.display().to_string()))?;
     fs_util::set_key_permissions(&template_path).await?;
+    let bundle_template_path = openbao_service_dir.join(OPENBAO_AGENT_CA_BUNDLE_TEMPLATE_FILENAME);
+    let bundle_template = build_ca_bundle_ctmpl_content(kv_mount, &resolved.service_name);
+    fs::write(&bundle_template_path, &bundle_template)
+        .await
+        .with_context(|| {
+            messages.error_write_file_failed(&bundle_template_path.display().to_string())
+        })?;
+    fs_util::set_key_permissions(&bundle_template_path).await?;
+    let template_specs = [
+        (
+            template_path.display().to_string(),
+            resolved.agent_config.display().to_string(),
+        ),
+        (
+            bundle_template_path.display().to_string(),
+            ca_bundle_path.display().to_string(),
+        ),
+    ];
 
     let role_id_path = secret_id_path
         .parent()
@@ -77,13 +96,16 @@ pub(super) async fn apply_local_service_configs(
     }
     fs_util::set_key_permissions(&token_path).await?;
     let agent_config_path = openbao_service_dir.join(OPENBAO_AGENT_CONFIG_FILENAME);
+    let templates = template_specs
+        .iter()
+        .map(|(source, destination)| (source.as_str(), destination.as_str()))
+        .collect::<Vec<_>>();
     let agent_hcl = render_openbao_agent_config(
         openbao_url,
         &role_id_path,
         secret_id_path,
         &token_path,
-        &template_path,
-        &resolved.agent_config,
+        &templates,
     );
     fs::write(&agent_config_path, agent_hcl)
         .await
@@ -197,14 +219,11 @@ fn render_openbao_agent_config(
     role_id_path: &Path,
     secret_id_path: &Path,
     token_path: &Path,
-    template_path: &Path,
-    destination_path: &Path,
+    templates: &[(&str, &str)],
 ) -> String {
     let role_id = role_id_path.display().to_string();
     let secret_id = secret_id_path.display().to_string();
     let token = token_path.display().to_string();
-    let tpl = template_path.display().to_string();
-    let dest = destination_path.display().to_string();
     bootroot::openbao::build_agent_config(
         openbao_url,
         &role_id,
@@ -212,7 +231,7 @@ fn render_openbao_agent_config(
         &token,
         Some("auth/approle"),
         bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
-        &[(&tpl, &dest)],
+        templates,
     )
 }
 
@@ -263,6 +282,17 @@ fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> St
     }
     result.push_str(&eab_block);
     result
+}
+
+fn build_ca_bundle_ctmpl_content(kv_mount: &str, service_name: &str) -> String {
+    let base = format!("{SERVICE_KV_BASE}/{service_name}");
+    format!(
+        "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
+         {{{{ if .Data.data.ca_bundle_pem }}}}\
+         {{{{ .Data.data.ca_bundle_pem }}}}\
+         {{{{ end }}}}\
+         {{{{ end }}}}\n"
+    )
 }
 
 /// Removes sections from pseudo-TOML content using line-based matching.
@@ -423,6 +453,17 @@ mod tests {
             r#"{{ with secret "secret/data/bootroot/services/edge-proxy/trust" }}trusted_ca_sha256 = {{ .Data.data.trusted_ca_sha256 | toJSON }}{{ end }}"#
         ));
         assert!(!output.contains(&fp));
+    }
+
+    #[test]
+    fn test_build_ca_bundle_ctmpl_reads_service_trust_bundle() {
+        let output = build_ca_bundle_ctmpl_content("secret", "edge-proxy");
+        assert!(
+            output
+                .contains(r#"{{ with secret "secret/data/bootroot/services/edge-proxy/trust" }}"#)
+        );
+        assert!(output.contains(r"{{ if .Data.data.ca_bundle_pem }}"));
+        assert!(output.contains(r"{{ .Data.data.ca_bundle_pem }}"));
     }
 
     #[test]

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1165,9 +1165,11 @@ fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str
         .join(service_name);
     let openbao_hcl = openbao_service_dir.join("agent.hcl");
     let openbao_ctmpl = openbao_service_dir.join("agent.toml.ctmpl");
+    let openbao_bundle_ctmpl = openbao_service_dir.join("ca-bundle.pem.ctmpl");
     let openbao_token = openbao_service_dir.join("token");
     assert!(openbao_hcl.exists());
     assert!(openbao_ctmpl.exists());
+    assert!(openbao_bundle_ctmpl.exists());
     assert!(openbao_token.exists());
 
     let hcl_mode = fs::metadata(&openbao_hcl)
@@ -1180,6 +1182,11 @@ fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str
         .permissions()
         .mode()
         & 0o777;
+    let bundle_ctmpl_mode = fs::metadata(&openbao_bundle_ctmpl)
+        .expect("openbao bundle ctmpl metadata")
+        .permissions()
+        .mode()
+        & 0o777;
     let token_mode = fs::metadata(&openbao_token)
         .expect("openbao token metadata")
         .permissions()
@@ -1187,6 +1194,7 @@ fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str
         & 0o777;
     assert_eq!(hcl_mode, 0o600);
     assert_eq!(ctmpl_mode, 0o600);
+    assert_eq!(bundle_ctmpl_mode, 0o600);
     assert_eq!(token_mode, 0o600);
 
     let ctmpl_contents = fs::read_to_string(&openbao_ctmpl).expect("read ctmpl");
@@ -1198,12 +1206,54 @@ fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str
         !ctmpl_contents.contains("test-responder-hmac"),
         "ctmpl should not contain literal secret values"
     );
+    let bundle_ctmpl_contents =
+        fs::read_to_string(&openbao_bundle_ctmpl).expect("read bundle ctmpl");
+    assert!(
+        bundle_ctmpl_contents.contains("{{ with secret \"secret/data/bootroot/services/"),
+        "bundle ctmpl should contain template directives"
+    );
+    assert!(
+        bundle_ctmpl_contents.contains(".Data.data.ca_bundle_pem"),
+        "bundle ctmpl should render ca_bundle_pem"
+    );
+    assert!(
+        !bundle_ctmpl_contents.contains("TRUST"),
+        "bundle ctmpl should not contain literal trust values"
+    );
 
     let hcl_contents = fs::read_to_string(&openbao_hcl).expect("read agent.hcl");
     assert!(
         hcl_contents.contains("vault {"),
         "agent.hcl should contain vault block"
     );
+    assert!(
+        hcl_contents.contains(&format!(
+            "source = \"{}\"",
+            path_relative_to_root_or_self(root, &openbao_ctmpl).display()
+        )),
+        "agent.hcl should render agent.toml"
+    );
+    assert!(
+        hcl_contents.contains(&format!(
+            "source = \"{}\"",
+            path_relative_to_root_or_self(root, &openbao_bundle_ctmpl).display()
+        )),
+        "agent.hcl should render the CA bundle template"
+    );
+    assert!(
+        hcl_contents.contains(&format!(
+            "destination = \"{}\"",
+            root.join("certs").join("ca-bundle.pem").display()
+        )),
+        "agent.hcl should target a CA bundle output path"
+    );
+}
+
+fn path_relative_to_root_or_self<'a>(
+    root: &'a std::path::Path,
+    path: &'a std::path::Path,
+) -> &'a std::path::Path {
+    path.strip_prefix(root).unwrap_or(path)
 }
 
 fn write_cert_with_dns(

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -81,6 +81,21 @@ async fn test_same_host_local_file_happy_path() {
         ctmpl_contents.contains("{{ with secret \"secret/data/bootroot/services/"),
         "ctmpl should contain template directives"
     );
+    let bundle_ctmpl_path = temp
+        .path()
+        .join("secrets")
+        .join("openbao")
+        .join("services")
+        .join(SERVICE_NAME)
+        .join("ca-bundle.pem.ctmpl");
+    assert!(bundle_ctmpl_path.exists());
+    assert_mode(&bundle_ctmpl_path, 0o600);
+    let bundle_ctmpl_contents = fs::read_to_string(&bundle_ctmpl_path).expect("read bundle ctmpl");
+    assert!(
+        bundle_ctmpl_contents.contains("{{ with secret \"secret/data/bootroot/services/"),
+        "bundle ctmpl should contain template directives"
+    );
+    assert!(bundle_ctmpl_contents.contains(".Data.data.ca_bundle_pem"));
 
     let hcl_path = temp
         .path()
@@ -94,6 +109,18 @@ async fn test_same_host_local_file_happy_path() {
         hcl_contents.contains("vault {"),
         "agent.hcl should contain vault block"
     );
+    assert!(hcl_contents.contains(&format!(
+        "source = \"{}\"",
+        path_relative_to_root_or_self(temp.path(), &ctmpl_path).display()
+    )));
+    assert!(hcl_contents.contains(&format!(
+        "source = \"{}\"",
+        path_relative_to_root_or_self(temp.path(), &bundle_ctmpl_path).display()
+    )));
+    assert!(hcl_contents.contains(&format!(
+        "destination = \"{}\"",
+        files.ca_bundle_path.display()
+    )));
 
     write_service_cert(&files.cert_path, &files.key_path).expect("write cert");
     write_fake_bootroot_agent(temp.path(), 0).expect("write fake bootroot-agent");
@@ -272,6 +299,10 @@ fn init_service_files(root: &Path) -> anyhow::Result<ServicePaths> {
         eab_path,
         ca_bundle_path,
     })
+}
+
+fn path_relative_to_root_or_self<'a>(root: &'a Path, path: &'a Path) -> &'a Path {
+    path.strip_prefix(root).unwrap_or(path)
 }
 
 fn run_service_add_local(


### PR DESCRIPTION
## Summary
- add a dedicated local-file OpenBao Agent template for `ca_bundle_pem`
- render both `agent.toml` and `ca-bundle.pem` from the per-service OpenBao Agent config
- extend local service and same-host E2E coverage for the extra template and HCL wiring

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `scripts/preflight/ci/check.sh`
- `cargo test --test bootroot_service --test e2e_same_host_local_file -- --nocapture`
- `cargo test test_build_ca_bundle_ctmpl_reads_service_trust_bundle -- --nocapture`

## Notes
- `scripts/preflight/ci/e2e-matrix.sh` and `scripts/preflight/ci/e2e-extended.sh` were attempted locally
- after supplying `POSTGRES_PASSWORD` and `GRAFANA_ADMIN_PASSWORD`, local Docker preflight was still blocked by this machine environment
- `127.0.0.1:5432` is already in use on this machine
- the no-hosts local lifecycle path also hit `step ca init` non-interactive `/dev/tty` allocation errors locally

Closes #430