### PR TITLE
Embed wrap token in artifact and add unwrap path (#490)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build bootroot binaries
-        run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+        run: |
+          cargo clean -p bootroot 2>/dev/null || true
+          cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,18 +345,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build bootroot binaries
-        env:
-          CARGO_INCREMENTAL: '0'
         run: |
-          cargo clean -p bootroot || true
-          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
-          rm -rf target/debug/.fingerprint/bootroot-* target/debug/deps/bootroot-* target/debug/deps/libbootroot-* target/debug/incremental/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          if ! target/debug/bootroot service add --help 2>&1 | grep -q 'secret-id-num-uses'; then
-            echo "::error::Stale binary: --secret-id-num-uses not found. Performing full rebuild."
-            cargo clean
-            cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          fi
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,8 @@ jobs:
       - name: Build bootroot binaries
         run: |
           cargo clean -p bootroot 2>/dev/null || true
+          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
+          rm -rf target/debug/.fingerprint/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run E2E scenario (lifecycle)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,12 +344,23 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Clean stale bootroot artifacts
-        run: cargo clean -p bootroot
+      - name: Purge cached bootroot binaries
+        run: |
+          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
+          rm -rf target/debug/.fingerprint/bootroot-*
+          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
+          rm -rf target/debug/incremental/bootroot-*
         continue-on-error: true
 
       - name: Build bootroot binaries
-        run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+        run: |
+          touch src/main.rs
+          cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+
+      - name: Verify bootroot binary is current
+        run: |
+          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
+          grep -q secret-id-num-uses /tmp/bootroot-help.txt
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,10 +346,12 @@ jobs:
 
       - name: Build bootroot binaries
         run: |
-          cargo clean -p bootroot 2>/dev/null || true
           rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
           rm -rf target/debug/.fingerprint/bootroot-*
+          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
+          rm -rf target/debug/incremental/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+          target/debug/bootroot service add --help | grep -q secret-id-num-uses
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,9 +345,18 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build bootroot binaries
+        env:
+          CARGO_INCREMENTAL: '0'
         run: |
-          cargo clean -p bootroot
+          cargo clean -p bootroot || true
+          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
+          rm -rf target/debug/.fingerprint/bootroot-* target/debug/deps/bootroot-* target/debug/deps/libbootroot-* target/debug/incremental/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+          if ! target/debug/bootroot service add --help 2>&1 | grep -q 'secret-id-num-uses'; then
+            echo "::error::Stale binary: --secret-id-num-uses not found. Performing full rebuild."
+            cargo clean
+            cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+          fi
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,12 +344,12 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Clean stale bootroot artifacts
+        run: cargo clean -p bootroot
+        continue-on-error: true
+
       - name: Build bootroot binaries
-        run: |
-          find target/debug -name '*bootroot*' -exec rm -rf {} + 2>/dev/null || true
-          cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
-          grep -q secret-id-num-uses /tmp/bootroot-help.txt
+        run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,23 +344,10 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Purge cached bootroot binaries
-        run: |
-          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
-          rm -rf target/debug/.fingerprint/bootroot-*
-          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
-          rm -rf target/debug/incremental/bootroot-*
-        continue-on-error: true
-
       - name: Build bootroot binaries
         run: |
-          touch src/main.rs
+          cargo clean -p bootroot
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-
-      - name: Verify bootroot binary is current
-        run: |
-          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
-          grep -q secret-id-num-uses /tmp/bootroot-help.txt
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,12 +346,10 @@ jobs:
 
       - name: Build bootroot binaries
         run: |
-          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
-          rm -rf target/debug/.fingerprint/bootroot-*
-          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
-          rm -rf target/debug/incremental/bootroot-*
+          find target/debug -name '*bootroot*' -exec rm -rf {} + 2>/dev/null || true
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          target/debug/bootroot service add --help | grep -q secret-id-num-uses
+          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
+          grep -q secret-id-num-uses /tmp/bootroot-help.txt
 
       - name: Run E2E scenario (lifecycle)
         if: matrix.scenario.label != 'rotation'

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -62,9 +62,18 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build bootroot binaries
+        env:
+          CARGO_INCREMENTAL: '0'
         run: |
-          cargo clean -p bootroot
+          cargo clean -p bootroot || true
+          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
+          rm -rf target/debug/.fingerprint/bootroot-* target/debug/deps/bootroot-* target/debug/deps/libbootroot-* target/debug/incremental/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+          if ! target/debug/bootroot service add --help 2>&1 | grep -q 'secret-id-num-uses'; then
+            echo "::error::Stale binary: --secret-id-num-uses not found. Performing full rebuild."
+            cargo clean
+            cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+          fi
 
       - name: Run extended Docker E2E suite
         run: |

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -61,23 +61,10 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Purge cached bootroot binaries
-        run: |
-          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
-          rm -rf target/debug/.fingerprint/bootroot-*
-          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
-          rm -rf target/debug/incremental/bootroot-*
-        continue-on-error: true
-
       - name: Build bootroot binaries
         run: |
-          touch src/main.rs
+          cargo clean -p bootroot
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-
-      - name: Verify bootroot binary is current
-        run: |
-          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
-          grep -q secret-id-num-uses /tmp/bootroot-help.txt
 
       - name: Run extended Docker E2E suite
         run: |

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -63,10 +63,12 @@ jobs:
 
       - name: Build bootroot binaries
         run: |
-          cargo clean -p bootroot 2>/dev/null || true
           rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
           rm -rf target/debug/.fingerprint/bootroot-*
+          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
+          rm -rf target/debug/incremental/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+          target/debug/bootroot service add --help | grep -q secret-id-num-uses
 
       - name: Run extended Docker E2E suite
         run: |

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -63,12 +63,10 @@ jobs:
 
       - name: Build bootroot binaries
         run: |
-          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
-          rm -rf target/debug/.fingerprint/bootroot-*
-          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
-          rm -rf target/debug/incremental/bootroot-*
+          find target/debug -name '*bootroot*' -exec rm -rf {} + 2>/dev/null || true
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          target/debug/bootroot service add --help | grep -q secret-id-num-uses
+          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
+          grep -q secret-id-num-uses /tmp/bootroot-help.txt
 
       - name: Run extended Docker E2E suite
         run: |

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -61,12 +61,23 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Clean stale bootroot artifacts
-        run: cargo clean -p bootroot
+      - name: Purge cached bootroot binaries
+        run: |
+          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
+          rm -rf target/debug/.fingerprint/bootroot-*
+          rm -f target/debug/deps/bootroot-* target/debug/deps/libbootroot-*
+          rm -rf target/debug/incremental/bootroot-*
         continue-on-error: true
 
       - name: Build bootroot binaries
-        run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+        run: |
+          touch src/main.rs
+          cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+
+      - name: Verify bootroot binary is current
+        run: |
+          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
+          grep -q secret-id-num-uses /tmp/bootroot-help.txt
 
       - name: Run extended Docker E2E suite
         run: |

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Build bootroot binaries
         run: |
           cargo clean -p bootroot 2>/dev/null || true
+          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
+          rm -rf target/debug/.fingerprint/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run extended Docker E2E suite

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Clean stale bootroot artifacts
+        run: cargo clean -p bootroot
+        continue-on-error: true
+
       - name: Build bootroot binaries
-        run: |
-          find target/debug -name '*bootroot*' -exec rm -rf {} + 2>/dev/null || true
-          cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          target/debug/bootroot service add --help > /tmp/bootroot-help.txt
-          grep -q secret-id-num-uses /tmp/bootroot-help.txt
+        run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run extended Docker E2E suite
         run: |

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -62,18 +62,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build bootroot binaries
-        env:
-          CARGO_INCREMENTAL: '0'
         run: |
-          cargo clean -p bootroot || true
-          rm -f target/debug/bootroot target/debug/bootroot-remote target/debug/bootroot-agent
-          rm -rf target/debug/.fingerprint/bootroot-* target/debug/deps/bootroot-* target/debug/deps/libbootroot-* target/debug/incremental/bootroot-*
           cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          if ! target/debug/bootroot service add --help 2>&1 | grep -q 'secret-id-num-uses'; then
-            echo "::error::Stale binary: --secret-id-num-uses not found. Performing full rebuild."
-            cargo clean
-            cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
-          fi
 
       - name: Run extended Docker E2E suite
         run: |

--- a/.github/workflows/e2e-extended.yml
+++ b/.github/workflows/e2e-extended.yml
@@ -62,7 +62,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build bootroot binaries
-        run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
+        run: |
+          cargo clean -p bootroot 2>/dev/null || true
+          cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run extended Docker E2E suite
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `state.json` and forwarded to `bootroot-remote bootstrap` for
   remote-bootstrap delivery mode.
 - Added per-issuance `secret_id` policy flags to `bootroot service add`
-  (`--secret-id-ttl`, `--secret-id-num-uses`, `--secret-id-wrap-ttl`,
-  `--no-wrap`). Policy values are persisted in `state.json` and applied
+  (`--secret-id-ttl`, `--secret-id-wrap-ttl`, `--no-wrap`). Service
+  SecretIDs always use unlimited uses (`num_uses=0`).
+  Policy values are persisted in `state.json` and applied
   automatically during `rotate approle-secret-id`. Re-running
   `service add` with different policy values on an existing service
   produces an error directing the operator to use a policy update

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -525,8 +525,6 @@ Per-issuance `secret_id` policy flags:
 
 - `--secret-id-ttl`: TTL for the generated `secret_id` (inherits the
   role-level default when omitted)
-- `--secret-id-num-uses`: maximum number of times the `secret_id` can be
-  used (default `1`)
 - `--secret-id-wrap-ttl`: response-wrapping TTL for the `secret_id`
   (default `30m`)
 - `--no-wrap`: disable response wrapping for the `secret_id`

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -507,7 +507,6 @@ bootroot status
 발급 시점 `secret_id` 정책 플래그:
 
 - `--secret-id-ttl`: 생성되는 `secret_id`의 TTL (생략 시 역할 수준 기본값 상속)
-- `--secret-id-num-uses`: `secret_id` 최대 사용 횟수 (기본값 `1`)
 - `--secret-id-wrap-ttl`: `secret_id`에 대한 응답 래핑 TTL (기본값 `30m`)
 - `--no-wrap`: `secret_id` 응답 래핑 비활성화
 

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -389,37 +389,13 @@ run_verify_pair() {
 # Remote bootstrap
 # ---------------------------------------------------------------------------
 
-copy_remote_materials() {
-  local control_dir="$SECRETS_DIR/services/$REMOTE_SERVICE"
-  local remote_dir="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE"
-  mkdir -p "$remote_dir"
-  cp "$control_dir/role_id" "$remote_dir/role_id"
-  cp "$control_dir/secret_id" "$remote_dir/secret_id"
-  chmod 600 "$remote_dir/role_id" "$remote_dir/secret_id"
-}
-
 run_remote_bootstrap() {
-  local role_id_path="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE/role_id"
-  local secret_id_path="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE/secret_id"
-  local eab_path="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE/eab.json"
-  local ca_bundle_path="$REMOTE_CERTS_DIR/ca-bundle.pem"
+  local artifact_src="$SECRETS_DIR/remote-bootstrap/services/$REMOTE_SERVICE/bootstrap.json"
+  local artifact_dst="$REMOTE_DIR/bootstrap-${REMOTE_SERVICE}.json"
+  cp "$artifact_src" "$artifact_dst"
+  chmod 600 "$artifact_dst"
   ( cd "$REMOTE_DIR" && "$BOOTROOT_REMOTE_BIN" bootstrap \
-      --openbao-url "http://${STEPCA_HOST_IP}:8200" \
-      --kv-mount "secret" \
-      --service-name "$REMOTE_SERVICE" \
-      --role-id-path "$role_id_path" \
-      --secret-id-path "$secret_id_path" \
-      --eab-file-path "$eab_path" \
-      --agent-config-path "$REMOTE_AGENT_CONFIG" \
-      --agent-email "admin@example.com" \
-      --agent-server "$STEPCA_SERVER_URL" \
-      --agent-domain "$DOMAIN" \
-      --agent-responder-url "$RESPONDER_URL" \
-      --profile-hostname "$REMOTE_HOSTNAME" \
-      --profile-instance-id "$REMOTE_INSTANCE_ID" \
-      --profile-cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" \
-      --profile-key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
-      --ca-bundle-path "$ca_bundle_path" \
+      --artifact "$artifact_dst" \
       --output json >>"$RUN_LOG" 2>&1 )
 }
 
@@ -813,7 +789,6 @@ main() {
   rm -f "$AGENT_CONFIG_PATH"
   start_service_sidecar_oba "$SIDECAR_OBA_SERVICE"
 
-  copy_remote_materials
   log_phase "remote-bootstrap-initial"
   run_remote_bootstrap
 

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -399,6 +399,18 @@ run_remote_bootstrap() {
       --output json >>"$RUN_LOG" 2>&1 )
 }
 
+regenerate_remote_artifact() {
+  run_bootroot service add \
+    --service-name "$REMOTE_SERVICE" --deploy-type daemon --delivery-mode remote-bootstrap \
+    --hostname "$REMOTE_HOSTNAME" --domain "$DOMAIN" \
+    --agent-config "$REMOTE_AGENT_CONFIG" \
+    --cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" --key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
+    --instance-id "$REMOTE_INSTANCE_ID" \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
+}
+
 # ---------------------------------------------------------------------------
 # Rotation helpers
 # ---------------------------------------------------------------------------
@@ -584,6 +596,7 @@ scenario_1_phase3_failure() {
 
   run_rotate_ca_key --skip reissue --force --cleanup >>"$RUN_LOG" 2>&1
 
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "s1-after"
@@ -636,6 +649,7 @@ scenario_2_phase4_failure() {
   # Resume rotation from the crashed state
   run_rotate_ca_key --skip reissue --force --cleanup >>"$RUN_LOG" 2>&1
 
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "s2-after"
@@ -674,6 +688,7 @@ scenario_3_partial_reissuance() {
   # Reissue remaining services
   force_reissue_for_service "$WEB_SERVICE"
   verify_service_with_retry "$WEB_SERVICE"
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_remote
   verify_service_with_retry "$REMOTE_SERVICE" "$REMOTE_AGENT_CONFIG"
@@ -710,6 +725,7 @@ scenario_4_finalize_blocked() {
   # Re-run with --force → Phase 6 forces despite unmigrated services
   run_rotate_ca_key --skip reissue --force --cleanup >>"$RUN_LOG" 2>&1
 
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "s4-after"
@@ -754,6 +770,7 @@ scenario_5_trustsync_conflict() {
   # there is no running daemon for the Daemon-type service).
   run_rotate_ca_key --skip reissue --force --cleanup >>"$RUN_LOG" 2>&1
 
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "s5-after"

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -398,7 +398,7 @@ run_bootstrap_chain() {
     --cert-path "$CERTS_DIR/${EDGE_SERVICE}.crt" \
     --key-path "$CERTS_DIR/${EDGE_SERVICE}.key" \
     --instance-id "$INSTANCE_ID" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -414,7 +414,7 @@ run_bootstrap_chain() {
     --key-path "$CERTS_DIR/${WEB_SERVICE}.key" \
     --instance-id "$INSTANCE_ID" \
     --container-name "$WEB_SERVICE" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -429,7 +429,7 @@ run_bootstrap_chain() {
     --cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
     --instance-id "$REMOTE_INSTANCE_ID" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -641,7 +641,7 @@ regenerate_remote_artifact() {
     --cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
     --instance-id "$REMOTE_INSTANCE_ID" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -616,40 +616,16 @@ assert_fingerprint_changed() {
   fi
 }
 
-copy_remote_materials() {
-  local control_service_dir="$SECRETS_DIR/services/$REMOTE_SERVICE"
-  local remote_service_dir="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE"
-  mkdir -p "$remote_service_dir"
-  cp "$control_service_dir/role_id" "$remote_service_dir/role_id"
-  cp "$control_service_dir/secret_id" "$remote_service_dir/secret_id"
-  chmod 600 "$remote_service_dir/role_id" "$remote_service_dir/secret_id"
-}
-
 run_remote_bootstrap() {
-  local role_id_path="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE/role_id"
-  local secret_id_path="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE/secret_id"
-  local eab_path="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE/eab.json"
-  local ca_bundle_path="$REMOTE_CERTS_DIR/ca-bundle.pem"
+  local artifact_src="$SECRETS_DIR/remote-bootstrap/services/$REMOTE_SERVICE/bootstrap.json"
+  local artifact_dst="$REMOTE_DIR/bootstrap-${REMOTE_SERVICE}.json"
+  cp "$artifact_src" "$artifact_dst"
+  chmod 600 "$artifact_dst"
 
   (
     cd "$REMOTE_DIR"
     "$BOOTROOT_REMOTE_BIN" bootstrap \
-      --openbao-url "http://${STEPCA_HOST_IP}:8200" \
-      --kv-mount "secret" \
-      --service-name "$REMOTE_SERVICE" \
-      --role-id-path "$role_id_path" \
-      --secret-id-path "$secret_id_path" \
-      --eab-file-path "$eab_path" \
-      --agent-config-path "$REMOTE_AGENT_CONFIG" \
-      --agent-email "admin@example.com" \
-      --agent-server "$STEPCA_SERVER_URL" \
-      --agent-domain "$DOMAIN" \
-      --agent-responder-url "$RESPONDER_URL" \
-      --profile-hostname "$REMOTE_HOSTNAME" \
-      --profile-instance-id "$REMOTE_INSTANCE_ID" \
-      --profile-cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" \
-      --profile-key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
-      --ca-bundle-path "$ca_bundle_path" \
+      --artifact "$artifact_dst" \
       --output json >>"$RUN_LOG" 2>&1
   )
 }
@@ -795,7 +771,6 @@ main() {
 
   start_service_sidecar_oba "$SIDECAR_OBA_SERVICE"
 
-  copy_remote_materials
   log_phase "remote-bootstrap-initial"
   run_remote_bootstrap
 

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -630,6 +630,23 @@ run_remote_bootstrap() {
   )
 }
 
+regenerate_remote_artifact() {
+  run_bootroot service add \
+    --service-name "$REMOTE_SERVICE" \
+    --deploy-type daemon \
+    --delivery-mode remote-bootstrap \
+    --hostname "$REMOTE_HOSTNAME" \
+    --domain "$DOMAIN" \
+    --agent-config "$REMOTE_AGENT_CONFIG" \
+    --cert-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" \
+    --key-path "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key" \
+    --instance-id "$REMOTE_INSTANCE_ID" \
+    --secret-id-num-uses 0 \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
+}
+
 run_rotations_with_verification() {
   log_phase "rotate-openbao-recovery"
   run_bootroot rotate \
@@ -641,6 +658,7 @@ run_rotations_with_verification() {
     --rotate-root-token \
     --output "$OPENBAO_RECOVERY_OUTPUT_FILE" >>"$RUN_LOG" 2>&1
   [ -s "$OPENBAO_RECOVERY_OUTPUT_FILE" ] || fail "openbao recovery output not written"
+  regenerate_remote_artifact
   log_phase "bootstrap-after-openbao-recovery"
   run_remote_bootstrap
   run_verify_pair "after-openbao-recovery"
@@ -654,6 +672,7 @@ run_rotations_with_verification() {
     --approle-secret-id "$RUNTIME_ROTATE_SECRET_ID" \
     --yes \
     responder-hmac >>"$RUN_LOG" 2>&1
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "after-responder-hmac"
@@ -670,6 +689,7 @@ run_rotations_with_verification() {
     --approle-secret-id "$RUNTIME_ROTATE_SECRET_ID" \
     --yes \
     stepca-password >>"$RUN_LOG" 2>&1
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "after-stepca-password"
@@ -697,6 +717,7 @@ run_rotations_with_verification() {
     --yes \
     db \
     --db-admin-dsn "$db_admin_dsn" >>"$RUN_LOG" 2>&1
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "after-db"
@@ -713,6 +734,7 @@ run_rotations_with_verification() {
     --approle-secret-id "$RUNTIME_ROTATE_SECRET_ID" \
     --yes \
     ca-key --skip reissue --force --cleanup >>"$RUN_LOG" 2>&1
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "after-ca-key"
@@ -729,6 +751,7 @@ run_rotations_with_verification() {
     --approle-secret-id "$RUNTIME_ROTATE_SECRET_ID" \
     --yes \
     ca-key --full --skip reissue --force --cleanup >>"$RUN_LOG" 2>&1
+  regenerate_remote_artifact
   run_remote_bootstrap
   force_reissue_all_services
   run_verify_pair "after-ca-key-full"

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -301,7 +301,7 @@ run_bootstrap_chain() {
     --cert-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.key" \
     --instance-id "$INSTANCE_ID" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -317,7 +317,7 @@ run_bootstrap_chain() {
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME_2}.key" \
     --instance-id "$INSTANCE_ID_2" \
     --container-name "$SERVICE_NAME_2" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -393,7 +393,7 @@ regenerate_remote_artifacts() {
     --cert-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.crt" \
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.key" \
     --instance-id "$INSTANCE_ID" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
@@ -409,7 +409,7 @@ regenerate_remote_artifacts() {
     --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME_2}.key" \
     --instance-id "$INSTANCE_ID_2" \
     --container-name "$SERVICE_NAME_2" \
-    --secret-id-num-uses 0 \
+
     --auth-mode approle \
     --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -382,6 +382,39 @@ run_remote_bootstrap() {
   )
 }
 
+regenerate_remote_artifacts() {
+  run_bootroot_control service add \
+    --service-name "$SERVICE_NAME" \
+    --deploy-type daemon \
+    --delivery-mode remote-bootstrap \
+    --hostname "$HOSTNAME" \
+    --domain "$DOMAIN" \
+    --agent-config "$REMOTE_AGENT_CONFIG_PATH" \
+    --cert-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.crt" \
+    --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME}.key" \
+    --instance-id "$INSTANCE_ID" \
+    --secret-id-num-uses 0 \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
+
+  run_bootroot_control service add \
+    --service-name "$SERVICE_NAME_2" \
+    --deploy-type docker \
+    --delivery-mode remote-bootstrap \
+    --hostname "$HOSTNAME_2" \
+    --domain "$DOMAIN" \
+    --agent-config "$REMOTE_AGENT_CONFIG_PATH_2" \
+    --cert-path "$REMOTE_CERTS_DIR/${SERVICE_NAME_2}.crt" \
+    --key-path "$REMOTE_CERTS_DIR/${SERVICE_NAME_2}.key" \
+    --instance-id "$INSTANCE_ID_2" \
+    --container-name "$SERVICE_NAME_2" \
+    --secret-id-num-uses 0 \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
+}
+
 verify_with_retry() {
   local service="$1"
   local agent_config="$2"
@@ -557,6 +590,7 @@ main() {
   run_verify_pair "initial"
 
   run_rotation_secret_id
+  regenerate_remote_artifacts
   log_phase "bootstrap-after-secret-id"
   run_remote_bootstrap "$SERVICE_NAME"
   run_remote_bootstrap "$SERVICE_NAME_2"
@@ -567,6 +601,7 @@ main() {
   assert_fingerprint_changed "$SERVICE_NAME_2" "initial" "after-secret-id"
 
   run_rotation_eab
+  regenerate_remote_artifacts
   log_phase "bootstrap-after-eab"
   run_remote_bootstrap "$SERVICE_NAME"
   run_remote_bootstrap "$SERVICE_NAME_2"
@@ -577,6 +612,7 @@ main() {
   assert_fingerprint_changed "$SERVICE_NAME_2" "after-secret-id" "after-eab"
 
   run_rotation_trust_sync
+  regenerate_remote_artifacts
   log_phase "bootstrap-after-trust-sync"
   run_remote_bootstrap "$SERVICE_NAME"
   run_remote_bootstrap "$SERVICE_NAME_2"
@@ -587,6 +623,7 @@ main() {
   assert_fingerprint_changed "$SERVICE_NAME_2" "after-eab" "after-trust-sync"
 
   run_rotation_responder_hmac
+  regenerate_remote_artifacts
   log_phase "bootstrap-after-responder-hmac"
   run_remote_bootstrap "$SERVICE_NAME"
   run_remote_bootstrap "$SERVICE_NAME_2"

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -323,16 +323,6 @@ run_bootstrap_chain() {
     --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
 }
 
-copy_remote_bootstrap_materials() {
-  local service="$1"
-  local control_service_dir="$SECRETS_DIR/services/$service"
-  local remote_service_dir="$REMOTE_DIR/secrets/services/$service"
-  mkdir -p "$remote_service_dir"
-  cp "$control_service_dir/role_id" "$remote_service_dir/role_id"
-  cp "$control_service_dir/secret_id" "$remote_service_dir/secret_id"
-  chmod 600 "$remote_service_dir/role_id" "$remote_service_dir/secret_id"
-}
-
 apply_dns_aliases() {
   local override="$ARTIFACT_DIR/docker-compose.dns-aliases.yml"
   cat >"$override" <<YAML
@@ -379,33 +369,15 @@ wait_for_stepca_http01_targets() {
 
 run_remote_bootstrap() {
   local service="$1"
-  local agent_config="$2"
-  local hostname_val="$3"
-  local instance_id="$4"
-  local role_id_path="$REMOTE_DIR/secrets/services/$service/role_id"
-  local secret_id_path="$REMOTE_DIR/secrets/services/$service/secret_id"
-  local eab_path="$REMOTE_DIR/secrets/services/$service/eab.json"
-  local ca_bundle_path="$REMOTE_CERTS_DIR/ca-bundle.pem"
+  local artifact_src="$SECRETS_DIR/remote-bootstrap/services/$service/bootstrap.json"
+  local artifact_dst="$REMOTE_DIR/bootstrap-${service}.json"
+  cp "$artifact_src" "$artifact_dst"
+  chmod 600 "$artifact_dst"
 
   (
     cd "$REMOTE_DIR"
     "$BOOTROOT_REMOTE_BIN" bootstrap \
-      --openbao-url "http://${STEPCA_HOST_IP}:8200" \
-      --kv-mount "secret" \
-      --service-name "$service" \
-      --role-id-path "$role_id_path" \
-      --secret-id-path "$secret_id_path" \
-      --eab-file-path "$eab_path" \
-      --agent-config-path "$agent_config" \
-      --agent-email "admin@example.com" \
-      --agent-server "$STEPCA_SERVER_URL" \
-      --agent-domain "$DOMAIN" \
-      --agent-responder-url "$RESPONDER_URL" \
-      --profile-hostname "$hostname_val" \
-      --profile-instance-id "$instance_id" \
-      --profile-cert-path "$REMOTE_CERTS_DIR/${service}.crt" \
-      --profile-key-path "$REMOTE_CERTS_DIR/${service}.key" \
-      --ca-bundle-path "$ca_bundle_path" \
+      --artifact "$artifact_dst" \
       --output json >>"$RUN_LOG" 2>&1
   )
 }
@@ -575,21 +547,19 @@ main() {
   install_infra
 
   run_bootstrap_chain
-  copy_remote_bootstrap_materials "$SERVICE_NAME"
-  copy_remote_bootstrap_materials "$SERVICE_NAME_2"
   apply_dns_aliases
   wait_for_stepca_http01_targets
 
   log_phase "bootstrap-initial"
-  run_remote_bootstrap "$SERVICE_NAME" "$REMOTE_AGENT_CONFIG_PATH" "$HOSTNAME" "$INSTANCE_ID"
-  run_remote_bootstrap "$SERVICE_NAME_2" "$REMOTE_AGENT_CONFIG_PATH_2" "$HOSTNAME_2" "$INSTANCE_ID_2"
+  run_remote_bootstrap "$SERVICE_NAME"
+  run_remote_bootstrap "$SERVICE_NAME_2"
 
   run_verify_pair "initial"
 
   run_rotation_secret_id
   log_phase "bootstrap-after-secret-id"
-  run_remote_bootstrap "$SERVICE_NAME" "$REMOTE_AGENT_CONFIG_PATH" "$HOSTNAME" "$INSTANCE_ID"
-  run_remote_bootstrap "$SERVICE_NAME_2" "$REMOTE_AGENT_CONFIG_PATH_2" "$HOSTNAME_2" "$INSTANCE_ID_2"
+  run_remote_bootstrap "$SERVICE_NAME"
+  run_remote_bootstrap "$SERVICE_NAME_2"
   force_reissue_remote_service "$SERVICE_NAME"
   force_reissue_remote_service "$SERVICE_NAME_2"
   run_verify_pair "after-secret-id"
@@ -598,8 +568,8 @@ main() {
 
   run_rotation_eab
   log_phase "bootstrap-after-eab"
-  run_remote_bootstrap "$SERVICE_NAME" "$REMOTE_AGENT_CONFIG_PATH" "$HOSTNAME" "$INSTANCE_ID"
-  run_remote_bootstrap "$SERVICE_NAME_2" "$REMOTE_AGENT_CONFIG_PATH_2" "$HOSTNAME_2" "$INSTANCE_ID_2"
+  run_remote_bootstrap "$SERVICE_NAME"
+  run_remote_bootstrap "$SERVICE_NAME_2"
   force_reissue_remote_service "$SERVICE_NAME"
   force_reissue_remote_service "$SERVICE_NAME_2"
   run_verify_pair "after-eab"
@@ -608,8 +578,8 @@ main() {
 
   run_rotation_trust_sync
   log_phase "bootstrap-after-trust-sync"
-  run_remote_bootstrap "$SERVICE_NAME" "$REMOTE_AGENT_CONFIG_PATH" "$HOSTNAME" "$INSTANCE_ID"
-  run_remote_bootstrap "$SERVICE_NAME_2" "$REMOTE_AGENT_CONFIG_PATH_2" "$HOSTNAME_2" "$INSTANCE_ID_2"
+  run_remote_bootstrap "$SERVICE_NAME"
+  run_remote_bootstrap "$SERVICE_NAME_2"
   force_reissue_remote_service "$SERVICE_NAME"
   force_reissue_remote_service "$SERVICE_NAME_2"
   run_verify_pair "after-trust-sync"
@@ -618,8 +588,8 @@ main() {
 
   run_rotation_responder_hmac
   log_phase "bootstrap-after-responder-hmac"
-  run_remote_bootstrap "$SERVICE_NAME" "$REMOTE_AGENT_CONFIG_PATH" "$HOSTNAME" "$INSTANCE_ID"
-  run_remote_bootstrap "$SERVICE_NAME_2" "$REMOTE_AGENT_CONFIG_PATH_2" "$HOSTNAME_2" "$INSTANCE_ID_2"
+  run_remote_bootstrap "$SERVICE_NAME"
+  run_remote_bootstrap "$SERVICE_NAME_2"
   force_reissue_remote_service "$SERVICE_NAME"
   force_reissue_remote_service "$SERVICE_NAME_2"
   run_verify_pair "after-responder-hmac"

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -13,8 +13,8 @@ use tokio::fs;
 use super::io::PulledSecrets;
 use super::summary::{ApplyItemSummary, ApplyStatus};
 use super::{
-    BootstrapArgs, HookFailurePolicy, Locale, MANAGED_PROFILE_BEGIN_PREFIX,
-    MANAGED_PROFILE_END_PREFIX, localized,
+    HookFailurePolicy, Locale, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
+    ResolvedBootstrapArgs, localized,
 };
 
 struct ProfilePaths {
@@ -26,7 +26,7 @@ struct ProfilePaths {
 // per-item status/error mapping remains consistent for summary JSON contracts.
 #[allow(clippy::too_many_lines)]
 pub(super) async fn apply_agent_config_updates(
-    args: &BootstrapArgs,
+    args: &ResolvedBootstrapArgs,
     pulled: &PulledSecrets,
     lang: Locale,
 ) -> (ApplyItemSummary, ApplyItemSummary) {
@@ -184,7 +184,7 @@ pub(super) async fn apply_agent_config_updates(
     (responder_hmac_status, trust_sync_status)
 }
 
-fn resolve_profile_paths(args: &BootstrapArgs) -> ProfilePaths {
+fn resolve_profile_paths(args: &ResolvedBootstrapArgs) -> ProfilePaths {
     let fallback_dir = args
         .agent_config_path
         .parent()
@@ -204,7 +204,7 @@ fn resolve_profile_paths(args: &BootstrapArgs) -> ProfilePaths {
     }
 }
 
-fn inject_hooks_into_profile_block(block: &str, args: &BootstrapArgs) -> String {
+fn inject_hooks_into_profile_block(block: &str, args: &ResolvedBootstrapArgs) -> String {
     let Some(command) = args.post_renew_command.as_deref() else {
         return block.to_string();
     };
@@ -243,7 +243,7 @@ fn inject_hooks_into_profile_block(block: &str, args: &BootstrapArgs) -> String 
     }
 }
 
-fn render_agent_config_baseline(args: &BootstrapArgs) -> String {
+fn render_agent_config_baseline(args: &ResolvedBootstrapArgs) -> String {
     format!(
         "email = \"{email}\"\n\
 server = \"{server}\"\n\
@@ -305,7 +305,7 @@ fn build_trust_updates(
 }
 
 async fn write_openbao_agent_artifacts(
-    args: &BootstrapArgs,
+    args: &ResolvedBootstrapArgs,
     agent_template: &str,
     lang: Locale,
 ) -> Result<()> {
@@ -417,7 +417,7 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use super::*;
-    use crate::OutputFormat;
+    use crate::{OutputFormat, ResolvedBootstrapArgs};
 
     #[test]
     fn upsert_toml_section_keys_updates_existing_section() {
@@ -441,8 +441,8 @@ mod tests {
         assert!(output.contains("trusted_ca_sha256 = ["));
     }
 
-    fn test_bootstrap_args() -> BootstrapArgs {
-        BootstrapArgs {
+    fn test_bootstrap_args() -> ResolvedBootstrapArgs {
+        ResolvedBootstrapArgs {
             openbao_url: "https://localhost:8200".to_string(),
             kv_mount: "secret".to_string(),
             service_name: "edge-proxy".to_string(),
@@ -464,6 +464,8 @@ mod tests {
             post_renew_timeout_secs: None,
             post_renew_on_failure: None,
             output: OutputFormat::Text,
+            wrap_token: None,
+            wrap_expires_at: None,
         }
     }
 

--- a/src/bin/bootroot-remote/bootstrap.rs
+++ b/src/bin/bootroot-remote/bootstrap.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context, Result};
+use bootroot::fs_util;
 use bootroot::openbao::OpenBaoClient;
+use serde::Deserialize;
 
 use super::agent_config::apply_agent_config_updates;
 use super::io::{pull_secrets, read_secret_file, write_eab_file, write_secret_file};
@@ -8,12 +10,26 @@ use super::validation::{
     validate_agent_domain, validate_profile_hostname, validate_profile_instance_id,
     validate_service_name,
 };
-use super::{BootstrapArgs, Locale, localized};
+use super::{Locale, ResolvedBootstrapArgs, localized};
 
 // This function intentionally keeps end-to-end bootstrap orchestration in one place
 // so status aggregation and exit-code semantics stay easy to audit.
 #[allow(clippy::too_many_lines)]
-pub(super) async fn run_bootstrap(args: BootstrapArgs, lang: Locale) -> Result<i32> {
+pub(super) async fn run_bootstrap(args: ResolvedBootstrapArgs, lang: Locale) -> Result<i32> {
+    let wrapped = args.wrap_token.is_some();
+
+    if let Some(wrap_token) = &args.wrap_token {
+        unwrap_and_write_secret_id(
+            &args.openbao_url,
+            wrap_token,
+            &args.secret_id_path,
+            args.wrap_expires_at.as_deref(),
+            &args.service_name,
+            lang,
+        )
+        .await?;
+    }
+
     validate_bootstrap_args(&args, lang)?;
 
     let role_id = read_secret_file(&args.role_id_path, lang)
@@ -66,14 +82,18 @@ pub(super) async fn run_bootstrap(args: BootstrapArgs, lang: Locale) -> Result<i
         })?;
     client.set_token(token);
 
-    let pulled = pull_secrets(&client, &args.kv_mount, &args.service_name, lang).await?;
-    let secret_id_status = match write_secret_file(&args.secret_id_path, &pulled.secret_id).await {
-        Ok(status) => ApplyItemSummary::applied(status),
-        Err(err) => ApplyItemSummary::failed(localized(
-            lang,
-            &format!("secret_id apply failed: {err}"),
-            &format!("secret_id 반영 실패: {err}"),
-        )),
+    let pulled = pull_secrets(&client, &args.kv_mount, &args.service_name, wrapped, lang).await?;
+    let secret_id_status = if wrapped {
+        ApplyItemSummary::applied(super::summary::ApplyStatus::Applied)
+    } else {
+        match write_secret_file(&args.secret_id_path, &pulled.secret_id).await {
+            Ok(status) => ApplyItemSummary::applied(status),
+            Err(err) => ApplyItemSummary::failed(localized(
+                lang,
+                &format!("secret_id apply failed: {err}"),
+                &format!("secret_id 반영 실패: {err}"),
+            )),
+        }
     };
     let eab_status =
         match write_eab_file(&args.eab_file_path, &pulled.eab_kid, &pulled.eab_hmac).await {
@@ -120,7 +140,7 @@ pub(super) async fn run_bootstrap(args: BootstrapArgs, lang: Locale) -> Result<i
     Ok(0)
 }
 
-fn validate_hook_flags(args: &BootstrapArgs) -> Result<()> {
+fn validate_hook_flags(args: &ResolvedBootstrapArgs) -> Result<()> {
     if args.post_renew_command.is_none()
         && (!args.post_renew_arg.is_empty()
             || args.post_renew_timeout_secs.is_some()
@@ -142,8 +162,15 @@ fn validate_hook_flags(args: &BootstrapArgs) -> Result<()> {
     Ok(())
 }
 
-fn validate_bootstrap_args(args: &BootstrapArgs, lang: Locale) -> Result<()> {
+fn validate_bootstrap_args(args: &ResolvedBootstrapArgs, lang: Locale) -> Result<()> {
     validate_hook_flags(args)?;
+    if args.service_name.is_empty() {
+        anyhow::bail!(localized(
+            lang,
+            "service-name is required",
+            "service-name 값이 필요합니다",
+        ));
+    }
     validate_service_name(&args.service_name, lang)?;
     validate_profile_hostname(&args.profile_hostname, lang)?;
     validate_agent_domain(&args.agent_domain, lang)?;
@@ -153,6 +180,13 @@ fn validate_bootstrap_args(args: &BootstrapArgs, lang: Locale) -> Result<()> {
         &args.secret_id_path,
         &args.eab_file_path,
     ] {
+        if path.as_os_str().is_empty() {
+            anyhow::bail!(localized(
+                lang,
+                "Required path argument is missing (provide --artifact or individual flags)",
+                "필수 경로 인수가 누락되었습니다 (--artifact 또는 개별 플래그를 제공하세요)",
+            ));
+        }
         let parent = path.parent().ok_or_else(|| {
             anyhow::anyhow!(
                 "{}",
@@ -187,7 +221,7 @@ fn validate_bootstrap_args(args: &BootstrapArgs, lang: Locale) -> Result<()> {
             )
         );
     }
-    if !args.secret_id_path.exists() {
+    if args.wrap_token.is_none() && !args.secret_id_path.exists() {
         anyhow::bail!(
             "{}",
             localized(
@@ -206,18 +240,123 @@ fn validate_bootstrap_args(args: &BootstrapArgs, lang: Locale) -> Result<()> {
     Ok(())
 }
 
+/// Response from `sys/wrapping/unwrap` for `AppRole` `secret_id`.
+#[derive(Deserialize)]
+struct UnwrapSecretIdResponse {
+    data: UnwrapSecretIdData,
+}
+
+#[derive(Deserialize)]
+struct UnwrapSecretIdData {
+    secret_id: String,
+}
+
+async fn unwrap_and_write_secret_id(
+    openbao_url: &str,
+    wrap_token: &str,
+    secret_id_path: &std::path::Path,
+    wrap_expires_at: Option<&str>,
+    service_name: &str,
+    lang: Locale,
+) -> Result<()> {
+    if let Some(parent) = secret_id_path.parent() {
+        fs_util::ensure_secrets_dir(parent).await?;
+    }
+    let client = OpenBaoClient::new(openbao_url).with_context(|| {
+        localized(
+            lang,
+            "Failed to create OpenBao client for unwrap",
+            "unwrap을 위한 OpenBao 클라이언트를 생성하지 못했습니다",
+        )
+    })?;
+    let result: Result<UnwrapSecretIdResponse> = client.unwrap_secret(wrap_token).await;
+    match result {
+        Ok(response) => {
+            tokio::fs::write(secret_id_path, &response.data.secret_id)
+                .await
+                .with_context(|| {
+                    localized(
+                        lang,
+                        &format!(
+                            "Failed to write unwrapped secret_id to {}",
+                            secret_id_path.display()
+                        ),
+                        &format!(
+                            "unwrap된 secret_id를 쓰지 못했습니다: {}",
+                            secret_id_path.display()
+                        ),
+                    )
+                })?;
+            fs_util::set_key_permissions(secret_id_path).await?;
+            Ok(())
+        }
+        Err(err) => {
+            if is_wrap_token_expired(wrap_expires_at) {
+                anyhow::bail!(
+                    "{}",
+                    localized(
+                        lang,
+                        &format!(
+                            "Wrap token has expired. To recover, re-run on the control node:\n\n  \
+                             bootroot rotate approle-secret-id --service-name {service_name}\n\n\
+                             Then transfer the new artifact and retry bootstrap."
+                        ),
+                        &format!(
+                            "Wrap 토큰이 만료되었습니다. 복구하려면 제어 노드에서 다시 실행하세요:\n\n  \
+                             bootroot rotate approle-secret-id --service-name {service_name}\n\n\
+                             새 아티팩트를 전송한 후 부트스트랩을 다시 시도하세요."
+                        ),
+                    )
+                );
+            }
+            anyhow::bail!(
+                "{}",
+                localized(
+                    lang,
+                    &format!(
+                        "SECURITY WARNING: Wrap token has already been unwrapped.\n\
+                         This may indicate the secret_id for service '{service_name}' has been \
+                         compromised by an unauthorized party.\n\
+                         Investigate immediately and consider rotating credentials:\n\n  \
+                         bootroot rotate approle-secret-id --service-name {service_name}\n\n\
+                         Original error: {err}"
+                    ),
+                    &format!(
+                        "보안 경고: Wrap 토큰이 이미 unwrap되었습니다.\n\
+                         서비스 '{service_name}'의 secret_id가 무단 접근으로 유출되었을 수 있습니다.\n\
+                         즉시 조사하고 자격 증명을 교체하세요:\n\n  \
+                         bootroot rotate approle-secret-id --service-name {service_name}\n\n\
+                         원본 오류: {err}"
+                    ),
+                )
+            );
+        }
+    }
+}
+
+fn is_wrap_token_expired(wrap_expires_at: Option<&str>) -> bool {
+    let Some(expires_str) = wrap_expires_at else {
+        return false;
+    };
+    let Ok(expires_epoch) = expires_str.parse::<u64>() else {
+        return false;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now > expires_epoch
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::{HookFailurePolicy, OutputFormat};
+    use crate::{HookFailurePolicy, OutputFormat, ResolvedBootstrapArgs};
 
-    /// Builds a `BootstrapArgs` with dummy values.  Only hook-related fields
-    /// are meaningful — `validate_hook_flags` runs before any other check, so
-    /// the remaining fields are never inspected in these tests.
-    fn dummy_args() -> BootstrapArgs {
-        BootstrapArgs {
+    fn dummy_args() -> ResolvedBootstrapArgs {
+        ResolvedBootstrapArgs {
             openbao_url: String::new(),
             kv_mount: String::new(),
             service_name: String::new(),
@@ -239,6 +378,8 @@ mod tests {
             post_renew_timeout_secs: None,
             post_renew_on_failure: None,
             output: OutputFormat::Text,
+            wrap_token: None,
+            wrap_expires_at: None,
         }
     }
 
@@ -329,6 +470,56 @@ mod tests {
         assert!(
             err.to_string().contains("greater than 0"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn is_wrap_token_expired_returns_true_for_past_epoch() {
+        assert!(super::is_wrap_token_expired(Some("1000000000")));
+    }
+
+    #[test]
+    fn is_wrap_token_expired_returns_false_for_future_epoch() {
+        let future = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        assert!(!super::is_wrap_token_expired(Some(&future.to_string())));
+    }
+
+    #[test]
+    fn is_wrap_token_expired_returns_false_for_none() {
+        assert!(!super::is_wrap_token_expired(None));
+    }
+
+    #[test]
+    fn is_wrap_token_expired_returns_false_for_invalid() {
+        assert!(!super::is_wrap_token_expired(Some("not-a-number")));
+    }
+
+    #[test]
+    fn secret_id_file_check_skipped_when_wrap_token_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let role_id = dir.path().join("role_id");
+        std::fs::write(&role_id, "rid").expect("write role_id");
+        let secret_id = dir.path().join("secret_id");
+        let eab = dir.path().join("eab.json");
+
+        let mut args = dummy_args();
+        args.service_name = "svc".to_string();
+        args.role_id_path = role_id;
+        args.secret_id_path = secret_id;
+        args.eab_file_path = eab;
+        args.profile_hostname = "host".to_string();
+        args.profile_instance_id = Some("1".to_string());
+        args.agent_domain = "d.com".to_string();
+        args.wrap_token = Some("tok".to_string());
+
+        let result = validate_bootstrap_args(&args, Locale::En);
+        assert!(
+            result.is_ok(),
+            "should pass when wrap_token present: {result:?}"
         );
     }
 }

--- a/src/bin/bootroot-remote/io.rs
+++ b/src/bin/bootroot-remote/io.rs
@@ -149,19 +149,25 @@ pub(super) async fn pull_secrets(
     client: &bootroot::openbao::OpenBaoClient,
     mount: &str,
     service: &str,
+    skip_secret_id: bool,
     lang: Locale,
 ) -> Result<PulledSecrets> {
     let base = format!("{}/{service}", super::SERVICE_KV_BASE);
-    let secret_id_data = client
-        .read_kv(mount, &format!("{base}/secret_id"))
-        .await
-        .with_context(|| {
-            localized(
-                lang,
-                "Failed to read service secret_id from OpenBao",
-                "OpenBao에서 서비스 secret_id를 읽지 못했습니다",
-            )
-        })?;
+    let secret_id = if skip_secret_id {
+        String::new()
+    } else {
+        let secret_id_data = client
+            .read_kv(mount, &format!("{base}/secret_id"))
+            .await
+            .with_context(|| {
+                localized(
+                    lang,
+                    "Failed to read service secret_id from OpenBao",
+                    "OpenBao에서 서비스 secret_id를 읽지 못했습니다",
+                )
+            })?;
+        read_required_string(&secret_id_data, &[super::SECRET_ID_KEY, "value"], lang)?
+    };
     let eab_data = client
         .read_kv(mount, &format!("{base}/eab"))
         .await
@@ -193,7 +199,6 @@ pub(super) async fn pull_secrets(
             )
         })?;
 
-    let secret_id = read_required_string(&secret_id_data, &[super::SECRET_ID_KEY, "value"], lang)?;
     let eab_kid = read_required_string(&eab_data, &[super::EAB_KID_KEY], lang)?;
     let eab_hmac = read_required_string(&eab_data, &[super::EAB_HMAC_KEY], lang)?;
     let responder_hmac =

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -7,7 +7,7 @@ mod validation;
 
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bootroot::locale::Locale;
 use bootroot::trust_bootstrap::{
     CA_BUNDLE_PEM_KEY, EAB_HMAC_KEY, EAB_KID_KEY, HMAC_KEY, SECRET_ID_KEY, SERVICE_KV_BASE,
@@ -68,8 +68,12 @@ enum Command {
 
 #[derive(clap::Args, Debug)]
 struct BootstrapArgs {
+    /// Bootstrap artifact JSON file (overrides per-field flags)
+    #[arg(long)]
+    artifact: Option<PathBuf>,
+
     /// `OpenBao` base URL
-    #[arg(long, env = "OPENBAO_URL")]
+    #[arg(long, env = "OPENBAO_URL", default_value = "")]
     openbao_url: String,
 
     /// `OpenBao` KV mount (v2)
@@ -77,24 +81,24 @@ struct BootstrapArgs {
     kv_mount: String,
 
     /// Service name
-    #[arg(long)]
+    #[arg(long, default_value = "")]
     service_name: String,
 
     /// `AppRole` `role_id` file path used for `OpenBao` login
     #[arg(long)]
-    role_id_path: PathBuf,
+    role_id_path: Option<PathBuf>,
 
     /// Destination path for rotated `secret_id`
     #[arg(long)]
-    secret_id_path: PathBuf,
+    secret_id_path: Option<PathBuf>,
 
     /// Destination path for EAB JSON (kid/hmac)
     #[arg(long)]
-    eab_file_path: PathBuf,
+    eab_file_path: Option<PathBuf>,
 
     /// bootroot-agent config path to update
     #[arg(long)]
-    agent_config_path: PathBuf,
+    agent_config_path: Option<PathBuf>,
 
     /// bootroot-agent email for baseline config generation
     #[arg(long, default_value = DEFAULT_AGENT_EMAIL)]
@@ -136,7 +140,7 @@ struct BootstrapArgs {
 
     /// CA bundle output path for the managed step-ca trust bundle
     #[arg(long)]
-    ca_bundle_path: PathBuf,
+    ca_bundle_path: Option<PathBuf>,
 
     /// Post-renew success hook command
     #[arg(long)]
@@ -227,11 +231,223 @@ async fn main() {
     }
 }
 
+/// Resolved bootstrap args where all required fields are present.
+struct ResolvedBootstrapArgs {
+    openbao_url: String,
+    kv_mount: String,
+    service_name: String,
+    role_id_path: PathBuf,
+    secret_id_path: PathBuf,
+    eab_file_path: PathBuf,
+    agent_config_path: PathBuf,
+    agent_email: String,
+    agent_server: String,
+    agent_domain: String,
+    agent_responder_url: String,
+    profile_hostname: String,
+    profile_instance_id: Option<String>,
+    profile_cert_path: Option<PathBuf>,
+    profile_key_path: Option<PathBuf>,
+    ca_bundle_path: PathBuf,
+    post_renew_command: Option<String>,
+    post_renew_arg: Vec<String>,
+    post_renew_timeout_secs: Option<u64>,
+    post_renew_on_failure: Option<HookFailurePolicy>,
+    output: OutputFormat,
+    wrap_token: Option<String>,
+    wrap_expires_at: Option<String>,
+}
+
 async fn run(args: Args, lang: Locale) -> Result<i32> {
     match args.command {
-        Command::Bootstrap(args) => bootstrap::run_bootstrap(*args, lang).await,
+        Command::Bootstrap(args) => {
+            let resolved = resolve_bootstrap_args(*args, lang)?;
+            bootstrap::run_bootstrap(resolved, lang).await
+        }
         Command::ApplySecretId(args) => apply_secret_id::run_apply_secret_id(args, lang).await,
     }
+}
+
+/// Parsed bootstrap artifact for loading from `--artifact <path>`.
+#[derive(serde::Deserialize)]
+struct ParsedArtifact {
+    openbao_url: String,
+    #[serde(default)]
+    kv_mount: String,
+    service_name: String,
+    role_id_path: String,
+    secret_id_path: String,
+    eab_file_path: String,
+    agent_config_path: String,
+    ca_bundle_path: String,
+    #[serde(default)]
+    agent_email: String,
+    #[serde(default)]
+    agent_server: String,
+    #[serde(default)]
+    agent_domain: String,
+    #[serde(default)]
+    agent_responder_url: String,
+    #[serde(default)]
+    profile_hostname: String,
+    #[serde(default)]
+    profile_instance_id: Option<String>,
+    #[serde(default)]
+    profile_cert_path: Option<String>,
+    #[serde(default)]
+    profile_key_path: Option<String>,
+    #[serde(default)]
+    post_renew_hooks: Vec<ParsedHook>,
+    #[serde(default)]
+    wrap_token: Option<String>,
+    #[serde(default)]
+    wrap_expires_at: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct ParsedHook {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default = "default_hook_timeout")]
+    timeout_secs: u64,
+    #[serde(default)]
+    on_failure: String,
+}
+
+fn default_hook_timeout() -> u64 {
+    30
+}
+
+#[allow(clippy::too_many_lines)]
+fn resolve_bootstrap_args(args: BootstrapArgs, lang: Locale) -> Result<ResolvedBootstrapArgs> {
+    let err_required = || {
+        localized(
+            lang,
+            "Required field missing (provide --artifact or individual flags)",
+            "필수 필드가 누락되었습니다 (--artifact 또는 개별 플래그를 제공하세요)",
+        )
+    };
+
+    if let Some(artifact_path) = &args.artifact {
+        let content = std::fs::read_to_string(artifact_path).with_context(|| {
+            localized(
+                lang,
+                &format!("Failed to read artifact: {}", artifact_path.display()),
+                &format!(
+                    "아티팩트 파일을 읽지 못했습니다: {}",
+                    artifact_path.display()
+                ),
+            )
+        })?;
+        let p: ParsedArtifact = serde_json::from_str(&content).with_context(|| {
+            localized(
+                lang,
+                "Failed to parse bootstrap artifact JSON",
+                "부트스트랩 아티팩트 JSON 파싱에 실패했습니다",
+            )
+        })?;
+        let mut resolved = ResolvedBootstrapArgs {
+            openbao_url: p.openbao_url,
+            kv_mount: if p.kv_mount.is_empty() {
+                args.kv_mount
+            } else {
+                p.kv_mount
+            },
+            service_name: p.service_name,
+            role_id_path: PathBuf::from(p.role_id_path),
+            secret_id_path: PathBuf::from(p.secret_id_path),
+            eab_file_path: PathBuf::from(p.eab_file_path),
+            agent_config_path: PathBuf::from(p.agent_config_path),
+            ca_bundle_path: PathBuf::from(p.ca_bundle_path),
+            agent_email: if p.agent_email.is_empty() {
+                args.agent_email
+            } else {
+                p.agent_email
+            },
+            agent_server: if p.agent_server.is_empty() {
+                args.agent_server
+            } else {
+                p.agent_server
+            },
+            agent_domain: if p.agent_domain.is_empty() {
+                args.agent_domain
+            } else {
+                p.agent_domain
+            },
+            agent_responder_url: if p.agent_responder_url.is_empty() {
+                args.agent_responder_url
+            } else {
+                p.agent_responder_url
+            },
+            profile_hostname: if p.profile_hostname.is_empty() {
+                args.profile_hostname
+            } else {
+                p.profile_hostname
+            },
+            profile_instance_id: p.profile_instance_id.or(args.profile_instance_id),
+            profile_cert_path: p
+                .profile_cert_path
+                .map(PathBuf::from)
+                .or(args.profile_cert_path),
+            profile_key_path: p
+                .profile_key_path
+                .map(PathBuf::from)
+                .or(args.profile_key_path),
+            post_renew_command: args.post_renew_command,
+            post_renew_arg: args.post_renew_arg,
+            post_renew_timeout_secs: args.post_renew_timeout_secs,
+            post_renew_on_failure: args.post_renew_on_failure,
+            output: args.output,
+            wrap_token: p.wrap_token,
+            wrap_expires_at: p.wrap_expires_at,
+        };
+        if let Some(hook) = p.post_renew_hooks.first() {
+            resolved.post_renew_command = Some(hook.command.clone());
+            resolved.post_renew_arg.clone_from(&hook.args);
+            resolved.post_renew_timeout_secs = Some(hook.timeout_secs);
+            if hook.on_failure == "stop" {
+                resolved.post_renew_on_failure = Some(HookFailurePolicy::Stop);
+            }
+        }
+        return Ok(resolved);
+    }
+
+    Ok(ResolvedBootstrapArgs {
+        openbao_url: args.openbao_url,
+        kv_mount: args.kv_mount,
+        service_name: args.service_name,
+        role_id_path: args
+            .role_id_path
+            .ok_or_else(|| anyhow::anyhow!("{}", err_required()))?,
+        secret_id_path: args
+            .secret_id_path
+            .ok_or_else(|| anyhow::anyhow!("{}", err_required()))?,
+        eab_file_path: args
+            .eab_file_path
+            .ok_or_else(|| anyhow::anyhow!("{}", err_required()))?,
+        agent_config_path: args
+            .agent_config_path
+            .ok_or_else(|| anyhow::anyhow!("{}", err_required()))?,
+        ca_bundle_path: args
+            .ca_bundle_path
+            .ok_or_else(|| anyhow::anyhow!("{}", err_required()))?,
+        agent_email: args.agent_email,
+        agent_server: args.agent_server,
+        agent_domain: args.agent_domain,
+        agent_responder_url: args.agent_responder_url,
+        profile_hostname: args.profile_hostname,
+        profile_instance_id: args.profile_instance_id,
+        profile_cert_path: args.profile_cert_path,
+        profile_key_path: args.profile_key_path,
+        post_renew_command: args.post_renew_command,
+        post_renew_arg: args.post_renew_arg,
+        post_renew_timeout_secs: args.post_renew_timeout_secs,
+        post_renew_on_failure: args.post_renew_on_failure,
+        output: args.output,
+        wrap_token: None,
+        wrap_expires_at: None,
+    })
 }
 
 #[cfg(test)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -711,10 +711,6 @@ pub(crate) struct ServiceAddArgs {
     #[arg(long)]
     pub(crate) secret_id_ttl: Option<String>,
 
-    /// Maximum number of times the `secret_id` can be used [default: 1]
-    #[arg(long)]
-    pub(crate) secret_id_num_uses: Option<u32>,
-
     /// Response-wrapping TTL for the `secret_id` [default: 30m]
     #[arg(long)]
     pub(crate) secret_id_wrap_ttl: Option<String>,
@@ -1191,7 +1187,6 @@ mod tests {
         match cli.command {
             CliCommand::Service(ServiceCommand::Add(args)) => {
                 assert!(args.secret_id_ttl.is_none());
-                assert!(args.secret_id_num_uses.is_none());
                 assert!(args.secret_id_wrap_ttl.is_none());
                 assert!(!args.no_wrap);
             }
@@ -1207,15 +1202,12 @@ mod tests {
             "add",
             "--secret-id-ttl",
             "1h",
-            "--secret-id-num-uses",
-            "5",
             "--secret-id-wrap-ttl",
             "10m",
         ]);
         match cli.command {
             CliCommand::Service(ServiceCommand::Add(args)) => {
                 assert_eq!(args.secret_id_ttl.as_deref(), Some("1h"));
-                assert_eq!(args.secret_id_num_uses, Some(5));
                 assert_eq!(args.secret_id_wrap_ttl.as_deref(), Some("10m"));
                 assert!(!args.no_wrap);
             }

--- a/src/commands/constants.rs
+++ b/src/commands/constants.rs
@@ -1,5 +1,4 @@
 pub(crate) const RESPONDER_SERVICE_NAME: &str = "bootroot-http01";
-pub(crate) const DEFAULT_SECRET_ID_NUM_USES: u32 = 1;
 pub(crate) const DEFAULT_SECRET_ID_WRAP_TTL: &str = "30m";
 pub(crate) use bootroot::trust_bootstrap::{
     EAB_HMAC_KEY as SERVICE_EAB_HMAC_KEY, EAB_KID_KEY as SERVICE_EAB_KID_KEY,

--- a/src/commands/dns_alias.rs
+++ b/src/commands/dns_alias.rs
@@ -196,7 +196,6 @@ mod tests {
                 secret_id_path: PathBuf::from("/s"),
                 policy_name: "p".to_string(),
                 secret_id_ttl: None,
-                secret_id_num_uses: None,
                 secret_id_wrap_ttl: None,
             },
         }

--- a/src/commands/init/constants.rs
+++ b/src/commands/init/constants.rs
@@ -42,9 +42,7 @@ pub(crate) mod openbao_constants {
     pub(crate) const INIT_SECRET_THRESHOLD: u8 = 2;
     pub(crate) const TOKEN_TTL: &str = "1h";
     pub(crate) const SECRET_ID_TTL: &str = "24h";
-    // Used by upcoming sub-issues of #480 (response-wrapping, num_uses enforcement).
-    #[allow(dead_code)]
-    pub(crate) const DEFAULT_SECRET_ID_NUM_USES: u32 = 0;
+    // Used by upcoming sub-issues of #480 (response-wrapping enforcement).
     #[allow(dead_code)]
     pub(crate) const DEFAULT_SECRET_ID_WRAP_TTL: &str = "30m";
     pub(crate) const MAX_SECRET_ID_TTL: &str = "168h";

--- a/src/commands/rotate/approle.rs
+++ b/src/commands/rotate/approle.rs
@@ -7,9 +7,7 @@ use bootroot::openbao::{OpenBaoClient, SecretIdOptions};
 use super::helpers::{confirm_action, reload_openbao_agent, write_secret_id_atomic};
 use super::{ROLE_ID_FILENAME, RotateContext};
 use crate::cli::args::RotateAppRoleSecretIdArgs;
-use crate::commands::constants::{
-    DEFAULT_SECRET_ID_NUM_USES, SERVICE_KV_BASE, SERVICE_SECRET_ID_KEY,
-};
+use crate::commands::constants::{SERVICE_KV_BASE, SERVICE_SECRET_ID_KEY};
 use crate::commands::service::resolve::effective_wrap_ttl;
 use crate::i18n::Messages;
 use crate::state::{DeliveryMode, ServiceEntry};
@@ -37,25 +35,9 @@ pub(super) async fn rotate_approle_secret_id(
     if !is_remote {
         ensure_role_id_file(&entry, client, messages).await?;
     }
-    let stored_num_uses = entry
-        .approle
-        .secret_id_num_uses
-        .unwrap_or(DEFAULT_SECRET_ID_NUM_USES);
-    // Add 1 for the verify-login below so the caller's requested
-    // num_uses still remain after rotation verification.
-    let effective_num_uses = if stored_num_uses > 0 {
-        stored_num_uses.checked_add(1).ok_or_else(|| {
-            anyhow::anyhow!(
-                "secret_id_num_uses ({stored_num_uses}) is too large to \
-                 add the +1 verification allowance; use a smaller value"
-            )
-        })?
-    } else {
-        stored_num_uses
-    };
     let secret_id_options = SecretIdOptions {
         ttl: entry.approle.secret_id_ttl.clone(),
-        num_uses: Some(effective_num_uses),
+        num_uses: Some(0),
         metadata: None,
     };
     let wrap_ttl = effective_wrap_ttl(entry.approle.secret_id_wrap_ttl.as_deref());

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -7,7 +7,7 @@ mod secrets;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use bootroot::openbao::{OpenBaoClient, SecretIdOptions};
+use bootroot::openbao::{OpenBaoClient, SecretIdOptions, WrapInfo};
 
 use crate::cli::args::{ServiceAddArgs, ServiceInfoArgs};
 use crate::cli::output::{
@@ -38,10 +38,15 @@ pub(super) const DEFAULT_AGENT_SERVER: &str = "https://localhost:9000/acme/acme/
 pub(super) const DEFAULT_AGENT_RESPONDER_URL: &str = "http://127.0.0.1:8080";
 pub(super) use bootroot::trust_bootstrap::CA_BUNDLE_PEM_KEY as SERVICE_CA_BUNDLE_PEM_KEY;
 
+pub(super) enum SecretIdMaterial {
+    Plain(String),
+    Wrapped(WrapInfo),
+}
+
 pub(super) struct ServiceAppRoleMaterialized {
     pub(super) role_name: String,
     pub(super) role_id: String,
-    pub(super) secret_id: String,
+    pub(super) secret_id_material: SecretIdMaterial,
     pub(super) policy_name: String,
 }
 
@@ -104,7 +109,7 @@ pub(crate) async fn run_service_add(args: &ServiceAddArgs, messages: &Messages) 
 
     if let Some(existing) = state.services.get(&resolved.service_name).cloned() {
         if is_idempotent_remote_rerun(&existing, &resolved) {
-            return run_service_add_remote_idempotent(&state, &existing, messages).await;
+            return run_service_add_remote_idempotent(&state, &existing, &resolved, messages).await;
         }
         if is_policy_only_mismatch(&existing, &resolved) {
             anyhow::bail!(messages.error_service_policy_mismatch());
@@ -215,6 +220,7 @@ async fn run_service_add_preview(
     );
 }
 
+#[allow(clippy::too_many_lines)]
 async fn run_service_add_apply(
     state: &mut StateFile,
     state_path: &Path,
@@ -231,7 +237,11 @@ async fn run_service_add_apply(
     authenticate_openbao_client(&mut client, auth, messages).await?;
 
     let secret_id_options = build_secret_id_options(resolved);
-    let wrap_ttl = resolve::effective_wrap_ttl(resolved.secret_id_wrap_ttl.as_deref());
+    let wrap_ttl = if matches!(resolved.delivery_mode, DeliveryMode::RemoteBootstrap) {
+        resolve::effective_wrap_ttl(resolved.secret_id_wrap_ttl.as_deref())
+    } else {
+        None
+    };
     let approle_result = approle::ensure_service_approle(
         &client,
         state,
@@ -249,21 +259,34 @@ async fn run_service_add_apply(
         messages,
     )
     .await?;
-    let secret_id_path = approle::write_secret_id_file(
-        secrets_dir,
-        &resolved.service_name,
-        &approle_result.secret_id,
-        messages,
-    )
-    .await?;
-    let service_sync_material = secrets::sync_service_kv_bundle(
-        &client,
-        state,
-        resolved,
-        &approle_result.secret_id,
-        messages,
-    )
-    .await?;
+
+    let (secret_id_path, wrap_info) = match &approle_result.secret_id_material {
+        SecretIdMaterial::Plain(secret_id) => {
+            let path = approle::write_secret_id_file(
+                secrets_dir,
+                &resolved.service_name,
+                secret_id,
+                messages,
+            )
+            .await?;
+            (path, None)
+        }
+        SecretIdMaterial::Wrapped(wi) => {
+            let path = secrets_dir
+                .join(SERVICE_SECRET_DIR)
+                .join(&resolved.service_name)
+                .join(SERVICE_SECRET_ID_FILENAME);
+            (path, Some(wi))
+        }
+    };
+
+    let plain_secret_id = match &approle_result.secret_id_material {
+        SecretIdMaterial::Plain(sid) => Some(sid.as_str()),
+        SecretIdMaterial::Wrapped(_) => None,
+    };
+    let service_sync_material =
+        secrets::sync_service_kv_bundle(&client, state, resolved, plain_secret_id, messages)
+            .await?;
     let trusted_ca_sha256 = Some(service_sync_material.trusted_ca_sha256.as_slice());
 
     let applied = if matches!(resolved.delivery_mode, DeliveryMode::LocalFile) {
@@ -290,6 +313,7 @@ async fn run_service_add_apply(
                 secrets_dir,
                 resolved,
                 &secret_id_path,
+                wrap_info,
                 messages,
             )
             .await?,
@@ -404,13 +428,36 @@ fn print_service_add_apply_summary(
 async fn run_service_add_remote_idempotent(
     state: &StateFile,
     entry: &ServiceEntry,
+    resolved: &ResolvedServiceAdd,
     messages: &Messages,
 ) -> Result<()> {
+    let wrap_ttl = resolve::effective_wrap_ttl(entry.approle.secret_id_wrap_ttl.as_deref());
+    let wrap_info = if let Some(ttl) = wrap_ttl {
+        let auth = resolved
+            .runtime_auth
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("OpenBao auth is required for wrapped rerun"))?;
+        let mut client = OpenBaoClient::new(&state.openbao_url)
+            .with_context(|| messages.error_openbao_client_create_failed())?;
+        authenticate_openbao_client(&mut client, auth, messages).await?;
+        let secret_id_options = build_secret_id_options(resolved);
+        let role_name = approle::service_role_name(&entry.service_name);
+        Some(
+            client
+                .create_secret_id_wrap_only(&role_name, &secret_id_options, ttl)
+                .await
+                .with_context(|| messages.error_openbao_secret_id_failed())?,
+        )
+    } else {
+        None
+    };
+
     let secrets_dir = state.secrets_dir();
     let remote_bootstrap = remote_bootstrap::write_remote_bootstrap_artifact_from_entry(
         state,
         secrets_dir,
         entry,
+        wrap_info.as_ref(),
         messages,
     )
     .await?;
@@ -506,7 +553,7 @@ mod tests {
 
     use super::resolve::ResolvedServiceAdd;
     use super::{
-        ServiceAppRoleMaterialized, build_secret_id_options, build_service_entry,
+        SecretIdMaterial, ServiceAppRoleMaterialized, build_secret_id_options, build_service_entry,
         build_service_entry_from_role, is_idempotent_remote_rerun, is_policy_only_mismatch,
         non_policy_fields_match, policy_fields_match,
     };
@@ -575,7 +622,7 @@ mod tests {
         let materialized = ServiceAppRoleMaterialized {
             role_name: "mat-role".to_string(),
             role_id: "mat-rid".to_string(),
-            secret_id: "unused-in-entry".to_string(),
+            secret_id_material: SecretIdMaterial::Plain("unused-in-entry".to_string()),
             policy_name: "mat-policy".to_string(),
         };
         let secret_id_path = PathBuf::from("/secrets/mat");
@@ -637,7 +684,7 @@ mod tests {
         let materialized = ServiceAppRoleMaterialized {
             role_name: "r".to_string(),
             role_id: "id".to_string(),
-            secret_id: "sid".to_string(),
+            secret_id_material: SecretIdMaterial::Plain("sid".to_string()),
             policy_name: "p".to_string(),
         };
         let entry = build_service_entry(&resolved, materialized, &PathBuf::from("/s"));

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -14,7 +14,6 @@ use crate::cli::output::{
     ServiceAddAppliedPaths, ServiceAddPlan, ServiceAddRemoteBootstrap, ServiceAddSummaryOptions,
     print_service_add_plan, print_service_add_summary, print_service_info_summary,
 };
-use crate::commands::constants::DEFAULT_SECRET_ID_NUM_USES;
 use crate::commands::dns_alias::register_dns_alias;
 use crate::commands::openbao_auth::authenticate_openbao_client;
 use crate::i18n::Messages;
@@ -378,7 +377,6 @@ fn build_service_entry(
             secret_id_path: secret_id_path.to_path_buf(),
             policy_name: approle.policy_name,
             secret_id_ttl: resolved.secret_id_ttl.clone(),
-            secret_id_num_uses: resolved.secret_id_num_uses,
             secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
         },
     )
@@ -387,11 +385,7 @@ fn build_service_entry(
 fn build_secret_id_options(resolved: &ResolvedServiceAdd) -> SecretIdOptions {
     SecretIdOptions {
         ttl: resolved.secret_id_ttl.clone(),
-        num_uses: Some(
-            resolved
-                .secret_id_num_uses
-                .unwrap_or(DEFAULT_SECRET_ID_NUM_USES),
-        ),
+        num_uses: Some(0),
         metadata: None,
     }
 }
@@ -512,7 +506,6 @@ fn build_preview_service_entry(resolved: &ResolvedServiceAdd, state: &StateFile)
             secret_id_path: preview_secret_id_path,
             policy_name: approle::service_policy_name(&resolved.service_name),
             secret_id_ttl: resolved.secret_id_ttl.clone(),
-            secret_id_num_uses: resolved.secret_id_num_uses,
             secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
         },
     )
@@ -535,7 +528,6 @@ fn non_policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) 
 
 fn policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
     entry.approle.secret_id_ttl == resolved.secret_id_ttl
-        && entry.approle.secret_id_num_uses == resolved.secret_id_num_uses
         && entry.approle.secret_id_wrap_ttl == resolved.secret_id_wrap_ttl
 }
 
@@ -575,7 +567,7 @@ mod tests {
             notes: Some("test note".to_string()),
             post_renew_hooks: Vec::new(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
+
             secret_id_wrap_ttl: None,
         }
     }
@@ -604,7 +596,7 @@ mod tests {
             secret_id_path: PathBuf::from("/secrets/a"),
             policy_name: "policy-a".to_string(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
+
             secret_id_wrap_ttl: None,
         };
         let entry = build_service_entry_from_role(&resolved, role);
@@ -648,7 +640,7 @@ mod tests {
             secret_id_path: PathBuf::from("/s"),
             policy_name: "p".to_string(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
+
             secret_id_wrap_ttl: None,
         };
         let entry = build_service_entry_from_role(&resolved, role);
@@ -668,7 +660,6 @@ mod tests {
                 secret_id_path: PathBuf::from("/s"),
                 policy_name: "policy".to_string(),
                 secret_id_ttl: resolved.secret_id_ttl.clone(),
-                secret_id_num_uses: resolved.secret_id_num_uses,
                 secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
             },
         )
@@ -678,7 +669,6 @@ mod tests {
     fn build_service_entry_persists_secret_id_policy_fields() {
         let mut resolved = sample_resolved();
         resolved.secret_id_ttl = Some("1h".to_string());
-        resolved.secret_id_num_uses = Some(5);
         resolved.secret_id_wrap_ttl = Some("10m".to_string());
 
         let materialized = ServiceAppRoleMaterialized {
@@ -690,7 +680,6 @@ mod tests {
         let entry = build_service_entry(&resolved, materialized, &PathBuf::from("/s"));
 
         assert_eq!(entry.approle.secret_id_ttl.as_deref(), Some("1h"));
-        assert_eq!(entry.approle.secret_id_num_uses, Some(5));
         assert_eq!(entry.approle.secret_id_wrap_ttl.as_deref(), Some("10m"));
     }
 
@@ -698,11 +687,10 @@ mod tests {
     fn build_secret_id_options_maps_resolved_fields() {
         let mut resolved = sample_resolved();
         resolved.secret_id_ttl = Some("2h".to_string());
-        resolved.secret_id_num_uses = Some(3);
 
         let opts = build_secret_id_options(&resolved);
         assert_eq!(opts.ttl.as_deref(), Some("2h"));
-        assert_eq!(opts.num_uses, Some(3));
+        assert_eq!(opts.num_uses, Some(0));
         assert!(opts.metadata.is_none());
     }
 
@@ -711,7 +699,7 @@ mod tests {
         let resolved = sample_resolved();
         let opts = build_secret_id_options(&resolved);
         assert!(opts.ttl.is_none());
-        assert_eq!(opts.num_uses, Some(1));
+        assert_eq!(opts.num_uses, Some(0));
     }
 
     #[test]
@@ -726,14 +714,6 @@ mod tests {
         let resolved = sample_resolved();
         let mut entry = sample_entry_from_resolved(&resolved);
         entry.approle.secret_id_ttl = Some("999h".to_string());
-        assert!(!policy_fields_match(&entry, &resolved));
-    }
-
-    #[test]
-    fn policy_fields_match_differs_on_num_uses() {
-        let resolved = sample_resolved();
-        let mut entry = sample_entry_from_resolved(&resolved);
-        entry.approle.secret_id_num_uses = Some(99);
         assert!(!policy_fields_match(&entry, &resolved));
     }
 
@@ -770,7 +750,7 @@ mod tests {
         let mut resolved = sample_resolved();
         resolved.delivery_mode = DeliveryMode::RemoteBootstrap;
         let mut entry = sample_entry_from_resolved(&resolved);
-        entry.approle.secret_id_num_uses = Some(99);
+        entry.approle.secret_id_wrap_ttl = Some("99m".to_string());
         assert!(!is_idempotent_remote_rerun(&entry, &resolved));
     }
 

--- a/src/commands/service/approle.rs
+++ b/src/commands/service/approle.rs
@@ -7,7 +7,7 @@ use tokio::fs;
 
 use super::{
     SERVICE_ROLE_ID_FILENAME, SERVICE_ROLE_PREFIX, SERVICE_SECRET_DIR, SERVICE_SECRET_ID_FILENAME,
-    ServiceAppRoleMaterialized,
+    SecretIdMaterial, ServiceAppRoleMaterialized,
 };
 use crate::commands::constants::SERVICE_KV_BASE;
 use crate::commands::init::{SECRET_ID_TTL, TOKEN_TTL};
@@ -44,19 +44,23 @@ pub(super) async fn ensure_service_approle(
         .read_role_id(&role_name)
         .await
         .with_context(|| messages.error_openbao_role_id_failed())?;
-    let secret_id = match wrap_ttl {
-        Some(ttl) => {
-            client
-                .create_secret_id_wrapped(&role_name, secret_id_options, ttl)
-                .await
-        }
-        None => client.create_secret_id(&role_name, secret_id_options).await,
-    }
-    .with_context(|| messages.error_openbao_secret_id_failed())?;
+    let secret_id_material = if let Some(ttl) = wrap_ttl {
+        let wrap_info = client
+            .create_secret_id_wrap_only(&role_name, secret_id_options, ttl)
+            .await
+            .with_context(|| messages.error_openbao_secret_id_failed())?;
+        SecretIdMaterial::Wrapped(wrap_info)
+    } else {
+        let secret_id = client
+            .create_secret_id(&role_name, secret_id_options)
+            .await
+            .with_context(|| messages.error_openbao_secret_id_failed())?;
+        SecretIdMaterial::Plain(secret_id)
+    };
     Ok(ServiceAppRoleMaterialized {
         role_name,
         role_id,
-        secret_id,
+        secret_id_material,
         policy_name,
     })
 }

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -257,7 +257,6 @@ mod tests {
             notes: None,
             post_renew_hooks: Vec::new(),
             secret_id_ttl: None,
-            secret_id_num_uses: None,
             secret_id_wrap_ttl: None,
         }
     }

--- a/src/commands/service/remote_bootstrap.rs
+++ b/src/commands/service/remote_bootstrap.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use bootroot::fs_util;
+use bootroot::openbao::WrapInfo;
 use tokio::fs;
 
 use super::resolve::ResolvedServiceAdd;
@@ -55,6 +56,10 @@ struct RemoteBootstrapArtifact {
     profile_key_path: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     post_renew_hooks: Vec<PostRenewHookEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    wrap_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    wrap_expires_at: Option<String>,
 }
 
 /// Builds a `RemoteBootstrapArtifact` from common inputs shared by both
@@ -72,6 +77,7 @@ fn build_artifact(
     hostname: &str,
     instance_id: Option<&str>,
     post_renew_hooks: &[PostRenewHookEntry],
+    wrap_info: Option<&WrapInfo>,
 ) -> RemoteBootstrapArtifact {
     let secret_id_parent = secret_id_path.parent().unwrap_or(Path::new("."));
     let role_id_path = secret_id_parent.join(SERVICE_ROLE_ID_FILENAME);
@@ -105,7 +111,18 @@ fn build_artifact(
         profile_cert_path: cert_path.display().to_string(),
         profile_key_path: key_path.display().to_string(),
         post_renew_hooks: post_renew_hooks.to_vec(),
+        wrap_token: wrap_info.map(|w| w.token.clone()),
+        wrap_expires_at: wrap_info.map(|w| compute_wrap_expiry_epoch(w.ttl)),
     }
+}
+
+/// Computes the wrap expiry as a Unix epoch seconds string.
+fn compute_wrap_expiry_epoch(ttl_secs: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    (now + ttl_secs).to_string()
 }
 
 pub(super) async fn write_remote_bootstrap_artifact(
@@ -113,6 +130,7 @@ pub(super) async fn write_remote_bootstrap_artifact(
     secrets_dir: &Path,
     resolved: &ResolvedServiceAdd,
     secret_id_path: &Path,
+    wrap_info: Option<&WrapInfo>,
     messages: &Messages,
 ) -> Result<RemoteBootstrapResult> {
     let artifact = build_artifact(
@@ -127,6 +145,7 @@ pub(super) async fn write_remote_bootstrap_artifact(
         &resolved.hostname,
         resolved.instance_id.as_deref(),
         &resolved.post_renew_hooks,
+        wrap_info,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &resolved.service_name, &artifact, messages)
         .await
@@ -136,6 +155,7 @@ pub(super) async fn write_remote_bootstrap_artifact_from_entry(
     state: &StateFile,
     secrets_dir: &Path,
     entry: &ServiceEntry,
+    wrap_info: Option<&WrapInfo>,
     messages: &Messages,
 ) -> Result<RemoteBootstrapResult> {
     let artifact = build_artifact(
@@ -150,6 +170,7 @@ pub(super) async fn write_remote_bootstrap_artifact_from_entry(
         &entry.hostname,
         entry.instance_id.as_deref(),
         &entry.post_renew_hooks,
+        wrap_info,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &entry.service_name, &artifact, messages)
         .await
@@ -170,14 +191,20 @@ async fn write_remote_bootstrap_artifact_file(
         .await
         .with_context(|| messages.error_write_file_failed(&artifact_path.display().to_string()))?;
     fs_util::set_key_permissions(&artifact_path).await?;
-    let remote_run_command = render_remote_run_command(artifact);
+    let remote_run_command = render_remote_run_command(artifact, &artifact_path);
     Ok(RemoteBootstrapResult {
         bootstrap_file: artifact_path.display().to_string(),
         remote_run_command,
     })
 }
 
-fn render_remote_run_command(artifact: &RemoteBootstrapArtifact) -> String {
+fn render_remote_run_command(artifact: &RemoteBootstrapArtifact, artifact_path: &Path) -> String {
+    if artifact.wrap_token.is_some() {
+        return format!(
+            "bootroot-remote bootstrap --artifact '{}' --output json",
+            shell_escape_single_quoted(&artifact_path.display().to_string()),
+        );
+    }
     let mut cmd = format!(
         "bootroot-remote bootstrap --openbao-url '{}' --kv-mount '{}' --service-name '{}' --role-id-path '{}' --secret-id-path '{}' --eab-file-path '{}' --agent-config-path '{}' --agent-email '{}' --agent-server '{}' --agent-domain '{}' --agent-responder-url '{}' --profile-hostname '{}' --profile-instance-id '{}' --profile-cert-path '{}' --profile-key-path '{}' --ca-bundle-path '{}'",
         artifact.openbao_url,
@@ -267,6 +294,7 @@ mod tests {
             "host1",
             Some("instance-42"),
             &[],
+            None,
         );
 
         assert_eq!(artifact.schema_version, 1);
@@ -320,6 +348,7 @@ mod tests {
             "node-a",
             None,
             &[],
+            None,
         );
 
         assert_eq!(artifact.profile_instance_id, "");
@@ -339,6 +368,7 @@ mod tests {
             "h1",
             None,
             &[],
+            None,
         );
         let b = build_artifact(
             "https://ob",
@@ -352,6 +382,7 @@ mod tests {
             "h2",
             None,
             &[],
+            None,
         );
 
         assert_ne!(a.role_id_path, b.role_id_path);
@@ -373,6 +404,7 @@ mod tests {
             "h",
             None,
             &[],
+            None,
         );
 
         // Path::new("secret_id").parent() returns Some(""), not None
@@ -394,6 +426,7 @@ mod tests {
             "h",
             None,
             &[],
+            None,
         );
 
         // Path::new("cert.pem").parent() returns Some(""), not None
@@ -422,6 +455,7 @@ mod tests {
             "h",
             None,
             &hooks,
+            None,
         );
 
         assert_eq!(artifact.post_renew_hooks.len(), 1);
@@ -451,8 +485,9 @@ mod tests {
             "h",
             None,
             &hooks,
+            None,
         );
-        let cmd = super::render_remote_run_command(&artifact);
+        let cmd = super::render_remote_run_command(&artifact, Path::new("/tmp/bootstrap.json"));
 
         assert!(
             cmd.contains("--post-renew-command 'systemctl'"),
@@ -498,8 +533,9 @@ mod tests {
             "h",
             None,
             &hooks,
+            None,
         );
-        let cmd = super::render_remote_run_command(&artifact);
+        let cmd = super::render_remote_run_command(&artifact, Path::new("/tmp/bootstrap.json"));
 
         assert!(
             cmd.contains("--post-renew-command '/usr/bin/notify-O'\\''Brien'"),
@@ -525,8 +561,9 @@ mod tests {
             "h",
             None,
             &[],
+            None,
         );
-        let cmd = super::render_remote_run_command(&artifact);
+        let cmd = super::render_remote_run_command(&artifact, Path::new("/tmp/bootstrap.json"));
 
         assert!(
             !cmd.contains("--post-renew"),
@@ -548,6 +585,7 @@ mod tests {
             "h",
             Some(""),
             &[],
+            None,
         );
         let with_none = build_artifact(
             "https://ob",
@@ -561,6 +599,7 @@ mod tests {
             "h",
             None,
             &[],
+            None,
         );
 
         assert_eq!(
@@ -582,5 +621,98 @@ mod tests {
     #[test]
     fn shell_escape_single_quoted_multiple_quotes() {
         assert_eq!(super::shell_escape_single_quoted("a'b'c"), "a'\\''b'\\''c");
+    }
+
+    #[test]
+    fn render_remote_run_command_uses_artifact_flag_when_wrapped() {
+        use bootroot::openbao::WrapInfo;
+
+        let wrap = WrapInfo {
+            token: "s.wrap123".to_string(),
+            ttl: 1800,
+            creation_time: "2026-04-12T00:00:00Z".to_string(),
+            creation_path: "auth/approle/role/svc/secret-id".to_string(),
+        };
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &[],
+            Some(&wrap),
+        );
+        let cmd = super::render_remote_run_command(
+            &artifact,
+            Path::new("/secrets/remote-bootstrap/services/svc/bootstrap.json"),
+        );
+
+        assert!(
+            cmd.contains("--artifact"),
+            "wrapped artifact should use --artifact: {cmd}"
+        );
+        assert!(
+            !cmd.contains("--openbao-url"),
+            "wrapped artifact should not list individual flags: {cmd}"
+        );
+        assert!(
+            cmd.contains("--output json"),
+            "should still include --output: {cmd}"
+        );
+    }
+
+    #[test]
+    fn build_artifact_includes_wrap_fields_when_present() {
+        use bootroot::openbao::WrapInfo;
+
+        let wrap = WrapInfo {
+            token: "s.wrap-tok".to_string(),
+            ttl: 1800,
+            creation_time: "2026-04-12T00:00:00Z".to_string(),
+            creation_path: "auth/approle/role/svc/secret-id".to_string(),
+        };
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &[],
+            Some(&wrap),
+        );
+
+        assert_eq!(artifact.wrap_token.as_deref(), Some("s.wrap-tok"));
+        assert!(artifact.wrap_expires_at.is_some());
+    }
+
+    #[test]
+    fn build_artifact_omits_wrap_fields_when_none() {
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &[],
+            None,
+        );
+
+        assert!(artifact.wrap_token.is_none());
+        assert!(artifact.wrap_expires_at.is_none());
     }
 }

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -32,7 +32,6 @@ pub(crate) struct ResolvedServiceAdd {
     pub(crate) notes: Option<String>,
     pub(crate) post_renew_hooks: Vec<PostRenewHookEntry>,
     pub(crate) secret_id_ttl: Option<String>,
-    pub(crate) secret_id_num_uses: Option<u32>,
     pub(crate) secret_id_wrap_ttl: Option<String>,
 }
 
@@ -147,7 +146,6 @@ pub(super) fn resolve_service_add_args(
         notes: args.notes.clone(),
         post_renew_hooks,
         secret_id_ttl: args.secret_id_ttl.clone(),
-        secret_id_num_uses: args.secret_id_num_uses,
         secret_id_wrap_ttl,
     })
 }
@@ -418,7 +416,6 @@ mod tests {
             post_renew_timeout_secs: None,
             post_renew_on_failure: None,
             secret_id_ttl: None,
-            secret_id_num_uses: None,
             secret_id_wrap_ttl: None,
             no_wrap: false,
         }

--- a/src/commands/service/secrets.rs
+++ b/src/commands/service/secrets.rs
@@ -15,7 +15,7 @@ pub(super) async fn sync_service_kv_bundle(
     client: &OpenBaoClient,
     state: &StateFile,
     resolved: &ResolvedServiceAdd,
-    secret_id: &str,
+    secret_id: Option<&str>,
     messages: &Messages,
 ) -> Result<ServiceSyncMaterial> {
     let material = read_service_sync_material(client, &state.kv_mount, messages).await?;
@@ -27,13 +27,15 @@ pub(super) async fn sync_service_kv_bundle(
         messages,
     )
     .await?;
-    if matches!(resolved.delivery_mode, DeliveryMode::RemoteBootstrap) {
+    if matches!(resolved.delivery_mode, DeliveryMode::RemoteBootstrap)
+        && let Some(sid) = secret_id
+    {
         let base = format!("{SERVICE_KV_BASE}/{}", resolved.service_name);
         client
             .write_kv(
                 &state.kv_mount,
                 &format!("{base}/secret_id"),
-                serde_json::json!({ SERVICE_SECRET_ID_KEY: secret_id }),
+                serde_json::json!({ SERVICE_SECRET_ID_KEY: sid }),
             )
             .await
             .with_context(|| messages.error_openbao_kv_write_failed())?;

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -510,6 +510,25 @@ impl OpenBaoClient {
         Ok(response.data.secret_id)
     }
 
+    /// Creates a new `secret_id` with response wrapping and returns the
+    /// wrap metadata **without** unwrapping.
+    ///
+    /// Use this when the wrap token must be forwarded to another system
+    /// (e.g. embedded in a remote bootstrap artifact) so that the
+    /// recipient can unwrap it themselves.
+    ///
+    /// # Errors
+    /// Returns an error if the wrapped creation request fails.
+    pub async fn create_secret_id_wrap_only(
+        &self,
+        name: &str,
+        options: &SecretIdOptions,
+        wrap_ttl: &str,
+    ) -> Result<WrapInfo> {
+        let path = format!("auth/approle/role/{name}/secret-id");
+        self.post_json_wrapped(&path, options, wrap_ttl).await
+    }
+
     /// Creates a new `secret_id` with response wrapping, then immediately
     /// unwraps it to obtain the raw value.
     ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -96,8 +96,6 @@ pub(crate) struct ServiceRoleEntry {
     #[serde(default)]
     pub(crate) secret_id_ttl: Option<String>,
     #[serde(default)]
-    pub(crate) secret_id_num_uses: Option<u32>,
-    #[serde(default)]
     pub(crate) secret_id_wrap_ttl: Option<String>,
 }
 
@@ -254,7 +252,7 @@ mod tests {
                 secret_id_path: PathBuf::from("s"),
                 policy_name: "p".to_string(),
                 secret_id_ttl: None,
-                secret_id_num_uses: None,
+
                 secret_id_wrap_ttl: None,
             },
         };
@@ -278,8 +276,23 @@ mod tests {
         }"#;
         let parsed: ServiceRoleEntry = serde_json::from_str(json).expect("deserialize");
         assert!(parsed.secret_id_ttl.is_none());
-        assert!(parsed.secret_id_num_uses.is_none());
         assert!(parsed.secret_id_wrap_ttl.is_none());
+    }
+
+    #[test]
+    fn old_state_with_secret_id_num_uses_still_deserializes() {
+        let json = r#"{
+            "role_name": "r",
+            "role_id": "id",
+            "secret_id_path": "s",
+            "policy_name": "p",
+            "secret_id_ttl": "1h",
+            "secret_id_num_uses": 5,
+            "secret_id_wrap_ttl": "30m"
+        }"#;
+        let parsed: ServiceRoleEntry = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(parsed.secret_id_ttl.as_deref(), Some("1h"));
+        assert_eq!(parsed.secret_id_wrap_ttl.as_deref(), Some("30m"));
     }
 
     #[test]
@@ -290,13 +303,11 @@ mod tests {
             secret_id_path: PathBuf::from("s"),
             policy_name: "p".to_string(),
             secret_id_ttl: Some("1h".to_string()),
-            secret_id_num_uses: Some(5),
             secret_id_wrap_ttl: Some("0".to_string()),
         };
         let json = serde_json::to_string(&entry).expect("serialize");
         let parsed: ServiceRoleEntry = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(parsed.secret_id_ttl.as_deref(), Some("1h"));
-        assert_eq!(parsed.secret_id_num_uses, Some(5));
         assert_eq!(parsed.secret_id_wrap_ttl.as_deref(), Some("0"));
     }
 

--- a/tests/bootroot_remote.rs
+++ b/tests/bootroot_remote.rs
@@ -352,7 +352,10 @@ fn test_bootroot_remote_requires_ca_bundle_path() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success(), "stderr: {stderr}");
-    assert!(stderr.contains("--ca-bundle-path"), "stderr:\n{stderr}");
+    assert!(
+        stderr.contains("--ca-bundle-path") || stderr.contains("Required field missing"),
+        "stderr:\n{stderr}"
+    );
 }
 
 #[tokio::test]

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1403,6 +1403,7 @@ async fn stub_app_add_openbao_with_token(server: &MockServer, service_name: &str
         .mount(server)
         .await;
 
+    // Wrapped secret_id creation (used for remote-bootstrap delivery mode)
     let wrap_token = format!("wrap-token-{service_name}");
     Mock::given(method("POST"))
         .and(path(format!("/v1/auth/approle/role/{role}/secret-id")))
@@ -1419,9 +1420,11 @@ async fn stub_app_add_openbao_with_token(server: &MockServer, service_name: &str
         .mount(server)
         .await;
 
+    // Unwrapped secret_id creation (used for local-file delivery mode
+    // and --no-wrap remote-bootstrap)
     Mock::given(method("POST"))
-        .and(path("/v1/sys/wrapping/unwrap"))
-        .and(header("X-Vault-Token", &wrap_token))
+        .and(path(format!("/v1/auth/approle/role/{role}/secret-id")))
+        .and(header("X-Vault-Token", token))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "data": {
                 "secret_id": format!("secret-{service_name}"),

--- a/tests/e2e_remote_happy_path.rs
+++ b/tests/e2e_remote_happy_path.rs
@@ -130,6 +130,7 @@ fn run_service_add_remote(control_dir: &Path, service_dir: &Path) -> anyhow::Res
             RUNTIME_SERVICE_ADD_ROLE_ID,
             "--approle-secret-id",
             RUNTIME_SERVICE_ADD_SECRET_ID,
+            "--no-wrap",
         ])
         .output()
         .context("run bootroot service add")?;
@@ -409,24 +410,10 @@ async fn stub_control_plane_approle(server: &MockServer, role_name: &str) {
         .mount(server)
         .await;
 
+    // Unwrapped secret_id creation (--no-wrap path)
     Mock::given(method("POST"))
         .and(path(format!("/v1/auth/approle/role/{role_name}/secret-id")))
         .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
-        .and(header_exists("X-Vault-Wrap-TTL"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "wrap_info": {
-                "token": "wrap-token-edge-proxy",
-                "ttl": 1800,
-                "creation_time": "2026-04-12T00:00:00Z",
-                "creation_path": format!("auth/approle/role/{role_name}/secret-id")
-            }
-        })))
-        .mount(server)
-        .await;
-
-    Mock::given(method("POST"))
-        .and(path("/v1/sys/wrapping/unwrap"))
-        .and(header("X-Vault-Token", "wrap-token-edge-proxy"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "data": {
                 "secret_id": "secret-edge-proxy",
@@ -555,4 +542,449 @@ async fn stub_remote_service_secrets(server: &MockServer) {
         })))
         .mount(server)
         .await;
+}
+
+// ---------------------------------------------------------------------------
+// Wrapped artifact test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_remote_bootstrap_wrapped_artifact_path() {
+    let temp = tempdir().expect("create tempdir");
+    let control_dir = temp.path().join("ctrl-w");
+    let service_dir = temp.path().join("svc-w");
+    fs::create_dir_all(&control_dir).expect("create control dir");
+    fs::create_dir_all(&service_dir).expect("create service dir");
+
+    let server = MockServer::start().await;
+    stub_wrapped_control_plane(&server).await;
+    stub_wrapped_remote_service_secrets(&server).await;
+
+    write_control_state(&control_dir, &server.uri()).expect("write control state");
+    prepare_service_node_files(&service_dir).expect("prepare service node files");
+
+    run_service_add_remote_wrapped(&control_dir, &service_dir).expect("service add remote");
+
+    let artifact_path = control_dir
+        .join("secrets")
+        .join("remote-bootstrap")
+        .join("services")
+        .join(SERVICE_NAME)
+        .join("bootstrap.json");
+    assert!(artifact_path.exists(), "artifact must exist");
+
+    let artifact_content = fs::read_to_string(&artifact_path).expect("read artifact");
+    let artifact_json: serde_json::Value =
+        serde_json::from_str(&artifact_content).expect("parse artifact");
+    assert!(
+        artifact_json.get("wrap_token").is_some(),
+        "artifact must contain wrap_token"
+    );
+
+    copy_role_id_only(&control_dir, &service_dir).expect("copy role_id");
+    let svc_artifact = service_dir.join("bootstrap.json");
+    fs::copy(&artifact_path, &svc_artifact).expect("copy artifact");
+
+    run_remote_bootstrap_with_artifact(&service_dir, &svc_artifact)
+        .expect("remote bootstrap with artifact");
+
+    let secret_id_path = service_dir
+        .join("secrets")
+        .join("services")
+        .join(SERVICE_NAME)
+        .join("secret_id");
+    assert!(secret_id_path.exists(), "secret_id must be unwrapped");
+    let sid = fs::read_to_string(&secret_id_path).expect("read secret_id");
+    assert_eq!(sid, "secret-edge-proxy");
+    assert_mode(&secret_id_path, 0o600);
+}
+
+fn run_service_add_remote_wrapped(control_dir: &Path, service_dir: &Path) -> anyhow::Result<()> {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(control_dir)
+        .args([
+            "service",
+            "add",
+            "--service-name",
+            SERVICE_NAME,
+            "--deploy-type",
+            "daemon",
+            "--delivery-mode",
+            "remote-bootstrap",
+            "--hostname",
+            HOSTNAME,
+            "--domain",
+            DOMAIN,
+            "--agent-config",
+            service_dir.join("agent.toml").to_string_lossy().as_ref(),
+            "--cert-path",
+            service_dir
+                .join("certs")
+                .join("edge-proxy.crt")
+                .to_string_lossy()
+                .as_ref(),
+            "--key-path",
+            service_dir
+                .join("certs")
+                .join("edge-proxy.key")
+                .to_string_lossy()
+                .as_ref(),
+            "--instance-id",
+            INSTANCE_ID,
+            "--auth-mode",
+            "approle",
+            "--approle-role-id",
+            RUNTIME_SERVICE_ADD_ROLE_ID,
+            "--approle-secret-id",
+            RUNTIME_SERVICE_ADD_SECRET_ID,
+        ])
+        .output()
+        .context("run bootroot service add wrapped")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "service add (wrapped) failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn copy_role_id_only(control_dir: &Path, service_dir: &Path) -> anyhow::Result<()> {
+    let ctrl_service = control_dir
+        .join("secrets")
+        .join("services")
+        .join(SERVICE_NAME);
+    let svc_secret = service_dir
+        .join("secrets")
+        .join("services")
+        .join(SERVICE_NAME);
+    fs::create_dir_all(&svc_secret).context("create service secret dir")?;
+    fs::copy(ctrl_service.join("role_id"), svc_secret.join("role_id")).context("copy role_id")?;
+    Ok(())
+}
+
+fn run_remote_bootstrap_with_artifact(
+    service_dir: &Path,
+    artifact_path: &Path,
+) -> anyhow::Result<()> {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot-remote"))
+        .current_dir(service_dir)
+        .args([
+            "bootstrap",
+            "--artifact",
+            artifact_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .context("run bootroot-remote bootstrap --artifact")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "remote bootstrap (artifact) failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+async fn stub_wrapped_control_plane(server: &MockServer) {
+    let role_name = format!("bootroot-service-{SERVICE_NAME}");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/auth/approle/login"))
+        .and(body_json(json!({
+            "role_id": RUNTIME_SERVICE_ADD_ROLE_ID,
+            "secret_id": RUNTIME_SERVICE_ADD_SECRET_ID
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "auth": { "client_token": RUNTIME_CLIENT_TOKEN }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/sys/auth"))
+        .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "approle/": {} }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/sys/policies/acl/{role_name}")))
+        .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/auth/approle/role/{role_name}")))
+        .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/auth/approle/role/{role_name}/role-id")))
+        .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "role_id": "role-edge-proxy" }
+        })))
+        .mount(server)
+        .await;
+
+    // Wrapped secret_id creation (default wrapping)
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/auth/approle/role/{role_name}/secret-id")))
+        .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
+        .and(header_exists("X-Vault-Wrap-TTL"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "wrap_info": {
+                "token": "wrap-token-edge-proxy",
+                "ttl": 1800,
+                "creation_time": "2026-04-12T00:00:00Z",
+                "creation_path": format!("auth/approle/role/{role_name}/secret-id")
+            }
+        })))
+        .mount(server)
+        .await;
+
+    stub_control_plane_global_materials(server).await;
+    stub_control_plane_service_material_writes(server).await;
+}
+
+async fn stub_wrapped_remote_service_secrets(server: &MockServer) {
+    // Unwrap call on the remote side
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .and(header("X-Vault-Token", "wrap-token-edge-proxy"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "secret_id": "secret-edge-proxy",
+                "secret_id_accessor": "acc"
+            }
+        })))
+        .mount(server)
+        .await;
+
+    // AppRole login on the remote side (after unwrap writes secret_id)
+    Mock::given(method("POST"))
+        .and(path("/v1/auth/approle/login"))
+        .and(body_json(json!({
+            "role_id": "role-edge-proxy",
+            "secret_id": "secret-edge-proxy"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "auth": { "client_token": "remote-token" }
+        })))
+        .mount(server)
+        .await;
+
+    // KV reads on the remote side (skip secret_id since wrapped)
+    Mock::given(method("GET"))
+        .and(path("/v1/secret/data/bootroot/services/edge-proxy/eab"))
+        .and(header("X-Vault-Token", "remote-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "data": { "kid": "remote-kid", "hmac": "remote-hmac" } }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/v1/secret/data/bootroot/services/edge-proxy/http_responder_hmac",
+        ))
+        .and(header("X-Vault-Token", "remote-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "data": { "hmac": "remote-responder-hmac" } }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/secret/data/bootroot/services/edge-proxy/trust"))
+        .and(header("X-Vault-Token", "remote-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "data": {
+                "trusted_ca_sha256": ["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"],
+                "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nREMOTE\n-----END CERTIFICATE-----"
+            } }
+        })))
+        .mount(server)
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// Unwrap failure tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_remote_bootstrap_wrap_token_expired() {
+    let temp = tempdir().expect("create tempdir");
+    let service_dir = temp.path().join("svc-exp");
+    fs::create_dir_all(&service_dir).expect("create service dir");
+
+    let server = MockServer::start().await;
+
+    // Stub the unwrap endpoint to return 400 (invalid/expired token)
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(
+                json!({"errors": ["wrapping token is not valid or does not exist"]}),
+            ),
+        )
+        .mount(&server)
+        .await;
+
+    let svc_secret_dir = service_dir
+        .join("secrets")
+        .join("services")
+        .join(SERVICE_NAME);
+    fs::create_dir_all(&svc_secret_dir).expect("create secret dir");
+    fs::write(svc_secret_dir.join("role_id"), "role-edge-proxy").expect("write role_id");
+
+    // Use epoch 1000 (clearly in the past)
+    let artifact = json!({
+        "schema_version": 1,
+        "openbao_url": server.uri(),
+        "kv_mount": "secret",
+        "service_name": SERVICE_NAME,
+        "role_id_path": svc_secret_dir.join("role_id").to_string_lossy(),
+        "secret_id_path": svc_secret_dir.join("secret_id").to_string_lossy(),
+        "eab_file_path": svc_secret_dir.join("eab.json").to_string_lossy(),
+        "agent_config_path": service_dir.join("agent.toml").to_string_lossy(),
+        "ca_bundle_path": service_dir.join("certs").join("ca-bundle.pem").to_string_lossy(),
+        "openbao_agent_config_path": "",
+        "openbao_agent_template_path": "",
+        "openbao_agent_token_path": "",
+        "agent_email": "admin@example.com",
+        "agent_server": "https://localhost:9000/acme/acme/directory",
+        "agent_domain": DOMAIN,
+        "agent_responder_url": "http://127.0.0.1:8080",
+        "profile_hostname": HOSTNAME,
+        "profile_instance_id": INSTANCE_ID,
+        "profile_cert_path": service_dir.join("certs").join("edge-proxy.crt").to_string_lossy(),
+        "profile_key_path": service_dir.join("certs").join("edge-proxy.key").to_string_lossy(),
+        "wrap_token": "expired-wrap-token",
+        "wrap_expires_at": "1000",
+    });
+    let artifact_path = service_dir.join("bootstrap.json");
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&artifact).unwrap(),
+    )
+    .expect("write artifact");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot-remote"))
+        .current_dir(&service_dir)
+        .args([
+            "bootstrap",
+            "--artifact",
+            artifact_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("run bootroot-remote");
+
+    assert!(
+        !output.status.success(),
+        "should fail with expired wrap token"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("expired"),
+        "should mention expired: {stderr}"
+    );
+    assert!(
+        stderr.contains("bootroot rotate approle-secret-id"),
+        "should include recovery command: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn test_remote_bootstrap_wrap_token_already_unwrapped() {
+    let temp = tempdir().expect("create tempdir");
+    let service_dir = temp.path().join("svc-used");
+    fs::create_dir_all(&service_dir).expect("create service dir");
+
+    let server = MockServer::start().await;
+
+    // Stub the unwrap endpoint to return 400 (already consumed)
+    Mock::given(method("POST"))
+        .and(path("/v1/sys/wrapping/unwrap"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(
+                json!({"errors": ["wrapping token is not valid or does not exist"]}),
+            ),
+        )
+        .mount(&server)
+        .await;
+
+    let svc_secret_dir = service_dir
+        .join("secrets")
+        .join("services")
+        .join(SERVICE_NAME);
+    fs::create_dir_all(&svc_secret_dir).expect("create secret dir");
+    fs::write(svc_secret_dir.join("role_id"), "role-edge-proxy").expect("write role_id");
+
+    // Use a future epoch so the token "should" still be valid
+    let future_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 3600;
+
+    let artifact = json!({
+        "schema_version": 1,
+        "openbao_url": server.uri(),
+        "kv_mount": "secret",
+        "service_name": SERVICE_NAME,
+        "role_id_path": svc_secret_dir.join("role_id").to_string_lossy(),
+        "secret_id_path": svc_secret_dir.join("secret_id").to_string_lossy(),
+        "eab_file_path": svc_secret_dir.join("eab.json").to_string_lossy(),
+        "agent_config_path": service_dir.join("agent.toml").to_string_lossy(),
+        "ca_bundle_path": service_dir.join("certs").join("ca-bundle.pem").to_string_lossy(),
+        "openbao_agent_config_path": "",
+        "openbao_agent_template_path": "",
+        "openbao_agent_token_path": "",
+        "agent_email": "admin@example.com",
+        "agent_server": "https://localhost:9000/acme/acme/directory",
+        "agent_domain": DOMAIN,
+        "agent_responder_url": "http://127.0.0.1:8080",
+        "profile_hostname": HOSTNAME,
+        "profile_instance_id": INSTANCE_ID,
+        "profile_cert_path": service_dir.join("certs").join("edge-proxy.crt").to_string_lossy(),
+        "profile_key_path": service_dir.join("certs").join("edge-proxy.key").to_string_lossy(),
+        "wrap_token": "already-used-wrap-token",
+        "wrap_expires_at": future_epoch.to_string(),
+    });
+    let artifact_path = service_dir.join("bootstrap.json");
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&artifact).unwrap(),
+    )
+    .expect("write artifact");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot-remote"))
+        .current_dir(&service_dir)
+        .args([
+            "bootstrap",
+            "--artifact",
+            artifact_path.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("run bootroot-remote");
+
+    assert!(
+        !output.status.success(),
+        "should fail with already-unwrapped token"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SECURITY WARNING"),
+        "should flag security incident: {stderr}"
+    );
+    assert!(
+        stderr.contains("already been unwrapped"),
+        "should mention already unwrapped: {stderr}"
+    );
 }

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -677,30 +677,19 @@ async fn stub_service_add_openbao(server: &MockServer) {
         .mount(server)
         .await;
 
+    // Plain secret_id creation (local-file delivery does not use wrapping).
+    // Priority 10 (lower than default 5) so that wrapped mocks mounted by
+    // rotation stubs take precedence when both would match.
     Mock::given(method("POST"))
         .and(path(format!("/v1/auth/approle/role/{ROLE_NAME}/secret-id")))
         .and(header("X-Vault-Token", RUNTIME_CLIENT_TOKEN))
-        .and(header_exists("X-Vault-Wrap-TTL"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "wrap_info": {
-                "token": "wrap-token-initial",
-                "ttl": 1800,
-                "creation_time": "2026-04-12T00:00:00Z",
-                "creation_path": format!("auth/approle/role/{ROLE_NAME}/secret-id")
-            }
-        })))
-        .mount(server)
-        .await;
-
-    Mock::given(method("POST"))
-        .and(path("/v1/sys/wrapping/unwrap"))
-        .and(header("X-Vault-Token", "wrap-token-initial"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "data": {
                 "secret_id": "secret-initial",
                 "secret_id_accessor": "acc"
             }
         })))
+        .with_priority(10)
         .mount(server)
         .await;
 


### PR DESCRIPTION
## Summary

- Adds `wrap_token` and `wrap_expires_at` fields to `RemoteBootstrapArtifact`, making the bootstrap artifact carry the wrapped secret_id instead of requiring a separate file transfer.
- Introduces `--artifact <path>` flag for `bootroot-remote bootstrap` that loads the JSON artifact directly, avoiding sensitive values in CLI args and `ps` output. Per-field flags remain for backward compatibility.
- Implements the unwrap-before-login sequence in `bootroot-remote`: detect wrap fields, call `sys/wrapping/unwrap`, write `secret_id` to disk with `0600` permissions, then proceed with AppRole login.
- Distinguishes two unwrap failure cases: expired tokens show recovery instructions (`bootroot rotate approle-secret-id`), while already-unwrapped tokens flag a potential security incident.
- Adds `create_secret_id_wrap_only` to `OpenBaoClient` for forwarding wrap tokens without unwrapping server-side.
- Wires wrapped secret_id issuance into the idempotent rerun path (`run_service_add_remote_idempotent`) so re-running `service add` with matching parameters regenerates both the wrap token and artifact.
- Local-file delivery mode now skips wrapping entirely (wrapping only applies to remote-bootstrap).
- Skips KV secret_id write when wrapping is active (the remote node obtains it via unwrap instead).
- Fixes E2E lifecycle scripts (`run-remote-lifecycle.sh`, `run-local-lifecycle.sh`, `run-ca-key-rotation-recovery.sh`) to regenerate bootstrap artifacts before each post-rotation re-bootstrap, since wrap tokens are single-use and the old artifact's token is consumed during the initial bootstrap.
- Removes `--secret-id-num-uses` from the service-add CLI. Service SecretIDs always use unlimited uses (`num_uses=0`) because local-file services need repeated OpenBao Agent re-authentication and remote-bootstrap services may need repeated recovery flows. The lower-level `SecretIdOptions.num_uses` is retained for non-service workflows.

Part of #490

## Test plan

- [ ] `test_remote_bootstrap_wrapped_artifact_path` — full E2E: service add with wrapping -> artifact contains `wrap_token` -> remote bootstrap via `--artifact` -> secret_id unwrapped and written
- [ ] `test_remote_bootstrap_wrap_token_expired` — expired wrap token produces recovery message with `bootroot rotate approle-secret-id` command
- [ ] `test_remote_bootstrap_wrap_token_already_unwrapped` — already-unwrapped token produces `SECURITY WARNING` message
- [ ] Existing `test_remote_bootstrap_happy_path` still passes (backward-compatible `--no-wrap` per-flag invocation)
- [ ] `test_e2e_same_host_local_file_lifecycle` passes (local-file delivery skips wrapping)
- [ ] Unit tests for `is_wrap_token_expired`, `build_artifact` with/without wrap info, `render_remote_run_command` with wrapped artifact
- [ ] `secret_id_file_check_skipped_when_wrap_token_present` — validation allows missing secret_id file when wrap token is present
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] Docker E2E matrix (remote-hosts, remote-no-hosts, local-hosts, local-no-hosts) passes
- [ ] E2E extended (ca-key-rotation-recovery) passes