### PR TITLE
Clarify PostgreSQL sslmode docs

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -223,6 +223,10 @@ automation path. For example, place `step-ca+PostgreSQL` on a CA machine,
 edge service machine. Also, we cannot guarantee that the current `bootroot`
 setup fully supports this topology class.
 
+In that split-deployment class, do not reuse the local PostgreSQL examples
+with `sslmode=disable`. Configure PostgreSQL TLS and choose an appropriate
+`sslmode` for the remote trust boundary.
+
 Services added by `bootroot service add` may run either on the same machine as
 step-ca or on different machines. Regardless of placement, each service runtime
 must include both OpenBao Agent and bootroot-agent.

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -112,6 +112,12 @@ Examples:
 - Production (TLS enforced):
   `postgresql://step:<secret>@db.internal:5432/stepca?sslmode=require`
 
+The `sslmode=disable` example is only for the default topology where step-ca
+and PostgreSQL stay on the same machine and inside the same local trust
+boundary. If PostgreSQL moves to another machine or another network trust
+boundary, do not reuse the local-only example. Switch to PostgreSQL TLS with
+an appropriate `sslmode`.
+
 **Important**: When step-ca runs in a container, the `db.dataSource` host is
 **inside the container network**. The effective host must be the Compose
 service name (for example, `postgres`).
@@ -177,7 +183,9 @@ If these conditions are violated, `bootroot init`, `bootroot infra up`, and
 `bootroot rotate db` fail fast.
 
 When moving beyond a single-host trust boundary, switch to TLS-based DB
-transport (`sslmode=require` or `sslmode=verify-full`).
+transport (`sslmode=require` or `sslmode=verify-full`). In other words,
+`sslmode=disable` is documented only for the same-machine default topology,
+not for split step-ca/PostgreSQL deployments.
 
 ### Bare Metal
 

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -69,6 +69,9 @@ If you see `dial tcp 127.0.0.1:5432: connect: connection refused`, DSN host in
 - `localhost`/`127.0.0.1`/`::1` input should be normalized to `postgres`
 - Remote hosts like `db.internal` fail by design under single-host guardrails
 - Check init summary DB host conversion line (`from -> to`)
+- If you intentionally split step-ca and PostgreSQL across machines, do not
+  reuse the local `sslmode=disable` example. Use PostgreSQL TLS with
+  `sslmode=require` or `sslmode=verify-full`.
 
 ### responder check failures
 

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -200,6 +200,10 @@ CLI 사용법은 [CLI 문서](cli.md)와 [CLI 예제](cli-examples.md)에 정리
 `bootroot` 구성에서 이러한 토폴로지를 충분히 지원한다고 단정할 수는
 없습니다.
 
+이런 분리 배치에서는 로컬 PostgreSQL 예시의 `sslmode=disable`을 그대로
+재사용하면 안 됩니다. 원격 신뢰 경계에 맞게 PostgreSQL TLS와 적절한
+`sslmode`를 구성해야 합니다.
+
 `bootroot service add`로 등록한 서비스는 step-ca가 설치된 머신에서
 동작할 수도 있고, 다른 머신에서 동작할 수도 있습니다. 어떤 배치이든
 서비스 런타임에는 OpenBao Agent와 bootroot-agent를 함께 구성해야 합니다.

--- a/docs/ko/installation.md
+++ b/docs/ko/installation.md
@@ -109,6 +109,11 @@ postgresql://<user>:<password>@<host>:<port>/<db>?sslmode=<mode>
 - 운영(SSL 강제):
   `postgresql://step:<secret>@db.internal:5432/stepca?sslmode=require`
 
+`sslmode=disable` 예시는 step-ca와 PostgreSQL이 같은 머신, 같은 로컬 신뢰
+경계 안에 있는 기본 토폴로지 전용입니다. PostgreSQL을 다른 머신이나 다른
+네트워크 신뢰 경계로 분리하는 경우에는 이 로컬 예시를 그대로 재사용하지 말고
+PostgreSQL TLS와 적절한 `sslmode`를 사용해야 합니다.
+
 **중요**: step-ca가 컨테이너에서 실행 중이면 `db.dataSource`의 호스트는
 **컨테이너 내부 기준**입니다. 최종적으로는 Compose 서비스 이름(예:
 `postgres`)을 사용해야 합니다.
@@ -181,7 +186,9 @@ scripts/impl/update-ca-db-dsn.sh
 `bootroot rotate db`는 즉시 실패합니다.
 
 단일 호스트 신뢰 경계를 벗어나는 경우에는 DB 전송을 TLS 기반으로
-전환하세요(`sslmode=require` 또는 `sslmode=verify-full`).
+전환하세요(`sslmode=require` 또는 `sslmode=verify-full`). 다시 말해
+`sslmode=disable`은 같은 머신 기본 토폴로지에만 해당하며,
+step-ca/PostgreSQL 분리 배치에는 사용하면 안 됩니다.
 
 ### 베어메탈
 

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -68,6 +68,9 @@
 - `localhost`/`127.0.0.1`/`::1` 입력은 init 과정에서 `postgres`로 정규화되는지 확인
 - `db.internal` 같은 원격 호스트는 단일 호스트 가드레일에서 실패(설계된 동작)
 - init summary의 DB 호스트 변환 라인(`from -> to`) 확인
+- step-ca와 PostgreSQL을 서로 다른 머신에 분리 배치하려는 경우에는
+  로컬 예시의 `sslmode=disable`을 재사용하지 말고 PostgreSQL TLS와
+  `sslmode=require` 또는 `sslmode=verify-full`을 사용
 
 ### responder 체크 관련
 


### PR DESCRIPTION
Closes #445

## Summary
- clarify that `sslmode=disable` is only documented for the default same-machine step-ca/PostgreSQL topology
- tell operators to switch to PostgreSQL TLS when they split step-ca and PostgreSQL across machines or trust boundaries
- align the EN/KO installation, overview, and troubleshooting docs with that boundary

## Testing
- `scripts/preflight/ci/check.sh`
