### PR TITLE
Generate Docker sidecar agent config in service add (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added `agent-docker.hcl` generation to `bootroot service add`
+  (local-file mode). The Docker variant uses the Docker-internal
+  OpenBao address (`bootroot-openbao:8200`) and container-side paths under
+  `/openbao/secrets/`. When TLS is enabled (`https`), the config
+  includes a `ca_cert` field pointing to a pre-seeded bootstrap CA
+  bundle so the sidecar agent can verify the OpenBao server on first
+  startup. The existing `agent.hcl` output is unchanged. (Part of
+  #518)
 - Added `--openbao-bind <IP>:<port>`, `--openbao-tls-required`,
   `--openbao-bind-wildcard`, and `--openbao-advertise-addr <IP>:<port>`
   flags to `bootroot infra install`. Operators can opt into non-loopback

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -23,6 +23,7 @@ pub(crate) struct ServiceAddPlan<'a> {
 pub(crate) struct ServiceAddAppliedPaths<'a> {
     pub(crate) agent_config: &'a str,
     pub(crate) openbao_agent_config: &'a str,
+    pub(crate) openbao_agent_docker_config: &'a str,
     pub(crate) openbao_agent_template: &'a str,
 }
 
@@ -121,6 +122,10 @@ fn print_local_apply_summary(paths: &ServiceAddAppliedPaths<'_>, messages: &Mess
     println!(
         "{}",
         messages.service_summary_auto_applied_openbao_config(paths.openbao_agent_config)
+    );
+    println!(
+        "{}",
+        messages.service_summary_auto_applied_openbao_config(paths.openbao_agent_docker_config)
     );
     println!(
         "{}",

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -16,7 +16,7 @@ pub(crate) use constants::{
     OPENBAO_TLS_DEFAULT_NOT_AFTER, OPENBAO_TLS_DEFAULT_RENEW_BEFORE, OPENBAO_TLS_KEY_PATH,
     RESPONDER_CONFIG_DIR, RESPONDER_CONFIG_NAME, SECRET_BYTES,
 };
-pub(crate) use paths::{compose_has_responder, to_container_path};
+pub(crate) use paths::{compose_has_responder, resolve_openbao_agent_addr, to_container_path};
 pub(crate) use steps::openbao_tls::{reissue_openbao_tls_cert, write_openbao_hcl_plaintext};
 pub(crate) use steps::{
     compute_ca_bundle_pem, compute_ca_fingerprints, prompt_yes_no, read_ca_cert_fingerprint,

--- a/src/commands/init/paths.rs
+++ b/src/commands/init/paths.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
-use super::constants::{DEFAULT_RESPONDER_ADMIN_URL, RESPONDER_CONFIG_DIR, RESPONDER_CONFIG_NAME};
+use super::constants::{
+    DEFAULT_RESPONDER_ADMIN_URL, OPENBAO_CONTAINER_NAME, RESPONDER_CONFIG_DIR,
+    RESPONDER_CONFIG_NAME,
+};
 use crate::cli::args::InitArgs;
 use crate::commands::constants::RESPONDER_SERVICE_NAME;
 use crate::commands::guardrails::parse_hcl_string_value;
@@ -101,13 +104,33 @@ fn responder_tls_configured(secrets_dir: &Path) -> Result<bool> {
         && parse_hcl_string_value(&content, "tls_key_path").is_some())
 }
 
+/// Rewrites an `OpenBao` URL so that Docker-network containers can reach
+/// the server via its container name.
+///
+/// When `compose_has_openbao` is `true`, the host portion of `openbao_url`
+/// is unconditionally replaced with [`OPENBAO_CONTAINER_NAME`] while the
+/// scheme and port are preserved.  This covers loopback addresses
+/// (`localhost`, `127.0.0.1`) as well as specific bind IPs
+/// (`192.168.1.10`) that the host uses but that are unreachable from
+/// sibling containers on the Docker bridge network.
 pub(crate) fn resolve_openbao_agent_addr(openbao_url: &str, compose_has_openbao: bool) -> String {
     if !compose_has_openbao {
         return openbao_url.to_string();
     }
-    openbao_url
-        .replace("localhost", "openbao")
-        .replace("127.0.0.1", "openbao")
+    let Some((scheme, after_scheme)) = openbao_url.split_once("://") else {
+        return openbao_url.to_string();
+    };
+    // For IPv6 addresses like [::1]:8200 the port follows ']:', for
+    // IPv4 / hostnames like 192.168.1.10:8200 it follows ':'.
+    let port = if let Some(bracket_pos) = after_scheme.find(']') {
+        after_scheme.get(bracket_pos + 2..)
+    } else {
+        after_scheme.split_once(':').map(|(_, p)| p)
+    };
+    match port {
+        Some(p) => format!("{scheme}://{OPENBAO_CONTAINER_NAME}:{p}"),
+        None => format!("{scheme}://{OPENBAO_CONTAINER_NAME}"),
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -680,15 +680,16 @@ fn build_openbao_agent_config(
         .iter()
         .map(|(s, d)| (s.as_str(), d.as_str()))
         .collect();
-    bootroot::openbao::build_agent_config(
+    bootroot::openbao::build_agent_config(&bootroot::openbao::AgentConfigParams {
         openbao_addr,
         role_id_path,
         secret_id_path,
-        INIT_AGENT_TOKEN_PATH,
-        None,
-        bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
-        &tpl_refs,
-    )
+        token_path: INIT_AGENT_TOKEN_PATH,
+        mount_path: None,
+        render_interval: bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
+        templates: &tpl_refs,
+        ca_cert: None,
+    })
 }
 
 async fn write_openbao_agent_compose_override(
@@ -893,13 +894,25 @@ services:
     #[test]
     fn test_resolve_openbao_agent_addr_replaces_localhost() {
         let addr = resolve_openbao_agent_addr("http://localhost:8200", true);
-        assert_eq!(addr, "http://openbao:8200");
+        assert_eq!(addr, "http://bootroot-openbao:8200");
     }
 
     #[test]
-    fn test_resolve_openbao_agent_addr_keeps_remote() {
-        let addr = resolve_openbao_agent_addr("http://openbao:8200", true);
-        assert_eq!(addr, "http://openbao:8200");
+    fn test_resolve_openbao_agent_addr_replaces_specific_ip() {
+        let addr = resolve_openbao_agent_addr("https://192.168.1.10:8200", true);
+        assert_eq!(addr, "https://bootroot-openbao:8200");
+    }
+
+    #[test]
+    fn test_resolve_openbao_agent_addr_replaces_fqdn() {
+        let addr = resolve_openbao_agent_addr("http://openbao.example.com:8200", true);
+        assert_eq!(addr, "http://bootroot-openbao:8200");
+    }
+
+    #[test]
+    fn test_resolve_openbao_agent_addr_preserves_when_no_compose() {
+        let addr = resolve_openbao_agent_addr("https://192.168.1.10:8200", false);
+        assert_eq!(addr, "https://192.168.1.10:8200");
     }
 
     #[test]

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -27,6 +27,7 @@ pub(super) const SERVICE_ROLE_ID_FILENAME: &str = "role_id";
 pub(super) const SERVICE_SECRET_ID_FILENAME: &str = "secret_id";
 pub(super) const OPENBAO_SERVICE_CONFIG_DIR: &str = "openbao/services";
 pub(super) const OPENBAO_AGENT_CONFIG_FILENAME: &str = "agent.hcl";
+pub(super) const OPENBAO_AGENT_DOCKER_CONFIG_FILENAME: &str = "agent-docker.hcl";
 pub(super) const OPENBAO_AGENT_TEMPLATE_FILENAME: &str = "agent.toml.ctmpl";
 pub(super) const OPENBAO_AGENT_CA_BUNDLE_TEMPLATE_FILENAME: &str = "ca-bundle.pem.ctmpl";
 pub(super) const OPENBAO_AGENT_TOKEN_FILENAME: &str = "token";
@@ -49,6 +50,7 @@ pub(super) struct ServiceAppRoleMaterialized {
 pub(super) struct LocalApplyResult {
     agent_config: String,
     openbao_agent_config: String,
+    openbao_agent_docker_config: String,
     openbao_agent_template: String,
 }
 
@@ -418,6 +420,7 @@ fn print_service_add_apply_summary(
             applied: applied.map(|result| ServiceAddAppliedPaths {
                 agent_config: &result.agent_config,
                 openbao_agent_config: &result.openbao_agent_config,
+                openbao_agent_docker_config: &result.openbao_agent_docker_config,
                 openbao_agent_template: &result.openbao_agent_template,
             }),
             remote: remote_bootstrap.map(|result| ServiceAddRemoteBootstrap {

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -14,12 +14,19 @@ use super::resolve::ResolvedServiceAdd;
 use super::{
     LocalApplyResult, MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX,
     OPENBAO_AGENT_CA_BUNDLE_TEMPLATE_FILENAME, OPENBAO_AGENT_CONFIG_FILENAME,
-    OPENBAO_AGENT_TEMPLATE_FILENAME, OPENBAO_AGENT_TOKEN_FILENAME, OPENBAO_SERVICE_CONFIG_DIR,
-    SERVICE_ROLE_ID_FILENAME, ServiceSyncMaterial,
+    OPENBAO_AGENT_DOCKER_CONFIG_FILENAME, OPENBAO_AGENT_TEMPLATE_FILENAME,
+    OPENBAO_AGENT_TOKEN_FILENAME, OPENBAO_SERVICE_CONFIG_DIR, SERVICE_ROLE_ID_FILENAME,
+    ServiceSyncMaterial,
 };
+use crate::commands::init::{resolve_openbao_agent_addr, to_container_path};
 use crate::i18n::Messages;
 use crate::state::PostRenewHookEntry;
 
+/// Mount point inside service sidecar containers where the host
+/// `secrets_dir` is bind-mounted.
+const SIDECAR_CONTAINER_MOUNT: &str = "/openbao/secrets";
+
+#[allow(clippy::too_many_lines)]
 pub(super) async fn apply_local_service_configs(
     secrets_dir: &Path,
     resolved: &ResolvedServiceAdd,
@@ -53,6 +60,17 @@ pub(super) async fn apply_local_service_configs(
     let acme_updates = vec![("http_responder_hmac", sync_material.responder_hmac.clone())];
     next = bootroot::toml_util::upsert_section_keys(&next, "acme", &acme_updates)?;
     write_local_ca_bundle(&ca_bundle_path, &sync_material.ca_bundle_pem, messages).await?;
+    let svc_cred_dir = secret_id_path.parent().unwrap_or(secrets_dir);
+    // Pre-seed the same ca-bundle.pem path that the agent template
+    // renders to, so the sidecar can verify TLS on first boot and
+    // then track live trust updates from KV after the template runs.
+    let docker_ca_bundle_path = svc_cred_dir.join(DOCKER_RENDERED_CA_BUNDLE);
+    write_local_ca_bundle(
+        &docker_ca_bundle_path,
+        &sync_material.ca_bundle_pem,
+        messages,
+    )
+    .await?;
     fs::write(&resolved.agent_config, &next)
         .await
         .with_context(|| {
@@ -120,9 +138,27 @@ pub(super) async fn apply_local_service_configs(
         })?;
     fs_util::set_key_permissions(&agent_config_path).await?;
 
+    let docker_config_path = openbao_service_dir.join(OPENBAO_AGENT_DOCKER_CONFIG_FILENAME);
+    let docker_hcl = render_docker_agent_config(&DockerAgentConfigInputs {
+        secrets_dir,
+        openbao_url,
+        role_id_path: &role_id_path,
+        secret_id_path,
+        token_path: &token_path,
+        agent_template_path: &template_path,
+        ca_bundle_template_path: &bundle_template_path,
+    })?;
+    fs::write(&docker_config_path, docker_hcl)
+        .await
+        .with_context(|| {
+            messages.error_write_file_failed(&docker_config_path.display().to_string())
+        })?;
+    fs_util::set_key_permissions(&docker_config_path).await?;
+
     Ok(LocalApplyResult {
         agent_config: resolved.agent_config.display().to_string(),
         openbao_agent_config: agent_config_path.display().to_string(),
+        openbao_agent_docker_config: docker_config_path.display().to_string(),
         openbao_agent_template: template_path.display().to_string(),
     })
 }
@@ -213,15 +249,106 @@ fn render_openbao_agent_config(
     let role_id = role_id_path.display().to_string();
     let secret_id = secret_id_path.display().to_string();
     let token = token_path.display().to_string();
-    bootroot::openbao::build_agent_config(
-        openbao_url,
-        &role_id,
-        &secret_id,
-        &token,
-        Some("auth/approle"),
-        bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
+    bootroot::openbao::build_agent_config(&bootroot::openbao::AgentConfigParams {
+        openbao_addr: openbao_url,
+        role_id_path: &role_id,
+        secret_id_path: &secret_id,
+        token_path: &token,
+        mount_path: Some("auth/approle"),
+        render_interval: bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
         templates,
-    )
+        ca_cert: None,
+    })
+}
+
+/// Name used for the rendered agent config inside the Docker container.
+const DOCKER_RENDERED_AGENT_CONFIG: &str = "agent.toml";
+
+/// Name used for the rendered CA bundle inside the Docker container.
+const DOCKER_RENDERED_CA_BUNDLE: &str = "ca-bundle.pem";
+
+/// Inputs for [`render_docker_agent_config`].
+struct DockerAgentConfigInputs<'a> {
+    secrets_dir: &'a Path,
+    openbao_url: &'a str,
+    role_id_path: &'a Path,
+    secret_id_path: &'a Path,
+    token_path: &'a Path,
+    agent_template_path: &'a Path,
+    ca_bundle_template_path: &'a Path,
+}
+
+/// Renders an `OpenBao` agent config for use inside a Docker sidecar
+/// container.  Translates all host paths to their container-side
+/// equivalents under [`SIDECAR_CONTAINER_MOUNT`] and replaces the
+/// `OpenBao` address with the Docker-internal hostname.
+///
+/// Template sources (`.ctmpl` files) are mapped via [`to_container_path`]
+/// since they reside under `secrets_dir`.  Template destinations are
+/// placed at well-known names inside the service's `OpenBao` directory
+/// within the container mount, because the host-side destinations may
+/// be outside `secrets_dir`.
+///
+/// When the `openbao_url` scheme is `https`, includes the `ca_cert`
+/// field pointing to the same container-side CA bundle that the agent
+/// template renders.  The caller pre-seeds this file during
+/// `service add` so the agent can verify TLS on its very first
+/// connection; subsequent template renders then keep the file in sync
+/// with the live trust bundle from KV.
+fn render_docker_agent_config(inputs: &DockerAgentConfigInputs<'_>) -> Result<String> {
+    let sd = inputs.secrets_dir;
+    let docker_addr = resolve_openbao_agent_addr(inputs.openbao_url, true);
+    let role_id = to_container_path(sd, inputs.role_id_path, SIDECAR_CONTAINER_MOUNT)?;
+    let secret_id = to_container_path(sd, inputs.secret_id_path, SIDECAR_CONTAINER_MOUNT)?;
+    let token = to_container_path(sd, inputs.token_path, SIDECAR_CONTAINER_MOUNT)?;
+
+    let tpl_source = to_container_path(sd, inputs.agent_template_path, SIDECAR_CONTAINER_MOUNT)?;
+    // Render destinations: the per-service credential directory
+    // (<secrets_dir>/services/<svc>/) so the service can access
+    // rendered output via the shared secrets_dir bind-mount.
+    let svc_cred_dir = inputs.secret_id_path.parent().unwrap_or(inputs.secrets_dir);
+    let tpl_dest = to_container_path(
+        sd,
+        &svc_cred_dir.join(DOCKER_RENDERED_AGENT_CONFIG),
+        SIDECAR_CONTAINER_MOUNT,
+    )?;
+    let ca_tpl_source =
+        to_container_path(sd, inputs.ca_bundle_template_path, SIDECAR_CONTAINER_MOUNT)?;
+    let ca_tpl_dest = to_container_path(
+        sd,
+        &svc_cred_dir.join(DOCKER_RENDERED_CA_BUNDLE),
+        SIDECAR_CONTAINER_MOUNT,
+    )?;
+
+    // Point ca_cert at the same path the CA bundle template renders
+    // to.  The caller pre-seeds this file during `service add`, so
+    // the agent can verify TLS on its very first connection.  Once the
+    // agent renders the template, the file is overwritten with the
+    // live bundle from KV, keeping trust in sync across CA rotations.
+    let ca_cert = if docker_addr.starts_with("https://") {
+        Some(ca_tpl_dest.clone())
+    } else {
+        None
+    };
+
+    let templates = [(tpl_source, tpl_dest), (ca_tpl_source, ca_tpl_dest)];
+    let tpl_refs: Vec<(&str, &str)> = templates
+        .iter()
+        .map(|(s, d)| (s.as_str(), d.as_str()))
+        .collect();
+
+    Ok(bootroot::openbao::build_agent_config(
+        &bootroot::openbao::AgentConfigParams {
+            openbao_addr: &docker_addr,
+            role_id_path: &role_id,
+            secret_id_path: &secret_id,
+            token_path: &token,
+            mount_path: Some("auth/approle"),
+            render_interval: bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
+            templates: &tpl_refs,
+            ca_cert: ca_cert.as_deref(),
+        },
+    ))
 }
 
 fn build_ctmpl_content(contents: &str, kv_mount: &str, service_name: &str) -> String {
@@ -575,5 +702,158 @@ mod tests {
         let args = hook["args"].as_array().expect("args must be an array");
         assert_eq!(args.get(0).unwrap().as_str().unwrap(), "line1\tline2");
         assert_eq!(args.get(1).unwrap().as_str().unwrap(), "back\\slash");
+    }
+
+    #[test]
+    fn docker_config_uses_container_paths_and_openbao_hostname() {
+        let secrets_dir = Path::new("/project/secrets");
+        let svc_dir = secrets_dir.join("openbao/services/edge");
+        let cred_dir = secrets_dir.join("services/edge");
+        let hcl = render_docker_agent_config(&DockerAgentConfigInputs {
+            secrets_dir,
+            openbao_url: "http://localhost:8200",
+            role_id_path: &cred_dir.join("role_id"),
+            secret_id_path: &cred_dir.join("secret_id"),
+            token_path: &svc_dir.join("token"),
+            agent_template_path: &svc_dir.join("agent.toml.ctmpl"),
+            ca_bundle_template_path: &svc_dir.join("ca-bundle.pem.ctmpl"),
+        })
+        .unwrap();
+
+        assert!(
+            hcl.contains(r#"address = "http://bootroot-openbao:8200""#),
+            "must use Docker-internal address"
+        );
+        assert!(
+            hcl.contains("/openbao/secrets/services/edge/role_id"),
+            "role_id must be container path"
+        );
+        assert!(
+            hcl.contains("/openbao/secrets/services/edge/secret_id"),
+            "secret_id must be container path"
+        );
+        assert!(
+            hcl.contains("/openbao/secrets/openbao/services/edge/token"),
+            "token must be container path"
+        );
+        assert!(
+            hcl.contains("/openbao/secrets/openbao/services/edge/agent.toml.ctmpl"),
+            "template source must be container path"
+        );
+        assert!(
+            hcl.contains("/openbao/secrets/services/edge/agent.toml"),
+            "template dest must be container path"
+        );
+        assert!(
+            hcl.contains("/openbao/secrets/openbao/services/edge/ca-bundle.pem.ctmpl"),
+            "ca bundle template source must be container path"
+        );
+        assert!(
+            hcl.contains("/openbao/secrets/services/edge/ca-bundle.pem"),
+            "ca bundle dest must be container path"
+        );
+        assert!(
+            !hcl.contains("ca_cert"),
+            "http address must not include ca_cert"
+        );
+    }
+
+    #[test]
+    fn docker_config_includes_ca_cert_when_tls_enabled() {
+        let secrets_dir = Path::new("/project/secrets");
+        let svc_dir = secrets_dir.join("openbao/services/edge");
+        let cred_dir = secrets_dir.join("services/edge");
+        let hcl = render_docker_agent_config(&DockerAgentConfigInputs {
+            secrets_dir,
+            openbao_url: "https://localhost:8200",
+            role_id_path: &cred_dir.join("role_id"),
+            secret_id_path: &cred_dir.join("secret_id"),
+            token_path: &svc_dir.join("token"),
+            agent_template_path: &svc_dir.join("agent.toml.ctmpl"),
+            ca_bundle_template_path: &svc_dir.join("ca-bundle.pem.ctmpl"),
+        })
+        .unwrap();
+
+        assert!(
+            hcl.contains(r#"address = "https://bootroot-openbao:8200""#),
+            "must use https Docker-internal address"
+        );
+        assert!(
+            hcl.contains(r#"ca_cert = "/openbao/secrets/services/edge/ca-bundle.pem""#),
+            "ca_cert must point at template-rendered bundle for live trust updates"
+        );
+    }
+
+    #[test]
+    fn docker_config_omits_ca_cert_when_http() {
+        let secrets_dir = Path::new("/project/secrets");
+        let svc_dir = secrets_dir.join("openbao/services/edge");
+        let cred_dir = secrets_dir.join("services/edge");
+        let hcl = render_docker_agent_config(&DockerAgentConfigInputs {
+            secrets_dir,
+            openbao_url: "http://127.0.0.1:8200",
+            role_id_path: &cred_dir.join("role_id"),
+            secret_id_path: &cred_dir.join("secret_id"),
+            token_path: &svc_dir.join("token"),
+            agent_template_path: &svc_dir.join("agent.toml.ctmpl"),
+            ca_bundle_template_path: &svc_dir.join("ca-bundle.pem.ctmpl"),
+        })
+        .unwrap();
+
+        assert!(
+            hcl.contains(r#"address = "http://bootroot-openbao:8200""#),
+            "127.0.0.1 must be replaced with bootroot-openbao"
+        );
+        assert!(!hcl.contains("ca_cert"), "http must not include ca_cert");
+    }
+
+    #[test]
+    fn docker_config_rewrites_specific_ip_to_container_name() {
+        let secrets_dir = Path::new("/project/secrets");
+        let svc_dir = secrets_dir.join("openbao/services/edge");
+        let cred_dir = secrets_dir.join("services/edge");
+        let hcl = render_docker_agent_config(&DockerAgentConfigInputs {
+            secrets_dir,
+            openbao_url: "https://192.168.1.10:8200",
+            role_id_path: &cred_dir.join("role_id"),
+            secret_id_path: &cred_dir.join("secret_id"),
+            token_path: &svc_dir.join("token"),
+            agent_template_path: &svc_dir.join("agent.toml.ctmpl"),
+            ca_bundle_template_path: &svc_dir.join("ca-bundle.pem.ctmpl"),
+        })
+        .unwrap();
+
+        assert!(
+            hcl.contains(r#"address = "https://bootroot-openbao:8200""#),
+            "specific IP must be replaced with Docker-internal hostname"
+        );
+        assert!(
+            hcl.contains(r#"ca_cert = "/openbao/secrets/services/edge/ca-bundle.pem""#),
+            "https with specific IP must use template-rendered ca_cert"
+        );
+    }
+
+    #[test]
+    fn host_agent_config_unchanged_by_docker_additions() {
+        let hcl = render_openbao_agent_config(
+            "http://localhost:8200",
+            Path::new("/secrets/services/edge/role_id"),
+            Path::new("/secrets/services/edge/secret_id"),
+            Path::new("/secrets/openbao/services/edge/token"),
+            &[("/tpl.ctmpl", "/out.toml")],
+        );
+
+        assert!(
+            hcl.contains(r#"address = "http://localhost:8200""#),
+            "host config must keep original address"
+        );
+        assert!(
+            hcl.contains(r#"role_id_file_path = "/secrets/services/edge/role_id""#),
+            "host config must keep host paths"
+        );
+        assert!(
+            !hcl.contains("ca_cert"),
+            "host config must not include ca_cert"
+        );
     }
 }

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -952,34 +952,46 @@ impl OpenBaoClient {
 /// Interval at which the `OpenBao` agent re-renders static secrets.
 pub const STATIC_SECRET_RENDER_INTERVAL: &str = "30s";
 
+/// Parameters for [`build_agent_config`].
+pub struct AgentConfigParams<'a> {
+    /// Vault/`OpenBao` server address.
+    pub openbao_addr: &'a str,
+    /// Path to the `AppRole` role-ID file.
+    pub role_id_path: &'a str,
+    /// Path to the `AppRole` secret-ID file.
+    pub secret_id_path: &'a str,
+    /// Path where the agent writes its token.
+    pub token_path: &'a str,
+    /// Optional auth mount path (e.g. `"auth/approle"`).
+    pub mount_path: Option<&'a str>,
+    /// Value for `static_secret_render_interval`.
+    pub render_interval: &'a str,
+    /// `(source, destination)` pairs for template blocks.
+    pub templates: &'a [(&'a str, &'a str)],
+    /// Optional path to a CA certificate bundle for TLS verification of
+    /// the `OpenBao` server.
+    pub ca_cert: Option<&'a str>,
+}
+
 /// Builds an `OpenBao` agent HCL configuration string.
-///
-/// # Arguments
-///
-/// * `openbao_addr` – Vault/`OpenBao` server address.
-/// * `role_id_path` – Path to the `AppRole` role-ID file.
-/// * `secret_id_path` – Path to the `AppRole` secret-ID file.
-/// * `token_path` – Path where the agent writes its token.
-/// * `mount_path` – Optional auth mount path (e.g. `"auth/approle"`).
-/// * `render_interval` – Value for `static_secret_render_interval`.
-/// * `templates` – `(source, destination)` pairs for template blocks.
 #[must_use]
-pub fn build_agent_config(
-    openbao_addr: &str,
-    role_id_path: &str,
-    secret_id_path: &str,
-    token_path: &str,
-    mount_path: Option<&str>,
-    render_interval: &str,
-    templates: &[(&str, &str)],
-) -> String {
-    let mount_line = match mount_path {
+pub fn build_agent_config(params: &AgentConfigParams<'_>) -> String {
+    let mount_line = match params.mount_path {
         Some(mp) => format!("\n    mount_path = \"{mp}\""),
         None => String::new(),
     };
+    let tls_line = match params.ca_cert {
+        Some(path) => format!("\n  ca_cert = \"{path}\""),
+        None => String::new(),
+    };
+    let openbao_addr = params.openbao_addr;
+    let role_id_path = params.role_id_path;
+    let secret_id_path = params.secret_id_path;
+    let token_path = params.token_path;
+    let render_interval = params.render_interval;
     let mut config = format!(
         r#"vault {{
-  address = "{openbao_addr}"
+  address = "{openbao_addr}"{tls_line}
 }}
 
 auto_auth {{
@@ -1002,7 +1014,7 @@ template_config {{
 }}
 "#
     );
-    for (source_path, destination_path) in templates {
+    for (source_path, destination_path) in params.templates {
         write!(
             &mut config,
             r#"
@@ -1214,49 +1226,84 @@ mod agent_config_tests {
 
     #[test]
     fn without_mount_path() {
-        let hcl = build_agent_config(
-            "http://openbao:8200",
-            "/role_id",
-            "/secret_id",
-            "/token",
-            None,
-            "30s",
-            &[("/tpl.ctmpl", "/out.toml")],
-        );
+        let hcl = build_agent_config(&AgentConfigParams {
+            openbao_addr: "http://openbao:8200",
+            role_id_path: "/role_id",
+            secret_id_path: "/secret_id",
+            token_path: "/token",
+            mount_path: None,
+            render_interval: "30s",
+            templates: &[("/tpl.ctmpl", "/out.toml")],
+            ca_cert: None,
+        });
         assert!(hcl.contains(r#"address = "http://openbao:8200""#));
         assert!(hcl.contains("role_id_file_path = \"/role_id\""));
         assert!(!hcl.contains("mount_path"));
+        assert!(!hcl.contains("ca_cert"));
         assert!(hcl.contains(r#"static_secret_render_interval = "30s""#));
         assert!(hcl.contains(r#"source = "/tpl.ctmpl""#));
     }
 
     #[test]
     fn with_mount_path() {
-        let hcl = build_agent_config(
-            "http://openbao:8200",
-            "/role_id",
-            "/secret_id",
-            "/token",
-            Some("auth/approle"),
-            "30s",
-            &[("/tpl.ctmpl", "/out.toml")],
-        );
+        let hcl = build_agent_config(&AgentConfigParams {
+            openbao_addr: "http://openbao:8200",
+            role_id_path: "/role_id",
+            secret_id_path: "/secret_id",
+            token_path: "/token",
+            mount_path: Some("auth/approle"),
+            render_interval: "30s",
+            templates: &[("/tpl.ctmpl", "/out.toml")],
+            ca_cert: None,
+        });
         assert!(hcl.contains(r#"mount_path = "auth/approle""#));
     }
 
     #[test]
     fn multiple_templates() {
-        let hcl = build_agent_config(
-            "http://openbao:8200",
-            "/role_id",
-            "/secret_id",
-            "/token",
-            None,
-            "30s",
-            &[("/a.ctmpl", "/a.out"), ("/b.ctmpl", "/b.out")],
-        );
+        let hcl = build_agent_config(&AgentConfigParams {
+            openbao_addr: "http://openbao:8200",
+            role_id_path: "/role_id",
+            secret_id_path: "/secret_id",
+            token_path: "/token",
+            mount_path: None,
+            render_interval: "30s",
+            templates: &[("/a.ctmpl", "/a.out"), ("/b.ctmpl", "/b.out")],
+            ca_cert: None,
+        });
         assert!(hcl.contains(r#"source = "/a.ctmpl""#));
         assert!(hcl.contains(r#"source = "/b.ctmpl""#));
+    }
+
+    #[test]
+    fn with_ca_cert() {
+        let hcl = build_agent_config(&AgentConfigParams {
+            openbao_addr: "https://openbao:8200",
+            role_id_path: "/role_id",
+            secret_id_path: "/secret_id",
+            token_path: "/token",
+            mount_path: Some("auth/approle"),
+            render_interval: "30s",
+            templates: &[("/tpl.ctmpl", "/out.toml")],
+            ca_cert: Some("/certs/ca-bundle.pem"),
+        });
+        assert!(hcl.contains(r#"address = "https://openbao:8200""#));
+        assert!(hcl.contains(r#"ca_cert = "/certs/ca-bundle.pem""#));
+    }
+
+    #[test]
+    fn without_ca_cert() {
+        let hcl = build_agent_config(&AgentConfigParams {
+            openbao_addr: "http://openbao:8200",
+            role_id_path: "/role_id",
+            secret_id_path: "/secret_id",
+            token_path: "/token",
+            mount_path: None,
+            render_interval: "30s",
+            templates: &[("/tpl.ctmpl", "/out.toml")],
+            ca_cert: None,
+        });
+        assert!(!hcl.contains("ca_cert"));
     }
 }
 

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1316,6 +1316,7 @@ fn assert_state_contains_default_delivery_mode(root: &std::path::Path) {
     );
 }
 
+#[allow(clippy::too_many_lines)]
 fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str) {
     let openbao_service_dir = root
         .join("secrets")
@@ -1406,6 +1407,50 @@ fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str
         )),
         "agent.hcl should target a CA bundle output path"
     );
+
+    // Verify Docker sidecar agent config
+    let docker_hcl = openbao_service_dir.join("agent-docker.hcl");
+    assert!(docker_hcl.exists(), "agent-docker.hcl must be generated");
+    let docker_hcl_mode = fs::metadata(&docker_hcl)
+        .expect("docker hcl metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(docker_hcl_mode, 0o600, "agent-docker.hcl must be 0600");
+
+    let docker_hcl_contents = fs::read_to_string(&docker_hcl).expect("read agent-docker.hcl");
+    assert!(
+        docker_hcl_contents.contains("vault {"),
+        "agent-docker.hcl should contain vault block"
+    );
+    assert!(
+        docker_hcl_contents.contains(r#"address = "http://bootroot-openbao:"#),
+        "agent-docker.hcl should use Docker-internal address: {docker_hcl_contents}"
+    );
+    assert!(
+        docker_hcl_contents.contains("/openbao/secrets/"),
+        "agent-docker.hcl should use container-side paths: {docker_hcl_contents}"
+    );
+    assert!(
+        !docker_hcl_contents.contains("localhost"),
+        "agent-docker.hcl must not reference localhost: {docker_hcl_contents}"
+    );
+
+    // Verify CA bundle is pre-seeded in the credential directory at the
+    // same path the agent template renders to, so the sidecar can both
+    // bootstrap TLS and track live trust updates after the template runs.
+    let cred_dir = root.join("secrets").join("services").join(service_name);
+    let docker_ca = cred_dir.join("ca-bundle.pem");
+    assert!(
+        docker_ca.exists(),
+        "CA bundle must be pre-seeded for Docker sidecar TLS"
+    );
+    let docker_ca_mode = fs::metadata(&docker_ca)
+        .expect("docker ca metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(docker_ca_mode, 0o600, "Docker CA bundle must be 0600");
 }
 
 fn path_relative_to_root_or_self<'a>(


### PR DESCRIPTION
## Summary

- Extend the agent HCL builder (`build_agent_config`) to accept an `AgentConfigParams` struct with an optional `ca_cert` field for TLS verification of the OpenBao server.
- Generate `agent-docker.hcl` alongside the existing `agent.hcl` during `bootroot service add` (local-file mode). The Docker variant uses the Docker-internal OpenBao address (`bootroot-openbao:8200`) and container-side paths under `/openbao/secrets/`.
- Template render destinations use the per-service credential directory (`/openbao/secrets/services/<svc>/`), matching the manual sidecar example in `configuration.md`. This keeps rendered output accessible to the service via the shared `secrets_dir` bind-mount.
- `resolve_openbao_agent_addr` unconditionally replaces the host portion of the OpenBao URL with the container name when Docker compose includes OpenBao, covering loopback addresses, specific bind IPs, and FQDNs alike.
- When TLS is enabled (`https`), the Docker config includes a `ca_cert` field pointing to the same `ca-bundle.pem` that the agent template renders from KV. `service add` pre-seeds this file with the current trust bundle so the sidecar can verify TLS on its very first connection (before any template has rendered). Once running, the agent's template keeps the file in sync with the live trust bundle from OpenBao KV, so CA rotations are tracked automatically. When TLS is disabled (`http`), the field is omitted.
- The existing `agent.hcl` output is unchanged.

Closes #518

## Non-goals (tracked separately)

- **Starting or managing the sidecar container** — tracked in #520.
- **Remote (non-local Docker) deployments** — tracked in #519.
- **Certificate issuance or renewal for sidecar agents** — out of scope for this issue.

## Test plan

- [x] `bootroot service add` produces a valid `agent-docker.hcl` alongside `agent.hcl`
- [x] The Docker variant uses container-side paths (`/openbao/secrets/...`) and the Docker-internal OpenBao address (`bootroot-openbao:8200`)
- [x] Template destinations target the service credential directory (`/openbao/secrets/services/<svc>/`), matching the docs convention
- [x] TLS-enabled OpenBao: `agent-docker.hcl` includes `ca_cert` pointing to the template-rendered CA bundle
- [x] TLS-disabled OpenBao: `agent-docker.hcl` omits `ca_cert`
- [x] Non-loopback `openbao_url` (e.g. `https://192.168.1.10:8200`) is rewritten to `bootroot-openbao` in the Docker config
- [x] Existing `agent.hcl` output is unchanged by the Docker additions
- [x] Unit tests cover all of the above scenarios (`docker_config_uses_container_paths_and_openbao_hostname`, `docker_config_includes_ca_cert_when_tls_enabled`, `docker_config_omits_ca_cert_when_http`, `docker_config_rewrites_specific_ip_to_container_name`, `host_agent_config_unchanged_by_docker_additions`)
- [x] Integration test (`assert_openbao_service_agent_files`) verifies `agent-docker.hcl` is generated with correct permissions and content