### PR TITLE
Remove secret_id_num_uses from service policy (#497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `--secret-id-num-uses` from `bootroot service add` and from
+  `rotate approle-secret-id` policy state. Service SecretIDs are now
+  always issued with unlimited uses (`num_uses = 0`). The lower-level
+  OpenBao client still supports bounded-use SecretIDs for non-service
+  workflows.
+
 ### Fixed
 
 - Fixed daemon-mode retries silently dropping CLI overrides (`--email`,
@@ -38,12 +46,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `state.json` and forwarded to `bootroot-remote bootstrap` for
   remote-bootstrap delivery mode.
 - Added per-issuance `secret_id` policy flags to `bootroot service add`
-  (`--secret-id-ttl`, `--secret-id-num-uses`, `--secret-id-wrap-ttl`,
-  `--no-wrap`). Policy values are persisted in `state.json` and applied
-  automatically during `rotate approle-secret-id`. Re-running
-  `service add` with different policy values on an existing service
-  produces an error directing the operator to use a policy update
-  command.
+  (`--secret-id-ttl`, `--secret-id-wrap-ttl`, `--no-wrap`). Policy
+  values are persisted in `state.json` and applied automatically during
+  `rotate approle-secret-id`. Re-running `service add` with different
+  policy values on an existing service produces an error directing the
+  operator to use a policy update command.
 - Added automatic HTTP-01 DNS alias registration on `service add`. The
   validation FQDN is registered as a Docker network alias on
   `bootroot-http01` at runtime, removing the need for a hand-written

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -525,8 +525,6 @@ Per-issuance `secret_id` policy flags:
 
 - `--secret-id-ttl`: TTL for the generated `secret_id` (inherits the
   role-level default when omitted)
-- `--secret-id-num-uses`: maximum number of times the `secret_id` can be
-  used (default `1`)
 - `--secret-id-wrap-ttl`: response-wrapping TTL for the `secret_id`
   (default `30m`)
 - `--no-wrap`: disable response wrapping for the `secret_id`

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -507,7 +507,6 @@ bootroot status
 발급 시점 `secret_id` 정책 플래그:
 
 - `--secret-id-ttl`: 생성되는 `secret_id`의 TTL (생략 시 역할 수준 기본값 상속)
-- `--secret-id-num-uses`: `secret_id` 최대 사용 횟수 (기본값 `1`)
 - `--secret-id-wrap-ttl`: `secret_id`에 대한 응답 래핑 TTL (기본값 `30m`)
 - `--no-wrap`: `secret_id` 응답 래핑 비활성화
 

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -398,7 +398,6 @@ run_bootstrap_chain() {
     --cert-path "$CERTS_DIR/${EDGE_SERVICE}.crt" \
     --key-path "$CERTS_DIR/${EDGE_SERVICE}.key" \
     --instance-id "$INSTANCE_ID" \
-    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -414,7 +413,6 @@ run_bootstrap_chain() {
     --key-path "$CERTS_DIR/${WEB_SERVICE}.key" \
     --instance-id "$INSTANCE_ID" \
     --container-name "$WEB_SERVICE" \
-    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -429,7 +427,6 @@ run_bootstrap_chain() {
     --cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
     --instance-id "$REMOTE_INSTANCE_ID" \
-    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -301,7 +301,6 @@ run_bootstrap_chain() {
     --cert-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.key" \
     --instance-id "$INSTANCE_ID" \
-    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -317,7 +316,6 @@ run_bootstrap_chain() {
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME_2}.key" \
     --instance-id "$INSTANCE_ID_2" \
     --container-name "$SERVICE_NAME_2" \
-    --secret-id-num-uses 0 \
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -711,10 +711,6 @@ pub(crate) struct ServiceAddArgs {
     #[arg(long)]
     pub(crate) secret_id_ttl: Option<String>,
 
-    /// Maximum number of times the `secret_id` can be used [default: 1]
-    #[arg(long)]
-    pub(crate) secret_id_num_uses: Option<u32>,
-
     /// Response-wrapping TTL for the `secret_id` [default: 30m]
     #[arg(long)]
     pub(crate) secret_id_wrap_ttl: Option<String>,
@@ -1191,7 +1187,6 @@ mod tests {
         match cli.command {
             CliCommand::Service(ServiceCommand::Add(args)) => {
                 assert!(args.secret_id_ttl.is_none());
-                assert!(args.secret_id_num_uses.is_none());
                 assert!(args.secret_id_wrap_ttl.is_none());
                 assert!(!args.no_wrap);
             }
@@ -1207,15 +1202,12 @@ mod tests {
             "add",
             "--secret-id-ttl",
             "1h",
-            "--secret-id-num-uses",
-            "5",
             "--secret-id-wrap-ttl",
             "10m",
         ]);
         match cli.command {
             CliCommand::Service(ServiceCommand::Add(args)) => {
                 assert_eq!(args.secret_id_ttl.as_deref(), Some("1h"));
-                assert_eq!(args.secret_id_num_uses, Some(5));
                 assert_eq!(args.secret_id_wrap_ttl.as_deref(), Some("10m"));
                 assert!(!args.no_wrap);
             }

--- a/src/commands/constants.rs
+++ b/src/commands/constants.rs
@@ -1,5 +1,4 @@
 pub(crate) const RESPONDER_SERVICE_NAME: &str = "bootroot-http01";
-pub(crate) const DEFAULT_SECRET_ID_NUM_USES: u32 = 1;
 pub(crate) const DEFAULT_SECRET_ID_WRAP_TTL: &str = "30m";
 pub(crate) use bootroot::trust_bootstrap::{
     EAB_HMAC_KEY as SERVICE_EAB_HMAC_KEY, EAB_KID_KEY as SERVICE_EAB_KID_KEY,

--- a/src/commands/dns_alias.rs
+++ b/src/commands/dns_alias.rs
@@ -196,7 +196,6 @@ mod tests {
                 secret_id_path: PathBuf::from("/s"),
                 policy_name: "p".to_string(),
                 secret_id_ttl: None,
-                secret_id_num_uses: None,
                 secret_id_wrap_ttl: None,
             },
         }

--- a/src/commands/init/constants.rs
+++ b/src/commands/init/constants.rs
@@ -42,9 +42,7 @@ pub(crate) mod openbao_constants {
     pub(crate) const INIT_SECRET_THRESHOLD: u8 = 2;
     pub(crate) const TOKEN_TTL: &str = "1h";
     pub(crate) const SECRET_ID_TTL: &str = "24h";
-    // Used by upcoming sub-issues of #480 (response-wrapping, num_uses enforcement).
-    #[allow(dead_code)]
-    pub(crate) const DEFAULT_SECRET_ID_NUM_USES: u32 = 0;
+    // Used by upcoming sub-issues of #480 (response-wrapping).
     #[allow(dead_code)]
     pub(crate) const DEFAULT_SECRET_ID_WRAP_TTL: &str = "30m";
     pub(crate) const MAX_SECRET_ID_TTL: &str = "168h";

--- a/src/commands/rotate/approle.rs
+++ b/src/commands/rotate/approle.rs
@@ -7,9 +7,7 @@ use bootroot::openbao::{OpenBaoClient, SecretIdOptions};
 use super::helpers::{confirm_action, reload_openbao_agent, write_secret_id_atomic};
 use super::{ROLE_ID_FILENAME, RotateContext};
 use crate::cli::args::RotateAppRoleSecretIdArgs;
-use crate::commands::constants::{
-    DEFAULT_SECRET_ID_NUM_USES, SERVICE_KV_BASE, SERVICE_SECRET_ID_KEY,
-};
+use crate::commands::constants::{SERVICE_KV_BASE, SERVICE_SECRET_ID_KEY};
 use crate::commands::service::resolve::effective_wrap_ttl;
 use crate::i18n::Messages;
 use crate::state::{DeliveryMode, ServiceEntry};
@@ -37,25 +35,9 @@ pub(super) async fn rotate_approle_secret_id(
     if !is_remote {
         ensure_role_id_file(&entry, client, messages).await?;
     }
-    let stored_num_uses = entry
-        .approle
-        .secret_id_num_uses
-        .unwrap_or(DEFAULT_SECRET_ID_NUM_USES);
-    // Add 1 for the verify-login below so the caller's requested
-    // num_uses still remain after rotation verification.
-    let effective_num_uses = if stored_num_uses > 0 {
-        stored_num_uses.checked_add(1).ok_or_else(|| {
-            anyhow::anyhow!(
-                "secret_id_num_uses ({stored_num_uses}) is too large to \
-                 add the +1 verification allowance; use a smaller value"
-            )
-        })?
-    } else {
-        stored_num_uses
-    };
     let secret_id_options = SecretIdOptions {
         ttl: entry.approle.secret_id_ttl.clone(),
-        num_uses: Some(effective_num_uses),
+        num_uses: Some(0),
         metadata: None,
     };
     let wrap_ttl = effective_wrap_ttl(entry.approle.secret_id_wrap_ttl.as_deref());

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -14,7 +14,6 @@ use crate::cli::output::{
     ServiceAddAppliedPaths, ServiceAddPlan, ServiceAddRemoteBootstrap, ServiceAddSummaryOptions,
     print_service_add_plan, print_service_add_summary, print_service_info_summary,
 };
-use crate::commands::constants::DEFAULT_SECRET_ID_NUM_USES;
 use crate::commands::dns_alias::register_dns_alias;
 use crate::commands::openbao_auth::authenticate_openbao_client;
 use crate::i18n::Messages;
@@ -354,7 +353,6 @@ fn build_service_entry(
             secret_id_path: secret_id_path.to_path_buf(),
             policy_name: approle.policy_name,
             secret_id_ttl: resolved.secret_id_ttl.clone(),
-            secret_id_num_uses: resolved.secret_id_num_uses,
             secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
         },
     )
@@ -363,11 +361,7 @@ fn build_service_entry(
 fn build_secret_id_options(resolved: &ResolvedServiceAdd) -> SecretIdOptions {
     SecretIdOptions {
         ttl: resolved.secret_id_ttl.clone(),
-        num_uses: Some(
-            resolved
-                .secret_id_num_uses
-                .unwrap_or(DEFAULT_SECRET_ID_NUM_USES),
-        ),
+        num_uses: Some(0),
         metadata: None,
     }
 }
@@ -465,7 +459,6 @@ fn build_preview_service_entry(resolved: &ResolvedServiceAdd, state: &StateFile)
             secret_id_path: preview_secret_id_path,
             policy_name: approle::service_policy_name(&resolved.service_name),
             secret_id_ttl: resolved.secret_id_ttl.clone(),
-            secret_id_num_uses: resolved.secret_id_num_uses,
             secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
         },
     )
@@ -488,7 +481,6 @@ fn non_policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) 
 
 fn policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
     entry.approle.secret_id_ttl == resolved.secret_id_ttl
-        && entry.approle.secret_id_num_uses == resolved.secret_id_num_uses
         && entry.approle.secret_id_wrap_ttl == resolved.secret_id_wrap_ttl
 }
 
@@ -528,7 +520,6 @@ mod tests {
             notes: Some("test note".to_string()),
             post_renew_hooks: Vec::new(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
             secret_id_wrap_ttl: None,
         }
     }
@@ -557,7 +548,6 @@ mod tests {
             secret_id_path: PathBuf::from("/secrets/a"),
             policy_name: "policy-a".to_string(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
             secret_id_wrap_ttl: None,
         };
         let entry = build_service_entry_from_role(&resolved, role);
@@ -601,7 +591,6 @@ mod tests {
             secret_id_path: PathBuf::from("/s"),
             policy_name: "p".to_string(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
             secret_id_wrap_ttl: None,
         };
         let entry = build_service_entry_from_role(&resolved, role);
@@ -621,7 +610,6 @@ mod tests {
                 secret_id_path: PathBuf::from("/s"),
                 policy_name: "policy".to_string(),
                 secret_id_ttl: resolved.secret_id_ttl.clone(),
-                secret_id_num_uses: resolved.secret_id_num_uses,
                 secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
             },
         )
@@ -631,7 +619,6 @@ mod tests {
     fn build_service_entry_persists_secret_id_policy_fields() {
         let mut resolved = sample_resolved();
         resolved.secret_id_ttl = Some("1h".to_string());
-        resolved.secret_id_num_uses = Some(5);
         resolved.secret_id_wrap_ttl = Some("10m".to_string());
 
         let materialized = ServiceAppRoleMaterialized {
@@ -643,7 +630,6 @@ mod tests {
         let entry = build_service_entry(&resolved, materialized, &PathBuf::from("/s"));
 
         assert_eq!(entry.approle.secret_id_ttl.as_deref(), Some("1h"));
-        assert_eq!(entry.approle.secret_id_num_uses, Some(5));
         assert_eq!(entry.approle.secret_id_wrap_ttl.as_deref(), Some("10m"));
     }
 
@@ -651,20 +637,19 @@ mod tests {
     fn build_secret_id_options_maps_resolved_fields() {
         let mut resolved = sample_resolved();
         resolved.secret_id_ttl = Some("2h".to_string());
-        resolved.secret_id_num_uses = Some(3);
 
         let opts = build_secret_id_options(&resolved);
         assert_eq!(opts.ttl.as_deref(), Some("2h"));
-        assert_eq!(opts.num_uses, Some(3));
+        assert_eq!(opts.num_uses, Some(0));
         assert!(opts.metadata.is_none());
     }
 
     #[test]
-    fn build_secret_id_options_none_ttl() {
+    fn build_secret_id_options_always_unlimited() {
         let resolved = sample_resolved();
         let opts = build_secret_id_options(&resolved);
         assert!(opts.ttl.is_none());
-        assert_eq!(opts.num_uses, Some(1));
+        assert_eq!(opts.num_uses, Some(0));
     }
 
     #[test]
@@ -679,14 +664,6 @@ mod tests {
         let resolved = sample_resolved();
         let mut entry = sample_entry_from_resolved(&resolved);
         entry.approle.secret_id_ttl = Some("999h".to_string());
-        assert!(!policy_fields_match(&entry, &resolved));
-    }
-
-    #[test]
-    fn policy_fields_match_differs_on_num_uses() {
-        let resolved = sample_resolved();
-        let mut entry = sample_entry_from_resolved(&resolved);
-        entry.approle.secret_id_num_uses = Some(99);
         assert!(!policy_fields_match(&entry, &resolved));
     }
 
@@ -723,7 +700,7 @@ mod tests {
         let mut resolved = sample_resolved();
         resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
         let mut entry = sample_entry_from_resolved(&resolved);
-        entry.approle.secret_id_num_uses = Some(99);
+        entry.approle.secret_id_wrap_ttl = Some("0".to_string());
         assert!(!is_idempotent_remote_rerun(&entry, &resolved));
     }
 

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -257,7 +257,6 @@ mod tests {
             notes: None,
             post_renew_hooks: Vec::new(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
             secret_id_wrap_ttl: None,
         }
     }

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -32,7 +32,6 @@ pub(crate) struct ResolvedServiceAdd {
     pub(crate) notes: Option<String>,
     pub(crate) post_renew_hooks: Vec<PostRenewHookEntry>,
     pub(crate) secret_id_ttl: Option<String>,
-    pub(crate) secret_id_num_uses: Option<u32>,
     pub(crate) secret_id_wrap_ttl: Option<String>,
 }
 
@@ -147,7 +146,6 @@ pub(super) fn resolve_service_add_args(
         notes: args.notes.clone(),
         post_renew_hooks,
         secret_id_ttl: args.secret_id_ttl.clone(),
-        secret_id_num_uses: args.secret_id_num_uses,
         secret_id_wrap_ttl,
     })
 }
@@ -418,7 +416,6 @@ mod tests {
             post_renew_timeout_secs: None,
             post_renew_on_failure: None,
             secret_id_ttl: None,
-            secret_id_num_uses: None,
             secret_id_wrap_ttl: None,
             no_wrap: false,
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -96,8 +96,6 @@ pub(crate) struct ServiceRoleEntry {
     #[serde(default)]
     pub(crate) secret_id_ttl: Option<String>,
     #[serde(default)]
-    pub(crate) secret_id_num_uses: Option<u32>,
-    #[serde(default)]
     pub(crate) secret_id_wrap_ttl: Option<String>,
 }
 
@@ -254,7 +252,6 @@ mod tests {
                 secret_id_path: PathBuf::from("s"),
                 policy_name: "p".to_string(),
                 secret_id_ttl: None,
-                secret_id_num_uses: None,
                 secret_id_wrap_ttl: None,
             },
         };
@@ -278,8 +275,23 @@ mod tests {
         }"#;
         let parsed: ServiceRoleEntry = serde_json::from_str(json).expect("deserialize");
         assert!(parsed.secret_id_ttl.is_none());
-        assert!(parsed.secret_id_num_uses.is_none());
         assert!(parsed.secret_id_wrap_ttl.is_none());
+    }
+
+    #[test]
+    fn old_state_with_secret_id_num_uses_still_deserializes() {
+        let json = r#"{
+            "role_name": "r",
+            "role_id": "id",
+            "secret_id_path": "s",
+            "policy_name": "p",
+            "secret_id_ttl": "1h",
+            "secret_id_num_uses": 5,
+            "secret_id_wrap_ttl": "30m"
+        }"#;
+        let parsed: ServiceRoleEntry = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(parsed.secret_id_ttl.as_deref(), Some("1h"));
+        assert_eq!(parsed.secret_id_wrap_ttl.as_deref(), Some("30m"));
     }
 
     #[test]
@@ -290,13 +302,11 @@ mod tests {
             secret_id_path: PathBuf::from("s"),
             policy_name: "p".to_string(),
             secret_id_ttl: Some("1h".to_string()),
-            secret_id_num_uses: Some(5),
             secret_id_wrap_ttl: Some("0".to_string()),
         };
         let json = serde_json::to_string(&entry).expect("serialize");
         let parsed: ServiceRoleEntry = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(parsed.secret_id_ttl.as_deref(), Some("1h"));
-        assert_eq!(parsed.secret_id_num_uses, Some(5));
         assert_eq!(parsed.secret_id_wrap_ttl.as_deref(), Some("0"));
     }
 


### PR DESCRIPTION
## Summary

- Remove `--secret-id-num-uses` from `bootroot service add` CLI and all supporting types (`ServiceRoleEntry`, `ResolvedServiceAdd`, `DEFAULT_SECRET_ID_NUM_USES`).
- Service SecretIDs are now always issued with `num_uses = 0` (unlimited) in both `service add` and `rotate approle-secret-id`.
- Remove the `checked_add(1)` overflow-guard / verification-allowance logic in rotation, which is no longer needed.
- Remove `secret_id_num_uses` from the idempotent-rerun policy-field comparison.
- Remove `--secret-id-num-uses 0` from E2E lifecycle scripts.
- Update CHANGELOG, CLI docs (en/ko), and unit tests.
- Keep generic `SecretIdOptions.num_uses` in the OpenBao client layer for non-service workflows.
- Add a backward-compatibility test ensuring older `state.json` files containing `secret_id_num_uses` still deserialize cleanly.

Closes #497

## Test plan

- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes (unit tests updated)
- [x] Older `state.json` with `secret_id_num_uses` field deserializes without error (covered by new test)
- [x] `bootroot service add --help` no longer shows `--secret-id-num-uses`
- [x] E2E local lifecycle (`scripts/impl/run-local-lifecycle.sh`) runs without `--secret-id-num-uses`
- [x] E2E remote lifecycle (`scripts/impl/run-remote-lifecycle.sh`) runs without `--secret-id-num-uses`
- [x] `rotate approle-secret-id` issues SecretIDs with unlimited uses
- [x] `scripts/preflight/run-all.sh` passes