### PR TITLE
Refactor trust bootstrap helpers

### DIFF
--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -2,13 +2,17 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use bootroot::fs_util;
+use bootroot::trust_bootstrap::{
+    build_managed_agent_ctmpl, build_trust_updates as build_shared_trust_updates,
+    render_managed_profile_block as render_profile,
+    upsert_managed_profile_block as upsert_shared_managed_profile_block,
+};
 use tokio::fs;
 
 use super::io::PulledSecrets;
 use super::summary::{ApplyItemSummary, ApplyStatus};
 use super::{
-    BootstrapArgs, Locale, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
-    SERVICE_KV_BASE, TRUSTED_CA_KEY, localized,
+    BootstrapArgs, Locale, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX, localized,
 };
 
 struct ProfilePaths {
@@ -228,170 +232,36 @@ fn render_managed_profile_block(
     cert_path: &Path,
     key_path: &Path,
 ) -> String {
-    format!(
-        "{MANAGED_PROFILE_BEGIN_PREFIX} {service_name}\n\
-[[profiles]]\n\
-service_name = \"{service_name}\"\n\
-instance_id = \"{instance_id}\"\n\
-hostname = \"{hostname}\"\n\n\
-[profiles.paths]\n\
-cert = \"{cert}\"\n\
-key = \"{key}\"\n\
-{MANAGED_PROFILE_END_PREFIX} {service_name}\n",
-        cert = cert_path.display(),
-        key = key_path.display(),
+    render_profile(
+        MANAGED_PROFILE_BEGIN_PREFIX,
+        MANAGED_PROFILE_END_PREFIX,
+        service_name,
+        instance_id,
+        hostname,
+        cert_path,
+        key_path,
     )
 }
 
 fn upsert_managed_profile_block(contents: &str, service_name: &str, replacement: &str) -> String {
-    let begin_marker = format!("{MANAGED_PROFILE_BEGIN_PREFIX} {service_name}");
-    let end_marker = format!("{MANAGED_PROFILE_END_PREFIX} {service_name}");
-    if let Some(begin) = contents.find(&begin_marker)
-        && let Some(end_relative) = contents[begin..].find(&end_marker)
-    {
-        let end = begin + end_relative + end_marker.len();
-        let suffix = contents[end..]
-            .strip_prefix('\n')
-            .unwrap_or(&contents[end..]);
-        let mut updated = String::new();
-        updated.push_str(&contents[..begin]);
-        if !updated.is_empty() && !updated.ends_with('\n') {
-            updated.push('\n');
-        }
-        updated.push_str(replacement);
-        if !suffix.is_empty() && !replacement.ends_with('\n') {
-            updated.push('\n');
-        }
-        updated.push_str(suffix);
-        return updated;
-    }
-    let mut updated = contents.trim_end().to_string();
-    if !updated.is_empty() {
-        updated.push_str("\n\n");
-    }
-    updated.push_str(replacement);
-    updated
+    upsert_shared_managed_profile_block(
+        contents,
+        MANAGED_PROFILE_BEGIN_PREFIX,
+        MANAGED_PROFILE_END_PREFIX,
+        service_name,
+        replacement,
+    )
 }
 
 pub(super) fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> String {
-    let base = format!("{SERVICE_KV_BASE}/{service_name}");
-
-    let hmac_template = format!(
-        "{{{{ with secret \"{kv_mount}/data/{base}/http_responder_hmac\" }}}}\
-         {{{{ .Data.data.hmac }}}}\
-         {{{{ end }}}}"
-    );
-    let with_hmac = replace_key_line_in_section(
-        contents,
-        "acme",
-        "http_responder_hmac",
-        &format!("http_responder_hmac = \"{hmac_template}\""),
-    );
-
-    let without_eab = remove_line_sections(&with_hmac, &["eab", "profiles.eab"]);
-
-    let trust_template_line = format!(
-        "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
-         trusted_ca_sha256 = {{{{ .Data.data.trusted_ca_sha256 | toJSON }}}}\
-         {{{{ end }}}}"
-    );
-    let with_trust =
-        replace_key_line_in_section(&without_eab, "trust", TRUSTED_CA_KEY, &trust_template_line);
-
-    let eab_block = format!(
-        "\n{{{{ with secret \"{kv_mount}/data/{base}/eab\" }}}}{{{{ if .Data.data.kid }}}}\n\
-         [eab]\n\
-         kid = \"{{{{ .Data.data.kid }}}}\"\n\
-         hmac = \"{{{{ .Data.data.hmac }}}}\"\n\
-         \n\
-         [profiles.eab]\n\
-         kid = \"{{{{ .Data.data.kid }}}}\"\n\
-         hmac = \"{{{{ .Data.data.hmac }}}}\"\n\
-         {{{{ end }}}}{{{{ end }}}}\n"
-    );
-
-    let mut result = with_trust;
-    if !result.ends_with('\n') {
-        result.push('\n');
-    }
-    result.push_str(&eab_block);
-    result
+    build_managed_agent_ctmpl(contents, kv_mount, service_name)
 }
 
 fn build_trust_updates(
     fingerprints: &[String],
     ca_bundle_path: &Path,
 ) -> Vec<(&'static str, String)> {
-    let mut updates = Vec::with_capacity(2);
-    updates.push(("ca_bundle_path", ca_bundle_path.display().to_string()));
-    updates.push((
-        TRUSTED_CA_KEY,
-        format!(
-            "[{}]",
-            fingerprints
-                .iter()
-                .map(|value| format!("\"{value}\""))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
-    ));
-    updates
-}
-
-/// Removes sections from pseudo-TOML content using line-based matching.
-///
-/// Used for Go template (ctmpl) files where the content is not valid
-/// TOML and cannot be parsed by `toml_edit`.
-fn remove_line_sections(contents: &str, sections: &[&str]) -> String {
-    let mut output = String::new();
-    let mut skip = false;
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if is_section_header(trimmed) {
-            let section_name = &trimmed[1..trimmed.len() - 1];
-            skip = sections.contains(&section_name);
-            if skip {
-                continue;
-            }
-        }
-        if skip {
-            continue;
-        }
-        output.push_str(line);
-        output.push('\n');
-    }
-    output
-}
-
-fn replace_key_line_in_section(
-    contents: &str,
-    section: &str,
-    key: &str,
-    replacement: &str,
-) -> String {
-    let mut output = String::new();
-    let mut in_section = false;
-    let mut replaced = false;
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if is_section_header(trimmed) {
-            in_section = trimmed == format!("[{section}]");
-        }
-        if in_section
-            && !replaced
-            && (trimmed.starts_with(&format!("{key} =")) || trimmed.starts_with(&format!("{key}=")))
-        {
-            output.push_str(replacement);
-            output.push('\n');
-            replaced = true;
-            continue;
-        }
-        output.push_str(line);
-        output.push('\n');
-    }
-    output
+    build_shared_trust_updates(fingerprints, ca_bundle_path)
 }
 
 async fn write_openbao_agent_artifacts(
@@ -500,10 +370,6 @@ template {{
         template_path = template_path.display(),
         destination_path = destination_path.display(),
     )
-}
-
-fn is_section_header(value: &str) -> bool {
-    value.starts_with('[') && value.ends_with(']')
 }
 
 #[cfg(test)]

--- a/src/bin/bootroot-remote/io.rs
+++ b/src/bin/bootroot-remote/io.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bootroot::fs_util;
 use tokio::fs;
 
@@ -109,10 +109,14 @@ pub(super) async fn write_secret_file(path: &Path, contents: &str) -> Result<App
     } else {
         format!("{contents}\n")
     };
-    let current = if path.exists() {
-        fs::read_to_string(path).await.unwrap_or_default()
-    } else {
-        String::new()
+    let current = match fs::read_to_string(path).await {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!("Failed to read existing secret file: {}", path.display())
+            });
+        }
     };
     if current == next {
         fs_util::set_key_permissions(path).await?;
@@ -206,11 +210,14 @@ pub(super) async fn pull_secrets(
         ca_bundle_pem,
     })
 }
-
-use anyhow::Context;
-
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[cfg(unix)]
+    use tempfile::tempdir;
+
     use super::*;
 
     #[test]
@@ -221,5 +228,26 @@ mod tests {
         let parsed =
             read_required_fingerprints(&data, Locale::En).expect("parse trust fingerprints");
         assert_eq!(parsed.len(), 2);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_secret_file_fails_when_existing_file_is_unreadable() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("secret.txt");
+        std::fs::write(&path, "old\n").expect("write secret");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o200))
+            .expect("chmod secret");
+
+        let err = write_secret_file(&path, "next")
+            .await
+            .expect_err("unreadable existing file should fail");
+        assert!(
+            err.to_string()
+                .contains("Failed to read existing secret file")
+        );
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("restore secret permissions");
     }
 }

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -9,15 +9,12 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use bootroot::locale::Locale;
+use bootroot::trust_bootstrap::{
+    CA_BUNDLE_PEM_KEY, EAB_HMAC_KEY, EAB_KID_KEY, HMAC_KEY, SECRET_ID_KEY, SERVICE_KV_BASE,
+    TRUSTED_CA_KEY,
+};
 use clap::{Parser, ValueEnum};
 
-const SERVICE_KV_BASE: &str = "bootroot/services";
-const SECRET_ID_KEY: &str = "secret_id";
-const HMAC_KEY: &str = "hmac";
-const EAB_KID_KEY: &str = "kid";
-const EAB_HMAC_KEY: &str = "hmac";
-const TRUSTED_CA_KEY: &str = "trusted_ca_sha256";
-const CA_BUNDLE_PEM_KEY: &str = "ca_bundle_pem";
 const MANAGED_PROFILE_BEGIN_PREFIX: &str = "# BEGIN BOOTROOT REMOTE PROFILE";
 const MANAGED_PROFILE_END_PREFIX: &str = "# END BOOTROOT REMOTE PROFILE";
 const DEFAULT_AGENT_EMAIL: &str = "admin@example.com";

--- a/src/commands/constants.rs
+++ b/src/commands/constants.rs
@@ -1,7 +1,6 @@
 pub(crate) const RESPONDER_SERVICE_NAME: &str = "bootroot-http01";
-pub(crate) const SERVICE_KV_BASE: &str = "bootroot/services";
-pub(crate) const SERVICE_SECRET_ID_KEY: &str = "secret_id";
-pub(crate) const SERVICE_EAB_KID_KEY: &str = "kid";
-pub(crate) const SERVICE_EAB_HMAC_KEY: &str = "hmac";
-pub(crate) const SERVICE_RESPONDER_HMAC_KEY: &str = "hmac";
-pub(crate) const CA_TRUST_KEY: &str = "trusted_ca_sha256";
+pub(crate) use bootroot::trust_bootstrap::{
+    EAB_HMAC_KEY as SERVICE_EAB_HMAC_KEY, EAB_KID_KEY as SERVICE_EAB_KID_KEY,
+    HMAC_KEY as SERVICE_RESPONDER_HMAC_KEY, SECRET_ID_KEY as SERVICE_SECRET_ID_KEY,
+    SERVICE_KV_BASE, TRUSTED_CA_KEY as CA_TRUST_KEY,
+};

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -31,10 +31,10 @@ pub(super) const REMOTE_BOOTSTRAP_DIR: &str = "remote-bootstrap/services";
 pub(super) const REMOTE_BOOTSTRAP_FILENAME: &str = "bootstrap.json";
 pub(super) const MANAGED_PROFILE_BEGIN_PREFIX: &str = "# BEGIN bootroot managed profile:";
 pub(super) const MANAGED_PROFILE_END_PREFIX: &str = "# END bootroot managed profile:";
-pub(super) const SERVICE_CA_BUNDLE_PEM_KEY: &str = "ca_bundle_pem";
 pub(super) const DEFAULT_AGENT_EMAIL: &str = "admin@example.com";
 pub(super) const DEFAULT_AGENT_SERVER: &str = "https://localhost:9000/acme/acme/directory";
 pub(super) const DEFAULT_AGENT_RESPONDER_URL: &str = "http://127.0.0.1:8080";
+pub(super) use bootroot::trust_bootstrap::CA_BUNDLE_PEM_KEY as SERVICE_CA_BUNDLE_PEM_KEY;
 
 pub(super) struct ServiceAppRoleMaterialized {
     pub(super) role_name: String,

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -2,6 +2,10 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use bootroot::fs_util;
+use bootroot::trust_bootstrap::{
+    build_ca_bundle_ctmpl, build_managed_agent_ctmpl, build_trust_updates,
+    render_managed_profile_block as render_managed_profile, upsert_managed_profile_block,
+};
 use tokio::fs;
 
 use super::resolve::ResolvedServiceAdd;
@@ -11,7 +15,6 @@ use super::{
     OPENBAO_AGENT_TEMPLATE_FILENAME, OPENBAO_AGENT_TOKEN_FILENAME, OPENBAO_SERVICE_CONFIG_DIR,
     SERVICE_ROLE_ID_FILENAME, ServiceSyncMaterial,
 };
-use crate::commands::constants::{CA_TRUST_KEY, SERVICE_KV_BASE};
 use crate::i18n::Messages;
 
 pub(super) async fn apply_local_service_configs(
@@ -134,80 +137,25 @@ async fn write_local_ca_bundle(path: &Path, bundle_pem: &str, messages: &Message
 }
 
 fn render_managed_profile_block(args: &ResolvedServiceAdd) -> String {
-    let instance_id = args.instance_id.as_deref().unwrap_or_default();
-    let mut lines = Vec::new();
-    lines.push(format!(
-        "{MANAGED_PROFILE_BEGIN_PREFIX} {}",
-        args.service_name
-    ));
-    lines.push("[[profiles]]".to_string());
-    lines.push(format!("service_name = \"{}\"", args.service_name));
-    lines.push(format!("instance_id = \"{instance_id}\""));
-    lines.push(format!("hostname = \"{}\"", args.hostname));
-    lines.push(String::new());
-    lines.push("[profiles.paths]".to_string());
-    lines.push(format!("cert = \"{}\"", args.cert_path.display()));
-    lines.push(format!("key = \"{}\"", args.key_path.display()));
-    lines.push(format!(
-        "{MANAGED_PROFILE_END_PREFIX} {}",
-        args.service_name
-    ));
-    format!("{}\n", lines.join("\n"))
+    render_managed_profile(
+        MANAGED_PROFILE_BEGIN_PREFIX,
+        MANAGED_PROFILE_END_PREFIX,
+        &args.service_name,
+        args.instance_id.as_deref().unwrap_or_default(),
+        &args.hostname,
+        &args.cert_path,
+        &args.key_path,
+    )
 }
 
 fn upsert_managed_profile(contents: &str, service_name: &str, replacement: &str) -> String {
-    let begin_marker = format!("{MANAGED_PROFILE_BEGIN_PREFIX} {service_name}");
-    let end_marker = format!("{MANAGED_PROFILE_END_PREFIX} {service_name}");
-    if let Some(begin) = contents.find(&begin_marker)
-        && let Some(end_relative) = contents[begin..].find(&end_marker)
-    {
-        let end = begin + end_relative + end_marker.len();
-        let suffix = contents[end..]
-            .strip_prefix('\n')
-            .unwrap_or(&contents[end..]);
-        let mut updated = String::new();
-        updated.push_str(&contents[..begin]);
-        if !updated.is_empty() && !updated.ends_with('\n') {
-            updated.push('\n');
-        }
-        updated.push_str(replacement);
-        if !suffix.is_empty() && !replacement.ends_with('\n') {
-            updated.push('\n');
-        }
-        updated.push_str(suffix);
-        return updated;
-    }
-
-    let mut updated = contents.trim_end().to_string();
-    if !updated.is_empty() {
-        updated.push_str("\n\n");
-    }
-    updated.push_str(replacement);
-    updated
-}
-
-fn build_trust_updates(
-    fingerprints: &[String],
-    ca_bundle_path: &Path,
-) -> Vec<(&'static str, String)> {
-    let mut updates = Vec::with_capacity(2);
-    updates.push(("ca_bundle_path", ca_bundle_path.display().to_string()));
-    updates.push((
-        CA_TRUST_KEY,
-        format!(
-            "[{}]",
-            fingerprints
-                .iter()
-                .map(|value| format!("\"{value}\""))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
-    ));
-    updates
-}
-
-fn is_section_header(line: &str) -> bool {
-    line.starts_with('[') && line.ends_with(']')
+    upsert_managed_profile_block(
+        contents,
+        MANAGED_PROFILE_BEGIN_PREFIX,
+        MANAGED_PROFILE_END_PREFIX,
+        service_name,
+        replacement,
+    )
 }
 
 fn render_openbao_agent_config(
@@ -232,117 +180,11 @@ fn render_openbao_agent_config(
 }
 
 fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> String {
-    let base = format!("{SERVICE_KV_BASE}/{service_name}");
-
-    let hmac_template = format!(
-        "{{{{ with secret \"{kv_mount}/data/{base}/http_responder_hmac\" }}}}\
-         {{{{ .Data.data.hmac }}}}\
-         {{{{ end }}}}"
-    );
-    let with_hmac = replace_key_line_in_section(
-        contents,
-        "acme",
-        "http_responder_hmac",
-        &format!("http_responder_hmac = \"{hmac_template}\""),
-    );
-
-    let without_eab = remove_line_sections(&with_hmac, &["eab", "profiles.eab"]);
-
-    let trust_template_line = format!(
-        "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
-         trusted_ca_sha256 = {{{{ .Data.data.trusted_ca_sha256 | toJSON }}}}\
-         {{{{ end }}}}"
-    );
-    let with_trust = replace_key_line_in_section(
-        &without_eab,
-        "trust",
-        "trusted_ca_sha256",
-        &trust_template_line,
-    );
-
-    let eab_block = format!(
-        "\n{{{{ with secret \"{kv_mount}/data/{base}/eab\" }}}}{{{{ if .Data.data.kid }}}}\n\
-         [eab]\n\
-         kid = \"{{{{ .Data.data.kid }}}}\"\n\
-         hmac = \"{{{{ .Data.data.hmac }}}}\"\n\
-         \n\
-         [profiles.eab]\n\
-         kid = \"{{{{ .Data.data.kid }}}}\"\n\
-         hmac = \"{{{{ .Data.data.hmac }}}}\"\n\
-         {{{{ end }}}}{{{{ end }}}}\n"
-    );
-
-    let mut result = with_trust;
-    if !result.ends_with('\n') {
-        result.push('\n');
-    }
-    result.push_str(&eab_block);
-    result
+    build_managed_agent_ctmpl(contents, kv_mount, service_name)
 }
 
 fn build_ca_bundle_ctmpl_content(kv_mount: &str, service_name: &str) -> String {
-    let base = format!("{SERVICE_KV_BASE}/{service_name}");
-    format!(
-        "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
-         {{{{ .Data.data.ca_bundle_pem }}}}\
-         {{{{ end }}}}\n"
-    )
-}
-
-/// Removes sections from pseudo-TOML content using line-based matching.
-///
-/// Used for Go template (ctmpl) files where the content is not valid
-/// TOML and cannot be parsed by `toml_edit`.
-fn remove_line_sections(contents: &str, sections: &[&str]) -> String {
-    let mut output = String::new();
-    let mut skip = false;
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if is_section_header(trimmed) {
-            let section_name = &trimmed[1..trimmed.len() - 1];
-            skip = sections.contains(&section_name);
-            if skip {
-                continue;
-            }
-        }
-        if skip {
-            continue;
-        }
-        output.push_str(line);
-        output.push('\n');
-    }
-    output
-}
-
-fn replace_key_line_in_section(
-    contents: &str,
-    section: &str,
-    key: &str,
-    replacement: &str,
-) -> String {
-    let mut output = String::new();
-    let mut in_section = false;
-    let mut replaced = false;
-
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if is_section_header(trimmed) {
-            in_section = trimmed == format!("[{section}]");
-        }
-        if in_section
-            && !replaced
-            && (trimmed.starts_with(&format!("{key} =")) || trimmed.starts_with(&format!("{key}=")))
-        {
-            output.push_str(replacement);
-            output.push('\n');
-            replaced = true;
-            continue;
-        }
-        output.push_str(line);
-        output.push('\n');
-    }
-    output
+    build_ca_bundle_ctmpl(kv_mount, service_name)
 }
 
 #[cfg(test)]
@@ -351,6 +193,7 @@ mod tests {
 
     use super::super::resolve::ResolvedServiceAdd;
     use super::*;
+    use crate::commands::constants::CA_TRUST_KEY;
     use crate::state::{DeliveryMode, DeployType};
 
     fn test_resolved() -> ResolvedServiceAdd {

--- a/src/commands/trust.rs
+++ b/src/commands/trust.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use bootroot::openbao::OpenBaoClient;
+use bootroot::trust_bootstrap::CA_BUNDLE_PEM_KEY;
 use serde::{Deserialize, Serialize};
 
 use crate::commands::constants::{CA_TRUST_KEY, SERVICE_KV_BASE};
@@ -12,7 +13,6 @@ use crate::commands::init::PATH_CA_TRUST;
 use crate::i18n::Messages;
 use crate::state::ServiceEntry;
 
-const CA_BUNDLE_PEM_KEY: &str = "ca_bundle_pem";
 const SERVICE_TRUST_KV_SUFFIX: &str = "trust";
 const ROTATION_STATE_FILENAME: &str = "rotation-state.json";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod openbao;
 pub mod profile;
 pub mod tls;
 pub mod toml_util;
+pub mod trust_bootstrap;
 pub mod utils;
 
 mod daemon;

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -1,0 +1,279 @@
+use std::path::Path;
+
+pub const SERVICE_KV_BASE: &str = "bootroot/services";
+pub const SECRET_ID_KEY: &str = "secret_id";
+pub const HMAC_KEY: &str = "hmac";
+pub const EAB_KID_KEY: &str = "kid";
+pub const EAB_HMAC_KEY: &str = "hmac";
+pub const TRUSTED_CA_KEY: &str = "trusted_ca_sha256";
+pub const CA_BUNDLE_PEM_KEY: &str = "ca_bundle_pem";
+pub const CA_BUNDLE_PATH_KEY: &str = "ca_bundle_path";
+
+const ACME_SECTION_NAME: &str = "acme";
+const TRUST_SECTION_NAME: &str = "trust";
+const EAB_SECTION_NAME: &str = "eab";
+const PROFILE_EAB_SECTION_NAME: &str = "profiles.eab";
+const HTTP_RESPONDER_HMAC_KEY: &str = "http_responder_hmac";
+
+/// Renders a managed profile block for `agent.toml`.
+#[must_use]
+pub fn render_managed_profile_block(
+    begin_prefix: &str,
+    end_prefix: &str,
+    service_name: &str,
+    instance_id: &str,
+    hostname: &str,
+    cert_path: &Path,
+    key_path: &Path,
+) -> String {
+    format!(
+        "{begin_prefix} {service_name}\n\
+[[profiles]]\n\
+service_name = \"{service_name}\"\n\
+instance_id = \"{instance_id}\"\n\
+hostname = \"{hostname}\"\n\n\
+[profiles.paths]\n\
+cert = \"{cert}\"\n\
+key = \"{key}\"\n\
+{end_prefix} {service_name}\n",
+        cert = cert_path.display(),
+        key = key_path.display(),
+    )
+}
+
+/// Upserts a managed profile block in `agent.toml`.
+#[must_use]
+pub fn upsert_managed_profile_block(
+    contents: &str,
+    begin_prefix: &str,
+    end_prefix: &str,
+    service_name: &str,
+    replacement: &str,
+) -> String {
+    let begin_marker = format!("{begin_prefix} {service_name}");
+    let end_marker = format!("{end_prefix} {service_name}");
+    if let Some(begin) = contents.find(&begin_marker)
+        && let Some(end_relative) = contents[begin..].find(&end_marker)
+    {
+        let end = begin + end_relative + end_marker.len();
+        let suffix = contents[end..]
+            .strip_prefix('\n')
+            .unwrap_or(&contents[end..]);
+        let mut updated = String::new();
+        updated.push_str(&contents[..begin]);
+        if !updated.is_empty() && !updated.ends_with('\n') {
+            updated.push('\n');
+        }
+        updated.push_str(replacement);
+        if !suffix.is_empty() && !replacement.ends_with('\n') {
+            updated.push('\n');
+        }
+        updated.push_str(suffix);
+        return updated;
+    }
+
+    let mut updated = contents.trim_end().to_string();
+    if !updated.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(replacement);
+    updated
+}
+
+/// Builds trust section updates for a managed service profile.
+#[must_use]
+pub fn build_trust_updates(
+    fingerprints: &[String],
+    ca_bundle_path: &Path,
+) -> Vec<(&'static str, String)> {
+    let rendered_fingerprints = format!(
+        "[{}]",
+        fingerprints
+            .iter()
+            .map(|value| format!("\"{value}\""))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    vec![
+        (CA_BUNDLE_PATH_KEY, ca_bundle_path.display().to_string()),
+        (TRUSTED_CA_KEY, rendered_fingerprints),
+    ]
+}
+
+/// Builds an `OpenBao` Agent ctmpl for managed `agent.toml` updates.
+#[must_use]
+pub fn build_managed_agent_ctmpl(contents: &str, kv_mount: &str, service_name: &str) -> String {
+    let base = format!("{SERVICE_KV_BASE}/{service_name}");
+
+    let hmac_template = format!(
+        "{{{{ with secret \"{kv_mount}/data/{base}/http_responder_hmac\" }}}}\
+         {{{{ .Data.data.hmac }}}}\
+         {{{{ end }}}}"
+    );
+    let with_hmac = replace_key_line_in_section(
+        contents,
+        ACME_SECTION_NAME,
+        HTTP_RESPONDER_HMAC_KEY,
+        &format!("{HTTP_RESPONDER_HMAC_KEY} = \"{hmac_template}\""),
+    );
+
+    let without_eab =
+        remove_line_sections(&with_hmac, &[EAB_SECTION_NAME, PROFILE_EAB_SECTION_NAME]);
+
+    let trust_template_line = format!(
+        "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
+         {TRUSTED_CA_KEY} = {{{{ .Data.data.{TRUSTED_CA_KEY} | toJSON }}}}\
+         {{{{ end }}}}"
+    );
+    let with_trust = replace_key_line_in_section(
+        &without_eab,
+        TRUST_SECTION_NAME,
+        TRUSTED_CA_KEY,
+        &trust_template_line,
+    );
+
+    let eab_block = format!(
+        "\n{{{{ with secret \"{kv_mount}/data/{base}/eab\" }}}}{{{{ if .Data.data.{EAB_KID_KEY} }}}}\n\
+         [eab]\n\
+         kid = \"{{{{ .Data.data.{EAB_KID_KEY} }}}}\"\n\
+         hmac = \"{{{{ .Data.data.{EAB_HMAC_KEY} }}}}\"\n\
+         \n\
+         [profiles.eab]\n\
+         kid = \"{{{{ .Data.data.{EAB_KID_KEY} }}}}\"\n\
+         hmac = \"{{{{ .Data.data.{EAB_HMAC_KEY} }}}}\"\n\
+         {{{{ end }}}}{{{{ end }}}}\n"
+    );
+
+    let mut result = with_trust;
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result.push_str(&eab_block);
+    result
+}
+
+/// Builds an `OpenBao` Agent ctmpl for a rendered CA bundle file.
+#[must_use]
+pub fn build_ca_bundle_ctmpl(kv_mount: &str, service_name: &str) -> String {
+    let base = format!("{SERVICE_KV_BASE}/{service_name}");
+    format!(
+        "{{{{ with secret \"{kv_mount}/data/{base}/trust\" }}}}\
+         {{{{ .Data.data.{CA_BUNDLE_PEM_KEY} }}}}\
+         {{{{ end }}}}\n"
+    )
+}
+
+fn is_section_header(value: &str) -> bool {
+    value.starts_with('[') && value.ends_with(']')
+}
+
+fn remove_line_sections(contents: &str, sections: &[&str]) -> String {
+    let mut output = String::new();
+    let mut skip = false;
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if is_section_header(trimmed) {
+            let section_name = &trimmed[1..trimmed.len() - 1];
+            skip = sections.contains(&section_name);
+            if skip {
+                continue;
+            }
+        }
+        if skip {
+            continue;
+        }
+        output.push_str(line);
+        output.push('\n');
+    }
+    output
+}
+
+fn replace_key_line_in_section(
+    contents: &str,
+    section: &str,
+    key: &str,
+    replacement: &str,
+) -> String {
+    let mut output = String::new();
+    let mut in_section = false;
+    let mut replaced = false;
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if is_section_header(trimmed) {
+            in_section = trimmed == format!("[{section}]");
+        }
+        if in_section
+            && !replaced
+            && (trimmed.starts_with(&format!("{key} =")) || trimmed.starts_with(&format!("{key}=")))
+        {
+            output.push_str(replacement);
+            output.push('\n');
+            replaced = true;
+            continue;
+        }
+        output.push_str(line);
+        output.push('\n');
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    const BEGIN_PREFIX: &str = "# BEGIN managed profile:";
+    const END_PREFIX: &str = "# END managed profile:";
+
+    #[test]
+    fn upsert_managed_profile_block_is_idempotent() {
+        let block = render_managed_profile_block(
+            BEGIN_PREFIX,
+            END_PREFIX,
+            "edge-proxy",
+            "001",
+            "edge-node-01",
+            Path::new("certs/edge-proxy.crt"),
+            Path::new("certs/edge-proxy.key"),
+        );
+        let once = upsert_managed_profile_block("", BEGIN_PREFIX, END_PREFIX, "edge-proxy", &block);
+        let twice =
+            upsert_managed_profile_block(&once, BEGIN_PREFIX, END_PREFIX, "edge-proxy", &block);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn build_trust_updates_writes_bundle_and_pins_only() {
+        let updates = build_trust_updates(&["a".repeat(64)], Path::new("certs/ca-bundle.pem"));
+
+        assert_eq!(updates.len(), 2);
+        assert!(updates.iter().any(|(key, _)| *key == CA_BUNDLE_PATH_KEY));
+        assert!(updates.iter().any(|(key, _)| *key == TRUSTED_CA_KEY));
+    }
+
+    #[test]
+    fn build_managed_agent_ctmpl_replaces_hmac_and_trust() {
+        let input = "[acme]\nhttp_responder_hmac = \"old-hmac\"\n\n[trust]\ntrusted_ca_sha256 = [\"old\"]\n";
+        let output = build_managed_agent_ctmpl(input, "secret", "edge-proxy");
+
+        assert!(output.contains(
+            "{{ with secret \"secret/data/bootroot/services/edge-proxy/http_responder_hmac\" }}"
+        ));
+        assert!(output.contains("trusted_ca_sha256 = {{ .Data.data.trusted_ca_sha256 | toJSON }}"));
+        assert!(output.contains("[profiles.eab]"));
+        assert!(!output.contains("\"old-hmac\""));
+    }
+
+    #[test]
+    fn build_ca_bundle_ctmpl_reads_service_trust_bundle() {
+        let output = build_ca_bundle_ctmpl("secret", "edge-proxy");
+
+        assert!(
+            output.contains("{{ with secret \"secret/data/bootroot/services/edge-proxy/trust\" }}")
+        );
+        assert!(output.contains("{{ .Data.data.ca_bundle_pem }}"));
+    }
+}


### PR DESCRIPTION
Closes #442

## Summary
- move shared trust/bootstrap constants and managed profile/template helpers into `bootroot::trust_bootstrap`
- switch local-file and remote-bootstrap config mutation paths to the shared helpers so they stay aligned
- fail `bootroot-remote` secret writes when an existing file cannot be read instead of overwriting it silently

## Testing
- `cargo test trust_bootstrap --lib -- --nocapture`
- `cargo test commands::service::local_config::tests --bin bootroot -- --nocapture`
- `cargo test write_secret_file_fails_when_existing_file_is_unreadable --bin bootroot-remote -- --nocapture`
- `cargo test --test bootroot_service --test bootroot_remote --test e2e_same_host_local_file --test e2e_remote_happy_path -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `scripts/preflight/ci/check.sh`
- attempted `POSTGRES_PASSWORD=step-pass GRAFANA_ADMIN_PASSWORD=admin scripts/preflight/ci/e2e-matrix.sh`
- attempted `POSTGRES_PASSWORD=step-pass GRAFANA_ADMIN_PASSWORD=admin scripts/preflight/ci/e2e-extended.sh`

## Notes
- both Docker E2E preflight scripts reached `docker compose -f docker-compose.yml -f docker-compose.test.yml build step-ca bootroot-http01` on this machine and then stalled without further output, so I stopped them after reproducing the local environment limitation
