### PR TITLE
Add sorting guideline to coding standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ before generating code.
   * Otherwise use `num_traits` conversions and handle errors explicitly.
 * **Types**:
   * Prefer `enum` over `String` whenever a finite set of values is expected.
+* **Sorting**: Prefer `sort_unstable`, `sort_unstable_by`, and
+  `sort_unstable_by_key` over their stable counterparts. The unstable
+  variants are faster and allocate no extra memory. Use stable `sort` only
+  when equal elements must preserve their original relative order.
 * **Minimizing `clone`**: Avoid unnecessary `clone()` or similar methods
   (e.g., `to_string()`, `to_owned()`). Performance-critical code must not
   harbour hidden copies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ before generating code.
   * Otherwise use `num_traits` conversions and handle errors explicitly.
 * **Types**:
   * Prefer `enum` over `String` whenever a finite set of values is expected.
+* **Sorting**: Prefer `sort_unstable`, `sort_unstable_by`, and
+  `sort_unstable_by_key` over their stable counterparts. The unstable
+  variants are faster and allocate no extra memory. Use stable `sort` only
+  when equal elements must preserve their original relative order.
 * **Minimizing `clone`**: Avoid unnecessary `clone()` or similar methods
   (e.g., `to_string()`, `to_owned()`). Performance-critical code must not
   harbour hidden copies.


### PR DESCRIPTION
## Summary

- Add **Sorting** rule to both `CLAUDE.md` and `AGENTS.md`: prefer `sort_unstable` variants over stable `sort` for performance and zero extra allocation.
- Aligns bootroot coding standards with the same rule already present in multifold.

## Test plan

- [ ] Verify `CLAUDE.md` and `AGENTS.md` render correctly on GitHub