### PR TITLE
Add TTL rotation cadence guidance and warnings (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Added rotation cadence guidance to `service add`, `service update`,
+  and `init` CLI output. `init` always prints the rotation-cadence
+  note; `service add` and `service update` print it when
+  `--secret-id-ttl` is set explicitly. Documented the default vs
+  recommended TTL model and the rotation cadence rule in the
+  operations guide.
 - Changed idempotent `bootroot service add` rerun behavior for
   `remote-bootstrap` mode: when wrapping is enabled (the default), a
   rerun now issues a fresh `secret_id` with wrapping and regenerates

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -222,11 +222,16 @@ Input priority is **CLI flags > environment variables > prompts/defaults**.
 - `--stepca-url`: step-ca URL (default `https://localhost:9000`)
 - `--stepca-provisioner`: step-ca ACME provisioner name (default `acme`)
 - `--secret-id-ttl`: role-level `secret_id` TTL for AppRole roles
-  created during init (default `24h`). Values above the recommended
-  threshold of `48h` emit a warning. Values above the hard maximum of
-  `168h` are rejected. Per-service overrides can be set later with
+  created during init (default `24h`). Set this to at least 2× your
+  planned rotation interval so that a missed run does not expire
+  credentials. `24h` is the security-conservative default; use `48h` or
+  longer when operational slack is more important than minimising
+  exposure. Values above `48h` emit a warning; values above `168h` are
+  rejected. A rotation-cadence reminder is always printed to stderr.
+  Per-service overrides can be set later with
   `bootroot service add --secret-id-ttl` or
   `bootroot service update --secret-id-ttl`.
+  See [Operations > SecretID TTL and rotation cadence](operations.md#secretid-ttl-and-rotation-cadence).
 - `--eab-kid`, `--eab-hmac`: manual EAB input
   (environment variables: `EAB_KID`, `EAB_HMAC`)
 
@@ -531,7 +536,8 @@ also forwarded to `bootroot-remote bootstrap` for the
 Per-issuance `secret_id` policy flags:
 
 - `--secret-id-ttl`: TTL for the generated `secret_id` (inherits the
-  role-level default when omitted)
+  role-level default when omitted). Should be at least 2× the rotation
+  interval
 - `--secret-id-wrap-ttl`: response-wrapping TTL for the `secret_id`
   (default `30m`)
 - `--no-wrap`: disable response wrapping for the `secret_id`
@@ -584,7 +590,7 @@ full `service add` flow. At least one policy flag is required.
 - `--service-name`: service name identifier
 - `--secret-id-ttl`: TTL for the generated `secret_id` (use `"inherit"`
   to clear the per-service override and fall back to the role-level
-  default)
+  default). Should be at least 2× the rotation interval
 - `--secret-id-wrap-ttl`: response-wrapping TTL for the `secret_id`
   (use `"inherit"` to restore default wrapping behavior)
 - `--no-wrap`: disable response wrapping for the `secret_id`

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -159,6 +159,52 @@ Persistent=true
 WantedBy=timers.target
 ```
 
+## SecretID TTL and rotation cadence
+
+Service AppRole `secret_id` values are reusable runtime credentials. They
+survive normal restarts and re-authentication until the next planned
+rotation. The `secret_id_ttl` controls how long a SecretID remains valid
+after issuance.
+
+**Default TTL model:**
+
+- `24h` is the role-level default set during `bootroot init`. This is the
+  security-conservative choice: a shorter lifetime limits exposure when a
+  SecretID leaks.
+- `48h` (`RECOMMENDED_SECRET_ID_TTL`) is the CLI warning threshold. Values
+  above `48h` emit a CLI warning; values above `168h` (7 days) are rejected.
+  Use `48h` or longer when surviving missed rotation runs, maintenance
+  windows, and restart recovery is more important than minimising the
+  exposure window.
+
+**Rotation cadence rule:**
+
+Set the `secret_id_ttl` to at least **2× your rotation interval**. This
+buffer ensures that a single missed or delayed rotation run does not expire
+credentials and leave services unable to re-authenticate.
+
+| Rotation interval | Minimum recommended TTL |
+|-------------------|-------------------------|
+| 8h                | 16h                     |
+| 12h               | 24h (default)           |
+| 24h               | 48h                     |
+
+For example, with a 12-hour rotation schedule, the default `24h` TTL
+provides exactly one missed-run buffer. If your automation cannot
+guarantee timely execution, increase the TTL or shorten the rotation
+interval.
+
+**Per-service overrides:**
+
+- `bootroot service add --secret-id-ttl 48h` sets the TTL at issuance time.
+- `bootroot service update --secret-id-ttl 48h` changes the stored policy
+  (run `bootroot rotate approle-secret-id` afterward to apply).
+- Use `--secret-id-ttl inherit` to clear a per-service override and fall
+  back to the role-level default.
+
+When `--secret-id-ttl` is omitted during `service add`, the service
+inherits the role-level TTL configured during `bootroot init`.
+
 ## Updating service secret_id policy
 
 Use `bootroot service update` to change per-service `secret_id` policy

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -211,10 +211,16 @@ OpenBao 초기화/언실/정책/AppRole 구성, step-ca 초기화, 시크릿 등
 - `--stepca-url`: step-ca URL (기본값 `https://localhost:9000`)
 - `--stepca-provisioner`: step-ca ACME provisioner 이름 (기본값 `acme`)
 - `--secret-id-ttl`: 초기화 중 생성되는 AppRole 역할의 역할 수준
-  `secret_id` TTL (기본값 `24h`). 권장 임계값 `48h`를 초과하면 경고를
-  출력합니다. 하드 상한 `168h`를 초과하면 거부합니다. 서비스별
-  오버라이드는 이후 `bootroot service add --secret-id-ttl` 또는
+  `secret_id` TTL (기본값 `24h`). 계획된 회전 주기의 최소 2배 이상으로
+  설정하여 누락된 실행이 자격증명을 만료시키지 않도록 하세요. `24h`는
+  보안 보수적 기본값이며, 운영 여유가 노출 최소화보다 중요할 때 `48h`
+  이상을 사용하세요. `48h` 초과 시 경고를 출력하고, `168h` 초과 시
+  거부합니다. 회전 주기 안내가 항상 stderr에 출력됩니다.
+  서비스별 오버라이드는 이후
+  `bootroot service add --secret-id-ttl` 또는
   `bootroot service update --secret-id-ttl`로 설정할 수 있습니다.
+  [운영 > SecretID TTL과 회전 주기](operations.md#secretid-ttl)를
+  참고하세요.
 - `--eab-kid`, `--eab-hmac`: 수동 EAB 입력
   (환경 변수: `EAB_KID`, `EAB_HMAC`)
 
@@ -512,7 +518,8 @@ bootroot status
 
 발급 시점 `secret_id` 정책 플래그:
 
-- `--secret-id-ttl`: 생성되는 `secret_id`의 TTL (생략 시 역할 수준 기본값 상속)
+- `--secret-id-ttl`: 생성되는 `secret_id`의 TTL (생략 시 역할 수준 기본값
+  상속). 회전 주기의 최소 2배 이상이어야 합니다
 - `--secret-id-wrap-ttl`: `secret_id`에 대한 응답 래핑 TTL (기본값 `30m`)
 - `--no-wrap`: `secret_id` 응답 래핑 비활성화
 
@@ -560,7 +567,8 @@ bootroot status
 
 - `--service-name`: 서비스 이름 식별자
 - `--secret-id-ttl`: 생성되는 `secret_id`의 TTL (서비스별 오버라이드를
-  지우고 역할 수준 기본값으로 되돌리려면 `"inherit"` 사용)
+  지우고 역할 수준 기본값으로 되돌리려면 `"inherit"` 사용). 회전 주기의
+  최소 2배 이상이어야 합니다
 - `--secret-id-wrap-ttl`: `secret_id`의 응답 래핑 TTL (기본 래핑 동작을
   복원하려면 `"inherit"` 사용)
 - `--no-wrap`: `secret_id`의 응답 래핑 비활성화

--- a/docs/ko/operations.md
+++ b/docs/ko/operations.md
@@ -153,6 +153,48 @@ Persistent=true
 WantedBy=timers.target
 ```
 
+## SecretID TTL과 회전 주기
+
+서비스 AppRole `secret_id` 값은 재사용 가능한 런타임 자격증명입니다.
+정상적인 재시작과 재인증을 거쳐 다음 계획된 회전까지 유효합니다.
+`secret_id_ttl`은 발급 후 SecretID가 유효한 기간을 제어합니다.
+
+**기본 TTL 모델:**
+
+- `24h`는 `bootroot init` 시 설정되는 역할 수준 기본값입니다. 보안
+  보수적 선택으로, 짧은 수명은 SecretID 유출 시 노출을 제한합니다.
+- `48h`(`RECOMMENDED_SECRET_ID_TTL`)는 CLI 경고 임계값입니다. `48h` 초과
+  시 CLI 경고가 표시되며, `168h`(7일) 초과 시 거부됩니다. 누락된 회전
+  실행, 유지보수 기간, 재시작 복구를 견디는 것이 노출 창 최소화보다
+  중요할 때 `48h` 이상을 사용하세요.
+
+**회전 주기 규칙:**
+
+`secret_id_ttl`을 **회전 주기의 최소 2배** 이상으로 설정하세요. 이
+여유는 단일 누락 또는 지연된 회전 실행이 자격증명을 만료시켜 서비스가
+재인증할 수 없는 상황을 방지합니다.
+
+| 회전 주기 | 최소 권장 TTL   |
+|-----------|-----------------|
+| 8시간     | 16시간          |
+| 12시간    | 24시간 (기본값) |
+| 24시간    | 48시간          |
+
+예를 들어, 12시간 회전 스케줄에서 기본 `24h` TTL은 정확히 한 번의 누락
+버퍼를 제공합니다. 자동화가 적시 실행을 보장할 수 없다면 TTL을 늘리거나
+회전 주기를 줄이세요.
+
+**서비스별 재정의:**
+
+- `bootroot service add --secret-id-ttl 48h`는 발급 시 TTL을 설정합니다.
+- `bootroot service update --secret-id-ttl 48h`는 저장된 정책을
+  변경합니다(이후 `bootroot rotate approle-secret-id` 실행 필요).
+- `--secret-id-ttl inherit`를 사용하면 서비스별 재정의를 지우고 역할
+  수준 기본값으로 복원합니다.
+
+`service add` 시 `--secret-id-ttl`을 생략하면 `bootroot init` 시
+설정된 역할 수준 TTL을 상속합니다.
+
 ## 서비스 secret_id 정책 변경
 
 `bootroot service update`를 사용하면 `service add`를 다시 실행하지 않고

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -546,7 +546,9 @@ pub(crate) struct InitArgs {
     #[arg(long, env = "OPENBAO_UNSEAL_FILE")]
     pub(crate) openbao_unseal_from_file: Option<PathBuf>,
 
-    /// Role-level `secret_id` TTL for `AppRole` roles created during init
+    /// Role-level `secret_id` TTL for `AppRole` roles created during init.
+    /// Set this to at least 2× your planned rotation interval so that a
+    /// missed or delayed run does not expire credentials
     #[arg(long, default_value = SECRET_ID_TTL)]
     pub(crate) secret_id_ttl: String,
 
@@ -708,7 +710,8 @@ pub(crate) struct ServiceAddArgs {
     #[arg(long, value_enum)]
     pub(crate) post_renew_on_failure: Option<HookFailurePolicyArg>,
 
-    /// TTL for the generated `secret_id` (inherits role default when omitted)
+    /// TTL for the generated `secret_id` (inherits role default when omitted).
+    /// Should be at least 2× the rotation interval
     #[arg(long)]
     pub(crate) secret_id_ttl: Option<String>,
 
@@ -734,7 +737,8 @@ pub(crate) struct ServiceUpdateArgs {
     #[arg(long, required = true)]
     pub(crate) service_name: String,
 
-    /// TTL for the generated `secret_id` (use "inherit" to clear override)
+    /// TTL for the generated `secret_id` (use "inherit" to clear override).
+    /// Should be at least 2× the rotation interval
     #[arg(long)]
     pub(crate) secret_id_ttl: Option<String>,
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -15,6 +15,6 @@ pub(crate) use constants::{
 pub(crate) use paths::{compose_has_responder, to_container_path};
 pub(crate) use steps::{
     compute_ca_bundle_pem, compute_ca_fingerprints, prompt_yes_no, read_ca_cert_fingerprint,
-    run_init,
+    run_init, validate_secret_id_ttl,
 };
 pub(crate) use types::{DbCheckStatus, InitPlan, InitSummary, ResponderCheck, StepCaInitResult};

--- a/src/commands/init/constants.rs
+++ b/src/commands/init/constants.rs
@@ -41,11 +41,27 @@ pub(crate) mod openbao_constants {
     pub(crate) const INIT_SECRET_SHARES: u8 = 3;
     pub(crate) const INIT_SECRET_THRESHOLD: u8 = 2;
     pub(crate) const TOKEN_TTL: &str = "1h";
+
+    /// Default role-level `secret_id` TTL applied to every `AppRole` created
+    /// during `bootroot init`. This is the security-conservative default:
+    /// a shorter lifetime limits exposure when a `SecretID` leaks.
+    ///
+    /// Operators who rotate on a longer cadence should pass
+    /// `--secret-id-ttl` with a value that is at least 2× their rotation
+    /// interval so that a missed or delayed rotation run does not leave
+    /// services unable to re-authenticate.
     pub(crate) const SECRET_ID_TTL: &str = "24h";
-    // Used by upcoming sub-issues of #480 (response-wrapping).
-    #[allow(dead_code)]
-    pub(crate) const DEFAULT_SECRET_ID_WRAP_TTL: &str = "30m";
+
     pub(crate) const MAX_SECRET_ID_TTL: &str = "168h";
+
+    /// Warning threshold for `secret_id` TTL. Values above this threshold
+    /// trigger a CLI warning but are still accepted (up to
+    /// [`MAX_SECRET_ID_TTL`]).
+    ///
+    /// `24h` is the security-conservative default; use `48h` or longer
+    /// when operational slack (surviving missed rotation runs, maintenance
+    /// windows, restart recovery) is more important than minimising the
+    /// exposure window.
     pub(crate) const RECOMMENDED_SECRET_ID_TTL: &str = "48h";
 
     pub(crate) const POLICY_BOOTROOT_AGENT: &str = "bootroot-agent";

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -14,6 +14,7 @@ use bootroot::openbao::{InitResponse, OpenBaoClient};
 pub(crate) use ca_certs::{
     compute_ca_bundle_pem, compute_ca_fingerprints, read_ca_cert_fingerprint,
 };
+pub(crate) use openbao_setup::validate_secret_id_ttl;
 pub(crate) use orchestrator::run_init;
 pub(crate) use prompts::prompt_yes_no;
 

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -356,7 +356,7 @@ fn parse_ttl_to_secs(ttl: &str) -> Option<u64> {
 /// threshold but is still within the hard maximum, `Ok(None)` when the
 /// value is within both limits, or `Err` when the value is invalid or
 /// exceeds the hard maximum.
-pub(super) fn validate_secret_id_ttl(ttl: &str, messages: &Messages) -> Result<Option<String>> {
+pub(crate) fn validate_secret_id_ttl(ttl: &str, messages: &Messages) -> Result<Option<String>> {
     let secs = parse_ttl_to_secs(ttl)
         .ok_or_else(|| anyhow::anyhow!(messages.error_secret_id_ttl_invalid(ttl)))?;
     let max_secs =

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -37,6 +37,7 @@ pub(crate) async fn run_init(args: &InitArgs, messages: &Messages) -> Result<()>
     if let Some(warning) = validate_secret_id_ttl(&args.secret_id_ttl, messages)? {
         eprintln!("{warning}");
     }
+    eprintln!("{}", messages.hint_secret_id_ttl_rotation_cadence());
 
     ensure_all_services_localhost_binding(&args.compose.compose_file, messages)?;
     // Only check openbao + postgres; step-ca may not be bootstrapped yet.

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -16,6 +16,7 @@ use crate::cli::output::{
 };
 use crate::commands::constants::DEFAULT_SECRET_ID_WRAP_TTL;
 use crate::commands::dns_alias::register_dns_alias;
+use crate::commands::init::validate_secret_id_ttl;
 use crate::commands::openbao_auth::authenticate_openbao_client;
 use crate::i18n::Messages;
 use crate::state::{DeliveryMode, ServiceEntry, ServiceRoleEntry, StateFile};
@@ -83,6 +84,13 @@ pub(crate) async fn run_service_add(args: &ServiceAddArgs, messages: &Messages) 
     let resolved = resolve::resolve_service_add_args(args, messages, preview)?;
 
     resolve::validate_service_add(&resolved, messages)?;
+
+    if let Some(ref ttl) = resolved.secret_id_ttl {
+        if let Some(warning) = validate_secret_id_ttl(ttl, messages)? {
+            eprintln!("{warning}");
+        }
+        eprintln!("{}", messages.hint_secret_id_ttl_rotation_cadence());
+    }
 
     let agent_config = resolved.agent_config.display().to_string();
     let cert_path = resolved.cert_path.display().to_string();
@@ -517,11 +525,16 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
 
     let mut changes: Vec<String> = Vec::new();
 
+    let mut explicit_ttl_set = false;
     if let Some(ref new_ttl) = args.secret_id_ttl {
         let old_value = entry.approle.secret_id_ttl.clone();
         if new_ttl.eq_ignore_ascii_case(INHERIT_SENTINEL) {
             entry.approle.secret_id_ttl = None;
         } else {
+            if let Some(warning) = validate_secret_id_ttl(new_ttl, messages)? {
+                eprintln!("{warning}");
+            }
+            explicit_ttl_set = true;
             entry.approle.secret_id_ttl = Some(new_ttl.clone());
         }
         if old_value != entry.approle.secret_id_ttl {
@@ -557,6 +570,10 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
                 &display_wrap_ttl(entry.approle.secret_id_wrap_ttl.as_deref(), messages),
             ));
         }
+    }
+
+    if explicit_ttl_set {
+        eprintln!("{}", messages.hint_secret_id_ttl_rotation_cadence());
     }
 
     if changes.is_empty() {

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -414,6 +414,7 @@ pub(crate) struct Strings {
     pub(crate) service_update_summary: &'static str,
     pub(crate) service_update_field_changed: &'static str,
     pub(crate) service_update_rotate_hint: &'static str,
+    pub(crate) hint_secret_id_ttl_rotation_cadence: &'static str,
     pub(crate) service_info_secret_id_ttl: &'static str,
     pub(crate) service_info_secret_id_wrap_ttl: &'static str,
     pub(crate) policy_label_inherit: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -379,6 +379,7 @@ pub(super) static STRINGS: Strings = Strings {
     service_update_summary: "bootroot service update: summary",
     service_update_field_changed: "- {field}: {old} -> {new}",
     service_update_rotate_hint: "Run `bootroot rotate approle-secret-id` for the new policy to take effect.",
+    hint_secret_id_ttl_rotation_cadence: "NOTE: Ensure the secret_id TTL is at least 2× your rotation interval. For example, with a 12h rotation schedule, use a TTL of 24h or more. This buffer accounts for missed runs, maintenance windows, and restart recovery.",
     service_info_secret_id_ttl: "- secret_id TTL: {value}",
     service_info_secret_id_wrap_ttl: "- secret_id wrap TTL: {value}",
     policy_label_inherit: "inherit",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -379,6 +379,7 @@ pub(super) static STRINGS: Strings = Strings {
     service_update_summary: "bootroot service update: 요약",
     service_update_field_changed: "- {field}: {old} -> {new}",
     service_update_rotate_hint: "새로운 정책을 적용하려면 `bootroot rotate approle-secret-id`를 실행하세요.",
+    hint_secret_id_ttl_rotation_cadence: "참고: secret_id TTL은 회전 주기의 최소 2배 이상이어야 합니다. 예를 들어, 12시간 회전 스케줄에는 24시간 이상의 TTL을 사용하세요. 이 여유는 누락된 실행, 유지보수 기간, 재시작 복구를 고려한 것입니다.",
     service_info_secret_id_ttl: "- secret_id TTL: {value}",
     service_info_secret_id_wrap_ttl: "- secret_id wrap TTL: {value}",
     policy_label_inherit: "상속",

--- a/src/i18n/service.rs
+++ b/src/i18n/service.rs
@@ -814,6 +814,10 @@ impl Messages {
         self.strings().service_update_rotate_hint
     }
 
+    pub(crate) fn hint_secret_id_ttl_rotation_cadence(&self) -> &'static str {
+        self.strings().hint_secret_id_ttl_rotation_cadence
+    }
+
     pub(crate) fn service_info_secret_id_ttl(&self, value: &str) -> String {
         format_template(
             self.strings().service_info_secret_id_ttl,

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -2030,6 +2030,101 @@ fn test_service_update_shows_rotate_hint() {
 
 #[cfg(unix)]
 #[test]
+fn test_service_update_shows_ttl_rotation_cadence_hint() {
+    let temp_dir = tempdir().expect("create temp dir");
+    write_state_file(temp_dir.path(), "http://unused:8200").expect("write state.json");
+    write_state_with_app(temp_dir.path());
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "update",
+            "--service-name",
+            "edge-proxy",
+            "--secret-id-ttl",
+            "2h",
+        ])
+        .output()
+        .expect("run service update");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("NOTE: Ensure the secret_id TTL is at least 2"),
+        "should show rotation cadence hint on stderr, got: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_service_update_warns_when_ttl_exceeds_recommended() {
+    let temp_dir = tempdir().expect("create temp dir");
+    write_state_file(temp_dir.path(), "http://unused:8200").expect("write state.json");
+    write_state_with_app(temp_dir.path());
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "update",
+            "--service-name",
+            "edge-proxy",
+            "--secret-id-ttl",
+            "72h",
+        ])
+        .output()
+        .expect("run service update");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("WARNING: --secret-id-ttl (72h) exceeds the recommended threshold"),
+        "should warn about exceeding recommended TTL, got: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_service_update_rejects_ttl_exceeding_max() {
+    let temp_dir = tempdir().expect("create temp dir");
+    write_state_file(temp_dir.path(), "http://unused:8200").expect("write state.json");
+    write_state_with_app(temp_dir.path());
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "update",
+            "--service-name",
+            "edge-proxy",
+            "--secret-id-ttl",
+            "200h",
+        ])
+        .output()
+        .expect("run service update");
+
+    assert!(
+        !output.status.success(),
+        "should fail when TTL exceeds 168h"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("exceeds the maximum allowed value"),
+        "should report TTL exceeds max, got: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_service_update_noop_when_value_unchanged() {
     let temp_dir = tempdir().expect("create temp dir");
     write_state_file(temp_dir.path(), "http://unused:8200").expect("write state.json");
@@ -2060,7 +2155,8 @@ fn test_service_update_noop_when_value_unchanged() {
         "should report no changes when value is already set, got: {stdout}"
     );
 
-    // --secret-id-ttl with same value should also be a no-op
+    // --secret-id-ttl with same value should also be a no-op but still
+    // show the rotation-cadence hint
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
         .args([
@@ -2075,14 +2171,167 @@ fn test_service_update_noop_when_value_unchanged() {
         .expect("run service update");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}",);
+    assert!(
+        stdout.contains("No fields changed"),
+        "should report no changes when TTL is already set, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("NOTE: Ensure the secret_id TTL is at least 2"),
+        "should show rotation cadence hint even when value unchanged, got: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_service_add_print_only_shows_ttl_rotation_cadence_hint() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let agent_config = temp_dir.path().join("agent.toml");
+    let cert_path = temp_dir.path().join("certs").join("edge-proxy.crt");
+    let key_path = temp_dir.path().join("certs").join("edge-proxy.key");
+    fs::create_dir_all(cert_path.parent().expect("cert parent")).expect("create cert dir");
+
+    write_state_file(temp_dir.path(), "http://localhost:8200").expect("write state.json");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "add",
+            "--print-only",
+            "--service-name",
+            "edge-proxy",
+            "--deploy-type",
+            "daemon",
+            "--hostname",
+            "edge-node-01",
+            "--domain",
+            "trusted.domain",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+            "--cert-path",
+            cert_path.to_string_lossy().as_ref(),
+            "--key-path",
+            key_path.to_string_lossy().as_ref(),
+            "--instance-id",
+            "001",
+            "--secret-id-ttl",
+            "2h",
+        ])
+        .output()
+        .expect("run service add");
+
     assert!(
         output.status.success(),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stdout.contains("No fields changed"),
-        "should report no changes when TTL is already set, got: {stdout}"
+        stderr.contains("NOTE: Ensure the secret_id TTL is at least 2"),
+        "should show rotation cadence hint on stderr, got: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_service_add_print_only_warns_when_ttl_exceeds_recommended() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let agent_config = temp_dir.path().join("agent.toml");
+    let cert_path = temp_dir.path().join("certs").join("edge-proxy.crt");
+    let key_path = temp_dir.path().join("certs").join("edge-proxy.key");
+    fs::create_dir_all(cert_path.parent().expect("cert parent")).expect("create cert dir");
+
+    write_state_file(temp_dir.path(), "http://localhost:8200").expect("write state.json");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "add",
+            "--print-only",
+            "--service-name",
+            "edge-proxy",
+            "--deploy-type",
+            "daemon",
+            "--hostname",
+            "edge-node-01",
+            "--domain",
+            "trusted.domain",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+            "--cert-path",
+            cert_path.to_string_lossy().as_ref(),
+            "--key-path",
+            key_path.to_string_lossy().as_ref(),
+            "--instance-id",
+            "001",
+            "--secret-id-ttl",
+            "72h",
+        ])
+        .output()
+        .expect("run service add");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("WARNING: --secret-id-ttl (72h) exceeds the recommended threshold"),
+        "should warn about exceeding recommended TTL, got: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_service_add_print_only_rejects_ttl_exceeding_max() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let agent_config = temp_dir.path().join("agent.toml");
+    let cert_path = temp_dir.path().join("certs").join("edge-proxy.crt");
+    let key_path = temp_dir.path().join("certs").join("edge-proxy.key");
+    fs::create_dir_all(cert_path.parent().expect("cert parent")).expect("create cert dir");
+
+    write_state_file(temp_dir.path(), "http://localhost:8200").expect("write state.json");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "add",
+            "--print-only",
+            "--service-name",
+            "edge-proxy",
+            "--deploy-type",
+            "daemon",
+            "--hostname",
+            "edge-node-01",
+            "--domain",
+            "trusted.domain",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+            "--cert-path",
+            cert_path.to_string_lossy().as_ref(),
+            "--key-path",
+            key_path.to_string_lossy().as_ref(),
+            "--instance-id",
+            "001",
+            "--secret-id-ttl",
+            "200h",
+        ])
+        .output()
+        .expect("run service add");
+
+    assert!(
+        !output.status.success(),
+        "should fail when TTL exceeds 168h"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("exceeds the maximum allowed value"),
+        "should report TTL exceeds max, got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Emit a rotation-cadence reminder (`NOTE`) on every `init` run and when operators pass an explicit `--secret-id-ttl` to `service add` or `service update`, telling them to keep the TTL at least 2× their rotation interval. In `service update`, the NOTE is shown even when the passed value matches the current one (no-op), because the guidance is relevant whenever an operator is thinking about TTL.
- Validate TTL in `service add` / `service update` the same way `init` already does (warn > 48 h, reject > 168 h).
- Add a new "SecretID TTL and rotation cadence" section to the EN/KO operations guide with a cadence-vs-TTL table and per-service override instructions.
- Clarify `RECOMMENDED_SECRET_ID_TTL` as a CLI warning threshold (not an upper bound) in doc comments and the EN/KO operations guide.
- Update CLI reference (EN/KO) with rotation-cadence guidance and cross-links to the operations guide.
- Fix broken Korean anchor in CLI docs: MkDocs strips non-ASCII characters from auto-generated heading anchors, so `#secretid-ttl과-회전-주기` is corrected to `#secretid-ttl`.
- Add integration tests for TTL validation in `service add` (via `--print-only`) and `service update` (rotation-cadence hint, recommended-threshold warning, max-TTL rejection, no-op hint).

Closes #496

## Test plan

- [x] `cargo clippy --all-targets` passes with no warnings
- [x] `cargo fmt -- --check` passes
- [x] `bootroot init` prints the rotation-cadence NOTE
- [x] `bootroot service add --secret-id-ttl 36h` prints the rotation-cadence NOTE
- [x] `bootroot service add` (no `--secret-id-ttl`) does **not** print the NOTE
- [x] `bootroot service update --service-name foo --secret-id-ttl 72h` prints both the >48 h warning and the cadence NOTE
- [x] `bootroot service update --service-name foo --secret-id-ttl <same-value>` still prints the cadence NOTE (no-op path)
- [x] `bootroot service update --service-name foo --secret-id-ttl inherit` does **not** print the cadence NOTE
- [x] `bootroot service update --secret-id-ttl 200h` is rejected (> 168 h hard max)
- [x] `bootroot init --secret-id-ttl 200h` is rejected (> 168 h hard max)
- [x] New integration tests pass (`test_service_update_*` and `test_service_add_print_only_*`)
- [x] Operations guide sections render correctly in MkDocs (`mkdocs build --strict`)
- [x] Korean CLI cross-link to operations guide anchor `#secretid-ttl` resolves