### PR TITLE
Preserve CLI overrides across daemon retries (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed daemon-mode retries silently dropping CLI overrides (`--email`,
+  `--ca-url`, `--http-responder-url`, `--http-responder-hmac`). The retry
+  path reloaded the config file from disk without re-applying CLI-provided
+  values, causing the first attempt to succeed but subsequent attempts to
+  revert to file-only defaults.
 - Fixed `bootroot service add` (`local-file` mode) generating an agent config
   missing top-level `domain` and `[acme].http_responder_hmac`. The generated
   `agent.toml` is now ready to use without manual editing.

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -550,7 +550,10 @@ The command is considered failed when:
 Runs a one-shot issuance via bootroot-agent and verifies cert/key output.
 Use it after service onboarding or config changes to confirm issuance works.
 If you want **continuous renewal**, run bootroot-agent in daemon mode
-(without `--oneshot`) after verification.
+(without `--oneshot`) after verification. Any CLI overrides you pass
+(e.g. `--http-responder-hmac`, `--ca-url`) are preserved across
+daemon retry cycles, so the daemon behaves the same as `--oneshot`
+for those flags.
 
 ### Inputs
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -405,6 +405,11 @@ so CLI has the highest priority. For example, if `agent.toml` sets
 `email = "admin@example.com"`, running `bootroot-agent --email ops@example.com`
 uses `ops@example.com`.
 
+In daemon mode, the agent periodically reloads the config file from disk
+when retrying failed issuances. CLI overrides are preserved across these
+reloads — a value supplied via `--http-responder-hmac` on the command line
+remains in effect for every retry, not just the first attempt.
+
 ## HTTP-01 responder (responder.toml)
 
 The responder reads `responder.toml` (or `BOOTROOT_RESPONDER__*` env vars).

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -118,6 +118,17 @@ If mode and placement do not match, file/state updates go to the wrong path.
 - Requested SANs do not match step-ca provisioner policy
 - Validate both SAN generation and CA policy together
 
+### CLI HMAC works once then fails on retry (older builds)
+
+If the first issuance attempt succeeds but retries fail with
+`401 Unauthorized: Invalid signature`, and you are passing
+`--http-responder-hmac` (or other CLI overrides) without putting the value
+in `agent.toml`, upgrade to a build that includes the fix for #475.
+Older builds dropped CLI overrides on retry because the daemon reloaded the
+config file without re-applying command-line values. As a workaround on
+older builds, add `http_responder_hmac` to the `[acme]` section of
+`agent.toml` directly.
+
 ### Repeated ACME directory retries
 
 - Ensure `server` URL is `https://` (`http://` is rejected)

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -534,7 +534,9 @@ bootroot status
 bootroot-agent를 one-shot으로 실행해 발급을 검증합니다. 서비스 온보딩 직후
 또는 설정 변경 후에 실제 발급이 가능한지 확인할 때 사용합니다.
 검증 이후에도 **주기적 갱신을 원하면 bootroot-agent를 상시 모드로
-실행**해야 합니다(oneshot 없이 실행).
+실행**해야 합니다(oneshot 없이 실행). CLI로 전달한 오버라이드
+(예: `--http-responder-hmac`, `--ca-url`)는 데몬 재시도 시에도
+유지되므로, 해당 플래그는 `--oneshot`과 동일하게 동작합니다.
 
 ### 입력
 

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -373,6 +373,11 @@ backoff_secs = [5, 10, 30]
 그 외 설정(프로필, 재시도, 스케줄러, 훅, CA 번들 경로 등)은
 `agent.toml`에 정의해야 합니다.
 
+데몬 모드에서는 발급 재시도 시 설정 파일을 디스크에서 다시 읽습니다.
+CLI로 전달한 값은 매 재시도마다 다시 적용되므로, 예를 들어
+`--http-responder-hmac`으로 전달한 값은 첫 시도뿐 아니라 이후
+모든 재시도에서도 유지됩니다.
+
 ## HTTP-01 리스폰더 (responder.toml)
 
 리스폰더는 `responder.toml`(또는 `BOOTROOT_RESPONDER__*` 환경변수)을 읽습니다.

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -115,6 +115,17 @@
 - 요청 SAN이 step-ca 프로비저너 정책과 맞지 않을 때 발생합니다.
 - 서비스 SAN 생성 규칙과 CA 정책을 함께 점검하세요.
 
+### CLI HMAC이 첫 시도에서만 작동하고 재시도 시 실패(이전 빌드)
+
+첫 발급 시도는 성공하지만 재시도에서
+`401 Unauthorized: Invalid signature`로 실패하고,
+`--http-responder-hmac`(또는 기타 CLI 오버라이드)을 `agent.toml` 없이
+명령행으로만 전달한 경우, #475 수정이 포함된 빌드로 업그레이드하세요.
+이전 빌드에서는 데몬이 설정 파일을 다시 읽을 때 CLI 값을 재적용하지 않아
+재시도 시 CLI 오버라이드가 사라졌습니다. 이전 빌드의 임시 해결 방법은
+`agent.toml`의 `[acme]` 섹션에 `http_responder_hmac`을 직접 추가하는
+것입니다.
+
 ### ACME 디렉터리 재시도 반복
 
 - `server` URL이 `https://`인지 확인 (`http://` 거부)

--- a/src/bin/bootroot-agent.rs
+++ b/src/bin/bootroot-agent.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use bootroot::config::CliOverrides;
 use bootroot::{Args, config, eab, profile, run_daemon, run_oneshot};
 use clap::Parser;
 #[cfg(unix)]
@@ -32,6 +33,7 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let cli_overrides = CliOverrides::from(&args);
     let mut pending = None;
     #[cfg(unix)]
     let mut hup = signal(SignalKind::hangup())?;
@@ -47,6 +49,7 @@ async fn main() -> anyhow::Result<()> {
             final_eab,
             args.config.clone(),
             args.insecure,
+            cli_overrides.clone(),
         ));
         #[cfg(unix)]
         loop {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,30 @@ use serde::Deserialize;
 mod defaults;
 mod validation;
 
+/// CLI-provided overrides that must survive config reloads in daemon mode.
+///
+/// Fields mirror the subset of [`crate::Args`] that [`Settings::merge_with_args`]
+/// applies. Storing them separately lets the daemon re-apply overrides after
+/// every file-based reload without depending on the CLI parser.
+#[derive(Clone, Debug, Default)]
+pub struct CliOverrides {
+    pub email: Option<String>,
+    pub ca_url: Option<String>,
+    pub http_responder_url: Option<String>,
+    pub http_responder_hmac: Option<String>,
+}
+
+impl From<&crate::Args> for CliOverrides {
+    fn from(args: &crate::Args) -> Self {
+        Self {
+            email: args.email.clone(),
+            ca_url: args.ca_url.clone(),
+            http_responder_url: args.http_responder_url.clone(),
+            http_responder_hmac: args.http_responder_hmac.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Settings {
     pub email: String,
@@ -201,16 +225,21 @@ impl Settings {
 
     /// Merges CLI arguments into the settings, overriding values if present.
     pub fn merge_with_args(&mut self, args: &crate::Args) {
-        if let Some(email) = &args.email {
+        self.apply_overrides(&CliOverrides::from(args));
+    }
+
+    /// Re-applies CLI-provided overrides on top of these settings.
+    pub fn apply_overrides(&mut self, overrides: &CliOverrides) {
+        if let Some(email) = &overrides.email {
             email.clone_into(&mut self.email);
         }
-        if let Some(ca_url) = &args.ca_url {
+        if let Some(ca_url) = &overrides.ca_url {
             ca_url.clone_into(&mut self.server);
         }
-        if let Some(responder_url) = &args.http_responder_url {
+        if let Some(responder_url) = &overrides.http_responder_url {
             responder_url.clone_into(&mut self.acme.http_responder_url);
         }
-        if let Some(responder_hmac) = &args.http_responder_hmac {
+        if let Some(responder_hmac) = &overrides.http_responder_hmac {
             responder_hmac.clone_into(&mut self.acme.http_responder_hmac);
         }
     }
@@ -399,6 +428,93 @@ mod tests {
             settings.server,
             "https://localhost:9000/acme/acme/directory"
         );
+    }
+
+    #[test]
+    fn test_apply_overrides_replaces_all_fields() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        write_minimal_profile_config(&mut file);
+        let mut settings = Settings::new(Some(file.path().to_path_buf())).unwrap();
+
+        let overrides = CliOverrides {
+            email: Some("override@example.com".to_string()),
+            ca_url: Some("https://override-ca".to_string()),
+            http_responder_url: Some("http://override-responder".to_string()),
+            http_responder_hmac: Some("override-hmac".to_string()),
+        };
+
+        settings.apply_overrides(&overrides);
+
+        assert_eq!(settings.email, "override@example.com");
+        assert_eq!(settings.server, "https://override-ca");
+        assert_eq!(
+            settings.acme.http_responder_url,
+            "http://override-responder"
+        );
+        assert_eq!(settings.acme.http_responder_hmac, "override-hmac");
+    }
+
+    #[test]
+    fn test_apply_overrides_skips_none_fields() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        write_minimal_profile_config(&mut file);
+        let mut settings = Settings::new(Some(file.path().to_path_buf())).unwrap();
+        let original_email = settings.email.clone();
+        let original_server = settings.server.clone();
+
+        let overrides = CliOverrides::default();
+        settings.apply_overrides(&overrides);
+
+        assert_eq!(settings.email, original_email);
+        assert_eq!(settings.server, original_server);
+    }
+
+    /// Regression test for #475: reloading the config from disk then applying
+    /// CLI overrides must produce the CLI value, not the file/default value.
+    #[test]
+    fn test_reload_then_apply_overrides_preserves_cli_values() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        // Config deliberately omits http_responder_hmac so it falls back to
+        // the compiled default (empty string).
+        writeln!(
+            file,
+            r#"
+            domain = "trusted.domain"
+            email = "file@example.com"
+
+            [acme]
+            http_responder_url = "http://localhost:8080"
+
+            [[profiles]]
+            service_name = "edge-proxy"
+            instance_id = "001"
+            hostname = "edge-node-01"
+
+            [profiles.paths]
+            cert = "certs/edge-proxy-a.pem"
+            key = "certs/edge-proxy-a.key"
+        "#
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let overrides = CliOverrides {
+            email: None,
+            ca_url: Some("https://cli-ca".to_string()),
+            http_responder_url: None,
+            http_responder_hmac: Some("cli-hmac-secret".to_string()),
+        };
+
+        // Simulate the daemon retry path: reload from disk, then apply overrides.
+        let mut fresh = Settings::new(Some(file.path().to_path_buf())).unwrap();
+        fresh.apply_overrides(&overrides);
+
+        // CLI-provided values must win.
+        assert_eq!(fresh.server, "https://cli-ca");
+        assert_eq!(fresh.acme.http_responder_hmac, "cli-hmac-secret");
+        // File-provided values stay when CLI has no override.
+        assert_eq!(fresh.email, "file@example.com");
+        assert_eq!(fresh.acme.http_responder_url, "http://localhost:8080");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,6 +14,7 @@ const DEFAULT_AGENT_CONFIG_PATH: &str = "agent.toml";
 struct IssuanceRuntime {
     config_path: PathBuf,
     insecure_mode: bool,
+    cli_overrides: config::CliOverrides,
 }
 
 /// Runs the agent daemon loop for all profiles.
@@ -25,6 +26,7 @@ pub(crate) async fn run_daemon(
     default_eab: Option<eab::EabCredentials>,
     config_path: Option<PathBuf>,
     insecure_mode: bool,
+    cli_overrides: config::CliOverrides,
 ) -> anyhow::Result<()> {
     let max_concurrent = profile::max_concurrent_issuances(&settings)?;
     let semaphore = Arc::new(Semaphore::new(max_concurrent));
@@ -32,6 +34,7 @@ pub(crate) async fn run_daemon(
     let runtime = IssuanceRuntime {
         config_path: resolve_config_path(config_path.as_deref()),
         insecure_mode,
+        cli_overrides,
     };
 
     let shutdown_handle = tokio::spawn(async move {
@@ -139,6 +142,7 @@ pub(crate) async fn run_oneshot(
     let runtime = IssuanceRuntime {
         config_path: resolve_config_path(config_path.as_deref()),
         insecure_mode,
+        cli_overrides: config::CliOverrides::default(),
     };
     let mut handles = Vec::new();
 
@@ -242,19 +246,22 @@ async fn issue_with_retry(
     settings: &config::Settings,
     profile: &config::DaemonProfileSettings,
     eab: Option<eab::EabCredentials>,
-    config_path: &Path,
-    insecure_mode: bool,
+    runtime: &IssuanceRuntime,
 ) -> anyhow::Result<()> {
     let backoff = select_retry_backoff(settings, profile);
     let profile_domain = config::profile_domain(settings, profile);
-    let config_path_owned = config_path.to_path_buf();
+    let config_path_owned = runtime.config_path.clone();
+    let cli_overrides = runtime.cli_overrides.clone();
+    let insecure_mode = runtime.insecure_mode;
     issue_with_retry_inner(
         || {
             let path = config_path_owned.clone();
             let domain = profile_domain.clone();
             let eab = eab.clone();
+            let overrides = cli_overrides.clone();
             async move {
-                let fresh = config::Settings::new(Some(path))?;
+                let mut fresh = config::Settings::new(Some(path))?;
+                fresh.apply_overrides(&overrides);
                 let fresh_profile = fresh
                     .profiles
                     .iter()
@@ -390,14 +397,7 @@ async fn check_and_renew_profile(
     );
     let _permit = semaphore.acquire().await?;
     let profile_eab = profile::resolve_profile_eab(profile, default_eab);
-    let result = issue_with_retry(
-        settings,
-        profile,
-        profile_eab,
-        &runtime.config_path,
-        runtime.insecure_mode,
-    )
-    .await;
+    let result = issue_with_retry(settings, profile, profile_eab, runtime).await;
     if let Err(err) = &result {
         error!(
             "Profile '{}' renewal failed after retries: {err}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,16 @@ pub async fn run_daemon(
     default_eab: Option<eab::EabCredentials>,
     config_path: Option<PathBuf>,
     insecure_mode: bool,
+    cli_overrides: config::CliOverrides,
 ) -> anyhow::Result<()> {
-    daemon::run_daemon(settings, default_eab, config_path, insecure_mode).await
+    daemon::run_daemon(
+        settings,
+        default_eab,
+        config_path,
+        insecure_mode,
+        cli_overrides,
+    )
+    .await
 }
 
 /// Runs a single issuance pass for all profiles.


### PR DESCRIPTION
## Summary

- Introduced `CliOverrides` struct that captures CLI-provided values (`--email`, `--ca-url`, `--http-responder-url`, `--http-responder-hmac`) at startup.
- The daemon retry path now calls `Settings::apply_overrides()` after every config-file reload, keeping CLI flags sticky for the lifetime of the process.
- Added regression tests verifying that reload-then-apply preserves CLI values.

Closes #475

## Test plan

- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes, including the three new `CliOverrides` / `apply_overrides` unit tests
- [x] Manual: run `bootroot-agent` in daemon mode with `--http-responder-hmac` on the CLI (not in `agent.toml`) — verify retries still send the correct HMAC (no `401 Unauthorized`)
- [x] Manual: run `bootroot-agent --oneshot` with CLI overrides — verify behavior is unchanged
- [x] Manual: modify `agent.toml` between retries (e.g. change `email`) — verify the file change is picked up while CLI overrides still win for their fields
- [ ] `scripts/preflight/run-all.sh` passes