### PR TITLE
Bump rand to 0.10.1 to close Dependabot alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sha2",
  "stringprep",
 ]
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -2181,7 +2181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2338,7 +2338,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.0",
+ "rand 0.10.1",
  "socket2",
  "tokio",
  "tokio-util",


### PR DESCRIPTION
## Summary

- Bumps `rand` from 0.10.0 to 0.10.1 in `Cargo.lock` to close Dependabot alert #9 (GHSA-7rmj-vfwv-23wm — `rand` unsound with a custom logger using `rand::rng()`).
- bootroot does not depend on `rand` directly; it comes in through `tokio-postgres` / `postgres-protocol`, so a lockfile-only bump is sufficient.
- Separately, code scanning alert #59 (`rust/cleartext-logging` on `orchestrator.rs:38`) was dismissed out-of-band as a false positive. The logged value is a TTL duration warning string returned by `validate_secret_id_ttl`, not a secret; CodeQL flagged it only because the function name contains `secret`. No code change is appropriate for that alert.

Closes #505

## Test plan

- [ ] `cargo check --workspace --all-targets` passes locally
- [ ] CI `check`, `test-core`, and Docker E2E matrices pass
- [ ] Dependabot alert #9 auto-closes after merge to `main`