### PR TITLE
Pin OpenBao client TLS to artifact CA anchor (#511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- Bumped `rustls-webpki` from 0.103.10 to 0.103.12 to address
+  RUSTSEC-2026-0098 and RUSTSEC-2026-0099 (incorrect name-constraint
+  validation for URI and wildcard names).
+
 ### Removed
 
 - Removed `--secret-id-num-uses` from `bootroot service add` and from
@@ -37,10 +43,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   obtain `secret_id` before login. Unwrap failures are classified as
   expired (with recovery instructions) or already-unwrapped (flagged as
   a potential security incident).
-- Added `schema_version` field (`u32`, starting at `1`) to the
+- Added `schema_version` field (`u32`, currently `2`) to the
   `RemoteBootstrapArtifact` JSON written by
   `bootroot service add --delivery-mode remote-bootstrap`. Downstream
   parsers should check this field before accessing artifact fields.
+- Added `ca_bundle_pem` field to `RemoteBootstrapArtifact`, embedding
+  the control-plane CA PEM inline. During `bootroot-remote bootstrap`,
+  the PEM is written to `ca_bundle_path` before any OpenBao call and
+  used as the TLS trust anchor for HTTPS `openbao_url` endpoints.
+- Added `OpenBaoClient::with_pem_trust` constructor that anchors TLS
+  verification to an in-memory CA bundle with optional SHA-256 pinning,
+  integrating the same `PinnedCertVerifier` path used by
+  `build_http_client`. `tls::build_http_client_from_pem` now accepts
+  an optional `pins` parameter. `OpenBaoClient::with_client` remains
+  as an escape hatch for callers needing full `reqwest::Client` control.
 - Added remote-bootstrap operator guide (`docs/en/remote-bootstrap.md`,
   `docs/ko/remote-bootstrap.md`) covering transport options (SSH,
   Ansible, cloud-init, systemd-credentials), `secret_id` hygiene,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,9 +1900,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2181,7 +2181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/docs/en/remote-bootstrap.md
+++ b/docs/en/remote-bootstrap.md
@@ -111,7 +111,7 @@ scp -p \
   "$REMOTE_USER@$REMOTE_HOST:$REMOTE_BASE/secrets/services/$SERVICE/"
 
 # 3. Validate schema_version before running bootstrap
-if ! jq -e '.schema_version == 1' "$ARTIFACT" > /dev/null; then
+if ! jq -e '.schema_version == 2' "$ARTIFACT" > /dev/null; then
   echo "ERROR: unsupported schema_version in $ARTIFACT" >&2
   exit 1
 fi
@@ -208,10 +208,10 @@ For larger fleets with existing configuration management.
     - name: Validate schema_version
       ansible.builtin.assert:
         that:
-          - artifact.schema_version == 1
+          - artifact.schema_version == 2
         fail_msg: >-
           Unsupported schema_version {{ artifact.schema_version }};
-          this playbook supports version 1 only.
+          this playbook supports version 2 only.
 
     - name: Ensure secrets directory
       ansible.builtin.file:
@@ -407,7 +407,7 @@ The JSON artifact written to
 `secrets/remote-bootstrap/services/<service>/bootstrap.json` follows a
 versioned schema. Automation should check `schema_version` before parsing.
 
-Current version: **1**
+Current version: **2**
 
 | Field | Type | Description | Consumed by |
 | --- | --- | --- | --- |
@@ -419,7 +419,8 @@ Current version: **1**
 | `secret_id_path` | `string` | Path to AppRole `secret_id` file on the remote host | `--secret-id-path` |
 | `eab_file_path` | `string` | Path to EAB credentials JSON file | `--eab-file-path` |
 | `agent_config_path` | `string` | Path to `agent.toml` on the remote host | `--agent-config-path` |
-| `ca_bundle_path` | `string` | Path to CA trust bundle PEM file | `--ca-bundle-path` |
+| `ca_bundle_path` | `string` | Path to CA trust bundle PEM file on the remote host | `--ca-bundle-path` |
+| `ca_bundle_pem` | `string` | Inline PEM content of the control-plane CA trust anchor. Written to `ca_bundle_path` during bootstrap. When `openbao_url` uses HTTPS, this CA is used as the TLS trust anchor instead of the system trust store. Shared primitive — also consumed by the http01 admin client (#514). | Internal (TLS trust) |
 | `openbao_agent_config_path` | `string` | Path to OpenBao Agent config (HCL) | Internal |
 | `openbao_agent_template_path` | `string` | Path to OpenBao Agent template | Internal |
 | `openbao_agent_token_path` | `string` | Path to OpenBao Agent token file | Internal |
@@ -435,6 +436,13 @@ Current version: **1**
 | `wrap_token` | `string?` | Response-wrapped `secret_id` token (omitted when wrapping is disabled via `--no-wrap`). Sensitive — treat as a credential. | `bootroot-remote` unwrap path |
 | `wrap_expires_at` | `string?` | RFC 3339 timestamp when `wrap_token` expires (omitted when wrapping is disabled). | `bootroot-remote` unwrap error classification |
 
+### Version history
+
+| Version | Change |
+| --- | --- |
+| 2 | Added required `ca_bundle_pem` field (inline PEM of the control-plane CA anchor). |
+| 1 | Initial schema. |
+
 ### Versioning rules
 
 - **Breaking change** (field removed, renamed, or type changed): bump
@@ -443,4 +451,5 @@ Current version: **1**
     no bump required. Existing parsers ignore unknown keys.
 - **Consumer contract**: check `schema_version >= 1` and
     `schema_version <= <max supported>` before accessing fields. Fail
-    explicitly on unsupported versions.
+    explicitly on unsupported versions. `bootroot-remote` enforces this
+    check automatically when using `--artifact`.

--- a/docs/ko/remote-bootstrap.md
+++ b/docs/ko/remote-bootstrap.md
@@ -109,7 +109,7 @@ scp -p \
   "$REMOTE_USER@$REMOTE_HOST:$REMOTE_BASE/secrets/services/$SERVICE/"
 
 # 3. 부트스트랩 전 schema_version 검증
-if ! jq -e '.schema_version == 1' "$ARTIFACT" > /dev/null; then
+if ! jq -e '.schema_version == 2' "$ARTIFACT" > /dev/null; then
   echo "ERROR: $ARTIFACT 의 schema_version이 지원되지 않습니다" >&2
   exit 1
 fi
@@ -205,10 +205,10 @@ ExecStart=/usr/local/bin/bootroot-remote bootstrap \
     - name: schema_version 검증
       ansible.builtin.assert:
         that:
-          - artifact.schema_version == 1
+          - artifact.schema_version == 2
         fail_msg: >-
           지원되지 않는 schema_version {{ artifact.schema_version }};
-          이 플레이북은 버전 1만 지원합니다.
+          이 플레이북은 버전 2만 지원합니다.
 
     - name: 시크릿 디렉터리 생성
       ansible.builtin.file:
@@ -396,7 +396,7 @@ runcmd:
 아티팩트는 버전이 지정된 스키마를 따릅니다. 자동화에서는 파싱 전에
 `schema_version`을 확인해야 합니다.
 
-현재 버전: **1**
+현재 버전: **2**
 
 | 필드 | 타입 | 설명 | 사용처 |
 | --- | --- | --- | --- |
@@ -408,7 +408,8 @@ runcmd:
 | `secret_id_path` | `string` | 원격 호스트의 AppRole `secret_id` 파일 경로 | `--secret-id-path` |
 | `eab_file_path` | `string` | EAB 자격증명 JSON 파일 경로 | `--eab-file-path` |
 | `agent_config_path` | `string` | 원격 호스트의 `agent.toml` 경로 | `--agent-config-path` |
-| `ca_bundle_path` | `string` | CA trust bundle PEM 파일 경로 | `--ca-bundle-path` |
+| `ca_bundle_path` | `string` | 원격 호스트의 CA trust bundle PEM 파일 경로 | `--ca-bundle-path` |
+| `ca_bundle_pem` | `string` | 제어 노드 CA trust 앵커의 인라인 PEM 콘텐츠. 부트스트랩 시 `ca_bundle_path`에 기록됨. `openbao_url`이 HTTPS인 경우 시스템 trust store 대신 이 CA를 TLS trust 앵커로 사용. 공유 프리미티브 — http01 admin 클라이언트(#514)에서도 사용. | 내부 사용 (TLS trust) |
 | `openbao_agent_config_path` | `string` | OpenBao Agent 설정(HCL) 경로 | 내부 사용 |
 | `openbao_agent_template_path` | `string` | OpenBao Agent 템플릿 경로 | 내부 사용 |
 | `openbao_agent_token_path` | `string` | OpenBao Agent 토큰 파일 경로 | 내부 사용 |
@@ -424,6 +425,13 @@ runcmd:
 | `wrap_token` | `string?` | 응답 래핑된 `secret_id` 토큰 (`--no-wrap` 사용 시 생략). 민감 정보 — 자격 증명으로 취급하세요. | `bootroot-remote` 언래핑 경로 |
 | `wrap_expires_at` | `string?` | `wrap_token` 만료 시각 (RFC 3339 형식, 래핑 비활성화 시 생략). | `bootroot-remote` 언래핑 오류 분류 |
 
+### 버전 이력
+
+| 버전 | 변경사항 |
+| --- | --- |
+| 2 | 필수 필드 `ca_bundle_pem` 추가 (제어 노드 CA 앵커의 인라인 PEM). |
+| 1 | 초기 스키마. |
+
 ### 버전 관리 규칙
 
 - **호환성을 깨는 변경** (필드 삭제, 이름 변경, 타입 변경):
@@ -432,4 +440,5 @@ runcmd:
     증가 불필요. 기존 파서는 알 수 없는 키를 무시합니다.
 - **소비자 계약**: 필드에 접근하기 전에 `schema_version >= 1` 및
     `schema_version <= <지원 최대값>`을 확인하세요. 지원되지 않는 버전에서는
-    명시적으로 실패해야 합니다.
+    명시적으로 실패해야 합니다. `bootroot-remote`는 `--artifact` 사용 시
+    이 검사를 자동으로 수행합니다.

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -459,6 +459,7 @@ mod tests {
             profile_cert_path: None,
             profile_key_path: None,
             ca_bundle_path: PathBuf::from("/tmp/ca-bundle.pem"),
+            ca_bundle_pem: None,
             post_renew_command: None,
             post_renew_arg: Vec::new(),
             post_renew_timeout_secs: None,

--- a/src/bin/bootroot-remote/bootstrap.rs
+++ b/src/bin/bootroot-remote/bootstrap.rs
@@ -10,6 +10,42 @@ use super::validation::{
 };
 use super::{Locale, ResolvedBootstrapArgs, localized};
 
+/// Creates an [`OpenBaoClient`] for the given URL, anchoring TLS to the
+/// artifact-embedded CA bundle when the URL uses HTTPS.
+fn build_openbao_client(
+    openbao_url: &str,
+    ca_bundle_pem: Option<&str>,
+    lang: Locale,
+) -> Result<OpenBaoClient> {
+    if openbao_url.starts_with("https://") {
+        let pem = ca_bundle_pem.ok_or_else(|| {
+            anyhow::anyhow!(
+                "{}",
+                localized(
+                    lang,
+                    "HTTPS openbao_url requires ca_bundle_pem in the bootstrap artifact",
+                    "HTTPS openbao_url은 부트스트랩 아티팩트에 ca_bundle_pem이 필요합니다",
+                )
+            )
+        })?;
+        OpenBaoClient::with_pem_trust(openbao_url, pem, &[]).with_context(|| {
+            localized(
+                lang,
+                "Failed to build TLS client from artifact CA bundle",
+                "아티팩트 CA 번들로 TLS 클라이언트를 생성하지 못했습니다",
+            )
+        })
+    } else {
+        OpenBaoClient::new(openbao_url).with_context(|| {
+            localized(
+                lang,
+                "Failed to create OpenBao client",
+                "OpenBao 클라이언트를 생성하지 못했습니다",
+            )
+        })
+    }
+}
+
 /// Errors specific to wrap-token unwrapping.
 #[derive(Debug)]
 enum UnwrapError {
@@ -33,6 +69,27 @@ const OPENBAO_API_ERROR_PREFIX: &str = "OpenBao API error";
 pub(super) async fn run_bootstrap(args: ResolvedBootstrapArgs, lang: Locale) -> Result<i32> {
     validate_bootstrap_args(&args, lang)?;
 
+    // Write the artifact-embedded CA bundle to disk before any OpenBao
+    // call so that downstream consumers find the file even if bootstrap
+    // fails midway.
+    if let Some(pem) = &args.ca_bundle_pem {
+        write_secret_file(&args.ca_bundle_path, pem)
+            .await
+            .with_context(|| {
+                localized(
+                    lang,
+                    &format!(
+                        "Failed to write CA bundle to {}",
+                        args.ca_bundle_path.display()
+                    ),
+                    &format!(
+                        "CA 번들을 {}에 기록하지 못했습니다",
+                        args.ca_bundle_path.display()
+                    ),
+                )
+            })?;
+    }
+
     // When a wrap_token is present in the artifact, unwrap it to obtain
     // the secret_id and write it to the expected file path before login.
     if let Some(wrap_token) = &args.wrap_token {
@@ -42,6 +99,7 @@ pub(super) async fn run_bootstrap(args: ResolvedBootstrapArgs, lang: Locale) -> 
             args.wrap_expires_at.as_deref(),
             &args.secret_id_path,
             &args.service_name,
+            args.ca_bundle_pem.as_deref(),
             lang,
         )
         .await
@@ -82,13 +140,7 @@ pub(super) async fn run_bootstrap(args: ResolvedBootstrapArgs, lang: Locale) -> 
             )
         })?;
 
-    let mut client = OpenBaoClient::new(&args.openbao_url).with_context(|| {
-        localized(
-            lang,
-            "Failed to create OpenBao client",
-            "OpenBao 클라이언트를 생성하지 못했습니다",
-        )
-    })?;
+    let mut client = build_openbao_client(&args.openbao_url, args.ca_bundle_pem.as_deref(), lang)?;
     let token = client
         .login_approle(&role_id, &current_secret_id)
         .await
@@ -164,15 +216,10 @@ async fn unwrap_and_write_secret_id(
     wrap_expires_at: Option<&str>,
     secret_id_path: &std::path::Path,
     service_name: &str,
+    ca_bundle_pem: Option<&str>,
     lang: Locale,
 ) -> Result<()> {
-    let client = OpenBaoClient::new(openbao_url).with_context(|| {
-        localized(
-            lang,
-            "Failed to create OpenBao client for unwrap",
-            "언래핑을 위한 OpenBao 클라이언트를 생성하지 못했습니다",
-        )
-    })?;
+    let client = build_openbao_client(openbao_url, ca_bundle_pem, lang)?;
     match client.unwrap_secret_id(wrap_token).await {
         Ok(secret_id) => {
             write_secret_file(secret_id_path, &secret_id)
@@ -421,6 +468,7 @@ mod tests {
             profile_cert_path: None,
             profile_key_path: None,
             ca_bundle_path: PathBuf::new(),
+            ca_bundle_pem: None,
             post_renew_command: None,
             post_renew_arg: Vec::new(),
             post_renew_timeout_secs: None,

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -188,6 +188,7 @@ struct ResolvedBootstrapArgs {
     profile_cert_path: Option<PathBuf>,
     profile_key_path: Option<PathBuf>,
     ca_bundle_path: PathBuf,
+    ca_bundle_pem: Option<String>,
     post_renew_command: Option<String>,
     post_renew_arg: Vec<String>,
     post_renew_timeout_secs: Option<u64>,
@@ -275,8 +276,18 @@ async fn run(args: Args, lang: Locale) -> Result<i32> {
     }
 }
 
+/// Lowest `schema_version` that this binary understands.
+const MIN_SUPPORTED_SCHEMA_VERSION: u32 = 1;
+
 /// Highest `schema_version` that this binary understands.
-const MAX_SUPPORTED_SCHEMA_VERSION: u32 = 1;
+const MAX_SUPPORTED_SCHEMA_VERSION: u32 = 2;
+
+/// Minimal header used for the first stage of artifact parsing so that
+/// `schema_version` can be validated before attempting full deserialization.
+#[derive(serde::Deserialize)]
+struct ArtifactHeader {
+    schema_version: u32,
+}
 
 /// Bootstrap artifact JSON schema (subset relevant to bootroot-remote).
 #[derive(serde::Deserialize)]
@@ -308,6 +319,8 @@ struct BootstrapArtifact {
     profile_key_path: Option<String>,
     #[serde(default)]
     ca_bundle_path: Option<String>,
+    #[serde(default)]
+    ca_bundle_pem: Option<String>,
     #[serde(default)]
     post_renew_hooks: Vec<ArtifactHookEntry>,
     #[serde(default)]
@@ -346,16 +359,29 @@ async fn resolve_bootstrap_args(args: BootstrapArgs) -> Result<ResolvedBootstrap
         let contents = tokio::fs::read_to_string(path)
             .await
             .with_context(|| format!("Failed to read artifact file: {}", path.display()))?;
-        let parsed: BootstrapArtifact = serde_json::from_str(&contents)
+
+        // Stage 1: extract only schema_version so we can reject unsupported
+        // versions before full deserialization (a future schema may remove or
+        // rename fields, causing a confusing serde error).
+        let header: ArtifactHeader = serde_json::from_str(&contents)
             .with_context(|| format!("Failed to parse artifact file: {}", path.display()))?;
-        if parsed.schema_version > MAX_SUPPORTED_SCHEMA_VERSION {
+        if header.schema_version < MIN_SUPPORTED_SCHEMA_VERSION
+            || header.schema_version > MAX_SUPPORTED_SCHEMA_VERSION
+        {
             anyhow::bail!(
-                "Artifact schema_version {} is not supported (max supported: {}). \
+                "Artifact schema_version {} is not supported \
+                 (supported range: {}..={}). \
                  Upgrade bootroot-remote to a newer version.",
-                parsed.schema_version,
+                header.schema_version,
+                MIN_SUPPORTED_SCHEMA_VERSION,
                 MAX_SUPPORTED_SCHEMA_VERSION,
             );
         }
+
+        // Stage 2: deserialize the full artifact now that the version is known
+        // to be supported.
+        let parsed: BootstrapArtifact = serde_json::from_str(&contents)
+            .with_context(|| format!("Failed to parse artifact file: {}", path.display()))?;
         Some(parsed)
     } else {
         None
@@ -436,6 +462,8 @@ async fn resolve_bootstrap_args(args: BootstrapArgs) -> Result<ResolvedBootstrap
         .and_then(|a| a.profile_key_path.as_ref().map(PathBuf::from))
         .or(args.profile_key_path);
 
+    let ca_bundle_pem = artifact.as_ref().and_then(|a| a.ca_bundle_pem.clone());
+
     let wrap_token = artifact.as_ref().and_then(|a| a.wrap_token.clone());
     let wrap_expires_at = artifact.as_ref().and_then(|a| a.wrap_expires_at.clone());
 
@@ -483,6 +511,7 @@ async fn resolve_bootstrap_args(args: BootstrapArgs) -> Result<ResolvedBootstrap
         profile_cert_path,
         profile_key_path,
         ca_bundle_path,
+        ca_bundle_pem,
         post_renew_command,
         post_renew_arg,
         post_renew_timeout_secs,
@@ -726,22 +755,10 @@ mod tests {
         assert_eq!(resolved.post_renew_on_failure, None);
     }
 
-    #[tokio::test]
-    async fn resolve_bootstrap_args_rejects_unsupported_schema_version() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let artifact_json = serde_json::json!({
-            "schema_version": 99,
-            "openbao_url": "https://ob:8200",
-            "kv_mount": "kv",
-            "service_name": "svc",
-            "role_id_path": "/r",
-            "secret_id_path": "/s",
-            "eab_file_path": "/e",
-            "agent_config_path": "/a",
-        });
-        let artifact_path = write_artifact_file(dir.path(), &artifact_json.to_string());
-
-        let args = BootstrapArgs {
+    /// Returns `BootstrapArgs` pointing at the given artifact file with all
+    /// other fields set to defaults.
+    fn default_bootstrap_args(artifact_path: PathBuf) -> BootstrapArgs {
+        BootstrapArgs {
             artifact: Some(artifact_path),
             openbao_url: None,
             kv_mount: "secret".to_string(),
@@ -764,19 +781,69 @@ mod tests {
             post_renew_timeout_secs: None,
             post_renew_on_failure: None,
             output: OutputFormat::Text,
-        };
+        }
+    }
+
+    /// Asserts that `resolve_bootstrap_args` rejects the given artifact JSON
+    /// with the schema-version error message containing the given version.
+    async fn assert_rejects_schema_version(artifact_json: &serde_json::Value, version: u32) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let artifact_path = write_artifact_file(dir.path(), &artifact_json.to_string());
+        let args = default_bootstrap_args(artifact_path);
 
         let err = resolve_bootstrap_args(args)
             .await
             .expect_err("should reject unsupported schema");
         let msg = err.to_string();
-        assert!(
-            msg.contains("schema_version 99 is not supported"),
-            "unexpected error: {msg}"
-        );
+        let expected = format!("schema_version {version} is not supported");
+        assert!(msg.contains(&expected), "unexpected error: {msg}");
         assert!(
             msg.contains("Upgrade bootroot-remote"),
             "should suggest upgrade: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn resolve_bootstrap_args_rejects_future_schema_version() {
+        // Artifact with a future schema version whose shape matches today's
+        // struct — ensures the header-stage check fires before full parse.
+        let artifact_json = serde_json::json!({
+            "schema_version": 99,
+            "openbao_url": "https://ob:8200",
+            "kv_mount": "kv",
+            "service_name": "svc",
+            "role_id_path": "/r",
+            "secret_id_path": "/s",
+            "eab_file_path": "/e",
+            "agent_config_path": "/a",
+        });
+        assert_rejects_schema_version(&artifact_json, 99).await;
+    }
+
+    #[tokio::test]
+    async fn resolve_bootstrap_args_rejects_schema_version_zero() {
+        let artifact_json = serde_json::json!({
+            "schema_version": 0,
+            "openbao_url": "https://ob:8200",
+            "kv_mount": "kv",
+            "service_name": "svc",
+            "role_id_path": "/r",
+            "secret_id_path": "/s",
+            "eab_file_path": "/e",
+            "agent_config_path": "/a",
+        });
+        assert_rejects_schema_version(&artifact_json, 0).await;
+    }
+
+    #[tokio::test]
+    async fn resolve_bootstrap_args_rejects_future_schema_with_unknown_fields() {
+        // A future v3 artifact that has completely different fields.  Without
+        // two-stage parsing, serde would fail with a confusing missing-field
+        // error instead of the explicit version rejection.
+        let artifact_json = serde_json::json!({
+            "schema_version": 3,
+            "completely_new_field": true,
+        });
+        assert_rejects_schema_version(&artifact_json, 3).await;
     }
 }

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -301,6 +301,7 @@ async fn run_service_add_apply(
                 resolved,
                 &secret_id_path,
                 artifact_wrap_info.as_ref(),
+                &service_sync_material.ca_bundle_pem,
                 messages,
             )
             .await?,
@@ -437,16 +438,16 @@ async fn run_service_add_remote_idempotent(
     messages: &Messages,
 ) -> Result<()> {
     let secrets_dir = state.secrets_dir();
+    let mut client = OpenBaoClient::new(&state.openbao_url)
+        .with_context(|| messages.error_openbao_client_create_failed())?;
+    let auth = resolved
+        .runtime_auth
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("OpenBao auth is required"))?;
+    crate::commands::openbao_auth::authenticate_openbao_client(&mut client, auth, messages).await?;
+    let ca_bundle_pem = secrets::read_ca_bundle_pem(&client, &state.kv_mount, messages).await?;
     let wrap_ttl = resolve::effective_wrap_ttl(entry.approle.secret_id_wrap_ttl.as_deref());
     let artifact_wrap_info = if let Some(ttl) = wrap_ttl {
-        let mut client = OpenBaoClient::new(&state.openbao_url)
-            .with_context(|| messages.error_openbao_client_create_failed())?;
-        let auth = resolved
-            .runtime_auth
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("OpenBao auth is required"))?;
-        crate::commands::openbao_auth::authenticate_openbao_client(&mut client, auth, messages)
-            .await?;
         let secret_id_options = build_secret_id_options(resolved);
         let wrap_info = client
             .create_secret_id_wrap_only(&entry.approle.role_name, &secret_id_options, ttl)
@@ -463,6 +464,7 @@ async fn run_service_add_remote_idempotent(
         secrets_dir,
         entry,
         artifact_wrap_info.as_ref(),
+        &ca_bundle_pem,
         messages,
     )
     .await?;

--- a/src/commands/service/remote_bootstrap.rs
+++ b/src/commands/service/remote_bootstrap.rs
@@ -41,6 +41,7 @@ struct RemoteBootstrapArtifact {
     eab_file_path: String,
     agent_config_path: String,
     ca_bundle_path: String,
+    ca_bundle_pem: String,
     openbao_agent_config_path: String,
     openbao_agent_template_path: String,
     openbao_agent_token_path: String,
@@ -105,6 +106,7 @@ fn build_artifact(
     instance_id: Option<&str>,
     post_renew_hooks: &[PostRenewHookEntry],
     wrap_info: Option<&ArtifactWrapInfo>,
+    ca_bundle_pem: &str,
 ) -> RemoteBootstrapArtifact {
     let secret_id_parent = secret_id_path.parent().unwrap_or(Path::new("."));
     let role_id_path = secret_id_parent.join(SERVICE_ROLE_ID_FILENAME);
@@ -117,7 +119,7 @@ fn build_artifact(
         remote_openbao_agent_paths(secret_id_path, service_name);
 
     RemoteBootstrapArtifact {
-        schema_version: 1,
+        schema_version: 2,
         openbao_url: openbao_url.to_string(),
         kv_mount: kv_mount.to_string(),
         service_name: service_name.to_string(),
@@ -126,6 +128,7 @@ fn build_artifact(
         eab_file_path: eab_path.display().to_string(),
         agent_config_path: agent_config_path.display().to_string(),
         ca_bundle_path: ca_bundle_path.display().to_string(),
+        ca_bundle_pem: ca_bundle_pem.to_string(),
         openbao_agent_config_path: openbao_agent_config_path.display().to_string(),
         openbao_agent_template_path: openbao_agent_template_path.display().to_string(),
         openbao_agent_token_path: openbao_agent_token_path.display().to_string(),
@@ -149,6 +152,7 @@ pub(super) async fn write_remote_bootstrap_artifact(
     resolved: &ResolvedServiceAdd,
     secret_id_path: &Path,
     wrap_info: Option<&ArtifactWrapInfo>,
+    ca_bundle_pem: &str,
     messages: &Messages,
 ) -> Result<RemoteBootstrapResult> {
     let artifact = build_artifact(
@@ -164,6 +168,7 @@ pub(super) async fn write_remote_bootstrap_artifact(
         resolved.instance_id.as_deref(),
         &resolved.post_renew_hooks,
         wrap_info,
+        ca_bundle_pem,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &resolved.service_name, &artifact, messages)
         .await
@@ -174,6 +179,7 @@ pub(super) async fn write_remote_bootstrap_artifact_from_entry(
     secrets_dir: &Path,
     entry: &ServiceEntry,
     wrap_info: Option<&ArtifactWrapInfo>,
+    ca_bundle_pem: &str,
     messages: &Messages,
 ) -> Result<RemoteBootstrapResult> {
     let artifact = build_artifact(
@@ -189,6 +195,7 @@ pub(super) async fn write_remote_bootstrap_artifact_from_entry(
         entry.instance_id.as_deref(),
         &entry.post_renew_hooks,
         wrap_info,
+        ca_bundle_pem,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &entry.service_name, &artifact, messages)
         .await
@@ -308,6 +315,8 @@ mod tests {
 
     use super::build_artifact;
 
+    const TEST_CA_PEM: &str = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n";
+
     #[test]
     fn build_artifact_typical_case() {
         let artifact = build_artifact(
@@ -323,9 +332,10 @@ mod tests {
             Some("instance-42"),
             &[],
             None,
+            TEST_CA_PEM,
         );
 
-        assert_eq!(artifact.schema_version, 1);
+        assert_eq!(artifact.schema_version, 2);
         assert_eq!(artifact.openbao_url, "https://openbao.example.com:8200");
         assert_eq!(artifact.kv_mount, "secret");
         assert_eq!(artifact.service_name, "my-service");
@@ -377,6 +387,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
 
         assert_eq!(artifact.profile_instance_id, "");
@@ -397,6 +408,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
         let b = build_artifact(
             "https://ob",
@@ -411,6 +423,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
 
         assert_ne!(a.role_id_path, b.role_id_path);
@@ -433,6 +446,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
 
         // Path::new("secret_id").parent() returns Some(""), not None
@@ -455,6 +469,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
 
         // Path::new("cert.pem").parent() returns Some(""), not None
@@ -484,6 +499,7 @@ mod tests {
             None,
             &hooks,
             None,
+            TEST_CA_PEM,
         );
 
         assert_eq!(artifact.post_renew_hooks.len(), 1);
@@ -514,6 +530,7 @@ mod tests {
             None,
             &hooks,
             None,
+            TEST_CA_PEM,
         );
         let cmd = super::render_remote_run_command_legacy(&artifact);
 
@@ -562,6 +579,7 @@ mod tests {
             None,
             &hooks,
             None,
+            TEST_CA_PEM,
         );
         let cmd = super::render_remote_run_command_legacy(&artifact);
 
@@ -590,6 +608,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
         let cmd = super::render_remote_run_command_legacy(&artifact);
 
@@ -614,6 +633,7 @@ mod tests {
             Some(""),
             &[],
             None,
+            TEST_CA_PEM,
         );
         let with_none = build_artifact(
             "https://ob",
@@ -628,6 +648,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
 
         assert_eq!(
@@ -670,6 +691,7 @@ mod tests {
             None,
             &[],
             Some(&wrap),
+            TEST_CA_PEM,
         );
 
         assert_eq!(artifact.wrap_token.as_deref(), Some("hvs.wrap-token-123"));
@@ -698,6 +720,7 @@ mod tests {
             None,
             &[],
             Some(&wrap),
+            TEST_CA_PEM,
         );
         let cmd = super::render_remote_run_command(&artifact);
 
@@ -726,6 +749,7 @@ mod tests {
             None,
             &[],
             None,
+            TEST_CA_PEM,
         );
         let cmd = super::render_remote_run_command(&artifact);
 

--- a/src/commands/service/secrets.rs
+++ b/src/commands/service/secrets.rs
@@ -159,6 +159,27 @@ async fn write_service_kv_secrets(
     Ok(())
 }
 
+pub(super) async fn read_ca_bundle_pem(
+    client: &OpenBaoClient,
+    kv_mount: &str,
+    messages: &Messages,
+) -> Result<String> {
+    let trust = client
+        .read_kv(kv_mount, PATH_CA_TRUST)
+        .await
+        .with_context(|| {
+            format!(
+                "{} ({PATH_CA_TRUST})",
+                messages.error_openbao_kv_read_failed()
+            )
+        })?;
+    read_required_string(
+        &trust,
+        SERVICE_CA_BUNDLE_PEM_KEY,
+        &format!("OpenBao CA trust data missing key: {SERVICE_CA_BUNDLE_PEM_KEY}"),
+    )
+}
+
 pub(super) async fn read_ca_trust_material(
     client: &OpenBaoClient,
     kv_mount: &str,

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -175,6 +175,37 @@ impl OpenBaoClient {
         })
     }
 
+    /// Creates a new `OpenBao` client whose TLS verification is anchored
+    /// to the given PEM-encoded CA bundle with optional SHA-256 pins.
+    ///
+    /// This is the primary constructor for RN-side bootstrap: the PEM
+    /// content travels inside the bootstrap artifact and `pins` carries
+    /// optional SHA-256 fingerprints from `trust.trusted_ca_sha256`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the PEM content cannot be parsed or the HTTP
+    /// client fails to build.
+    pub fn with_pem_trust(base_url: &str, ca_pem: &str, pins: &[String]) -> Result<Self> {
+        let client = crate::tls::build_http_client_from_pem(ca_pem, pins)?;
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client,
+            token: None,
+        })
+    }
+
+    /// Creates a new `OpenBao` client with a pre-configured
+    /// [`reqwest::Client`].
+    #[must_use]
+    pub fn with_client(base_url: &str, client: Client) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client,
+            token: None,
+        }
+    }
+
     pub fn set_token(&mut self, token: String) {
         self.token = Some(token);
     }
@@ -1176,5 +1207,141 @@ mod agent_config_tests {
         );
         assert!(hcl.contains(r#"source = "/a.ctmpl""#));
         assert!(hcl.contains(r#"source = "/b.ctmpl""#));
+    }
+}
+
+/// End-to-end HTTPS tests proving that [`OpenBaoClient::with_pem_trust`]
+/// verifies against the artifact-embedded CA and rejects unknown CAs.
+#[cfg(test)]
+mod tls_integration_tests {
+    use std::sync::Arc;
+
+    use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair};
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio_rustls::TlsAcceptor;
+
+    use super::*;
+
+    struct TestCa {
+        cert: rcgen::Certificate,
+        issuer: Issuer<'static, KeyPair>,
+    }
+
+    impl TestCa {
+        fn generate() -> Self {
+            let key = KeyPair::generate().expect("generate CA key");
+            let mut params = CertificateParams::new(Vec::new()).expect("cert params");
+            params
+                .distinguished_name
+                .push(DnType::CommonName, "Test CA");
+            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+            let cert = params.self_signed(&key).expect("self-signed CA");
+            let issuer = Issuer::new(params, key);
+            Self { cert, issuer }
+        }
+
+        fn pem(&self) -> String {
+            self.cert.pem()
+        }
+
+        fn sign_server_cert(&self) -> ServerCert {
+            let key = KeyPair::generate().expect("generate server key");
+            let mut params =
+                CertificateParams::new(vec!["localhost".to_string()]).expect("cert params");
+            params
+                .distinguished_name
+                .push(DnType::CommonName, "localhost");
+            params.is_ca = IsCa::NoCa;
+            let cert = params
+                .signed_by(&key, &self.issuer)
+                .expect("signed server cert");
+            ServerCert {
+                cert_der: cert.der().to_vec(),
+                key_der: key.serialize_der(),
+            }
+        }
+    }
+
+    struct ServerCert {
+        cert_der: Vec<u8>,
+        key_der: Vec<u8>,
+    }
+
+    /// Starts a minimal HTTPS server that returns `200 OK` for every
+    /// request. Returns the port on `127.0.0.1`.
+    async fn start_tls_server(server: ServerCert) -> u16 {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let cert = CertificateDer::from(server.cert_der);
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(server.key_der));
+
+        let config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .expect("server TLS config");
+
+        let acceptor = TlsAcceptor::from(Arc::new(config));
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local addr").port();
+
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let acceptor = acceptor.clone();
+                tokio::spawn(async move {
+                    let Ok(mut tls) = acceptor.accept(stream).await else {
+                        return;
+                    };
+                    let mut buf = vec![0u8; 4096];
+                    let _ = tls.read(&mut buf).await;
+                    let _ = tls
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\n\
+                              Content-Length: 0\r\n\
+                              Connection: close\r\n\r\n",
+                        )
+                        .await;
+                    let _ = tls.shutdown().await;
+                });
+            }
+        });
+
+        port
+    }
+
+    #[tokio::test]
+    async fn with_pem_trust_validates_against_artifact_ca() {
+        let ca = TestCa::generate();
+        let server_cert = ca.sign_server_cert();
+        let port = start_tls_server(server_cert).await;
+
+        let client =
+            OpenBaoClient::with_pem_trust(&format!("https://localhost:{port}"), &ca.pem(), &[])
+                .expect("client with correct CA");
+
+        client
+            .health_check()
+            .await
+            .expect("health check should pass with artifact CA");
+    }
+
+    #[tokio::test]
+    async fn with_pem_trust_rejects_unknown_ca() {
+        let ca = TestCa::generate();
+        let wrong_ca = TestCa::generate();
+        let server_cert = ca.sign_server_cert();
+        let port = start_tls_server(server_cert).await;
+
+        let client = OpenBaoClient::with_pem_trust(
+            &format!("https://localhost:{port}"),
+            &wrong_ca.pem(),
+            &[],
+        )
+        .expect("client with wrong CA");
+
+        client
+            .health_check()
+            .await
+            .expect_err("health check should fail with wrong CA");
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -75,17 +75,54 @@ pub fn build_http_client(trust: &TrustSettings, insecure_mode: bool) -> Result<C
         .context("Failed to build trusted HTTP client")
 }
 
+/// Builds a [`reqwest::Client`] whose trust root is the given PEM-encoded
+/// CA bundle (in-memory, no file I/O), with optional SHA-256 certificate
+/// pinning.
+///
+/// This is the entry point for RN-side TLS bootstrap: the PEM content
+/// travels inside the bootstrap artifact and is used to verify the
+/// control-plane TLS certificate without relying on the system trust
+/// store.
+///
+/// When `pins` is non-empty the client enforces SHA-256 certificate
+/// pinning via the same [`PinnedCertVerifier`] path used by
+/// [`build_http_client`].
+///
+/// # Errors
+///
+/// Returns an error if the PEM content cannot be parsed or if the HTTP
+/// client fails to build.
+pub fn build_http_client_from_pem(pem_content: &str, pins: &[String]) -> Result<Client> {
+    install_crypto_provider();
+    let root_store = parse_pem_to_root_store(pem_content.as_bytes())?;
+    let pin_set: HashSet<String> = pins.iter().map(|p| p.to_ascii_lowercase()).collect();
+    let config = if pin_set.is_empty() {
+        ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth()
+    } else {
+        let verifier = WebPkiServerVerifier::builder(Arc::new(root_store.clone()))
+            .build()
+            .context("Failed to build TLS verifier")?;
+        let pinned = Arc::new(PinnedCertVerifier::new(verifier, pin_set));
+        let mut cfg = ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        cfg.dangerous().set_certificate_verifier(pinned);
+        cfg
+    };
+    Client::builder()
+        .use_preconfigured_tls(config)
+        .build()
+        .context("Failed to build HTTP client from PEM bundle")
+}
+
 fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-fn load_ca_bundle(
-    path: &std::path::Path,
-    pins: &[String],
-) -> Result<(rustls::RootCertStore, HashSet<String>)> {
-    let contents = std::fs::read(path)
-        .with_context(|| format!("Failed to read CA bundle at {}", path.display()))?;
-    let mut remaining = contents.as_slice();
+fn parse_pem_to_root_store(pem_bytes: &[u8]) -> Result<rustls::RootCertStore> {
+    let mut remaining = pem_bytes;
     let mut certs = Vec::new();
     while !remaining.is_empty() {
         if remaining.iter().all(u8::is_ascii_whitespace) {
@@ -107,6 +144,16 @@ fn load_ca_bundle(
             .add(CertificateDer::from(cert))
             .context("Failed to add CA certificate")?;
     }
+    Ok(root_store)
+}
+
+fn load_ca_bundle(
+    path: &std::path::Path,
+    pins: &[String],
+) -> Result<(rustls::RootCertStore, HashSet<String>)> {
+    let contents = std::fs::read(path)
+        .with_context(|| format!("Failed to read CA bundle at {}", path.display()))?;
+    let root_store = parse_pem_to_root_store(&contents)?;
     let pins = pins
         .iter()
         .map(|value| value.to_ascii_lowercase())
@@ -463,5 +510,75 @@ mod tests {
         }
         let cert = params.self_signed(&key).expect("self-signed cert");
         CertificateDer::from(cert.der().to_vec())
+    }
+
+    fn generate_ca_pem() -> String {
+        use rcgen::CertificateParams;
+
+        let key = KeyPair::generate().expect("generate key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Test CA");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key).expect("self-signed cert");
+        cert.pem()
+    }
+
+    #[test]
+    fn parse_pem_to_root_store_accepts_valid_pem() {
+        let pem = generate_ca_pem();
+        let store = parse_pem_to_root_store(pem.as_bytes()).expect("valid PEM");
+        assert!(!store.is_empty());
+    }
+
+    #[test]
+    fn parse_pem_to_root_store_rejects_empty_input() {
+        let err = parse_pem_to_root_store(b"").expect_err("empty input");
+        assert!(
+            err.to_string().contains("no certificates"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_pem_to_root_store_rejects_non_pem_content() {
+        let err = parse_pem_to_root_store(b"not a PEM").expect_err("non-PEM");
+        assert!(
+            err.to_string().contains("Failed to parse"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_pem_to_root_store_skips_whitespace_only_trailing() {
+        let mut pem = generate_ca_pem();
+        pem.push_str("   \n  \n");
+        let store = parse_pem_to_root_store(pem.as_bytes()).expect("trailing whitespace");
+        assert!(!store.is_empty());
+    }
+
+    #[test]
+    fn build_http_client_from_pem_succeeds_with_valid_pem() {
+        let pem = generate_ca_pem();
+        let client = build_http_client_from_pem(&pem, &[]);
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn build_http_client_from_pem_fails_with_empty_pem() {
+        let err = build_http_client_from_pem("", &[]).expect_err("empty PEM");
+        assert!(
+            err.to_string().contains("no certificates"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn build_http_client_from_pem_with_pins_succeeds() {
+        let pem = generate_ca_pem();
+        let pin = "aa".repeat(32);
+        let client = build_http_client_from_pem(&pem, &[pin]);
+        assert!(client.is_ok());
     }
 }

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -734,7 +734,7 @@ async fn test_app_add_remote_bootstrap_no_wrap_handoff_includes_secret_id() {
 }
 
 fn assert_remote_bootstrap_artifact_shape(bootstrap: &serde_json::Value) {
-    assert_eq!(bootstrap["schema_version"], 1);
+    assert_eq!(bootstrap["schema_version"], 2);
     assert_eq!(bootstrap["service_name"], "edge-proxy");
     assert_eq!(bootstrap["kv_mount"], "secret");
     assert!(bootstrap["role_id_path"].is_string());
@@ -742,6 +742,7 @@ fn assert_remote_bootstrap_artifact_shape(bootstrap: &serde_json::Value) {
     assert!(bootstrap["eab_file_path"].is_string());
     assert!(bootstrap["agent_config_path"].is_string());
     assert!(bootstrap["ca_bundle_path"].is_string());
+    assert!(bootstrap["ca_bundle_pem"].is_string());
     assert!(bootstrap["openbao_agent_config_path"].is_string());
     assert!(bootstrap["openbao_agent_template_path"].is_string());
     assert!(bootstrap["openbao_agent_token_path"].is_string());

--- a/tests/e2e_remote_happy_path.rs
+++ b/tests/e2e_remote_happy_path.rs
@@ -5,7 +5,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use anyhow::Context;
-use rcgen::generate_simple_self_signed;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, generate_simple_self_signed,
+};
 use serde_json::json;
 use tempfile::tempdir;
 use wiremock::matchers::{body_json, header, header_exists, method, path};
@@ -864,6 +866,308 @@ async fn test_remote_bootstrap_already_unwrapped_token() {
     assert!(
         stderr.contains("bootroot service add"),
         "should include service-add step to mint fresh wrap token: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TLS test infrastructure — CA generation and minimal HTTPS mock server
+// ---------------------------------------------------------------------------
+
+struct TestCa {
+    cert: rcgen::Certificate,
+    issuer: Issuer<'static, KeyPair>,
+}
+
+struct TlsServerCert {
+    cert_der: Vec<u8>,
+    key_der: Vec<u8>,
+}
+
+impl TestCa {
+    fn generate() -> Self {
+        let key = KeyPair::generate().expect("generate CA key");
+        let mut params = CertificateParams::new(Vec::new()).expect("cert params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Test CA");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key).expect("self-signed CA");
+        let issuer = Issuer::new(params, key);
+        Self { cert, issuer }
+    }
+
+    fn pem(&self) -> String {
+        self.cert.pem()
+    }
+
+    fn sign_server_cert(&self) -> TlsServerCert {
+        let key = KeyPair::generate().expect("generate server key");
+        let mut params =
+            CertificateParams::new(vec!["localhost".to_string()]).expect("cert params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "localhost");
+        params.is_ca = IsCa::NoCa;
+        let cert = params
+            .signed_by(&key, &self.issuer)
+            .expect("signed server cert");
+        TlsServerCert {
+            cert_der: cert.der().to_vec(),
+            key_der: key.serialize_der(),
+        }
+    }
+}
+
+/// Routes an HTTP request path to a canned `OpenBao` JSON response.
+fn openbao_route(request_path: &str) -> (u16, String) {
+    let body = match request_path {
+        "/v1/auth/approle/login" => json!({
+            "auth": { "client_token": "tls-token" }
+        }),
+        "/v1/secret/data/bootroot/services/edge-proxy/secret_id" => json!({
+            "data": { "data": { "secret_id": "tls-secret-id" } }
+        }),
+        "/v1/secret/data/bootroot/services/edge-proxy/eab" => json!({
+            "data": { "data": { "kid": "tls-kid", "hmac": "tls-hmac" } }
+        }),
+        "/v1/secret/data/bootroot/services/edge-proxy/http_responder_hmac" => json!({
+            "data": { "data": { "hmac": "tls-responder-hmac" } }
+        }),
+        "/v1/secret/data/bootroot/services/edge-proxy/trust" => json!({
+            "data": { "data": {
+                "trusted_ca_sha256": ["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"],
+                "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nTLS-MOCK\n-----END CERTIFICATE-----"
+            } }
+        }),
+        _ => return (404, r#"{"errors":["not found"]}"#.to_string()),
+    };
+    (200, body.to_string())
+}
+
+/// Starts a minimal HTTPS server that routes requests to canned `OpenBao`
+/// responses.  Returns the port on `127.0.0.1`.
+async fn start_openbao_tls_mock(server_cert: TlsServerCert) -> u16 {
+    use std::sync::Arc;
+
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio_rustls::TlsAcceptor;
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let cert = CertificateDer::from(server_cert.cert_der);
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(server_cert.key_der));
+
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key)
+        .expect("server TLS config");
+
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("local addr").port();
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let mut buf = vec![0u8; 8192];
+                let n = tls.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let request_path = request
+                    .lines()
+                    .next()
+                    .and_then(|l| l.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                let (status, body) = openbao_route(request_path);
+                let status_text = if status == 200 { "OK" } else { "Not Found" };
+                let response = format!(
+                    "HTTP/1.1 {status} {status_text}\r\n\
+                     Content-Type: application/json\r\n\
+                     Content-Length: {}\r\n\
+                     Connection: close\r\n\r\n\
+                     {body}",
+                    body.len()
+                );
+                let _ = tls.write_all(response.as_bytes()).await;
+                let _ = tls.shutdown().await;
+            });
+        }
+    });
+
+    port
+}
+
+/// Proves that `bootroot-remote bootstrap --artifact` with an HTTPS
+/// `openbao_url` succeeds when the artifact-embedded CA matches the
+/// server's issuer.  This exercises the full bootstrap code path
+/// (`build_openbao_client` → `OpenBaoClient::with_pem_trust` → TLS
+/// handshake → `AppRole` login → secret reads) over a real TLS connection.
+#[tokio::test]
+async fn test_remote_bootstrap_https_with_artifact_ca() {
+    let ca = TestCa::generate();
+    let server_cert = ca.sign_server_cert();
+    let port = start_openbao_tls_mock(server_cert).await;
+
+    let temp = tempdir().expect("create tempdir");
+    let service_dir = temp.path().join("tls-service");
+    fs::create_dir_all(&service_dir).expect("create service dir");
+    prepare_service_node_files(&service_dir).expect("prepare service node files");
+
+    let service_secrets = service_dir
+        .join("secrets")
+        .join("services")
+        .join(SERVICE_NAME);
+    let role_id_path = service_secrets.join("role_id");
+    let secret_id_path = service_secrets.join("secret_id");
+    fs::write(&role_id_path, "role-edge-proxy").expect("write role_id");
+    fs::write(&secret_id_path, "secret-edge-proxy").expect("write secret_id");
+
+    let openbao_agent_dir = service_dir
+        .join("secrets")
+        .join("openbao")
+        .join("services")
+        .join(SERVICE_NAME);
+
+    let artifact = json!({
+        "schema_version": 2,
+        "openbao_url": format!("https://localhost:{port}"),
+        "kv_mount": "secret",
+        "service_name": SERVICE_NAME,
+        "role_id_path": role_id_path.to_string_lossy(),
+        "secret_id_path": secret_id_path.to_string_lossy(),
+        "eab_file_path": service_secrets.join("eab.json").to_string_lossy(),
+        "agent_config_path": service_dir.join("agent.toml").to_string_lossy(),
+        "ca_bundle_path": service_dir.join("certs").join("ca-bundle.pem").to_string_lossy(),
+        "ca_bundle_pem": ca.pem(),
+        "openbao_agent_config_path": openbao_agent_dir.join("agent.hcl").to_string_lossy(),
+        "openbao_agent_template_path": openbao_agent_dir.join("agent.toml.ctmpl").to_string_lossy(),
+        "openbao_agent_token_path": openbao_agent_dir.join("token").to_string_lossy(),
+        "agent_email": "admin@example.com",
+        "agent_server": "https://localhost:9000/acme/acme/directory",
+        "agent_domain": DOMAIN,
+        "agent_responder_url": "http://127.0.0.1:8080",
+        "profile_hostname": HOSTNAME,
+        "profile_instance_id": INSTANCE_ID,
+        "profile_cert_path": service_dir.join("certs").join("edge-proxy.crt").to_string_lossy(),
+        "profile_key_path": service_dir.join("certs").join("edge-proxy.key").to_string_lossy(),
+    });
+    let artifact_path = service_dir.join("bootstrap.json");
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&artifact).unwrap(),
+    )
+    .expect("write artifact");
+
+    // Use tokio::process so the child process does not block the tokio
+    // thread — the TLS mock server is a tokio task on the same runtime.
+    let output = tokio::process::Command::new(env!("CARGO_BIN_EXE_bootroot-remote"))
+        .current_dir(&service_dir)
+        .arg("bootstrap")
+        .arg("--artifact")
+        .arg(&artifact_path)
+        .output()
+        .await
+        .expect("run bootroot-remote");
+
+    assert!(
+        output.status.success(),
+        "HTTPS bootstrap should succeed with artifact CA: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify secrets were written through the TLS-protected path.
+    let written_secret = fs::read_to_string(&secret_id_path).expect("read secret_id");
+    assert_eq!(written_secret.trim(), "tls-secret-id");
+}
+
+/// Proves that `bootroot-remote bootstrap --artifact` with an HTTPS
+/// `openbao_url` fails when the artifact carries a CA that did not issue
+/// the server certificate.  This confirms the bootstrap path does not
+/// fall back to the system trust store.
+#[tokio::test]
+async fn test_remote_bootstrap_https_rejects_wrong_ca() {
+    let ca = TestCa::generate();
+    let wrong_ca = TestCa::generate();
+    let server_cert = ca.sign_server_cert();
+    let port = start_openbao_tls_mock(server_cert).await;
+
+    let temp = tempdir().expect("create tempdir");
+    let service_dir = temp.path().join("tls-wrong-ca");
+    fs::create_dir_all(&service_dir).expect("create service dir");
+    prepare_service_node_files(&service_dir).expect("prepare service node files");
+
+    let service_secrets = service_dir
+        .join("secrets")
+        .join("services")
+        .join(SERVICE_NAME);
+    let role_id_path = service_secrets.join("role_id");
+    let secret_id_path = service_secrets.join("secret_id");
+    fs::write(&role_id_path, "role-edge-proxy").expect("write role_id");
+    fs::write(&secret_id_path, "secret-edge-proxy").expect("write secret_id");
+
+    let openbao_agent_dir = service_dir
+        .join("secrets")
+        .join("openbao")
+        .join("services")
+        .join(SERVICE_NAME);
+
+    // Embed the WRONG CA — the server cert was signed by `ca`, not `wrong_ca`.
+    let artifact = json!({
+        "schema_version": 2,
+        "openbao_url": format!("https://localhost:{port}"),
+        "kv_mount": "secret",
+        "service_name": SERVICE_NAME,
+        "role_id_path": role_id_path.to_string_lossy(),
+        "secret_id_path": secret_id_path.to_string_lossy(),
+        "eab_file_path": service_secrets.join("eab.json").to_string_lossy(),
+        "agent_config_path": service_dir.join("agent.toml").to_string_lossy(),
+        "ca_bundle_path": service_dir.join("certs").join("ca-bundle.pem").to_string_lossy(),
+        "ca_bundle_pem": wrong_ca.pem(),
+        "openbao_agent_config_path": openbao_agent_dir.join("agent.hcl").to_string_lossy(),
+        "openbao_agent_template_path": openbao_agent_dir.join("agent.toml.ctmpl").to_string_lossy(),
+        "openbao_agent_token_path": openbao_agent_dir.join("token").to_string_lossy(),
+        "agent_email": "admin@example.com",
+        "agent_server": "https://localhost:9000/acme/acme/directory",
+        "agent_domain": DOMAIN,
+        "agent_responder_url": "http://127.0.0.1:8080",
+        "profile_hostname": HOSTNAME,
+        "profile_instance_id": INSTANCE_ID,
+        "profile_cert_path": service_dir.join("certs").join("edge-proxy.crt").to_string_lossy(),
+        "profile_key_path": service_dir.join("certs").join("edge-proxy.key").to_string_lossy(),
+    });
+    let artifact_path = service_dir.join("bootstrap.json");
+    fs::write(
+        &artifact_path,
+        serde_json::to_string_pretty(&artifact).unwrap(),
+    )
+    .expect("write artifact");
+
+    let output = tokio::process::Command::new(env!("CARGO_BIN_EXE_bootroot-remote"))
+        .current_dir(&service_dir)
+        .arg("bootstrap")
+        .arg("--artifact")
+        .arg(&artifact_path)
+        .output()
+        .await
+        .expect("run bootroot-remote");
+
+    assert!(
+        !output.status.success(),
+        "HTTPS bootstrap should fail with wrong CA"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The exact error text depends on the TLS stack; check that bootstrap
+    // fails on the login request (which is the first network call).
+    assert!(
+        stderr.contains("TLS")
+            || stderr.contains("certificate")
+            || stderr.contains("login failed")
+            || stderr.contains("request failed"),
+        "error should indicate connection/TLS failure: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Embeds the control-plane CA PEM (`ca_bundle_pem`) in `RemoteBootstrapArtifact` and bumps `schema_version` to 2, so the RN can verify OpenBao TLS without the system trust store.
- Adds `OpenBaoClient::with_pem_trust` constructor that anchors TLS to an in-memory CA bundle with optional SHA-256 pinning, integrating the same `PinnedCertVerifier` path used by `build_http_client`. `with_client` remains as an escape hatch for full `reqwest::Client` control.
- `tls::build_http_client_from_pem` now accepts an optional `pins` slice for SHA-256 certificate pinning via the existing `trusted_ca_sha256` mechanism.
- In `bootroot-remote bootstrap`, writes the artifact PEM to `ca_bundle_path` on disk and uses `OpenBaoClient::with_pem_trust` as the sole TLS trust anchor for HTTPS `openbao_url` endpoints; HTTP loopback retains the default client.
- Uses two-stage artifact parsing: extracts `schema_version` from a minimal header struct first, rejects versions outside `1..=MAX_SUPPORTED_SCHEMA_VERSION`, then deserializes the full artifact. This prevents a future schema with renamed/removed fields from producing a confusing serde error instead of an explicit version rejection.
- Reads the CA bundle PEM from OpenBao KV (`ca-trust`) on the CN side during `service add` to populate the artifact field.
- Updates remote-bootstrap docs (EN + KO) to reflect schema version 2, document the `ca_bundle_pem` field, and fix validation examples.
- Bumps `rustls-webpki` from 0.103.10 to 0.103.12 to fix RUSTSEC-2026-0098 and RUSTSEC-2026-0099 (`cargo audit` failure).

Closes #511

## Test plan

- [x] `bootroot-remote bootstrap` against a TLS-enabled OpenBao validates using only the artifact-embedded CA anchor (`test_remote_bootstrap_https_with_artifact_ca` — full e2e HTTPS test with a real TLS server)
- [x] Wrong CA in the artifact fails with a TLS error, proving no system trust store fallback (`test_remote_bootstrap_https_rejects_wrong_ca`)
- [x] HTTP `openbao_url` (single-host loopback, TLS disabled) still works without regressions
- [x] `schema_version` is 2 in artifacts produced after this PR
- [x] `ca_bundle_pem` field is present and non-empty in generated artifacts
- [x] Two-stage schema version validation: rejects version 0 (below minimum), version 99 (above maximum), and version 3 with unknown fields (would fail serde before version check without two-stage parse)
- [x] `OpenBaoClient::with_pem_trust` unit-level TLS tests: `with_pem_trust_validates_against_artifact_ca` and `with_pem_trust_rejects_unknown_ca` (real TLS handshake)
- [x] `build_http_client_from_pem` unit tests pass (valid PEM, empty PEM, trailing whitespace, with pins)
- [x] `parse_pem_to_root_store` unit tests pass
- [x] Existing integration tests (`bootroot_service`) pass with updated schema assertions
- [x] Remote-bootstrap docs (EN + KO) updated: schema version 2, `ca_bundle_pem` field, version history table