### PR TITLE
Add secret_id policy flags to service add and rotate (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `--post-renew-on-failure`). Hook settings are persisted in
   `state.json` and forwarded to `bootroot-remote bootstrap` for
   remote-bootstrap delivery mode.
+- Added per-issuance `secret_id` policy flags to `bootroot service add`
+  (`--secret-id-ttl`, `--secret-id-num-uses`, `--secret-id-wrap-ttl`,
+  `--no-wrap`). Policy values are persisted in `state.json` and applied
+  automatically during `rotate approle-secret-id`. Re-running
+  `service add` with different policy values on an existing service
+  produces an error directing the operator to use a policy update
+  command.
 - Added automatic HTTP-01 DNS alias registration on `service add`. The
   validation FQDN is registered as a Docker network alias on
   `bootroot-http01` at runtime, removing the need for a hand-written

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -521,6 +521,21 @@ the equivalent low-level hook settings. These flags are
 also forwarded to `bootroot-remote bootstrap` for the
 `remote-bootstrap` delivery mode.
 
+Per-issuance `secret_id` policy flags:
+
+- `--secret-id-ttl`: TTL for the generated `secret_id` (inherits the
+  role-level default when omitted)
+- `--secret-id-num-uses`: maximum number of times the `secret_id` can be
+  used (default `1`)
+- `--secret-id-wrap-ttl`: response-wrapping TTL for the `secret_id`
+  (default `30m`)
+- `--no-wrap`: disable response wrapping for the `secret_id`
+
+These values are persisted in `state.json` and applied on
+`rotate approle-secret-id`. `--no-wrap` and `--secret-id-wrap-ttl` control
+the same field: `--no-wrap` sets the stored wrap TTL to `0`, disabling
+wrapping entirely.
+
 ### Interactive behavior
 
 - Prompts for missing required inputs (deploy type defaults to `daemon`).

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -504,6 +504,17 @@ bootroot status
 `remote-bootstrap` 전달 모드에서는 이 플래그가
 `bootroot-remote bootstrap`으로 전달됩니다.
 
+발급 시점 `secret_id` 정책 플래그:
+
+- `--secret-id-ttl`: 생성되는 `secret_id`의 TTL (생략 시 역할 수준 기본값 상속)
+- `--secret-id-num-uses`: `secret_id` 최대 사용 횟수 (기본값 `1`)
+- `--secret-id-wrap-ttl`: `secret_id`에 대한 응답 래핑 TTL (기본값 `30m`)
+- `--no-wrap`: `secret_id` 응답 래핑 비활성화
+
+이 값들은 `state.json`에 저장되며 `rotate approle-secret-id` 시 적용됩니다.
+`--no-wrap`과 `--secret-id-wrap-ttl`은 동일 필드를 제어합니다.
+`--no-wrap`은 저장되는 래핑 TTL을 `0`으로 설정하여 래핑을 완전히 비활성화합니다.
+
 ### 대화형 동작
 
 - 누락된 필수 입력을 프롬프트로 받습니다(배포 타입 기본값: `daemon`).

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -398,6 +398,7 @@ run_bootstrap_chain() {
     --cert-path "$CERTS_DIR/${EDGE_SERVICE}.crt" \
     --key-path "$CERTS_DIR/${EDGE_SERVICE}.key" \
     --instance-id "$INSTANCE_ID" \
+    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -413,6 +414,7 @@ run_bootstrap_chain() {
     --key-path "$CERTS_DIR/${WEB_SERVICE}.key" \
     --instance-id "$INSTANCE_ID" \
     --container-name "$WEB_SERVICE" \
+    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -427,6 +427,7 @@ run_bootstrap_chain() {
     --cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
     --instance-id "$REMOTE_INSTANCE_ID" \
+    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -301,6 +301,7 @@ run_bootstrap_chain() {
     --cert-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.key" \
     --instance-id "$INSTANCE_ID" \
+    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -316,6 +317,7 @@ run_bootstrap_chain() {
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME_2}.key" \
     --instance-id "$INSTANCE_ID_2" \
     --container-name "$SERVICE_NAME_2" \
+    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -706,6 +706,22 @@ pub(crate) struct ServiceAddArgs {
     /// Post-renew success hook failure policy (low-level)
     #[arg(long, value_enum)]
     pub(crate) post_renew_on_failure: Option<HookFailurePolicyArg>,
+
+    /// TTL for the generated `secret_id` (inherits role default when omitted)
+    #[arg(long)]
+    pub(crate) secret_id_ttl: Option<String>,
+
+    /// Maximum number of times the `secret_id` can be used [default: 1]
+    #[arg(long)]
+    pub(crate) secret_id_num_uses: Option<u32>,
+
+    /// Response-wrapping TTL for the `secret_id` [default: 30m]
+    #[arg(long)]
+    pub(crate) secret_id_wrap_ttl: Option<String>,
+
+    /// Disable response wrapping for the `secret_id`
+    #[arg(long, conflicts_with = "secret_id_wrap_ttl")]
+    pub(crate) no_wrap: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1167,5 +1183,67 @@ mod tests {
             }
             _ => panic!("expected service add"),
         }
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_secret_id_defaults() {
+        let cli = Cli::parse_from(["bootroot", "service", "add"]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert!(args.secret_id_ttl.is_none());
+                assert!(args.secret_id_num_uses.is_none());
+                assert!(args.secret_id_wrap_ttl.is_none());
+                assert!(!args.no_wrap);
+            }
+            _ => panic!("expected service add"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_secret_id_overrides() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "add",
+            "--secret-id-ttl",
+            "1h",
+            "--secret-id-num-uses",
+            "5",
+            "--secret-id-wrap-ttl",
+            "10m",
+        ]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert_eq!(args.secret_id_ttl.as_deref(), Some("1h"));
+                assert_eq!(args.secret_id_num_uses, Some(5));
+                assert_eq!(args.secret_id_wrap_ttl.as_deref(), Some("10m"));
+                assert!(!args.no_wrap);
+            }
+            _ => panic!("expected service add"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_no_wrap() {
+        let cli = Cli::parse_from(["bootroot", "service", "add", "--no-wrap"]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert!(args.no_wrap);
+            }
+            _ => panic!("expected service add"),
+        }
+    }
+
+    #[test]
+    fn test_cli_rejects_no_wrap_with_secret_id_wrap_ttl() {
+        let result = Cli::try_parse_from([
+            "bootroot",
+            "service",
+            "add",
+            "--no-wrap",
+            "--secret-id-wrap-ttl",
+            "10m",
+        ]);
+        assert!(result.is_err());
     }
 }

--- a/src/commands/constants.rs
+++ b/src/commands/constants.rs
@@ -1,4 +1,6 @@
 pub(crate) const RESPONDER_SERVICE_NAME: &str = "bootroot-http01";
+pub(crate) const DEFAULT_SECRET_ID_NUM_USES: u32 = 1;
+pub(crate) const DEFAULT_SECRET_ID_WRAP_TTL: &str = "30m";
 pub(crate) use bootroot::trust_bootstrap::{
     EAB_HMAC_KEY as SERVICE_EAB_HMAC_KEY, EAB_KID_KEY as SERVICE_EAB_KID_KEY,
     HMAC_KEY as SERVICE_RESPONDER_HMAC_KEY, SECRET_ID_KEY as SERVICE_SECRET_ID_KEY,

--- a/src/commands/dns_alias.rs
+++ b/src/commands/dns_alias.rs
@@ -195,6 +195,9 @@ mod tests {
                 role_id: "id".to_string(),
                 secret_id_path: PathBuf::from("/s"),
                 policy_name: "p".to_string(),
+                secret_id_ttl: None,
+                secret_id_num_uses: None,
+                secret_id_wrap_ttl: None,
             },
         }
     }

--- a/src/commands/init/constants.rs
+++ b/src/commands/init/constants.rs
@@ -44,7 +44,7 @@ pub(crate) mod openbao_constants {
     pub(crate) const SECRET_ID_TTL: &str = "24h";
     // Used by upcoming sub-issues of #480 (response-wrapping, num_uses enforcement).
     #[allow(dead_code)]
-    pub(crate) const DEFAULT_SECRET_ID_NUM_USES: u32 = 1;
+    pub(crate) const DEFAULT_SECRET_ID_NUM_USES: u32 = 0;
     #[allow(dead_code)]
     pub(crate) const DEFAULT_SECRET_ID_WRAP_TTL: &str = "30m";
     pub(crate) const MAX_SECRET_ID_TTL: &str = "168h";

--- a/src/commands/rotate/approle.rs
+++ b/src/commands/rotate/approle.rs
@@ -7,7 +7,10 @@ use bootroot::openbao::{OpenBaoClient, SecretIdOptions};
 use super::helpers::{confirm_action, reload_openbao_agent, write_secret_id_atomic};
 use super::{ROLE_ID_FILENAME, RotateContext};
 use crate::cli::args::RotateAppRoleSecretIdArgs;
-use crate::commands::constants::{SERVICE_KV_BASE, SERVICE_SECRET_ID_KEY};
+use crate::commands::constants::{
+    DEFAULT_SECRET_ID_NUM_USES, SERVICE_KV_BASE, SERVICE_SECRET_ID_KEY,
+};
+use crate::commands::service::resolve::effective_wrap_ttl;
 use crate::i18n::Messages;
 use crate::state::{DeliveryMode, ServiceEntry};
 
@@ -34,10 +37,41 @@ pub(super) async fn rotate_approle_secret_id(
     if !is_remote {
         ensure_role_id_file(&entry, client, messages).await?;
     }
-    let new_secret_id = client
-        .create_secret_id(&entry.approle.role_name, &SecretIdOptions::default())
-        .await
-        .with_context(|| messages.error_openbao_secret_id_failed())?;
+    let stored_num_uses = entry
+        .approle
+        .secret_id_num_uses
+        .unwrap_or(DEFAULT_SECRET_ID_NUM_USES);
+    // Add 1 for the verify-login below so the caller's requested
+    // num_uses still remain after rotation verification.
+    let effective_num_uses = if stored_num_uses > 0 {
+        stored_num_uses.checked_add(1).ok_or_else(|| {
+            anyhow::anyhow!(
+                "secret_id_num_uses ({stored_num_uses}) is too large to \
+                 add the +1 verification allowance; use a smaller value"
+            )
+        })?
+    } else {
+        stored_num_uses
+    };
+    let secret_id_options = SecretIdOptions {
+        ttl: entry.approle.secret_id_ttl.clone(),
+        num_uses: Some(effective_num_uses),
+        metadata: None,
+    };
+    let wrap_ttl = effective_wrap_ttl(entry.approle.secret_id_wrap_ttl.as_deref());
+    let new_secret_id = match wrap_ttl {
+        Some(ttl) => {
+            client
+                .create_secret_id_wrapped(&entry.approle.role_name, &secret_id_options, ttl)
+                .await
+        }
+        None => {
+            client
+                .create_secret_id(&entry.approle.role_name, &secret_id_options)
+                .await
+        }
+    }
+    .with_context(|| messages.error_openbao_secret_id_failed())?;
     if !is_remote {
         write_secret_id_atomic(&entry.approle.secret_id_path, &new_secret_id, messages).await?;
         reload_openbao_agent(&entry, messages)?;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1,19 +1,20 @@
 mod approle;
 mod local_config;
 mod remote_bootstrap;
-mod resolve;
+pub(crate) mod resolve;
 mod secrets;
 
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use bootroot::openbao::OpenBaoClient;
+use bootroot::openbao::{OpenBaoClient, SecretIdOptions};
 
 use crate::cli::args::{ServiceAddArgs, ServiceInfoArgs};
 use crate::cli::output::{
     ServiceAddAppliedPaths, ServiceAddPlan, ServiceAddRemoteBootstrap, ServiceAddSummaryOptions,
     print_service_add_plan, print_service_add_summary, print_service_info_summary,
 };
+use crate::commands::constants::DEFAULT_SECRET_ID_NUM_USES;
 use crate::commands::dns_alias::register_dns_alias;
 use crate::commands::openbao_auth::authenticate_openbao_client;
 use crate::i18n::Messages;
@@ -104,6 +105,9 @@ pub(crate) async fn run_service_add(args: &ServiceAddArgs, messages: &Messages) 
     if let Some(existing) = state.services.get(&resolved.service_name).cloned() {
         if is_idempotent_remote_rerun(&existing, &resolved) {
             return run_service_add_remote_idempotent(&state, &existing, messages).await;
+        }
+        if is_policy_only_mismatch(&existing, &resolved) {
+            anyhow::bail!(messages.error_service_policy_mismatch());
         }
         anyhow::bail!(messages.error_service_duplicate(&resolved.service_name));
     }
@@ -226,8 +230,17 @@ async fn run_service_add_apply(
         .with_context(|| messages.error_openbao_client_create_failed())?;
     authenticate_openbao_client(&mut client, auth, messages).await?;
 
-    let approle_result =
-        approle::ensure_service_approle(&client, state, &resolved.service_name, messages).await?;
+    let secret_id_options = build_secret_id_options(resolved);
+    let wrap_ttl = resolve::effective_wrap_ttl(resolved.secret_id_wrap_ttl.as_deref());
+    let approle_result = approle::ensure_service_approle(
+        &client,
+        state,
+        &resolved.service_name,
+        &secret_id_options,
+        wrap_ttl,
+        messages,
+    )
+    .await?;
     let secrets_dir = state.secrets_dir();
     approle::write_role_id_file(
         secrets_dir,
@@ -340,8 +353,23 @@ fn build_service_entry(
             role_id: approle.role_id,
             secret_id_path: secret_id_path.to_path_buf(),
             policy_name: approle.policy_name,
+            secret_id_ttl: resolved.secret_id_ttl.clone(),
+            secret_id_num_uses: resolved.secret_id_num_uses,
+            secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
         },
     )
+}
+
+fn build_secret_id_options(resolved: &ResolvedServiceAdd) -> SecretIdOptions {
+    SecretIdOptions {
+        ttl: resolved.secret_id_ttl.clone(),
+        num_uses: Some(
+            resolved
+                .secret_id_num_uses
+                .unwrap_or(DEFAULT_SECRET_ID_NUM_USES),
+        ),
+        metadata: None,
+    }
 }
 
 fn print_service_add_apply_summary(
@@ -436,11 +464,14 @@ fn build_preview_service_entry(resolved: &ResolvedServiceAdd, state: &StateFile)
             role_id: "dry-run".to_string(),
             secret_id_path: preview_secret_id_path,
             policy_name: approle::service_policy_name(&resolved.service_name),
+            secret_id_ttl: resolved.secret_id_ttl.clone(),
+            secret_id_num_uses: resolved.secret_id_num_uses,
+            secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
         },
     )
 }
 
-fn is_idempotent_remote_rerun(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
+fn non_policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
     matches!(entry.delivery_mode, DeliveryMode::RemoteBootstrap)
         && matches!(resolved.delivery_mode, DeliveryMode::RemoteBootstrap)
         && entry.deploy_type == resolved.deploy_type
@@ -455,12 +486,30 @@ fn is_idempotent_remote_rerun(entry: &ServiceEntry, resolved: &ResolvedServiceAd
         && entry.post_renew_hooks == resolved.post_renew_hooks
 }
 
+fn policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
+    entry.approle.secret_id_ttl == resolved.secret_id_ttl
+        && entry.approle.secret_id_num_uses == resolved.secret_id_num_uses
+        && entry.approle.secret_id_wrap_ttl == resolved.secret_id_wrap_ttl
+}
+
+fn is_idempotent_remote_rerun(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
+    non_policy_fields_match(entry, resolved) && policy_fields_match(entry, resolved)
+}
+
+fn is_policy_only_mismatch(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
+    non_policy_fields_match(entry, resolved) && !policy_fields_match(entry, resolved)
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::resolve::ResolvedServiceAdd;
-    use super::{ServiceAppRoleMaterialized, build_service_entry, build_service_entry_from_role};
+    use super::{
+        ServiceAppRoleMaterialized, build_secret_id_options, build_service_entry,
+        build_service_entry_from_role, is_idempotent_remote_rerun, is_policy_only_mismatch,
+        non_policy_fields_match, policy_fields_match,
+    };
     use crate::state::{DeliveryMode, DeployType, ServiceEntry, ServiceRoleEntry};
 
     fn sample_resolved() -> ResolvedServiceAdd {
@@ -478,6 +527,9 @@ mod tests {
             runtime_auth: None,
             notes: Some("test note".to_string()),
             post_renew_hooks: Vec::new(),
+            secret_id_ttl: None,
+            secret_id_num_uses: None,
+            secret_id_wrap_ttl: None,
         }
     }
 
@@ -504,6 +556,9 @@ mod tests {
             role_id: "rid-a".to_string(),
             secret_id_path: PathBuf::from("/secrets/a"),
             policy_name: "policy-a".to_string(),
+            secret_id_ttl: None,
+            secret_id_num_uses: None,
+            secret_id_wrap_ttl: None,
         };
         let entry = build_service_entry_from_role(&resolved, role);
 
@@ -545,6 +600,9 @@ mod tests {
             role_id: "id".to_string(),
             secret_id_path: PathBuf::from("/s"),
             policy_name: "p".to_string(),
+            secret_id_ttl: None,
+            secret_id_num_uses: None,
+            secret_id_wrap_ttl: None,
         };
         let entry = build_service_entry_from_role(&resolved, role);
 
@@ -552,5 +610,147 @@ mod tests {
         assert!(entry.instance_id.is_none());
         assert!(entry.container_name.is_none());
         assert!(entry.notes.is_none());
+    }
+
+    fn sample_entry_from_resolved(resolved: &ResolvedServiceAdd) -> ServiceEntry {
+        build_service_entry_from_role(
+            resolved,
+            ServiceRoleEntry {
+                role_name: "role".to_string(),
+                role_id: "rid".to_string(),
+                secret_id_path: PathBuf::from("/s"),
+                policy_name: "policy".to_string(),
+                secret_id_ttl: resolved.secret_id_ttl.clone(),
+                secret_id_num_uses: resolved.secret_id_num_uses,
+                secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
+            },
+        )
+    }
+
+    #[test]
+    fn build_service_entry_persists_secret_id_policy_fields() {
+        let mut resolved = sample_resolved();
+        resolved.secret_id_ttl = Some("1h".to_string());
+        resolved.secret_id_num_uses = Some(5);
+        resolved.secret_id_wrap_ttl = Some("10m".to_string());
+
+        let materialized = ServiceAppRoleMaterialized {
+            role_name: "r".to_string(),
+            role_id: "id".to_string(),
+            secret_id: "sid".to_string(),
+            policy_name: "p".to_string(),
+        };
+        let entry = build_service_entry(&resolved, materialized, &PathBuf::from("/s"));
+
+        assert_eq!(entry.approle.secret_id_ttl.as_deref(), Some("1h"));
+        assert_eq!(entry.approle.secret_id_num_uses, Some(5));
+        assert_eq!(entry.approle.secret_id_wrap_ttl.as_deref(), Some("10m"));
+    }
+
+    #[test]
+    fn build_secret_id_options_maps_resolved_fields() {
+        let mut resolved = sample_resolved();
+        resolved.secret_id_ttl = Some("2h".to_string());
+        resolved.secret_id_num_uses = Some(3);
+
+        let opts = build_secret_id_options(&resolved);
+        assert_eq!(opts.ttl.as_deref(), Some("2h"));
+        assert_eq!(opts.num_uses, Some(3));
+        assert!(opts.metadata.is_none());
+    }
+
+    #[test]
+    fn build_secret_id_options_none_ttl() {
+        let resolved = sample_resolved();
+        let opts = build_secret_id_options(&resolved);
+        assert!(opts.ttl.is_none());
+        assert_eq!(opts.num_uses, Some(1));
+    }
+
+    #[test]
+    fn policy_fields_match_identical() {
+        let resolved = sample_resolved();
+        let entry = sample_entry_from_resolved(&resolved);
+        assert!(policy_fields_match(&entry, &resolved));
+    }
+
+    #[test]
+    fn policy_fields_match_differs_on_ttl() {
+        let resolved = sample_resolved();
+        let mut entry = sample_entry_from_resolved(&resolved);
+        entry.approle.secret_id_ttl = Some("999h".to_string());
+        assert!(!policy_fields_match(&entry, &resolved));
+    }
+
+    #[test]
+    fn policy_fields_match_differs_on_num_uses() {
+        let resolved = sample_resolved();
+        let mut entry = sample_entry_from_resolved(&resolved);
+        entry.approle.secret_id_num_uses = Some(99);
+        assert!(!policy_fields_match(&entry, &resolved));
+    }
+
+    #[test]
+    fn policy_fields_match_differs_on_wrap_ttl() {
+        let resolved = sample_resolved();
+        let mut entry = sample_entry_from_resolved(&resolved);
+        entry.approle.secret_id_wrap_ttl = Some("0".to_string());
+        assert!(!policy_fields_match(&entry, &resolved));
+    }
+
+    #[test]
+    fn non_policy_fields_match_requires_remote_bootstrap() {
+        let mut resolved = sample_resolved();
+        resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
+        let mut entry = sample_entry_from_resolved(&resolved);
+        // Both are remote-bootstrap → match
+        assert!(non_policy_fields_match(&entry, &resolved));
+        // Entry is local-file → no match
+        entry.delivery_mode = DeliveryMode::LocalFile;
+        assert!(!non_policy_fields_match(&entry, &resolved));
+    }
+
+    #[test]
+    fn is_idempotent_remote_rerun_true_when_all_match() {
+        let mut resolved = sample_resolved();
+        resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
+        let entry = sample_entry_from_resolved(&resolved);
+        assert!(is_idempotent_remote_rerun(&entry, &resolved));
+    }
+
+    #[test]
+    fn is_idempotent_remote_rerun_false_when_policy_differs() {
+        let mut resolved = sample_resolved();
+        resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
+        let mut entry = sample_entry_from_resolved(&resolved);
+        entry.approle.secret_id_num_uses = Some(99);
+        assert!(!is_idempotent_remote_rerun(&entry, &resolved));
+    }
+
+    #[test]
+    fn is_policy_only_mismatch_true_when_only_policy_differs() {
+        let mut resolved = sample_resolved();
+        resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
+        let mut entry = sample_entry_from_resolved(&resolved);
+        entry.approle.secret_id_wrap_ttl = Some("0".to_string());
+        assert!(is_policy_only_mismatch(&entry, &resolved));
+    }
+
+    #[test]
+    fn is_policy_only_mismatch_false_when_non_policy_also_differs() {
+        let mut resolved = sample_resolved();
+        resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
+        let mut entry = sample_entry_from_resolved(&resolved);
+        entry.approle.secret_id_wrap_ttl = Some("0".to_string());
+        entry.hostname = "different".to_string();
+        assert!(!is_policy_only_mismatch(&entry, &resolved));
+    }
+
+    #[test]
+    fn is_policy_only_mismatch_false_when_all_match() {
+        let mut resolved = sample_resolved();
+        resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
+        let entry = sample_entry_from_resolved(&resolved);
+        assert!(!is_policy_only_mismatch(&entry, &resolved));
     }
 }

--- a/src/commands/service/approle.rs
+++ b/src/commands/service/approle.rs
@@ -18,6 +18,8 @@ pub(super) async fn ensure_service_approle(
     client: &OpenBaoClient,
     state: &StateFile,
     service_name: &str,
+    secret_id_options: &SecretIdOptions,
+    wrap_ttl: Option<&str>,
     messages: &Messages,
 ) -> Result<ServiceAppRoleMaterialized> {
     let policy_name = service_policy_name(service_name);
@@ -42,10 +44,15 @@ pub(super) async fn ensure_service_approle(
         .read_role_id(&role_name)
         .await
         .with_context(|| messages.error_openbao_role_id_failed())?;
-    let secret_id = client
-        .create_secret_id(&role_name, &SecretIdOptions::default())
-        .await
-        .with_context(|| messages.error_openbao_secret_id_failed())?;
+    let secret_id = match wrap_ttl {
+        Some(ttl) => {
+            client
+                .create_secret_id_wrapped(&role_name, secret_id_options, ttl)
+                .await
+        }
+        None => client.create_secret_id(&role_name, secret_id_options).await,
+    }
+    .with_context(|| messages.error_openbao_secret_id_failed())?;
     Ok(ServiceAppRoleMaterialized {
         role_name,
         role_id,

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -256,6 +256,9 @@ mod tests {
             runtime_auth: None,
             notes: None,
             post_renew_hooks: Vec::new(),
+            secret_id_ttl: None,
+            secret_id_num_uses: None,
+            secret_id_wrap_ttl: None,
         }
     }
 

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -7,6 +7,7 @@ use bootroot::input_validation::{
 
 use crate::cli::args::{HookFailurePolicyArg, ReloadStyle, ServiceAddArgs};
 use crate::cli::prompt::Prompt;
+use crate::commands::constants::DEFAULT_SECRET_ID_WRAP_TTL;
 use crate::commands::openbao_auth::{
     RuntimeAuthResolved, resolve_runtime_auth, resolve_runtime_auth_optional,
 };
@@ -30,6 +31,9 @@ pub(crate) struct ResolvedServiceAdd {
     pub(crate) runtime_auth: Option<RuntimeAuthResolved>,
     pub(crate) notes: Option<String>,
     pub(crate) post_renew_hooks: Vec<PostRenewHookEntry>,
+    pub(crate) secret_id_ttl: Option<String>,
+    pub(crate) secret_id_num_uses: Option<u32>,
+    pub(crate) secret_id_wrap_ttl: Option<String>,
 }
 
 pub(super) fn resolve_service_add_args(
@@ -122,6 +126,12 @@ pub(super) fn resolve_service_add_args(
 
     let post_renew_hooks = resolve_post_renew_hooks(args)?;
 
+    let secret_id_wrap_ttl = if args.no_wrap {
+        Some("0".to_string())
+    } else {
+        args.secret_id_wrap_ttl.clone()
+    };
+
     Ok(ResolvedServiceAdd {
         service_name,
         deploy_type,
@@ -136,6 +146,9 @@ pub(super) fn resolve_service_add_args(
         runtime_auth,
         notes: args.notes.clone(),
         post_renew_hooks,
+        secret_id_ttl: args.secret_id_ttl.clone(),
+        secret_id_num_uses: args.secret_id_num_uses,
+        secret_id_wrap_ttl,
     })
 }
 
@@ -154,6 +167,19 @@ pub(super) fn validate_service_add(args: &ResolvedServiceAdd, messages: &Message
         anyhow::bail!(messages.error_service_container_name_required());
     }
     Ok(())
+}
+
+/// Resolves the effective wrap TTL from the stored `Option`.
+///
+/// - `None` → default (`"30m"`)
+/// - `Some("0")` → wrapping disabled → returns `None`
+/// - `Some(ttl)` → explicit override
+pub(crate) fn effective_wrap_ttl(stored: Option<&str>) -> Option<&str> {
+    match stored {
+        None => Some(DEFAULT_SECRET_ID_WRAP_TTL),
+        Some("0") => None,
+        Some(ttl) => Some(ttl),
+    }
 }
 
 fn ensure_non_empty(value: &str, messages: &Messages) -> Result<String> {
@@ -391,6 +417,10 @@ mod tests {
             post_renew_arg: Vec::new(),
             post_renew_timeout_secs: None,
             post_renew_on_failure: None,
+            secret_id_ttl: None,
+            secret_id_num_uses: None,
+            secret_id_wrap_ttl: None,
+            no_wrap: false,
         }
     }
 
@@ -627,5 +657,20 @@ mod tests {
             err.to_string().contains("--post-renew-command"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn effective_wrap_ttl_none_returns_default() {
+        assert_eq!(effective_wrap_ttl(None), Some("30m"));
+    }
+
+    #[test]
+    fn effective_wrap_ttl_custom_returns_custom() {
+        assert_eq!(effective_wrap_ttl(Some("10m")), Some("10m"));
+    }
+
+    #[test]
+    fn effective_wrap_ttl_zero_disables_wrapping() {
+        assert_eq!(effective_wrap_ttl(Some("0")), None);
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -108,6 +108,7 @@ pub(crate) struct Strings {
     pub(crate) error_eab_auto_failed: &'static str,
     pub(crate) error_state_missing: &'static str,
     pub(crate) error_service_duplicate: &'static str,
+    pub(crate) error_service_policy_mismatch: &'static str,
     pub(crate) error_service_not_found: &'static str,
     pub(crate) error_service_instance_id_required: &'static str,
     pub(crate) error_service_container_name_required: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -68,6 +68,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_eab_auto_failed: "Automatic EAB issuance failed",
     error_state_missing: "state.json not found (run `bootroot init` first)",
     error_service_duplicate: "Service already exists: {value}",
+    error_service_policy_mismatch: "To change the secret_id policy for an existing service, use a policy update command",
     error_service_not_found: "Service not found: {value}",
     error_service_instance_id_required: "instance_id is required for all services",
     error_service_container_name_required: "container_name is required for docker services",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -68,6 +68,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_eab_auto_failed: "EAB 자동 발급에 실패했습니다",
     error_state_missing: "state.json을 찾을 수 없습니다 (`bootroot init`을 먼저 실행하세요)",
     error_service_duplicate: "서비스가 이미 존재합니다: {value}",
+    error_service_policy_mismatch: "기존 서비스의 secret_id 정책을 변경하려면 정책 업데이트 명령을 사용하세요",
     error_service_not_found: "서비스를 찾을 수 없습니다: {value}",
     error_service_instance_id_required: "모든 서비스에는 instance_id가 필요합니다",
     error_service_container_name_required: "도커 서비스에는 container_name이 필요합니다",

--- a/src/i18n/service.rs
+++ b/src/i18n/service.rs
@@ -11,6 +11,10 @@ impl Messages {
         )
     }
 
+    pub(crate) fn error_service_policy_mismatch(&self) -> &'static str {
+        self.strings().error_service_policy_mismatch
+    }
+
     pub(crate) fn error_service_not_found(&self, service_name: &str) -> String {
         format_template(
             self.strings().error_service_not_found,

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -510,6 +510,23 @@ impl OpenBaoClient {
         Ok(response.data.secret_id)
     }
 
+    /// Creates a new `secret_id` with response wrapping, then immediately
+    /// unwraps it to obtain the raw value.
+    ///
+    /// # Errors
+    /// Returns an error if wrapping or unwrapping fails.
+    pub async fn create_secret_id_wrapped(
+        &self,
+        name: &str,
+        options: &SecretIdOptions,
+        wrap_ttl: &str,
+    ) -> Result<String> {
+        let path = format!("auth/approle/role/{name}/secret-id");
+        let wrap_info = self.post_json_wrapped(&path, options, wrap_ttl).await?;
+        let response: SecretIdResponse = self.unwrap_secret(&wrap_info.token).await?;
+        Ok(response.data.secret_id)
+    }
+
     /// Logs in using an `AppRole` `role_id/secret_id` pair.
     ///
     /// # Errors
@@ -969,6 +986,51 @@ mod wrap_tests {
             .expect("put_json with wrap_ttl should succeed");
         assert_eq!(info.wrap_info.token, "wrap-put-token");
         assert_eq!(info.wrap_info.ttl, 30);
+    }
+
+    #[tokio::test]
+    async fn create_secret_id_wrapped_sends_header_and_unwraps() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/role/svc-role/secret-id"))
+            .and(header("X-Vault-Token", "root-token"))
+            .and(header("X-Vault-Wrap-TTL", "30m"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "wrap_info": {
+                    "token": "wrap-sid-token",
+                    "ttl": 1800,
+                    "creation_time": "2026-04-12T00:00:00Z",
+                    "creation_path": "auth/approle/role/svc-role/secret-id"
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/sys/wrapping/unwrap"))
+            .and(header("X-Vault-Token", "wrap-sid-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "secret_id": "unwrapped-secret-abc",
+                    "secret_id_accessor": "acc"
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_with_token(&server);
+        let opts = SecretIdOptions {
+            num_uses: Some(1),
+            ..Default::default()
+        };
+        let secret_id = client
+            .create_secret_id_wrapped("svc-role", &opts, "30m")
+            .await
+            .expect("create_secret_id_wrapped should succeed");
+        assert_eq!(secret_id, "unwrapped-secret-abc");
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -93,6 +93,12 @@ pub(crate) struct ServiceRoleEntry {
     pub(crate) role_id: String,
     pub(crate) secret_id_path: PathBuf,
     pub(crate) policy_name: String,
+    #[serde(default)]
+    pub(crate) secret_id_ttl: Option<String>,
+    #[serde(default)]
+    pub(crate) secret_id_num_uses: Option<u32>,
+    #[serde(default)]
+    pub(crate) secret_id_wrap_ttl: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -247,6 +253,9 @@ mod tests {
                 role_id: "id".to_string(),
                 secret_id_path: PathBuf::from("s"),
                 policy_name: "p".to_string(),
+                secret_id_ttl: None,
+                secret_id_num_uses: None,
+                secret_id_wrap_ttl: None,
             },
         };
         let json = serde_json::to_string_pretty(&entry).expect("serialize");
@@ -257,6 +266,38 @@ mod tests {
             parsed.post_renew_hooks[0].on_failure,
             HookFailurePolicyEntry::Stop
         );
+    }
+
+    #[test]
+    fn service_role_entry_without_policy_fields_deserializes_as_none() {
+        let json = r#"{
+            "role_name": "r",
+            "role_id": "id",
+            "secret_id_path": "s",
+            "policy_name": "p"
+        }"#;
+        let parsed: ServiceRoleEntry = serde_json::from_str(json).expect("deserialize");
+        assert!(parsed.secret_id_ttl.is_none());
+        assert!(parsed.secret_id_num_uses.is_none());
+        assert!(parsed.secret_id_wrap_ttl.is_none());
+    }
+
+    #[test]
+    fn service_role_entry_with_policy_fields_round_trips() {
+        let entry = ServiceRoleEntry {
+            role_name: "r".to_string(),
+            role_id: "id".to_string(),
+            secret_id_path: PathBuf::from("s"),
+            policy_name: "p".to_string(),
+            secret_id_ttl: Some("1h".to_string()),
+            secret_id_num_uses: Some(5),
+            secret_id_wrap_ttl: Some("0".to_string()),
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        let parsed: ServiceRoleEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.secret_id_ttl.as_deref(), Some("1h"));
+        assert_eq!(parsed.secret_id_num_uses, Some(5));
+        assert_eq!(parsed.secret_id_wrap_ttl.as_deref(), Some("0"));
     }
 
     #[test]

--- a/tests/bootroot_rotate.rs
+++ b/tests/bootroot_rotate.rs
@@ -203,6 +203,56 @@ async fn test_rotate_approle_secret_id_daemon_updates_secret() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn test_rotate_approle_secret_id_applies_default_wrapping_when_policy_absent() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let openbao = MockServer::start().await;
+    let secret_path =
+        prepare_app_state_no_policy(temp_dir.path(), &openbao.uri(), "daemon", "local-file")
+            .expect("prepare state");
+    fs::write(&secret_path, "old-secret").expect("seed secret_id");
+
+    let bin_dir = temp_dir.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    let pkill_log = temp_dir.path().join("pkill.log");
+    write_fake_pkill(&bin_dir, &pkill_log).expect("write fake pkill");
+
+    stub_openbao_for_wrapped_rotation(&openbao, "secret-wrapped").await;
+
+    let path = env::var("PATH").unwrap_or_default();
+    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let output = Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "rotate",
+            "--openbao-url",
+            &openbao.uri(),
+            "--root-token",
+            support::ROOT_TOKEN,
+            "--yes",
+            "approle-secret-id",
+            "--service-name",
+            SERVICE_NAME,
+        ])
+        .env("PATH", combined_path)
+        .env("PKILL_OUTPUT", &pkill_log)
+        .output()
+        .expect("run rotate approle-secret-id");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("AppRole secret_id rotated"));
+    assert!(stdout.contains("AppRole login OK"));
+
+    let updated = fs::read_to_string(&secret_path).expect("read secret_id");
+    assert_eq!(updated, "secret-wrapped");
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn test_rotate_approle_secret_id_docker_restarts_agent() {
     let temp_dir = tempdir().expect("create temp dir");
     let openbao = MockServer::start().await;
@@ -930,7 +980,7 @@ async fn test_rotate_openbao_recovery_show_secrets_reveals_plaintext() {
     );
 }
 
-fn prepare_app_state(
+fn prepare_app_state_no_policy(
     root: &Path,
     openbao_url: &str,
     deploy_type: &str,
@@ -967,6 +1017,44 @@ fn prepare_app_state(
     Ok(root.join(secret_id_path))
 }
 
+fn prepare_app_state(
+    root: &Path,
+    openbao_url: &str,
+    deploy_type: &str,
+    delivery_mode: &str,
+) -> anyhow::Result<PathBuf> {
+    write_state_file(root, openbao_url)?;
+    let state_path = root.join("state.json");
+    let contents = fs::read_to_string(&state_path).context("read state")?;
+    let mut state: serde_json::Value = serde_json::from_str(&contents).context("parse state")?;
+    let secret_id_path = PathBuf::from("secrets/services/edge-proxy/secret_id");
+    state["services"][SERVICE_NAME] = json!({
+        "service_name": SERVICE_NAME,
+        "deploy_type": deploy_type,
+        "delivery_mode": delivery_mode,
+        "hostname": "edge-node-01",
+        "domain": "trusted.domain",
+        "agent_config_path": "agent.toml",
+        "cert_path": "certs/edge-proxy.crt",
+        "key_path": "certs/edge-proxy.key",
+        "instance_id": "001",
+        "container_name": "edge-proxy",
+        "approle": {
+            "role_name": ROLE_NAME,
+            "role_id": ROLE_ID,
+            "secret_id_path": secret_id_path,
+            "policy_name": ROLE_NAME,
+            "secret_id_wrap_ttl": "0"
+        }
+    });
+    fs::write(&state_path, serde_json::to_string_pretty(&state)?).context("write state")?;
+
+    let secret_dir = root.join("secrets").join("services").join(SERVICE_NAME);
+    fs::create_dir_all(&secret_dir).context("create secrets dir")?;
+    fs::write(root.join("agent.toml"), "# agent").context("write agent config")?;
+    Ok(root.join(secret_id_path))
+}
+
 fn prepare_mixed_service_state(root: &Path, openbao_url: &str) -> anyhow::Result<()> {
     write_state_file(root, openbao_url)?;
     let state_path = root.join("state.json");
@@ -987,7 +1075,8 @@ fn prepare_mixed_service_state(root: &Path, openbao_url: &str) -> anyhow::Result
             "role_name": ROLE_NAME,
             "role_id": ROLE_ID,
             "secret_id_path": "secrets/services/edge-proxy/secret_id",
-            "policy_name": ROLE_NAME
+            "policy_name": ROLE_NAME,
+            "secret_id_wrap_ttl": "0"
         }
     });
     state["services"][SECONDARY_SERVICE_NAME] = json!({
@@ -1005,7 +1094,8 @@ fn prepare_mixed_service_state(root: &Path, openbao_url: &str) -> anyhow::Result
             "role_name": "bootroot-service-edge-alt",
             "role_id": "role-edge-alt",
             "secret_id_path": "secrets/services/edge-alt/secret_id",
-            "policy_name": "bootroot-service-edge-alt"
+            "policy_name": "bootroot-service-edge-alt",
+            "secret_id_wrap_ttl": "0"
         }
     });
     fs::write(&state_path, serde_json::to_string_pretty(&state)?).context("write state")?;
@@ -1048,6 +1138,73 @@ async fn stub_openbao_for_rotation(server: &MockServer, new_secret_id: &str) {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "data": { "secret_id": new_secret_id }
         })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/auth/approle/role/{ROLE_NAME}/role-id")))
+        .and(header("X-Vault-Token", support::ROOT_TOKEN))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "role_id": ROLE_ID }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/auth/approle/login"))
+        .and(body_json(json!({
+            "role_id": ROLE_ID,
+            "secret_id": new_secret_id
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "auth": { "client_token": "client-token" }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/v1/secret/data/bootroot/services/{SERVICE_NAME}/secret_id"
+        )))
+        .and(header("X-Vault-Token", support::ROOT_TOKEN))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(server)
+        .await;
+}
+
+async fn stub_openbao_for_wrapped_rotation(server: &MockServer, new_secret_id: &str) {
+    Mock::given(method("GET"))
+        .and(path("/v1/sys/health"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/auth/approle/role/{ROLE_NAME}/secret-id")))
+        .and(header("X-Vault-Token", support::ROOT_TOKEN))
+        .and(header("X-Vault-Wrap-TTL", "30m"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "wrap_info": {
+                "token": "wrap-rotation-token",
+                "ttl": 1800,
+                "creation_time": "2026-04-13T00:00:00Z",
+                "creation_path": format!("auth/approle/role/{ROLE_NAME}/secret-id")
+            }
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .and(header("X-Vault-Token", "wrap-rotation-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "secret_id": new_secret_id,
+                "secret_id_accessor": "acc"
+            }
+        })))
+        .expect(1)
         .mount(server)
         .await;
 

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -9,7 +9,7 @@ use anyhow::Context;
 use rcgen::generate_simple_self_signed;
 use serde_json::json;
 use tempfile::tempdir;
-use wiremock::matchers::{body_json, header, method, path};
+use wiremock::matchers::{body_json, header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[cfg(unix)]
@@ -1403,11 +1403,30 @@ async fn stub_app_add_openbao_with_token(server: &MockServer, service_name: &str
         .mount(server)
         .await;
 
+    let wrap_token = format!("wrap-token-{service_name}");
     Mock::given(method("POST"))
         .and(path(format!("/v1/auth/approle/role/{role}/secret-id")))
         .and(header("X-Vault-Token", token))
+        .and(header_exists("X-Vault-Wrap-TTL"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "secret_id": format!("secret-{service_name}") }
+            "wrap_info": {
+                "token": &wrap_token,
+                "ttl": 1800,
+                "creation_time": "2026-04-12T00:00:00Z",
+                "creation_path": format!("auth/approle/role/{role}/secret-id")
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .and(header("X-Vault-Token", &wrap_token))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "secret_id": format!("secret-{service_name}"),
+                "secret_id_accessor": "acc"
+            }
         })))
         .mount(server)
         .await;

--- a/tests/e2e_remote_happy_path.rs
+++ b/tests/e2e_remote_happy_path.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use rcgen::generate_simple_self_signed;
 use serde_json::json;
 use tempfile::tempdir;
-use wiremock::matchers::{body_json, header, method, path};
+use wiremock::matchers::{body_json, header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 const RUNTIME_SERVICE_ADD_ROLE_ID: &str = "runtime-service-add-role-id";
@@ -412,8 +412,26 @@ async fn stub_control_plane_approle(server: &MockServer, role_name: &str) {
     Mock::given(method("POST"))
         .and(path(format!("/v1/auth/approle/role/{role_name}/secret-id")))
         .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .and(header_exists("X-Vault-Wrap-TTL"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "secret_id": "secret-edge-proxy" }
+            "wrap_info": {
+                "token": "wrap-token-edge-proxy",
+                "ttl": 1800,
+                "creation_time": "2026-04-12T00:00:00Z",
+                "creation_path": format!("auth/approle/role/{role_name}/secret-id")
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .and(header("X-Vault-Token", "wrap-token-edge-proxy"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "secret_id": "secret-edge-proxy",
+                "secret_id_accessor": "acc"
+            }
         })))
         .mount(server)
         .await;

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use rcgen::generate_simple_self_signed;
 use serde_json::json;
 use tempfile::tempdir;
-use wiremock::matchers::{body_json, header, method, path};
+use wiremock::matchers::{body_json, header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 const RUNTIME_SERVICE_ADD_ROLE_ID: &str = "runtime-service-add-role-id";
@@ -680,8 +680,26 @@ async fn stub_service_add_openbao(server: &MockServer) {
     Mock::given(method("POST"))
         .and(path(format!("/v1/auth/approle/role/{ROLE_NAME}/secret-id")))
         .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .and(header_exists("X-Vault-Wrap-TTL"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "secret_id": "secret-initial" }
+            "wrap_info": {
+                "token": "wrap-token-initial",
+                "ttl": 1800,
+                "creation_time": "2026-04-12T00:00:00Z",
+                "creation_path": format!("auth/approle/role/{ROLE_NAME}/secret-id")
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .and(header("X-Vault-Token", "wrap-token-initial"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "secret_id": "secret-initial",
+                "secret_id_accessor": "acc"
+            }
         })))
         .mount(server)
         .await;
@@ -815,11 +833,30 @@ async fn stub_secret_id_rotation_openbao(server: &MockServer, secret_id: &str) {
         .mount(server)
         .await;
 
+    let wrap_token = format!("wrap-rot-{secret_id}");
     Mock::given(method("POST"))
         .and(path(format!("/v1/auth/approle/role/{ROLE_NAME}/secret-id")))
         .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .and(header_exists("X-Vault-Wrap-TTL"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "secret_id": secret_id }
+            "wrap_info": {
+                "token": &wrap_token,
+                "ttl": 1800,
+                "creation_time": "2026-04-12T00:00:00Z",
+                "creation_path": format!("auth/approle/role/{ROLE_NAME}/secret-id")
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .and(header("X-Vault-Token", &wrap_token))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "secret_id": secret_id,
+                "secret_id_accessor": "acc"
+            }
         })))
         .mount(server)
         .await;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use rcgen::{CertificateParams, DnType, KeyPair};
 use serde_json::json;
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 pub(crate) const ROOT_TOKEN: &str = "root-token";
@@ -349,11 +349,41 @@ async fn stub_approles(server: &MockServer) {
             .mount(server)
             .await;
 
+        // Non-wrapped path (used by init flow)
         Mock::given(method("POST"))
             .and(path(format!("/v1/auth/approle/role/{approle}/secret-id")))
             .and(header("X-Vault-Token", ROOT_TOKEN))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "data": { "secret_id": format!("secret-{approle}") }
+            })))
+            .mount(server)
+            .await;
+
+        // Wrapped path (used by service add flow)
+        let wrap_token = format!("wrap-token-{approle}");
+        Mock::given(method("POST"))
+            .and(path(format!("/v1/auth/approle/role/{approle}/secret-id")))
+            .and(header("X-Vault-Token", ROOT_TOKEN))
+            .and(header_exists("X-Vault-Wrap-TTL"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "wrap_info": {
+                    "token": &wrap_token,
+                    "ttl": 1800,
+                    "creation_time": "2026-04-12T00:00:00Z",
+                    "creation_path": format!("auth/approle/role/{approle}/secret-id")
+                }
+            })))
+            .mount(server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/sys/wrapping/unwrap"))
+            .and(header("X-Vault-Token", &wrap_token))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "secret_id": format!("secret-{approle}"),
+                    "secret_id_accessor": "acc"
+                }
             })))
             .mount(server)
             .await;


### PR DESCRIPTION
## Summary

- Add `--secret-id-ttl`, `--secret-id-num-uses` (default 1), `--secret-id-wrap-ttl` (default 30m), and `--no-wrap` flags to `service add`
- `--no-wrap` and `--secret-id-wrap-ttl` are mutually exclusive (Clap `conflicts_with`)
- Persist policy as flat `Option` fields on `ServiceRoleEntry` in `state.json` with `#[serde(default)]` for backward compatibility
- `None` encoding: `None` = use the default (num_uses=1, wrap_ttl=30m, inherit role-level TTL); `Some("0")` for wrap_ttl = wrapping disabled; `Some(value)` = explicit override
- Thread `SecretIdOptions` through the resolution and AppRole creation flow so `create_secret_id()` receives per-issuance policy
- Wire `wrap_ttl` through `ensure_service_approle` and `rotate approle-secret-id` to the wrapping layer: when wrapping is enabled, `create_secret_id_wrapped()` sends the `X-Vault-Wrap-TTL` header, immediately unwraps to obtain the raw `secret_id`
- Read stored policy from state during `rotate approle-secret-id` and pass to `create_secret_id()` with wrapping; when `num_uses > 0`, add 1 (with overflow guard) for the internal verify-login so the caller's requested uses remain intact
- Include policy fields in idempotent-rerun comparison; surface a localized (i18n) error when only policy differs on an existing service
- Update English and Korean CLI docs and CHANGELOG

Closes #489

## Not addressed

- **Wrapped idempotent rerun path**: the artifact schema (`wrap_token`, `wrap_expires_at`) does not exist until #490, so the wrapped rerun flow is deferred to that PR. This PR establishes the contract and ensures `create_secret_id()` with stored policy is available for #490.
- **`service update` subcommand**: does not exist yet (#491). The policy-mismatch error message uses a generic phrase ("use a policy update command") and will be updated by #491 to reference the concrete subcommand.

## Test plan

- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes (unit tests for CLI parsing defaults/overrides, state round-trip, `effective_wrap_ttl`, `build_secret_id_options`, `policy_fields_match`, `is_idempotent_remote_rerun`, `is_policy_only_mismatch`, `create_secret_id_wrapped`)
- [x] Existing state.json files without the new fields deserialize correctly (backward-compat test)
- [x] `--no-wrap` resolves `secret_id_wrap_ttl` to `Some("0")` in state
- [x] `--no-wrap` and `--secret-id-wrap-ttl` reject each other at parse time (Clap conflict test)
- [x] E2E service add and rotate tests exercise the wrapping path (`X-Vault-Wrap-TTL` header + unwrap)
- [x] `rotate approle-secret-id` reads stored policy from `ServiceRoleEntry` and applies defaults (num_uses=1, wrap_ttl=30m) when state fields are `None` — exercised by E2E test with absent policy fields
- [x] Re-running `service add` with different policy on an existing remote-bootstrap service produces the localized policy-mismatch error
- [x] Policy-mismatch error uses i18n Messages catalog (English and Korean)
- [x] Rotation verify-login adds +1 to `num_uses` when bounded (with checked arithmetic to prevent overflow), preserving the caller's requested uses