### PR TITLE
Enable local-file verify on first run

### DIFF
--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -64,7 +64,6 @@ pub(super) struct ServiceSyncMaterial {
 
 pub(super) struct CaTrustMaterial {
     pub(super) trusted_ca_sha256: Vec<String>,
-    pub(super) ca_bundle_pem: Option<String>,
 }
 
 pub(crate) use resolve::ResolvedServiceAdd;
@@ -225,11 +224,6 @@ async fn run_service_add_apply(
         .with_context(|| messages.error_openbao_client_create_failed())?;
     authenticate_openbao_client(&mut client, auth, messages).await?;
 
-    let ca_trust_material =
-        secrets::read_ca_trust_material(&client, &state.kv_mount, messages).await?;
-    let trusted_ca_sha256 = ca_trust_material
-        .as_ref()
-        .map(|material| material.trusted_ca_sha256.as_slice());
     let approle_result =
         approle::ensure_service_approle(&client, state, &resolved.service_name, messages).await?;
     let secrets_dir = state.secrets_dir();
@@ -247,7 +241,7 @@ async fn run_service_add_apply(
         messages,
     )
     .await?;
-    secrets::sync_service_kv_bundle(
+    let service_sync_material = secrets::sync_service_kv_bundle(
         &client,
         state,
         resolved,
@@ -255,6 +249,7 @@ async fn run_service_add_apply(
         messages,
     )
     .await?;
+    let trusted_ca_sha256 = Some(service_sync_material.trusted_ca_sha256.as_slice());
 
     let applied = if matches!(resolved.delivery_mode, DeliveryMode::LocalFile) {
         Some(
@@ -262,7 +257,7 @@ async fn run_service_add_apply(
                 secrets_dir,
                 resolved,
                 &secret_id_path,
-                ca_trust_material.as_ref(),
+                &service_sync_material,
                 &state.kv_mount,
                 &state.openbao_url,
                 messages,

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -6,19 +6,22 @@ use tokio::fs;
 
 use super::resolve::ResolvedServiceAdd;
 use super::{
-    CaTrustMaterial, LocalApplyResult, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
+    LocalApplyResult, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
     OPENBAO_AGENT_CA_BUNDLE_TEMPLATE_FILENAME, OPENBAO_AGENT_CONFIG_FILENAME,
     OPENBAO_AGENT_TEMPLATE_FILENAME, OPENBAO_AGENT_TOKEN_FILENAME, OPENBAO_SERVICE_CONFIG_DIR,
-    SERVICE_ROLE_ID_FILENAME,
+    SERVICE_ROLE_ID_FILENAME, ServiceSyncMaterial,
 };
 use crate::commands::constants::{CA_TRUST_KEY, SERVICE_KV_BASE};
 use crate::i18n::Messages;
+
+const VERIFY_CERTIFICATES_KEY: &str = "verify_certificates";
+const VERIFY_CERTIFICATES_TRUE: &str = "true";
 
 pub(super) async fn apply_local_service_configs(
     secrets_dir: &Path,
     resolved: &ResolvedServiceAdd,
     secret_id_path: &Path,
-    ca_trust_material: Option<&CaTrustMaterial>,
+    sync_material: &ServiceSyncMaterial,
     kv_mount: &str,
     openbao_url: &str,
     messages: &Messages,
@@ -40,12 +43,14 @@ pub(super) async fn apply_local_service_configs(
     };
     let with_profile = upsert_managed_profile(&current, &resolved.service_name, &profile);
     let mut next = with_profile;
-    if let Some(material) = ca_trust_material {
-        let trust_updates = build_trust_updates(&material.trusted_ca_sha256, &ca_bundle_path);
-        next = bootroot::toml_util::upsert_section_keys(&next, "trust", &trust_updates)?;
-        if let Some(bundle_pem) = material.ca_bundle_pem.as_deref() {
-            write_local_ca_bundle(&ca_bundle_path, bundle_pem, messages).await?;
-        }
+    let trust_updates = build_trust_updates(
+        &sync_material.trusted_ca_sha256,
+        &ca_bundle_path,
+        sync_material.ca_bundle_pem.is_some(),
+    );
+    next = bootroot::toml_util::upsert_section_keys(&next, "trust", &trust_updates)?;
+    if let Some(bundle_pem) = sync_material.ca_bundle_pem.as_deref() {
+        write_local_ca_bundle(&ca_bundle_path, bundle_pem, messages).await?;
     }
     fs::write(&resolved.agent_config, &next)
         .await
@@ -193,21 +198,28 @@ fn upsert_managed_profile(contents: &str, service_name: &str, replacement: &str)
 fn build_trust_updates(
     fingerprints: &[String],
     ca_bundle_path: &Path,
+    verify_certificates: bool,
 ) -> Vec<(&'static str, String)> {
-    vec![
-        ("ca_bundle_path", ca_bundle_path.display().to_string()),
-        (
-            CA_TRUST_KEY,
-            format!(
-                "[{}]",
-                fingerprints
-                    .iter()
-                    .map(|value| format!("\"{value}\""))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
+    let mut updates = Vec::with_capacity(3);
+    if verify_certificates {
+        updates.push((
+            VERIFY_CERTIFICATES_KEY,
+            VERIFY_CERTIFICATES_TRUE.to_string(),
+        ));
+    }
+    updates.push(("ca_bundle_path", ca_bundle_path.display().to_string()));
+    updates.push((
+        CA_TRUST_KEY,
+        format!(
+            "[{}]",
+            fingerprints
+                .iter()
+                .map(|value| format!("\"{value}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
-    ]
+    ));
+    updates
 }
 
 fn is_section_header(line: &str) -> bool {
@@ -390,6 +402,7 @@ mod tests {
         let updates = build_trust_updates(
             &["a".repeat(64), "b".repeat(64)],
             Path::new("certs/ca-bundle.pem"),
+            true,
         );
         let original = "[acme]\nhttp_responder_hmac = \"old\"\n";
         let once = bootroot::toml_util::upsert_section_keys(original, "trust", &updates).unwrap();
@@ -397,6 +410,7 @@ mod tests {
 
         assert_eq!(once, twice);
         assert!(once.contains("[trust]"));
+        assert!(once.contains("verify_certificates = true"));
         assert!(once.contains("ca_bundle_path = \"certs/ca-bundle.pem\""));
         assert!(once.contains("trusted_ca_sha256 = ["));
     }
@@ -409,6 +423,18 @@ mod tests {
 
         assert!(output.contains("extra = true"));
         assert!(output.contains("ca_bundle_path = \"certs/ca.pem\""));
+    }
+
+    #[test]
+    fn test_build_trust_updates_skips_verify_without_bundle() {
+        let updates =
+            build_trust_updates(&["a".repeat(64)], Path::new("certs/ca-bundle.pem"), false);
+
+        assert!(
+            !updates
+                .iter()
+                .any(|(key, _)| *key == VERIFY_CERTIFICATES_KEY)
+        );
     }
 
     #[test]

--- a/src/commands/service/secrets.rs
+++ b/src/commands/service/secrets.rs
@@ -17,7 +17,7 @@ pub(super) async fn sync_service_kv_bundle(
     resolved: &ResolvedServiceAdd,
     secret_id: &str,
     messages: &Messages,
-) -> Result<()> {
+) -> Result<ServiceSyncMaterial> {
     let material = read_service_sync_material(client, &state.kv_mount, messages).await?;
     write_service_kv_secrets(
         client,
@@ -38,7 +38,7 @@ pub(super) async fn sync_service_kv_bundle(
             .await
             .with_context(|| messages.error_openbao_kv_write_failed())?;
     }
-    Ok(())
+    Ok(material)
 }
 
 fn read_required_string(
@@ -193,13 +193,8 @@ pub(super) async fn read_ca_trust_material(
     if fingerprints.is_empty() {
         anyhow::bail!(messages.error_ca_trust_empty());
     }
-    let ca_bundle_pem = data
-        .get(SERVICE_CA_BUNDLE_PEM_KEY)
-        .and_then(serde_json::Value::as_str)
-        .map(ToOwned::to_owned);
     Ok(Some(CaTrustMaterial {
         trusted_ca_sha256: fingerprints,
-        ca_bundle_pem,
     }))
 }
 

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -816,6 +816,15 @@ async fn test_app_add_local_file_sets_verify_prerequisites() {
         .output()
         .expect("run service add");
     assert!(add_output.status.success());
+    let add_stdout = String::from_utf8_lossy(&add_output.stdout);
+    assert!(add_stdout.contains("[trust]"));
+    assert!(add_stdout.contains("verify_certificates = true"));
+    assert!(add_stdout.contains("trusted_ca_sha256"));
+    assert!(add_stdout.contains("ca_bundle_path"));
+    let agent_contents = fs::read_to_string(&agent_config).expect("read agent config");
+    assert!(agent_contents.contains("verify_certificates = true"));
+    assert!(agent_contents.contains("trusted_ca_sha256 = ["));
+    assert!(agent_contents.contains("ca_bundle_path = \""));
 
     write_cert_with_dns(
         &cert_path,
@@ -1021,10 +1030,12 @@ async fn test_app_add_includes_trust_snippet_when_present() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success());
     assert!(stdout.contains("[trust]"));
+    assert!(stdout.contains("verify_certificates = true"));
     assert!(stdout.contains("trusted_ca_sha256"));
     assert!(stdout.contains("ca_bundle_path"));
     let agent_contents = fs::read_to_string(&agent_config).expect("read agent config");
     assert!(agent_contents.contains("[trust]"));
+    assert!(agent_contents.contains("verify_certificates = true"));
     assert!(agent_contents.contains("trusted_ca_sha256"));
     assert!(agent_contents.contains("ca_bundle_path = \""));
     let bundle_path = temp_dir.path().join("certs").join("ca-bundle.pem");
@@ -1040,7 +1051,7 @@ async fn test_app_add_includes_trust_snippet_when_present() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn test_app_add_omits_trust_snippet_when_missing() {
+async fn test_app_add_uses_synced_trust_when_metadata_missing() {
     use support::ROOT_TOKEN;
 
     let temp_dir = tempdir().expect("create temp dir");
@@ -1085,8 +1096,14 @@ async fn test_app_add_omits_trust_snippet_when_missing() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success());
-    assert!(!stdout.contains("[trust]"));
-    assert!(!stdout.contains("trusted_ca_sha256"));
+    assert!(stdout.contains("[trust]"));
+    assert!(stdout.contains("verify_certificates = true"));
+    assert!(stdout.contains("trusted_ca_sha256"));
+    assert!(stdout.contains("ca_bundle_path"));
+    let agent_contents = fs::read_to_string(&agent_config).expect("read agent config");
+    assert!(agent_contents.contains("verify_certificates = true"));
+    assert!(agent_contents.contains("trusted_ca_sha256"));
+    assert!(agent_contents.contains("ca_bundle_path = \""));
 }
 
 #[cfg(unix)]

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -51,6 +51,7 @@ async fn test_same_host_local_file_happy_path() {
     assert!(agent_contents.contains("cert = \""));
     assert!(agent_contents.contains("key = \""));
     assert!(agent_contents.contains("[trust]"));
+    assert!(agent_contents.contains("verify_certificates = true"));
     assert!(agent_contents.contains("trusted_ca_sha256 = ["));
     assert!(agent_contents.contains("ca_bundle_path = \""));
 


### PR DESCRIPTION
## Summary
- use synced service trust material as the local-file source of truth during `service add`
- write `verify_certificates = true` immediately for local-file services when a CA bundle is present
- extend local service and same-host E2E assertions for first-run verified onboarding

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `scripts/preflight/ci/check.sh`
- `cargo test --test bootroot_service --test e2e_same_host_local_file -- --nocapture`
- `cargo test commands::service::local_config::tests --bin bootroot -- --nocapture`

## Notes
- Docker preflight was attempted locally
- the Rust/local-file coverage above passed cleanly
- local Docker validation was not completed cleanly because this machine had lingering fixed-name containers from prior runs (`bootroot-http01`, `bootroot-openbao`) that conflicted with the preflight harness

Closes #431