### PR TITLE
Add post-renew hook flags to service add (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added post-renew hook flags to `bootroot service add`. Services can now
+  configure a hook to run after successful certificate renewal at
+  registration time, removing the need to hand-edit `agent.toml`.
+  Two flag styles are supported: presets (`--reload-style systemd
+  --reload-target nginx`) and low-level (`--post-renew-command`,
+  `--post-renew-arg`, `--post-renew-timeout-secs`,
+  `--post-renew-on-failure`). Hook settings are persisted in
+  `state.json` and forwarded to `bootroot-remote bootstrap` for
+  remote-bootstrap delivery mode.
 - Added automatic HTTP-01 DNS alias registration on `service add`. The
   validation FQDN is registered as a Docker network alias on
   `bootroot-http01` at runtime, removing the need for a hand-written

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Open source dependencies:
   visualizes them for local ops.
 - **Service onboarding**: `bootroot service add` registers service metadata,
   creates an AppRole, automatically registers the HTTP-01 DNS alias on the
-  responder, and prints the run instructions for bootroot-agent and OpenBao
-  Agent — no manual `docker-compose.override.yml` required.
+  responder, optionally configures a post-renew hook (`--reload-style` or
+  `--post-renew-command`), and prints the run instructions for bootroot-agent
+  and OpenBao Agent — no manual config editing required.
 - **Certificate flow**: bootroot-agent issues/renews certs; OpenBao Agent
   renders secrets and config files for each service.
 

--- a/docs/en/cli-examples.md
+++ b/docs/en/cli-examples.md
@@ -277,6 +277,37 @@ In operations, start from the `remote run command template` printed by
 `--agent-responder-url` with remote-reachable endpoints such as
 `stepca.internal` and `responder.internal`.
 
+### 3-4) Post-renew hook (reload style preset)
+
+Use `--reload-style` and `--reload-target` to configure
+a post-renew hook that reloads the service after
+certificate renewal:
+
+```bash
+bootroot service add \
+  --service-name edge-proxy \
+  --deploy-type daemon \
+  --hostname edge-node-01 \
+  --domain trusted.domain \
+  --agent-config /etc/bootroot/agent.toml \
+  --cert-path /etc/bootroot/certs/edge-proxy.crt \
+  --key-path /etc/bootroot/certs/edge-proxy.key \
+  --instance-id 001 \
+  --reload-style systemd \
+  --reload-target nginx \
+  --root-token <OPENBAO_ROOT_TOKEN>
+```
+
+This expands into a `[profiles.hooks.post_renew]` entry
+in the generated `agent.toml` profile that runs
+`systemctl reload nginx` after each successful renewal.
+Other preset styles are `sighup` (sends `SIGHUP` via
+`pkill`), `docker-restart` (runs `docker restart`), and
+`none` (no hook). For full control, use the low-level
+flags `--post-renew-command`, `--post-renew-arg`,
+`--post-renew-timeout-secs`, and
+`--post-renew-on-failure` instead.
+
 After secret_id rotation on the control node, deliver the new secret_id to the
 remote node:
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -492,6 +492,35 @@ Input priority is **CLI flags > environment variables > prompts/defaults**.
 - `--print-only`: print snippets/next steps without writing state/files
 - `--dry-run`: alias of preview mode (same effect as `--print-only`)
 
+Post-renew hook flags (preset):
+
+- `--reload-style`: reload style preset
+  (`sighup`, `systemd`, `docker-restart`, or `none`)
+- `--reload-target`: target for the preset
+  (process name, systemd unit, or container name)
+
+Presets expand into the following `post_renew` hook
+entries in the generated `agent.toml` profile:
+
+- `systemd` + target `nginx` — `systemctl reload nginx`
+- `sighup` + target `nginx` — `pkill -HUP nginx`
+- `docker-restart` + target `my-container` — `docker restart my-container`
+- `none` — no hook
+
+Post-renew hook flags (low-level):
+
+- `--post-renew-command`: hook command to run after successful renewal
+- `--post-renew-arg`: hook argument (repeatable)
+- `--post-renew-timeout-secs`: hook timeout in seconds (default `30`)
+- `--post-renew-on-failure`: failure policy (`continue` or `stop`, default `continue`)
+
+Preset flags (`--reload-style`/`--reload-target`) and
+low-level flags (`--post-renew-*`) are mutually
+exclusive. When preset flags are used, they expand into
+the equivalent low-level hook settings. These flags are
+also forwarded to `bootroot-remote bootstrap` for the
+`remote-bootstrap` delivery mode.
+
 ### Interactive behavior
 
 - Prompts for missing required inputs (deploy type defaults to `daemon`).
@@ -1010,6 +1039,12 @@ Key inputs:
     `responder.internal`.
 - `--ca-bundle-path`
   - required output path for the managed step-ca trust bundle.
+- post-renew hook flags: `--reload-style`,
+  `--reload-target`, `--post-renew-command`,
+  `--post-renew-arg`, `--post-renew-timeout-secs`,
+  `--post-renew-on-failure` (same semantics as
+  `bootroot service add`; passed through from the
+  generated remote handoff command template)
 - `--summary-json` (optional) and `--output text|json` (default `text`)
 
 If `agent.toml` does not exist yet, bootstrap creates a baseline config and

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -376,6 +376,20 @@ Hooks run **after** issuance/renewal completes. Use `success` for actions that
 should run only when a certificate is issued/renewed, and `failure` for alerting
 or cleanup when issuance fails.
 
+Hooks can also be configured at `bootroot service add`
+time using CLI flags instead of editing `agent.toml`
+manually. Use the preset flags `--reload-style` and
+`--reload-target` for common reload patterns (e.g.
+`--reload-style systemd --reload-target nginx`), or the
+low-level flags `--post-renew-command`,
+`--post-renew-arg`, `--post-renew-timeout-secs`, and
+`--post-renew-on-failure` for full control. These flags
+generate the corresponding
+`[profiles.hooks.post_renew]` entry in the managed
+profile. For the `remote-bootstrap` delivery mode, the
+same flags are forwarded to
+`bootroot-remote bootstrap`.
+
 What hooks are used for:
 
 - Reload or restart a daemon so it reads the new certificate

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -60,6 +60,10 @@ bootroot monitoring status
 - Ensure key/secret permissions stay `0600`/`0700` on disk.
 - Use hooks to reload dependent services after renewals
   (hook definitions live in **Configuration**).
+  Hooks can be configured at service onboarding time via
+  `bootroot service add --reload-style`/`--reload-target` (presets) or
+  `--post-renew-command`/`--post-renew-arg` (low-level), which write the
+  `[profiles.hooks.post_renew]` entry into the managed `agent.toml` profile.
 - Services that use mTLS must be able to read the CA bundle
   (for example, `trust.ca_bundle_path`).
 

--- a/docs/ko/cli-examples.md
+++ b/docs/ko/cli-examples.md
@@ -274,6 +274,38 @@ bootroot-remote bootstrap \
 `--agent-server`, `--agent-responder-url`를 `stepca.internal`,
 `responder.internal` 같은 원격 접근 가능 엔드포인트로 바꿔서 사용하세요.
 
+### 3-4) 갱신 후 훅 (리로드 스타일 프리셋)
+
+`--reload-style`과 `--reload-target`을 사용하면
+인증서 갱신 후 서비스를 리로드하는 post-renew 훅을
+설정할 수 있습니다:
+
+```bash
+bootroot service add \
+  --service-name edge-proxy \
+  --deploy-type daemon \
+  --hostname edge-node-01 \
+  --domain trusted.domain \
+  --agent-config /etc/bootroot/agent.toml \
+  --cert-path /etc/bootroot/certs/edge-proxy.crt \
+  --key-path /etc/bootroot/certs/edge-proxy.key \
+  --instance-id 001 \
+  --reload-style systemd \
+  --reload-target nginx \
+  --root-token <OPENBAO_ROOT_TOKEN>
+```
+
+이 명령은 생성된 `agent.toml` 프로필에
+`[profiles.hooks.post_renew]` 항목을 추가하여
+갱신 성공 시마다 `systemctl reload nginx`를
+실행합니다. 다른 프리셋 스타일로는
+`sighup`(`pkill`로 `SIGHUP` 전송),
+`docker-restart`(`docker restart` 실행),
+`none`(훅 없음)이 있습니다. 세부 제어가 필요하면
+저수준 플래그 `--post-renew-command`,
+`--post-renew-arg`, `--post-renew-timeout-secs`,
+`--post-renew-on-failure`를 사용하세요.
+
 control node에서 secret_id 회전 후 새 secret_id를 원격 노드에 전달:
 
 ```bash

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -478,6 +478,32 @@ bootroot status
 - `--print-only`: 파일/state 변경 없이 안내/스니펫만 출력
 - `--dry-run`: preview 모드 별칭(`--print-only`와 동일)
 
+갱신 후 훅 플래그(프리셋):
+
+- `--reload-style`: 리로드 스타일 프리셋 (`sighup`, `systemd`, `docker-restart`, `none`)
+- `--reload-target`: 프리셋 대상 (프로세스 이름, systemd 유닛, 컨테이너 이름)
+
+프리셋은 생성된 `agent.toml` 프로필에 다음과 같은 `post_renew` 훅 항목으로 확장됩니다:
+
+- `systemd` + 대상 `nginx` — `systemctl reload nginx`
+- `sighup` + 대상 `nginx` — `pkill -HUP nginx`
+- `docker-restart` + 대상 `my-container` — `docker restart my-container`
+- `none` — 훅 없음
+
+갱신 후 훅 플래그(저수준):
+
+- `--post-renew-command`: 갱신 성공 후 실행할 훅 명령
+- `--post-renew-arg`: 훅 인자 (반복 가능)
+- `--post-renew-timeout-secs`: 훅 타임아웃(초, 기본값 `30`)
+- `--post-renew-on-failure`: 실패 정책 (`continue` 또는 `stop`, 기본값 `continue`)
+
+프리셋 플래그(`--reload-style`/`--reload-target`)와
+저수준 플래그(`--post-renew-*`)는 상호
+배타적입니다. 프리셋 플래그를 사용하면 동등한
+저수준 훅 설정으로 확장됩니다.
+`remote-bootstrap` 전달 모드에서는 이 플래그가
+`bootroot-remote bootstrap`으로 전달됩니다.
+
 ### 대화형 동작
 
 - 누락된 필수 입력을 프롬프트로 받습니다(배포 타입 기본값: `daemon`).
@@ -978,6 +1004,12 @@ OpenBao에 저장된 서비스 목표 상태(`secret_id`/`eab`/`responder_hmac`/
     바꿔야 합니다.
 - `--ca-bundle-path`
   - 관리되는 step-ca trust bundle을 쓸 출력 경로로 항상 필요합니다.
+- 갱신 후 훅 플래그: `--reload-style`,
+  `--reload-target`, `--post-renew-command`,
+  `--post-renew-arg`, `--post-renew-timeout-secs`,
+  `--post-renew-on-failure` (`bootroot service add`와
+  동일한 의미; 생성된 원격 handoff 명령 템플릿에서
+  전달)
 - `--summary-json`(선택), `--output text|json` (기본값 `text`)
 
 `agent.toml`이 아직 없으면 bootstrap 단계에서 baseline을 생성한 뒤, 서비스용

--- a/docs/ko/configuration.md
+++ b/docs/ko/configuration.md
@@ -335,6 +335,22 @@ backoff_secs = [5, 10, 30]
 훅은 인증서 발급/갱신이 끝난 뒤에 실행하는 후처리 작업입니다. `success`는
 해당 단계가 성공했을 때, `failure`는 실패했을 때 실행할 작업을 의미합니다.
 인증서를 읽는 데몬에 신호를 보내거나 재시작하는 등의 운영 작업을 넣습니다.
+
+훅은 `agent.toml`을 직접 편집하는 대신
+`bootroot service add` 시점에 CLI 플래그로도
+설정할 수 있습니다. 일반적인 리로드 패턴에는
+프리셋 플래그 `--reload-style`과
+`--reload-target`을 사용하고(예:
+`--reload-style systemd --reload-target nginx`),
+세부 제어가 필요하면 저수준 플래그
+`--post-renew-command`, `--post-renew-arg`,
+`--post-renew-timeout-secs`,
+`--post-renew-on-failure`를 사용합니다.
+이 플래그들은 관리 대상 프로필에 대응하는
+`[profiles.hooks.post_renew]` 항목을 생성합니다.
+`remote-bootstrap` 전달 모드에서는 동일한
+플래그가 `bootroot-remote bootstrap`으로
+전달됩니다.
 `systemctl reload`는 서비스가 `ExecReload`를 제공하거나 신호 기반 리로드를
 지원할 때만 동작합니다. 지원하지 않는 데몬은 `systemctl restart`로 다시
 시작해야 하고, 직접 `kill -HUP <pid>`처럼 신호를 보내는 방식도 사용할 수

--- a/docs/ko/operations.md
+++ b/docs/ko/operations.md
@@ -51,6 +51,13 @@ bootroot monitoring status
 - 발급/검증/훅 결과 로그를 모니터링합니다.
 - 키/시크릿 권한이 `0600`/`0700`으로 유지되는지 확인합니다.
 - 갱신 후 리로드가 필요하면 **설정**의 훅을 사용합니다.
+  서비스 온보딩 시
+  `bootroot service add --reload-style`/
+  `--reload-target`(프리셋) 또는
+  `--post-renew-command`/`--post-renew-arg`(저수준)로
+  훅을 설정할 수 있으며, 이 플래그들은 관리 대상
+  `agent.toml` 프로필에
+  `[profiles.hooks.post_renew]` 항목을 기록합니다.
 - mTLS를 사용하는 서비스는 CA 번들을 읽을 수 있어야 합니다
   (예: `trust.ca_bundle_path`).
 

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -12,7 +13,8 @@ use tokio::fs;
 use super::io::PulledSecrets;
 use super::summary::{ApplyItemSummary, ApplyStatus};
 use super::{
-    BootstrapArgs, Locale, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX, localized,
+    BootstrapArgs, HookFailurePolicy, Locale, MANAGED_PROFILE_BEGIN_PREFIX,
+    MANAGED_PROFILE_END_PREFIX, localized,
 };
 
 struct ProfilePaths {
@@ -76,19 +78,18 @@ pub(super) async fn apply_agent_config_updates(
                 );
             }
         };
-    let with_profile = upsert_managed_profile_block(
-        &trust_updated,
+    let profile_block = render_managed_profile_block(
         &args.service_name,
-        &render_managed_profile_block(
-            &args.service_name,
-            args.profile_instance_id
-                .as_deref()
-                .expect("validate_bootstrap_args requires profile_instance_id"),
-            &args.profile_hostname,
-            &profile_paths.cert_path,
-            &profile_paths.key_path,
-        ),
+        args.profile_instance_id
+            .as_deref()
+            .expect("validate_bootstrap_args requires profile_instance_id"),
+        &args.profile_hostname,
+        &profile_paths.cert_path,
+        &profile_paths.key_path,
     );
+    let profile_block = inject_hooks_into_profile_block(&profile_block, args);
+    let with_profile =
+        upsert_managed_profile_block(&trust_updated, &args.service_name, &profile_block);
 
     let responder_changed = hmac_updated != agent_config;
     let trust_changed = trust_updated != hmac_updated;
@@ -200,6 +201,45 @@ fn resolve_profile_paths(args: &BootstrapArgs) -> ProfilePaths {
     ProfilePaths {
         cert_path,
         key_path,
+    }
+}
+
+fn inject_hooks_into_profile_block(block: &str, args: &BootstrapArgs) -> String {
+    let Some(command) = args.post_renew_command.as_deref() else {
+        return block.to_string();
+    };
+    let timeout_secs = args.post_renew_timeout_secs.unwrap_or(30);
+    let on_failure = match args.post_renew_on_failure {
+        Some(HookFailurePolicy::Stop) => "stop",
+        _ => "continue",
+    };
+    let mut hook_toml = String::from("\n[[profiles.hooks.post_renew.success]]\n");
+    let _ = writeln!(
+        hook_toml,
+        "command = {}",
+        bootroot::toml_util::toml_encode_string(command)
+    );
+    if !args.post_renew_arg.is_empty() {
+        let formatted_args = args
+            .post_renew_arg
+            .iter()
+            .map(|a| bootroot::toml_util::toml_encode_string(a))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = writeln!(hook_toml, "args = [{formatted_args}]");
+    }
+    let _ = writeln!(hook_toml, "timeout_secs = {timeout_secs}");
+    let _ = writeln!(hook_toml, "on_failure = \"{on_failure}\"");
+
+    if let Some(end_pos) = block.rfind(MANAGED_PROFILE_END_PREFIX) {
+        let mut result = block[..end_pos].to_string();
+        result.push_str(&hook_toml);
+        result.push_str(&block[end_pos..]);
+        result
+    } else {
+        let mut result = block.to_string();
+        result.push_str(&hook_toml);
+        result
     }
 }
 
@@ -374,9 +414,10 @@ template {{
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
-    use super::build_trust_updates;
+    use super::*;
+    use crate::OutputFormat;
 
     #[test]
     fn upsert_toml_section_keys_updates_existing_section() {
@@ -398,5 +439,72 @@ mod tests {
         assert!(output.contains("[trust]"));
         assert!(output.contains("ca_bundle_path = \"certs/ca.pem\""));
         assert!(output.contains("trusted_ca_sha256 = ["));
+    }
+
+    fn test_bootstrap_args() -> BootstrapArgs {
+        BootstrapArgs {
+            openbao_url: "https://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+            service_name: "edge-proxy".to_string(),
+            role_id_path: PathBuf::from("/tmp/role_id"),
+            secret_id_path: PathBuf::from("/tmp/secrets/services/edge-proxy/secret_id"),
+            eab_file_path: PathBuf::from("/tmp/eab.json"),
+            agent_config_path: PathBuf::from("/tmp/agent.toml"),
+            agent_email: "admin@example.com".to_string(),
+            agent_server: "https://localhost:9443".to_string(),
+            agent_domain: "example.com".to_string(),
+            agent_responder_url: "http://localhost:8080".to_string(),
+            profile_hostname: "localhost".to_string(),
+            profile_instance_id: Some("001".to_string()),
+            profile_cert_path: None,
+            profile_key_path: None,
+            ca_bundle_path: PathBuf::from("/tmp/ca-bundle.pem"),
+            post_renew_command: None,
+            post_renew_arg: Vec::new(),
+            post_renew_timeout_secs: None,
+            post_renew_on_failure: None,
+            output: OutputFormat::Text,
+        }
+    }
+
+    #[test]
+    fn inject_hooks_escapes_control_characters() {
+        let mut args = test_bootstrap_args();
+        args.post_renew_command = Some("echo\nnext".to_string());
+        args.post_renew_arg = vec!["line1\tline2".to_string()];
+        args.post_renew_timeout_secs = Some(10);
+
+        let prefix = MANAGED_PROFILE_BEGIN_PREFIX;
+        let suffix = MANAGED_PROFILE_END_PREFIX;
+        let block = format!(
+            "{prefix} edge-proxy\n[[profiles]]\nservice_name = \"edge-proxy\"\n{suffix} edge-proxy\n",
+        );
+        let result = inject_hooks_into_profile_block(&block, &args);
+
+        // Extract just the hook section and parse it as TOML.
+        let wrapped = format!(
+            "[profiles]\n[profiles.hooks]\n[profiles.hooks.post_renew]{}",
+            &result[result
+                .find("\n[[profiles.hooks.post_renew.success]]")
+                .expect("hook header must exist")..]
+                .split(MANAGED_PROFILE_END_PREFIX)
+                .next()
+                .unwrap()
+        );
+        let doc: toml_edit::DocumentMut = wrapped
+            .parse()
+            .expect("rendered hook TOML with control chars must be parseable");
+
+        let success = doc["profiles"]["hooks"]["post_renew"]["success"]
+            .as_array_of_tables()
+            .expect("success must be an array of tables");
+        let hook = success.get(0).expect("must have one hook entry");
+        assert_eq!(
+            hook["command"].as_str().unwrap(),
+            "echo\nnext",
+            "command must round-trip through TOML"
+        );
+        let args_arr = hook["args"].as_array().expect("args must be an array");
+        assert_eq!(args_arr.get(0).unwrap().as_str().unwrap(), "line1\tline2");
     }
 }

--- a/src/bin/bootroot-remote/bootstrap.rs
+++ b/src/bin/bootroot-remote/bootstrap.rs
@@ -120,7 +120,30 @@ pub(super) async fn run_bootstrap(args: BootstrapArgs, lang: Locale) -> Result<i
     Ok(0)
 }
 
+fn validate_hook_flags(args: &BootstrapArgs) -> Result<()> {
+    if args.post_renew_command.is_none()
+        && (!args.post_renew_arg.is_empty()
+            || args.post_renew_timeout_secs.is_some()
+            || args.post_renew_on_failure.is_some())
+    {
+        anyhow::bail!(
+            "--post-renew-arg, --post-renew-timeout-secs, and \
+             --post-renew-on-failure require --post-renew-command"
+        );
+    }
+    if let Some(cmd) = args.post_renew_command.as_deref()
+        && cmd.trim().is_empty()
+    {
+        anyhow::bail!("--post-renew-command must not be empty");
+    }
+    if let Some(0) = args.post_renew_timeout_secs {
+        anyhow::bail!("--post-renew-timeout-secs must be greater than 0");
+    }
+    Ok(())
+}
+
 fn validate_bootstrap_args(args: &BootstrapArgs, lang: Locale) -> Result<()> {
+    validate_hook_flags(args)?;
     validate_service_name(&args.service_name, lang)?;
     validate_profile_hostname(&args.profile_hostname, lang)?;
     validate_agent_domain(&args.agent_domain, lang)?;
@@ -181,4 +204,131 @@ fn validate_bootstrap_args(args: &BootstrapArgs, lang: Locale) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::{HookFailurePolicy, OutputFormat};
+
+    /// Builds a `BootstrapArgs` with dummy values.  Only hook-related fields
+    /// are meaningful — `validate_hook_flags` runs before any other check, so
+    /// the remaining fields are never inspected in these tests.
+    fn dummy_args() -> BootstrapArgs {
+        BootstrapArgs {
+            openbao_url: String::new(),
+            kv_mount: String::new(),
+            service_name: String::new(),
+            role_id_path: PathBuf::new(),
+            secret_id_path: PathBuf::new(),
+            eab_file_path: PathBuf::new(),
+            agent_config_path: PathBuf::new(),
+            agent_email: String::new(),
+            agent_server: String::new(),
+            agent_domain: String::new(),
+            agent_responder_url: String::new(),
+            profile_hostname: String::new(),
+            profile_instance_id: None,
+            profile_cert_path: None,
+            profile_key_path: None,
+            ca_bundle_path: PathBuf::new(),
+            post_renew_command: None,
+            post_renew_arg: Vec::new(),
+            post_renew_timeout_secs: None,
+            post_renew_on_failure: None,
+            output: OutputFormat::Text,
+        }
+    }
+
+    #[test]
+    fn hook_flags_without_command_are_rejected() {
+        let mut args = dummy_args();
+        args.post_renew_arg = vec!["reload".to_string()];
+        args.post_renew_timeout_secs = Some(60);
+
+        let err = validate_hook_flags(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--post-renew-command"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn hook_timeout_alone_without_command_is_rejected() {
+        let mut args = dummy_args();
+        args.post_renew_timeout_secs = Some(60);
+
+        let err = validate_hook_flags(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--post-renew-command"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn hook_on_failure_alone_without_command_is_rejected() {
+        let mut args = dummy_args();
+        args.post_renew_on_failure = Some(HookFailurePolicy::Stop);
+
+        let err = validate_hook_flags(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--post-renew-command"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn hook_flags_with_command_are_accepted() {
+        let mut args = dummy_args();
+        args.post_renew_command = Some("/usr/bin/reload.sh".to_string());
+        args.post_renew_arg = vec!["--fast".to_string()];
+        args.post_renew_timeout_secs = Some(60);
+
+        assert!(validate_hook_flags(&args).is_ok());
+    }
+
+    #[test]
+    fn no_hook_flags_are_accepted() {
+        let args = dummy_args();
+        assert!(validate_hook_flags(&args).is_ok());
+    }
+
+    #[test]
+    fn empty_command_is_rejected() {
+        let mut args = dummy_args();
+        args.post_renew_command = Some(String::new());
+
+        let err = validate_hook_flags(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn whitespace_only_command_is_rejected() {
+        let mut args = dummy_args();
+        args.post_renew_command = Some("   ".to_string());
+
+        let err = validate_hook_flags(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn zero_timeout_is_rejected() {
+        let mut args = dummy_args();
+        args.post_renew_command = Some("reload.sh".to_string());
+        args.post_renew_timeout_secs = Some(0);
+
+        let err = validate_hook_flags(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("greater than 0"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -138,9 +138,31 @@ struct BootstrapArgs {
     #[arg(long)]
     ca_bundle_path: PathBuf,
 
+    /// Post-renew success hook command
+    #[arg(long)]
+    post_renew_command: Option<String>,
+
+    /// Post-renew success hook argument (repeatable)
+    #[arg(long)]
+    post_renew_arg: Vec<String>,
+
+    /// Post-renew success hook timeout in seconds
+    #[arg(long)]
+    post_renew_timeout_secs: Option<u64>,
+
+    /// Post-renew success hook failure policy (continue or stop)
+    #[arg(long, value_enum)]
+    post_renew_on_failure: Option<HookFailurePolicy>,
+
     /// Output format
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     output: OutputFormat,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum HookFailurePolicy {
+    Continue,
+    Stop,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -7,7 +7,7 @@ use crate::commands::init::{
     DEFAULT_COMPOSE_FILE, DEFAULT_KV_MOUNT, DEFAULT_OPENBAO_URL, DEFAULT_SECRETS_DIR,
     DEFAULT_STEPCA_PROVISIONER, DEFAULT_STEPCA_URL,
 };
-use crate::state::{DeliveryMode, DeployType};
+use crate::state::{DeliveryMode, DeployType, HookFailurePolicyEntry};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -117,6 +117,33 @@ pub(crate) enum AuthMode {
     Auto,
     Root,
     Approle,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReloadStyle {
+    /// Send SIGHUP to a process by name
+    Sighup,
+    /// Reload a systemd unit
+    Systemd,
+    /// Restart a Docker container
+    DockerRestart,
+    /// No post-renew hook
+    None,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HookFailurePolicyArg {
+    Continue,
+    Stop,
+}
+
+impl HookFailurePolicyArg {
+    pub(crate) fn into_entry(self) -> HookFailurePolicyEntry {
+        match self {
+            Self::Continue => HookFailurePolicyEntry::Continue,
+            Self::Stop => HookFailurePolicyEntry::Stop,
+        }
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -651,6 +678,30 @@ pub(crate) struct ServiceAddArgs {
     /// Freeform notes (optional)
     #[arg(long)]
     pub(crate) notes: Option<String>,
+
+    /// Reload style preset for post-renew hook
+    #[arg(long, value_enum)]
+    pub(crate) reload_style: Option<ReloadStyle>,
+
+    /// Target for reload-style preset (unit name, process name, or container)
+    #[arg(long)]
+    pub(crate) reload_target: Option<String>,
+
+    /// Post-renew success hook command (low-level)
+    #[arg(long)]
+    pub(crate) post_renew_command: Option<String>,
+
+    /// Post-renew success hook argument (repeatable, low-level)
+    #[arg(long)]
+    pub(crate) post_renew_arg: Vec<String>,
+
+    /// Post-renew success hook timeout in seconds (low-level)
+    #[arg(long)]
+    pub(crate) post_renew_timeout_secs: Option<u64>,
+
+    /// Post-renew success hook failure policy (low-level)
+    #[arg(long, value_enum)]
+    pub(crate) post_renew_on_failure: Option<HookFailurePolicyArg>,
 }
 
 #[derive(Args, Debug)]
@@ -1025,6 +1076,92 @@ mod tests {
                 assert_eq!(args.compose_file.compose_file, PathBuf::from("custom.yml"));
             }
             _ => panic!("expected monitoring down"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_reload_style() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "add",
+            "--reload-style",
+            "systemd",
+            "--reload-target",
+            "nginx",
+        ]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert!(matches!(args.reload_style, Some(ReloadStyle::Systemd)));
+                assert_eq!(args.reload_target.as_deref(), Some("nginx"));
+            }
+            _ => panic!("expected service add"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_post_renew_low_level() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "add",
+            "--post-renew-command",
+            "systemctl",
+            "--post-renew-arg",
+            "reload",
+            "--post-renew-arg",
+            "nginx",
+            "--post-renew-timeout-secs",
+            "60",
+            "--post-renew-on-failure",
+            "stop",
+        ]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert_eq!(args.post_renew_command.as_deref(), Some("systemctl"));
+                assert_eq!(args.post_renew_arg, vec!["reload", "nginx"]);
+                assert_eq!(args.post_renew_timeout_secs, Some(60));
+                assert!(matches!(
+                    args.post_renew_on_failure,
+                    Some(HookFailurePolicyArg::Stop)
+                ));
+            }
+            _ => panic!("expected service add"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_reload_style_docker_restart() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "add",
+            "--reload-style",
+            "docker-restart",
+            "--reload-target",
+            "my-container",
+        ]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert!(matches!(
+                    args.reload_style,
+                    Some(ReloadStyle::DockerRestart)
+                ));
+                assert_eq!(args.reload_target.as_deref(), Some("my-container"));
+            }
+            _ => panic!("expected service add"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_reload_style_none() {
+        let cli = Cli::parse_from(["bootroot", "service", "add", "--reload-style", "none"]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert!(matches!(args.reload_style, Some(ReloadStyle::None)));
+                assert!(args.reload_target.is_none());
+            }
+            _ => panic!("expected service add"),
         }
     }
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -2,7 +2,7 @@ use crate::commands::init::{InitPlan, InitSummary};
 use crate::i18n::{
     Messages, ServiceNextStepsDaemon, ServiceNextStepsDocker, ServiceOpenBaoAgentSteps,
 };
-use crate::state::{DeployType, ServiceEntry};
+use crate::state::{DeployType, PostRenewHookEntry, ServiceEntry};
 
 pub(crate) struct ServiceAddPlan<'a> {
     pub(crate) service_name: &'a str,
@@ -16,6 +16,7 @@ pub(crate) struct ServiceAddPlan<'a> {
     pub(crate) instance_id: Option<&'a str>,
     pub(crate) container_name: Option<&'a str>,
     pub(crate) notes: Option<&'a str>,
+    pub(crate) post_renew_hooks: &'a [PostRenewHookEntry],
 }
 
 pub(crate) struct ServiceAddAppliedPaths<'a> {
@@ -274,6 +275,12 @@ fn print_service_fields(entry: &ServiceEntry, messages: &Messages) {
     if let Some(notes) = entry.notes.as_deref() {
         println!("{}", messages.service_summary_notes(notes));
     }
+    for hook in &entry.post_renew_hooks {
+        println!(
+            "{}",
+            messages.service_summary_post_renew_hook(&format_hook(hook))
+        );
+    }
 }
 
 fn print_service_plan_fields(plan: &ServiceAddPlan<'_>, messages: &Messages) {
@@ -295,6 +302,12 @@ fn print_service_plan_fields(plan: &ServiceAddPlan<'_>, messages: &Messages) {
     }
     if let Some(notes) = plan.notes {
         println!("{}", messages.service_summary_notes(notes));
+    }
+    for hook in plan.post_renew_hooks {
+        println!(
+            "{}",
+            messages.service_summary_post_renew_hook(&format_hook(hook))
+        );
     }
 }
 
@@ -609,6 +622,12 @@ fn print_next_steps(summary: &InitSummary, messages: &Messages) {
             messages.next_steps_eab_hint(crate::commands::init::PATH_AGENT_EAB)
         );
     }
+}
+
+fn format_hook(hook: &PostRenewHookEntry) -> String {
+    let mut parts = vec![hook.command.clone()];
+    parts.extend(hook.args.iter().cloned());
+    parts.join(" ")
 }
 
 pub(crate) fn display_secret(value: &str, show_secrets: bool) -> String {

--- a/src/commands/dns_alias.rs
+++ b/src/commands/dns_alias.rs
@@ -189,6 +189,7 @@ mod tests {
             instance_id: instance_id.map(str::to_string),
             container_name: Some("ctr".to_string()),
             notes: None,
+            post_renew_hooks: Vec::new(),
             approle: ServiceRoleEntry {
                 role_name: "r".to_string(),
                 role_id: "id".to_string(),

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -97,6 +97,7 @@ pub(crate) async fn run_service_add(args: &ServiceAddArgs, messages: &Messages) 
         instance_id: resolved.instance_id.as_deref(),
         container_name: resolved.container_name.as_deref(),
         notes: resolved.notes.as_deref(),
+        post_renew_hooks: &resolved.post_renew_hooks,
     };
     print_service_add_plan(&plan, messages);
 
@@ -322,6 +323,7 @@ fn build_service_entry_from_role(
         instance_id: resolved.instance_id.clone(),
         container_name: resolved.container_name.clone(),
         notes: resolved.notes.clone(),
+        post_renew_hooks: resolved.post_renew_hooks.clone(),
         approle,
     }
 }
@@ -450,6 +452,7 @@ fn is_idempotent_remote_rerun(entry: &ServiceEntry, resolved: &ResolvedServiceAd
         && entry.instance_id == resolved.instance_id
         && entry.container_name == resolved.container_name
         && entry.notes == resolved.notes
+        && entry.post_renew_hooks == resolved.post_renew_hooks
 }
 
 #[cfg(test)]
@@ -474,6 +477,7 @@ mod tests {
             container_name: Some("ctr-1".to_string()),
             runtime_auth: None,
             notes: Some("test note".to_string()),
+            post_renew_hooks: Vec::new(),
         }
     }
 
@@ -489,6 +493,7 @@ mod tests {
         assert_eq!(entry.instance_id, resolved.instance_id);
         assert_eq!(entry.container_name, resolved.container_name);
         assert_eq!(entry.notes, resolved.notes);
+        assert_eq!(entry.post_renew_hooks, resolved.post_renew_hooks);
     }
 
     #[test]

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -1,7 +1,9 @@
+use std::fmt::Write as _;
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use bootroot::fs_util;
+use bootroot::toml_util::toml_encode_string;
 use bootroot::trust_bootstrap::{
     build_ca_bundle_ctmpl, build_managed_agent_ctmpl, build_trust_updates,
     render_managed_profile_block as render_managed_profile, upsert_managed_profile_block,
@@ -16,6 +18,7 @@ use super::{
     SERVICE_ROLE_ID_FILENAME, ServiceSyncMaterial,
 };
 use crate::i18n::Messages;
+use crate::state::PostRenewHookEntry;
 
 pub(super) async fn apply_local_service_configs(
     secrets_dir: &Path,
@@ -141,7 +144,7 @@ async fn write_local_ca_bundle(path: &Path, bundle_pem: &str, messages: &Message
 }
 
 fn render_managed_profile_block(args: &ResolvedServiceAdd) -> String {
-    render_managed_profile(
+    let base = render_managed_profile(
         MANAGED_PROFILE_BEGIN_PREFIX,
         MANAGED_PROFILE_END_PREFIX,
         &args.service_name,
@@ -149,7 +152,45 @@ fn render_managed_profile_block(args: &ResolvedServiceAdd) -> String {
         &args.hostname,
         &args.cert_path,
         &args.key_path,
-    )
+    );
+    inject_hooks_into_profile_block(&base, &args.post_renew_hooks)
+}
+
+fn inject_hooks_into_profile_block(block: &str, hooks: &[PostRenewHookEntry]) -> String {
+    if hooks.is_empty() {
+        return block.to_string();
+    }
+    let hooks_toml = render_hooks_toml(hooks);
+    if let Some(end_pos) = block.rfind(MANAGED_PROFILE_END_PREFIX) {
+        let mut result = block[..end_pos].to_string();
+        result.push_str(&hooks_toml);
+        result.push_str(&block[end_pos..]);
+        result
+    } else {
+        let mut result = block.to_string();
+        result.push_str(&hooks_toml);
+        result
+    }
+}
+
+fn render_hooks_toml(hooks: &[PostRenewHookEntry]) -> String {
+    let mut output = String::new();
+    for hook in hooks {
+        output.push_str("\n[[profiles.hooks.post_renew.success]]\n");
+        let _ = writeln!(output, "command = {}", toml_encode_string(&hook.command));
+        if !hook.args.is_empty() {
+            let args = hook
+                .args
+                .iter()
+                .map(|a| toml_encode_string(a))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let _ = writeln!(output, "args = [{args}]");
+        }
+        let _ = writeln!(output, "timeout_secs = {}", hook.timeout_secs);
+        let _ = writeln!(output, "on_failure = \"{}\"", hook.on_failure);
+    }
+    output
 }
 
 fn upsert_managed_profile(contents: &str, service_name: &str, replacement: &str) -> String {
@@ -214,6 +255,7 @@ mod tests {
             container_name: None,
             runtime_auth: None,
             notes: None,
+            post_renew_hooks: Vec::new(),
         }
     }
 
@@ -417,5 +459,118 @@ mod tests {
             bootroot::toml_util::upsert_section_keys(&twice, "acme", &acme_updates).unwrap();
 
         assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_render_hooks_toml_single_hook() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let hooks = vec![PostRenewHookEntry {
+            command: "systemctl".to_string(),
+            args: vec!["reload".to_string(), "nginx".to_string()],
+            timeout_secs: 30,
+            on_failure: HookFailurePolicyEntry::Continue,
+        }];
+        let toml = render_hooks_toml(&hooks);
+        assert!(toml.contains("[[profiles.hooks.post_renew.success]]"));
+        assert!(toml.contains("command = \"systemctl\""));
+        assert!(toml.contains("args = [\"reload\", \"nginx\"]"));
+        assert!(toml.contains("timeout_secs = 30"));
+        assert!(toml.contains("on_failure = \"continue\""));
+    }
+
+    #[test]
+    fn test_render_hooks_toml_empty() {
+        let toml = render_hooks_toml(&[]);
+        assert!(toml.is_empty());
+    }
+
+    #[test]
+    fn test_inject_hooks_into_profile_block() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let mut args = test_resolved();
+        args.post_renew_hooks = vec![PostRenewHookEntry {
+            command: "systemctl".to_string(),
+            args: vec!["reload".to_string(), "nginx".to_string()],
+            timeout_secs: 30,
+            on_failure: HookFailurePolicyEntry::Continue,
+        }];
+        let block = render_managed_profile_block(&args);
+        assert!(block.contains("[[profiles.hooks.post_renew.success]]"));
+        assert!(block.contains("command = \"systemctl\""));
+        assert!(block.contains(MANAGED_PROFILE_END_PREFIX));
+    }
+
+    #[test]
+    fn test_inject_hooks_preserves_end_marker() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let mut args = test_resolved();
+        args.post_renew_hooks = vec![PostRenewHookEntry {
+            command: "pkill".to_string(),
+            args: vec!["-HUP".to_string(), "myproc".to_string()],
+            timeout_secs: 15,
+            on_failure: HookFailurePolicyEntry::Stop,
+        }];
+        let block = render_managed_profile_block(&args);
+
+        let end_pos = block
+            .find(MANAGED_PROFILE_END_PREFIX)
+            .expect("end marker must exist");
+        let hook_pos = block
+            .find("[[profiles.hooks.post_renew.success]]")
+            .expect("hook must exist");
+        assert!(hook_pos < end_pos, "hook should appear before end marker");
+        assert!(block.contains("on_failure = \"stop\""));
+    }
+
+    #[test]
+    fn test_managed_profile_with_hooks_is_idempotent() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let mut args = test_resolved();
+        args.post_renew_hooks = vec![PostRenewHookEntry {
+            command: "systemctl".to_string(),
+            args: vec!["reload".to_string(), "nginx".to_string()],
+            timeout_secs: 30,
+            on_failure: HookFailurePolicyEntry::Continue,
+        }];
+        let block = render_managed_profile_block(&args);
+        let once = upsert_managed_profile("", "edge-proxy", &block);
+        let twice = upsert_managed_profile(&once, "edge-proxy", &block);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_render_hooks_toml_escapes_control_characters() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let hooks = vec![PostRenewHookEntry {
+            command: "echo\nnext".to_string(),
+            args: vec!["line1\tline2".to_string(), "back\\slash".to_string()],
+            timeout_secs: 10,
+            on_failure: HookFailurePolicyEntry::Continue,
+        }];
+        let toml = render_hooks_toml(&hooks);
+
+        // The output must be valid TOML — parse it to confirm.
+        let wrapped = format!("[profiles]\n[profiles.hooks]\n[profiles.hooks.post_renew]{toml}");
+        let doc: toml_edit::DocumentMut = wrapped
+            .parse()
+            .expect("rendered hook TOML with control chars must be parseable");
+
+        let success = doc["profiles"]["hooks"]["post_renew"]["success"]
+            .as_array_of_tables()
+            .expect("success must be an array of tables");
+        let hook = success.get(0).expect("must have one hook entry");
+        assert_eq!(
+            hook["command"].as_str().unwrap(),
+            "echo\nnext",
+            "command must round-trip through TOML"
+        );
+        let args = hook["args"].as_array().expect("args must be an array");
+        assert_eq!(args.get(0).unwrap().as_str().unwrap(), "line1\tline2");
+        assert_eq!(args.get(1).unwrap().as_str().unwrap(), "back\\slash");
     }
 }

--- a/src/commands/service/remote_bootstrap.rs
+++ b/src/commands/service/remote_bootstrap.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -12,7 +13,7 @@ use super::{
     RemoteBootstrapResult, SERVICE_ROLE_ID_FILENAME,
 };
 use crate::i18n::Messages;
-use crate::state::{ServiceEntry, StateFile};
+use crate::state::{PostRenewHookEntry, ServiceEntry, StateFile};
 
 #[derive(serde::Serialize)]
 struct RemoteBootstrapArtifact {
@@ -35,6 +36,8 @@ struct RemoteBootstrapArtifact {
     profile_instance_id: String,
     profile_cert_path: String,
     profile_key_path: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    post_renew_hooks: Vec<PostRenewHookEntry>,
 }
 
 /// Builds a `RemoteBootstrapArtifact` from common inputs shared by both
@@ -51,6 +54,7 @@ fn build_artifact(
     domain: &str,
     hostname: &str,
     instance_id: Option<&str>,
+    post_renew_hooks: &[PostRenewHookEntry],
 ) -> RemoteBootstrapArtifact {
     let secret_id_parent = secret_id_path.parent().unwrap_or(Path::new("."));
     let role_id_path = secret_id_parent.join(SERVICE_ROLE_ID_FILENAME);
@@ -82,6 +86,7 @@ fn build_artifact(
         profile_instance_id: instance_id.unwrap_or_default().to_string(),
         profile_cert_path: cert_path.display().to_string(),
         profile_key_path: key_path.display().to_string(),
+        post_renew_hooks: post_renew_hooks.to_vec(),
     }
 }
 
@@ -103,6 +108,7 @@ pub(super) async fn write_remote_bootstrap_artifact(
         &resolved.domain,
         &resolved.hostname,
         resolved.instance_id.as_deref(),
+        &resolved.post_renew_hooks,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &resolved.service_name, &artifact, messages)
         .await
@@ -125,6 +131,7 @@ pub(super) async fn write_remote_bootstrap_artifact_from_entry(
         &entry.domain,
         &entry.hostname,
         entry.instance_id.as_deref(),
+        &entry.post_renew_hooks,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &entry.service_name, &artifact, messages)
         .await
@@ -153,8 +160,8 @@ async fn write_remote_bootstrap_artifact_file(
 }
 
 fn render_remote_run_command(artifact: &RemoteBootstrapArtifact) -> String {
-    format!(
-        "bootroot-remote bootstrap --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --agent-email '{}' --agent-server '{}' --agent-domain '{}' --agent-responder-url '{}' --profile-hostname '{}' --profile-instance-id '{}' --profile-cert-path '{}' --profile-key-path '{}' --ca-bundle-path '{}' --output json",
+    let mut cmd = format!(
+        "bootroot-remote bootstrap --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --agent-email '{}' --agent-server '{}' --agent-domain '{}' --agent-responder-url '{}' --profile-hostname '{}' --profile-instance-id '{}' --profile-cert-path '{}' --profile-key-path '{}' --ca-bundle-path '{}'",
         artifact.openbao_url,
         artifact.kv_mount,
         artifact.service_name,
@@ -171,7 +178,36 @@ fn render_remote_run_command(artifact: &RemoteBootstrapArtifact) -> String {
         artifact.profile_cert_path,
         artifact.profile_key_path,
         artifact.ca_bundle_path,
-    )
+    );
+    if let Some(hook) = artifact.post_renew_hooks.first() {
+        let _ = write!(
+            cmd,
+            " --post-renew-command '{}'",
+            shell_escape_single_quoted(&hook.command)
+        );
+        for arg in &hook.args {
+            let _ = write!(
+                cmd,
+                " --post-renew-arg '{}'",
+                shell_escape_single_quoted(arg)
+            );
+        }
+        let _ = write!(cmd, " --post-renew-timeout-secs {}", hook.timeout_secs);
+        let _ = write!(
+            cmd,
+            " --post-renew-on-failure '{}'",
+            shell_escape_single_quoted(&hook.on_failure.to_string())
+        );
+    }
+    cmd.push_str(" --output json");
+    cmd
+}
+
+/// Escapes a string for embedding inside single quotes in a POSIX shell
+/// command. Replaces each `'` with `'\''` (end quote, literal quote,
+/// resume quote).
+fn shell_escape_single_quoted(value: &str) -> String {
+    value.replace('\'', "'\\''")
 }
 
 fn remote_openbao_agent_paths(
@@ -212,6 +248,7 @@ mod tests {
             "example.com",
             "host1",
             Some("instance-42"),
+            &[],
         );
 
         assert_eq!(artifact.openbao_url, "https://openbao.example.com:8200");
@@ -263,6 +300,7 @@ mod tests {
             "local.dev",
             "node-a",
             None,
+            &[],
         );
 
         assert_eq!(artifact.profile_instance_id, "");
@@ -281,6 +319,7 @@ mod tests {
             "a.com",
             "h1",
             None,
+            &[],
         );
         let b = build_artifact(
             "https://ob",
@@ -293,6 +332,7 @@ mod tests {
             "b.com",
             "h2",
             None,
+            &[],
         );
 
         assert_ne!(a.role_id_path, b.role_id_path);
@@ -313,6 +353,7 @@ mod tests {
             "d.com",
             "h",
             None,
+            &[],
         );
 
         // Path::new("secret_id").parent() returns Some(""), not None
@@ -333,10 +374,145 @@ mod tests {
             "d.com",
             "h",
             None,
+            &[],
         );
 
         // Path::new("cert.pem").parent() returns Some(""), not None
         assert_eq!(artifact.ca_bundle_path, "ca-bundle.pem");
+    }
+
+    #[test]
+    fn build_artifact_includes_hooks() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let hooks = vec![PostRenewHookEntry {
+            command: "systemctl".to_string(),
+            args: vec!["reload".to_string(), "nginx".to_string()],
+            timeout_secs: 30,
+            on_failure: HookFailurePolicyEntry::Continue,
+        }];
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &hooks,
+        );
+
+        assert_eq!(artifact.post_renew_hooks.len(), 1);
+        assert_eq!(artifact.post_renew_hooks[0].command, "systemctl");
+        assert_eq!(artifact.post_renew_hooks[0].args, vec!["reload", "nginx"]);
+    }
+
+    #[test]
+    fn render_remote_run_command_includes_hook_flags() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let hooks = vec![PostRenewHookEntry {
+            command: "systemctl".to_string(),
+            args: vec!["reload".to_string(), "nginx".to_string()],
+            timeout_secs: 60,
+            on_failure: HookFailurePolicyEntry::Stop,
+        }];
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &hooks,
+        );
+        let cmd = super::render_remote_run_command(&artifact);
+
+        assert!(
+            cmd.contains("--post-renew-command 'systemctl'"),
+            "missing --post-renew-command: {cmd}"
+        );
+        assert!(
+            cmd.contains("--post-renew-arg 'reload'"),
+            "missing first --post-renew-arg: {cmd}"
+        );
+        assert!(
+            cmd.contains("--post-renew-arg 'nginx'"),
+            "missing second --post-renew-arg: {cmd}"
+        );
+        assert!(
+            cmd.contains("--post-renew-timeout-secs 60"),
+            "missing --post-renew-timeout-secs: {cmd}"
+        );
+        assert!(
+            cmd.contains("--post-renew-on-failure 'stop'"),
+            "missing --post-renew-on-failure: {cmd}"
+        );
+    }
+
+    #[test]
+    fn render_remote_run_command_shell_escapes_single_quotes() {
+        use crate::state::{HookFailurePolicyEntry, PostRenewHookEntry};
+
+        let hooks = vec![PostRenewHookEntry {
+            command: "/usr/bin/notify-O'Brien".to_string(),
+            args: vec!["it's".to_string(), "done".to_string()],
+            timeout_secs: 30,
+            on_failure: HookFailurePolicyEntry::Continue,
+        }];
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &hooks,
+        );
+        let cmd = super::render_remote_run_command(&artifact);
+
+        assert!(
+            cmd.contains("--post-renew-command '/usr/bin/notify-O'\\''Brien'"),
+            "single quote in command not escaped: {cmd}"
+        );
+        assert!(
+            cmd.contains("--post-renew-arg 'it'\\''s'"),
+            "single quote in arg not escaped: {cmd}"
+        );
+    }
+
+    #[test]
+    fn render_remote_run_command_omits_hook_flags_when_empty() {
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &[],
+        );
+        let cmd = super::render_remote_run_command(&artifact);
+
+        assert!(
+            !cmd.contains("--post-renew"),
+            "should not contain hook flags: {cmd}"
+        );
     }
 
     #[test]
@@ -352,6 +528,7 @@ mod tests {
             "d.com",
             "h",
             Some(""),
+            &[],
         );
         let with_none = build_artifact(
             "https://ob",
@@ -364,11 +541,27 @@ mod tests {
             "d.com",
             "h",
             None,
+            &[],
         );
 
         assert_eq!(
             with_empty.profile_instance_id,
             with_none.profile_instance_id
         );
+    }
+
+    #[test]
+    fn shell_escape_single_quoted_no_quotes_unchanged() {
+        assert_eq!(super::shell_escape_single_quoted("hello"), "hello");
+    }
+
+    #[test]
+    fn shell_escape_single_quoted_replaces_single_quotes() {
+        assert_eq!(super::shell_escape_single_quoted("it's"), "it'\\''s");
+    }
+
+    #[test]
+    fn shell_escape_single_quoted_multiple_quotes() {
+        assert_eq!(super::shell_escape_single_quoted("a'b'c"), "a'\\''b'\\''c");
     }
 }

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -5,13 +5,15 @@ use bootroot::input_validation::{
     ValidationError, validate_dns_label, validate_domain_name, validate_numeric_instance_id,
 };
 
-use crate::cli::args::ServiceAddArgs;
+use crate::cli::args::{HookFailurePolicyArg, ReloadStyle, ServiceAddArgs};
 use crate::cli::prompt::Prompt;
 use crate::commands::openbao_auth::{
     RuntimeAuthResolved, resolve_runtime_auth, resolve_runtime_auth_optional,
 };
 use crate::i18n::Messages;
-use crate::state::{DeliveryMode, DeployType};
+use crate::state::{
+    DEFAULT_HOOK_TIMEOUT_SECS, DeliveryMode, DeployType, HookFailurePolicyEntry, PostRenewHookEntry,
+};
 
 #[derive(Debug)]
 pub(crate) struct ResolvedServiceAdd {
@@ -27,6 +29,7 @@ pub(crate) struct ResolvedServiceAdd {
     pub(crate) container_name: Option<String>,
     pub(crate) runtime_auth: Option<RuntimeAuthResolved>,
     pub(crate) notes: Option<String>,
+    pub(crate) post_renew_hooks: Vec<PostRenewHookEntry>,
 }
 
 pub(super) fn resolve_service_add_args(
@@ -117,6 +120,8 @@ pub(super) fn resolve_service_add_args(
         Some(resolve_runtime_auth(&args.runtime_auth, true, messages)?)
     };
 
+    let post_renew_hooks = resolve_post_renew_hooks(args)?;
+
     Ok(ResolvedServiceAdd {
         service_name,
         deploy_type,
@@ -130,6 +135,7 @@ pub(super) fn resolve_service_add_args(
         container_name,
         runtime_auth,
         notes: args.notes.clone(),
+        post_renew_hooks,
     })
 }
 
@@ -221,6 +227,104 @@ fn parse_deploy_type(value: &str, messages: &Messages) -> Result<DeployType> {
     }
 }
 
+fn resolve_post_renew_hooks(args: &ServiceAddArgs) -> Result<Vec<PostRenewHookEntry>> {
+    let has_preset = args.reload_style.is_some();
+    let has_low_level = args.post_renew_command.is_some()
+        || !args.post_renew_arg.is_empty()
+        || args.post_renew_timeout_secs.is_some()
+        || args.post_renew_on_failure.is_some();
+
+    if has_preset && has_low_level {
+        anyhow::bail!(
+            "--reload-style and --post-renew-* flags are mutually exclusive; use one or the other"
+        );
+    }
+
+    if let Some(style) = args.reload_style {
+        return resolve_reload_preset(style, args.reload_target.as_deref());
+    }
+
+    if let Some(command) = args.post_renew_command.as_deref() {
+        if command.trim().is_empty() {
+            anyhow::bail!("--post-renew-command must not be empty");
+        }
+        let timeout = args
+            .post_renew_timeout_secs
+            .unwrap_or(DEFAULT_HOOK_TIMEOUT_SECS);
+        if timeout == 0 {
+            anyhow::bail!("--post-renew-timeout-secs must be greater than 0");
+        }
+        let on_failure = args.post_renew_on_failure.map_or(
+            HookFailurePolicyEntry::default(),
+            HookFailurePolicyArg::into_entry,
+        );
+        return Ok(vec![PostRenewHookEntry {
+            command: command.to_string(),
+            args: args.post_renew_arg.clone(),
+            timeout_secs: timeout,
+            on_failure,
+        }]);
+    }
+
+    if args.reload_target.is_some() {
+        anyhow::bail!("--reload-target requires --reload-style");
+    }
+    if !args.post_renew_arg.is_empty()
+        || args.post_renew_timeout_secs.is_some()
+        || args.post_renew_on_failure.is_some()
+    {
+        anyhow::bail!(
+            "--post-renew-arg, --post-renew-timeout-secs, and --post-renew-on-failure require --post-renew-command"
+        );
+    }
+
+    Ok(Vec::new())
+}
+
+fn resolve_reload_preset(
+    style: ReloadStyle,
+    target: Option<&str>,
+) -> Result<Vec<PostRenewHookEntry>> {
+    match style {
+        ReloadStyle::None => Ok(Vec::new()),
+        ReloadStyle::Systemd => {
+            let unit = target.ok_or_else(|| {
+                anyhow::anyhow!("--reload-style systemd requires --reload-target <unit-name>")
+            })?;
+            Ok(vec![PostRenewHookEntry {
+                command: "systemctl".to_string(),
+                args: vec!["reload".to_string(), unit.to_string()],
+                timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
+                on_failure: HookFailurePolicyEntry::default(),
+            }])
+        }
+        ReloadStyle::Sighup => {
+            let name = target.ok_or_else(|| {
+                anyhow::anyhow!("--reload-style sighup requires --reload-target <process-name>")
+            })?;
+            Ok(vec![PostRenewHookEntry {
+                command: "pkill".to_string(),
+                args: vec!["-HUP".to_string(), name.to_string()],
+                timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
+                on_failure: HookFailurePolicyEntry::default(),
+            }])
+        }
+        ReloadStyle::DockerRestart => {
+            let container = target.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--reload-style docker-restart requires --reload-target <container-name>"
+                )
+            })?;
+            Ok(vec![PostRenewHookEntry {
+                command: "docker".to_string(),
+                args: vec!["restart".to_string(), container.to_string()],
+                timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
+                on_failure: HookFailurePolicyEntry::default(),
+            }])
+        }
+    }
+}
+
 fn resolve_path(
     value: Option<PathBuf>,
     label: &str,
@@ -251,4 +355,277 @@ fn validate_path(path: &Path, must_exist: bool, messages: &Messages) -> Result<(
         anyhow::bail!(messages.error_parent_not_found(&parent.display().to_string()));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::{AuthMode, RuntimeAuthArgs};
+
+    fn empty_args() -> ServiceAddArgs {
+        ServiceAddArgs {
+            service_name: None,
+            deploy_type: None,
+            delivery_mode: None,
+            dry_run: false,
+            print_only: false,
+            hostname: None,
+            domain: None,
+            agent_config: None,
+            cert_path: None,
+            key_path: None,
+            instance_id: None,
+            container_name: None,
+            runtime_auth: RuntimeAuthArgs {
+                auth_mode: AuthMode::Auto,
+                root_token: None,
+                approle_role_id: None,
+                approle_secret_id: None,
+                approle_role_id_file: None,
+                approle_secret_id_file: None,
+            },
+            notes: None,
+            reload_style: None,
+            reload_target: None,
+            post_renew_command: None,
+            post_renew_arg: Vec::new(),
+            post_renew_timeout_secs: None,
+            post_renew_on_failure: None,
+        }
+    }
+
+    #[test]
+    fn resolve_hooks_no_flags_returns_empty() {
+        let args = empty_args();
+        let hooks = resolve_post_renew_hooks(&args).unwrap();
+        assert!(hooks.is_empty());
+    }
+
+    #[test]
+    fn resolve_hooks_preset_and_low_level_command_are_mutually_exclusive() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Systemd);
+        args.reload_target = Some("nginx".to_string());
+        args.post_renew_command = Some("systemctl".to_string());
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_preset_and_low_level_timeout_are_mutually_exclusive() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Systemd);
+        args.reload_target = Some("nginx".to_string());
+        args.post_renew_timeout_secs = Some(60);
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_preset_and_low_level_on_failure_are_mutually_exclusive() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Systemd);
+        args.reload_target = Some("nginx".to_string());
+        args.post_renew_on_failure = Some(HookFailurePolicyArg::Stop);
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_preset_and_low_level_arg_are_mutually_exclusive() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::None);
+        args.post_renew_arg = vec!["reload".to_string()];
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_reload_target_without_style_errors() {
+        let mut args = empty_args();
+        args.reload_target = Some("nginx".to_string());
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--reload-target requires"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_systemd_preset_expands_correctly() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Systemd);
+        args.reload_target = Some("nginx".to_string());
+
+        let hooks = resolve_post_renew_hooks(&args).unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].command, "systemctl");
+        assert_eq!(hooks[0].args, vec!["reload", "nginx"]);
+        assert_eq!(hooks[0].timeout_secs, DEFAULT_HOOK_TIMEOUT_SECS);
+        assert_eq!(hooks[0].on_failure, HookFailurePolicyEntry::Continue);
+    }
+
+    #[test]
+    fn resolve_hooks_sighup_preset_expands_correctly() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Sighup);
+        args.reload_target = Some("myproc".to_string());
+
+        let hooks = resolve_post_renew_hooks(&args).unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].command, "pkill");
+        assert_eq!(hooks[0].args, vec!["-HUP", "myproc"]);
+    }
+
+    #[test]
+    fn resolve_hooks_docker_restart_preset_expands_correctly() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::DockerRestart);
+        args.reload_target = Some("my-ctr".to_string());
+
+        let hooks = resolve_post_renew_hooks(&args).unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].command, "docker");
+        assert_eq!(hooks[0].args, vec!["restart", "my-ctr"]);
+    }
+
+    #[test]
+    fn resolve_hooks_none_preset_returns_empty() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::None);
+
+        let hooks = resolve_post_renew_hooks(&args).unwrap();
+        assert!(hooks.is_empty());
+    }
+
+    #[test]
+    fn resolve_hooks_systemd_without_target_errors() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Systemd);
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--reload-target"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_low_level_with_defaults() {
+        let mut args = empty_args();
+        args.post_renew_command = Some("/usr/bin/reload.sh".to_string());
+
+        let hooks = resolve_post_renew_hooks(&args).unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].command, "/usr/bin/reload.sh");
+        assert!(hooks[0].args.is_empty());
+        assert_eq!(hooks[0].timeout_secs, DEFAULT_HOOK_TIMEOUT_SECS);
+        assert_eq!(hooks[0].on_failure, HookFailurePolicyEntry::Continue);
+    }
+
+    #[test]
+    fn resolve_hooks_low_level_with_all_overrides() {
+        let mut args = empty_args();
+        args.post_renew_command = Some("systemctl".to_string());
+        args.post_renew_arg = vec!["reload".to_string(), "nginx".to_string()];
+        args.post_renew_timeout_secs = Some(60);
+        args.post_renew_on_failure = Some(HookFailurePolicyArg::Stop);
+
+        let hooks = resolve_post_renew_hooks(&args).unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].command, "systemctl");
+        assert_eq!(hooks[0].args, vec!["reload", "nginx"]);
+        assert_eq!(hooks[0].timeout_secs, 60);
+        assert_eq!(hooks[0].on_failure, HookFailurePolicyEntry::Stop);
+    }
+
+    #[test]
+    fn resolve_hooks_empty_command_is_rejected() {
+        let mut args = empty_args();
+        args.post_renew_command = Some(String::new());
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_whitespace_only_command_is_rejected() {
+        let mut args = empty_args();
+        args.post_renew_command = Some("   ".to_string());
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_zero_timeout_is_rejected() {
+        let mut args = empty_args();
+        args.post_renew_command = Some("reload.sh".to_string());
+        args.post_renew_timeout_secs = Some(0);
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("greater than 0"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_post_renew_arg_without_command_errors() {
+        let mut args = empty_args();
+        args.post_renew_arg = vec!["reload".to_string()];
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--post-renew-command"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_post_renew_timeout_without_command_errors() {
+        let mut args = empty_args();
+        args.post_renew_timeout_secs = Some(60);
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--post-renew-command"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_post_renew_on_failure_without_command_errors() {
+        let mut args = empty_args();
+        args.post_renew_on_failure = Some(HookFailurePolicyArg::Stop);
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string().contains("--post-renew-command"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -215,6 +215,7 @@ pub(crate) struct Strings {
     pub(crate) service_summary_instance_id: &'static str,
     pub(crate) service_summary_container_name: &'static str,
     pub(crate) service_summary_notes: &'static str,
+    pub(crate) service_summary_post_renew_hook: &'static str,
     pub(crate) service_summary_policy: &'static str,
     pub(crate) service_summary_approle: &'static str,
     pub(crate) service_summary_secret_path: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -175,6 +175,7 @@ pub(super) static STRINGS: Strings = Strings {
     service_summary_instance_id: "- instance_id: {value}",
     service_summary_container_name: "- container name: {value}",
     service_summary_notes: "- notes: {value}",
+    service_summary_post_renew_hook: "- post-renew hook: {value}",
     service_summary_policy: "- policy: {value}",
     service_summary_approle: "- AppRole: {value}",
     service_summary_secret_path: "- secret_id path: {value}",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -175,6 +175,7 @@ pub(super) static STRINGS: Strings = Strings {
     service_summary_instance_id: "- instance_id: {value}",
     service_summary_container_name: "- 컨테이너 이름: {value}",
     service_summary_notes: "- 메모: {value}",
+    service_summary_post_renew_hook: "- 갱신 후 훅: {value}",
     service_summary_policy: "- 정책: {value}",
     service_summary_approle: "- AppRole: {value}",
     service_summary_secret_path: "- secret_id 경로: {value}",

--- a/src/i18n/service.rs
+++ b/src/i18n/service.rs
@@ -502,6 +502,13 @@ impl Messages {
         format_template(self.strings().service_summary_notes, &[("value", value)])
     }
 
+    pub(crate) fn service_summary_post_renew_hook(&self, value: &str) -> String {
+        format_template(
+            self.strings().service_summary_post_renew_hook,
+            &[("value", value)],
+        )
+    }
+
     pub(crate) fn service_summary_policy(&self, value: &str) -> String {
         format_template(self.strings().service_summary_policy, &[("value", value)])
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 const DEFAULT_SECRETS_DIR: &str = "secrets";
 const DEFAULT_STATE_FILE: &str = "state.json";
+pub(crate) const DEFAULT_HOOK_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct StateFile {
@@ -67,6 +68,8 @@ pub(crate) struct ServiceEntry {
     pub(crate) container_name: Option<String>,
     #[serde(default)]
     pub(crate) notes: Option<String>,
+    #[serde(default)]
+    pub(crate) post_renew_hooks: Vec<PostRenewHookEntry>,
     pub(crate) approle: ServiceRoleEntry,
 }
 
@@ -103,6 +106,35 @@ impl fmt::Display for DeployType {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_serde_string_value(self, formatter)
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum HookFailurePolicyEntry {
+    #[default]
+    Continue,
+    Stop,
+}
+
+impl fmt::Display for HookFailurePolicyEntry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_serde_string_value(self, formatter)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub(crate) struct PostRenewHookEntry {
+    pub(crate) command: String,
+    #[serde(default)]
+    pub(crate) args: Vec<String>,
+    #[serde(default = "default_hook_timeout_secs")]
+    pub(crate) timeout_secs: u64,
+    #[serde(default)]
+    pub(crate) on_failure: HookFailurePolicyEntry,
+}
+
+fn default_hook_timeout_secs() -> u64 {
+    DEFAULT_HOOK_TIMEOUT_SECS
 }
 
 fn write_serde_string_value<T: Serialize>(
@@ -156,5 +188,95 @@ mod tests {
                 "Display and serde disagree for {variant:?}"
             );
         }
+    }
+
+    #[test]
+    fn hook_failure_policy_display_matches_serde() {
+        for variant in [
+            HookFailurePolicyEntry::Continue,
+            HookFailurePolicyEntry::Stop,
+        ] {
+            let serialized = serde_json::to_value(variant)
+                .expect("serialize HookFailurePolicyEntry")
+                .as_str()
+                .expect("serde value is a string")
+                .to_string();
+            assert_eq!(
+                variant.to_string(),
+                serialized,
+                "Display and serde disagree for {variant:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn post_renew_hook_entry_round_trips_json() {
+        let hook = PostRenewHookEntry {
+            command: "systemctl".to_string(),
+            args: vec!["reload".to_string(), "nginx".to_string()],
+            timeout_secs: 30,
+            on_failure: HookFailurePolicyEntry::Continue,
+        };
+        let json = serde_json::to_string(&hook).expect("serialize");
+        let parsed: PostRenewHookEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(hook, parsed);
+    }
+
+    #[test]
+    fn service_entry_with_hooks_round_trips_json() {
+        let entry = ServiceEntry {
+            service_name: "svc".to_string(),
+            deploy_type: DeployType::Daemon,
+            delivery_mode: DeliveryMode::LocalFile,
+            hostname: "h".to_string(),
+            domain: "d.com".to_string(),
+            agent_config_path: PathBuf::from("agent.toml"),
+            cert_path: PathBuf::from("cert.pem"),
+            key_path: PathBuf::from("key.pem"),
+            instance_id: Some("001".to_string()),
+            container_name: None,
+            notes: None,
+            post_renew_hooks: vec![PostRenewHookEntry {
+                command: "pkill".to_string(),
+                args: vec!["-HUP".to_string(), "nginx".to_string()],
+                timeout_secs: 15,
+                on_failure: HookFailurePolicyEntry::Stop,
+            }],
+            approle: ServiceRoleEntry {
+                role_name: "r".to_string(),
+                role_id: "id".to_string(),
+                secret_id_path: PathBuf::from("s"),
+                policy_name: "p".to_string(),
+            },
+        };
+        let json = serde_json::to_string_pretty(&entry).expect("serialize");
+        let parsed: ServiceEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.post_renew_hooks.len(), 1);
+        assert_eq!(parsed.post_renew_hooks[0].command, "pkill");
+        assert_eq!(
+            parsed.post_renew_hooks[0].on_failure,
+            HookFailurePolicyEntry::Stop
+        );
+    }
+
+    #[test]
+    fn service_entry_without_hooks_deserializes_empty_vec() {
+        let json = r#"{
+            "service_name": "svc",
+            "deploy_type": "daemon",
+            "hostname": "h",
+            "domain": "d.com",
+            "agent_config_path": "agent.toml",
+            "cert_path": "cert.pem",
+            "key_path": "key.pem",
+            "approle": {
+                "role_name": "r",
+                "role_id": "id",
+                "secret_id_path": "s",
+                "policy_name": "p"
+            }
+        }"#;
+        let parsed: ServiceEntry = serde_json::from_str(json).expect("deserialize");
+        assert!(parsed.post_renew_hooks.is_empty());
     }
 }

--- a/src/toml_util.rs
+++ b/src/toml_util.rs
@@ -70,6 +70,16 @@ pub fn remove_sections(contents: &str, sections: &[&str]) -> Result<String> {
     Ok(doc.to_string())
 }
 
+/// Encodes a string as a TOML basic string with proper escaping.
+///
+/// Returns the value including surrounding double quotes, with all
+/// special characters (backslash, double quote, control characters
+/// such as newline and tab) properly escaped via `toml_edit`.
+#[must_use]
+pub fn toml_encode_string(s: &str) -> String {
+    Value::from(s).to_string()
+}
+
 /// Parses a raw string as a typed TOML value.
 ///
 /// Tries the TOML literal parser first to handle booleans (`true`,


### PR DESCRIPTION
## Summary

- Adds preset flags (`--reload-style`, `--reload-target`) and low-level flags (`--post-renew-command`, `--post-renew-arg`, `--post-renew-timeout-secs`, `--post-renew-on-failure`) to `bootroot service add` so that post-renew hooks can be configured at service registration time without hand-editing `agent.toml`.
- Threads hook data through all four layers identified in the issue: `ServiceAddArgs` (CLI), `ServiceEntry` (persistent state), local agent-config generator (`local_config.rs`), and remote bootstrap artifact/command (`remote_bootstrap.rs` + `bootroot-remote agent_config.rs`).
- Presets and low-level flags are mutually exclusive; presets expand into the equivalent low-level hook block. Idempotent re-runs (`is_idempotent_remote_rerun`) compare hook fields so state-driven rewrites preserve hook settings.
- `bootroot-remote bootstrap` validates hook flag coherence (rejects `--post-renew-arg`/`--post-renew-timeout-secs`/`--post-renew-on-failure` without `--post-renew-command`) instead of silently ignoring orphan flags.
- Both `service add` and `bootroot-remote bootstrap` reject empty/whitespace `--post-renew-command` and `--post-renew-timeout-secs 0`, matching the runtime config validation in `config/validation.rs`.
- Hook TOML emitters use `toml_edit::Value`-based encoding (via `toml_encode_string`) instead of manual escaping, correctly handling control characters (newline, tab, etc.) in command/arg values.

Closes #474

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (new unit tests for resolve, local_config, remote_bootstrap, state, cli args)
- [x] `--reload-style systemd --reload-target nginx` generates `systemctl reload nginx` hook in `agent.toml`
- [x] `--reload-style sighup --reload-target myproc` generates `pkill -HUP myproc` hook
- [x] `--reload-style docker-restart --reload-target ctr` generates `docker restart ctr` hook
- [x] `--reload-style none` generates no hook block
- [x] `--post-renew-command`/`--post-renew-arg` (low-level) generates correct hook block
- [x] Combining preset and low-level flags produces a clear error
- [x] `--reload-target` without `--reload-style` produces a clear error
- [x] `--post-renew-arg` without `--post-renew-command` produces a clear error
- [x] Empty/whitespace `--post-renew-command` is rejected
- [x] `--post-renew-timeout-secs 0` is rejected
- [x] Hook fields round-trip through `state.json` serialization
- [x] Existing `state.json` without `post_renew_hooks` deserializes with empty vec (backward compat)
- [x] Remote bootstrap artifact includes hook data and `bootroot-remote bootstrap` command template includes hook flags
- [x] `bootroot-remote bootstrap` with hook flags injects `[[profiles.hooks.post_renew.success]]` into `agent.toml`
- [x] `bootroot-remote bootstrap` rejects orphan `--post-renew-*` flags without `--post-renew-command`
- [x] `bootroot-remote bootstrap` rejects empty command and zero timeout
- [x] Idempotent remote re-run detects hook field changes correctly
- [x] Hook values with control characters (newline, tab) produce valid parseable TOML on both local and remote paths
- [x] CHANGELOG, README, EN docs, KO docs are updated