### PR TITLE
Add service agent start subcommand (#520)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -61,6 +61,22 @@ pub(crate) enum ServiceCommand {
     Add(Box<ServiceAddArgs>),
     Info(ServiceInfoArgs),
     Update(ServiceUpdateArgs),
+    #[command(subcommand)]
+    Agent(ServiceAgentCommand),
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum ServiceAgentCommand {
+    Start(ServiceAgentStartArgs),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct ServiceAgentStartArgs {
+    /// Service name identifier
+    pub(crate) service_name: String,
+
+    #[command(flatten)]
+    pub(crate) compose_file: ComposeFileArgs,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -1461,5 +1477,46 @@ mod tests {
             }
             _ => panic!("expected service update"),
         }
+    }
+
+    #[test]
+    fn test_cli_parses_service_agent_start() {
+        let cli = Cli::parse_from(["bootroot", "service", "agent", "start", "myapp"]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Agent(ServiceAgentCommand::Start(args))) => {
+                assert_eq!(args.service_name, "myapp");
+                assert_eq!(
+                    args.compose_file.compose_file,
+                    PathBuf::from("docker-compose.yml")
+                );
+            }
+            _ => panic!("expected service agent start"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_agent_start_custom_compose() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "agent",
+            "start",
+            "myapp",
+            "--compose-file",
+            "custom.yml",
+        ]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Agent(ServiceAgentCommand::Start(args))) => {
+                assert_eq!(args.service_name, "myapp");
+                assert_eq!(args.compose_file.compose_file, PathBuf::from("custom.yml"));
+            }
+            _ => panic!("expected service agent start"),
+        }
+    }
+
+    #[test]
+    fn test_cli_service_agent_start_requires_service_name() {
+        let result = Cli::try_parse_from(["bootroot", "service", "agent", "start"]);
+        assert!(result.is_err(), "service-name should be required");
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -16,7 +16,9 @@ pub(crate) use constants::{
     OPENBAO_TLS_DEFAULT_NOT_AFTER, OPENBAO_TLS_DEFAULT_RENEW_BEFORE, OPENBAO_TLS_KEY_PATH,
     RESPONDER_CONFIG_DIR, RESPONDER_CONFIG_NAME, SECRET_BYTES,
 };
-pub(crate) use paths::{compose_has_responder, resolve_openbao_agent_addr, to_container_path};
+pub(crate) use paths::{
+    compose_has_openbao, compose_has_responder, resolve_openbao_agent_addr, to_container_path,
+};
 pub(crate) use steps::openbao_tls::{reissue_openbao_tls_cert, write_openbao_hcl_plaintext};
 pub(crate) use steps::{
     compute_ca_bundle_pem, compute_ca_fingerprints, prompt_yes_no, read_ca_cert_fingerprint,

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1,3 +1,4 @@
+pub(crate) mod agent_start;
 mod approle;
 mod local_config;
 mod remote_bootstrap;

--- a/src/commands/service/agent_start.rs
+++ b/src/commands/service/agent_start.rs
@@ -1,0 +1,361 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use super::{OPENBAO_AGENT_DOCKER_CONFIG_FILENAME, OPENBAO_SERVICE_CONFIG_DIR};
+use crate::cli::args::ServiceAgentStartArgs;
+use crate::commands::infra::run_docker;
+use crate::commands::init::{compose_has_openbao, resolve_openbao_agent_addr};
+use crate::i18n::Messages;
+use crate::state::{DeliveryMode, DeployType, StateFile};
+
+/// Compose project name, matching the convention used by `bootroot init`.
+const COMPOSE_PROJECT: &str = "bootroot";
+
+/// Docker network created by `docker compose -p bootroot`.
+const COMPOSE_NETWORK: &str = "bootroot_default";
+
+/// Compose override filename written per service.
+const SERVICE_COMPOSE_OVERRIDE: &str = "docker-compose.override.yml";
+
+/// Mount point inside service sidecar containers.
+const SIDECAR_CONTAINER_MOUNT: &str = "/openbao/secrets";
+
+/// Runs `bootroot service agent start`.
+pub(crate) fn run_service_agent_start(
+    args: &ServiceAgentStartArgs,
+    messages: &Messages,
+) -> Result<()> {
+    let state_path = StateFile::default_path();
+    if !state_path.exists() {
+        anyhow::bail!(messages.error_state_missing());
+    }
+    let state =
+        StateFile::load(&state_path).with_context(|| messages.error_parse_state_failed())?;
+
+    let entry = state
+        .services
+        .get(&args.service_name)
+        .ok_or_else(|| anyhow::anyhow!(messages.error_service_not_found(&args.service_name)))?;
+
+    if entry.deploy_type != DeployType::Docker {
+        anyhow::bail!(messages.error_service_not_docker(&args.service_name));
+    }
+
+    if entry.delivery_mode == DeliveryMode::RemoteBootstrap {
+        anyhow::bail!(messages.error_service_remote_bootstrap(&args.service_name));
+    }
+
+    let secrets_dir = state.secrets_dir();
+    let service_openbao_dir = secrets_dir
+        .join(OPENBAO_SERVICE_CONFIG_DIR)
+        .join(&args.service_name);
+    let docker_config = service_openbao_dir.join(OPENBAO_AGENT_DOCKER_CONFIG_FILENAME);
+    if !docker_config.exists() {
+        anyhow::bail!(
+            messages.error_service_agent_config_missing(&docker_config.display().to_string())
+        );
+    }
+
+    let compose_file = &args.compose_file.compose_file;
+    let override_path = service_openbao_dir.join(SERVICE_COMPOSE_OVERRIDE);
+    write_service_agent_compose_override(
+        compose_file,
+        secrets_dir,
+        &service_openbao_dir,
+        &args.service_name,
+        &state.openbao_url,
+        messages,
+    )?;
+
+    let service_name = format!("openbao-agent-{}", args.service_name);
+    apply_service_agent_compose_override(compose_file, &override_path, &service_name, messages)?;
+
+    println!(
+        "{}",
+        messages.service_agent_start_completed(&args.service_name)
+    );
+    Ok(())
+}
+
+/// Writes a per-service compose override that defines the sidecar agent
+/// container.
+fn write_service_agent_compose_override(
+    compose_file: &Path,
+    secrets_dir: &Path,
+    service_openbao_dir: &Path,
+    service_name: &str,
+    openbao_url: &str,
+    messages: &Messages,
+) -> Result<()> {
+    let mount_root = std::fs::canonicalize(secrets_dir)
+        .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
+
+    let has_openbao = compose_has_openbao(compose_file, messages)?;
+    let depends_on = if has_openbao {
+        "    depends_on:\n      - openbao\n"
+    } else {
+        ""
+    };
+
+    let meta = std::fs::metadata(&mount_root)
+        .with_context(|| messages.error_resolve_path_failed(&mount_root.display().to_string()))?;
+    let user = {
+        use std::os::unix::fs::MetadataExt;
+        format!("{}:{}", meta.uid(), meta.gid())
+    };
+
+    let docker_addr = resolve_openbao_agent_addr(openbao_url, has_openbao);
+
+    let config_rel = service_openbao_dir
+        .join(OPENBAO_AGENT_DOCKER_CONFIG_FILENAME)
+        .strip_prefix(secrets_dir)
+        .with_context(|| {
+            messages.error_resolve_path_failed(&service_openbao_dir.display().to_string())
+        })?
+        .to_string_lossy()
+        .to_string();
+    let container_config_path = format!("{SIDECAR_CONTAINER_MOUNT}/{config_rel}");
+
+    let compose_service = format!("openbao-agent-{service_name}");
+    let container_name = format!("bootroot-openbao-agent-{service_name}");
+
+    // When OpenBao uses TLS, also pass the CA bundle path so the
+    // container picks up VAULT_CACERT automatically.
+    let ca_env = if docker_addr.starts_with("https://") {
+        let ca_path = format!("{SIDECAR_CONTAINER_MOUNT}/services/{service_name}/ca-bundle.pem");
+        format!("      - VAULT_CACERT={ca_path}\n")
+    } else {
+        String::new()
+    };
+
+    let contents = format!(
+        r#"services:
+  {compose_service}:
+    image: openbao/openbao:latest
+    container_name: {container_name}
+    user: "{user}"
+    restart: always
+    command: ["agent", "-config={container_config_path}"]
+{depends_on}    environment:
+      - VAULT_ADDR={docker_addr}
+{ca_env}    volumes:
+      - {secrets_path}:{SIDECAR_CONTAINER_MOUNT}
+    networks:
+      - default
+networks:
+  default:
+    name: {COMPOSE_NETWORK}
+    external: true
+"#,
+        secrets_path = mount_root.display(),
+    );
+
+    let override_path = service_openbao_dir.join(SERVICE_COMPOSE_OVERRIDE);
+    std::fs::write(&override_path, contents)
+        .with_context(|| messages.error_write_file_failed(&override_path.display().to_string()))?;
+
+    Ok(())
+}
+
+/// Calls `docker compose` to bring up the service agent sidecar.
+fn apply_service_agent_compose_override(
+    compose_file: &Path,
+    override_path: &Path,
+    service_name: &str,
+    messages: &Messages,
+) -> Result<()> {
+    let compose_str = compose_file.to_string_lossy();
+    let override_str = override_path.to_string_lossy();
+    let args = [
+        "compose",
+        "-p",
+        COMPOSE_PROJECT,
+        "-f",
+        &compose_str,
+        "-f",
+        &override_str,
+        "up",
+        "-d",
+        service_name,
+    ];
+    run_docker(&args, "docker compose service agent start", messages)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn compose_override_contains_service_definition() {
+        let dir = tempdir().unwrap();
+        let secrets = dir.path().join("secrets");
+        std::fs::create_dir_all(&secrets).unwrap();
+
+        let compose_file = dir.path().join("docker-compose.yml");
+        std::fs::write(
+            &compose_file,
+            "services:\n  openbao:\n    image: openbao/openbao:latest\n",
+        )
+        .unwrap();
+
+        let svc_dir = secrets.join("openbao/services/myapp");
+        std::fs::create_dir_all(&svc_dir).unwrap();
+        std::fs::write(svc_dir.join(OPENBAO_AGENT_DOCKER_CONFIG_FILENAME), "").unwrap();
+
+        let messages = crate::i18n::test_messages();
+        write_service_agent_compose_override(
+            &compose_file,
+            &secrets,
+            &svc_dir,
+            "myapp",
+            "http://localhost:8200",
+            &messages,
+        )
+        .unwrap();
+
+        let override_path = svc_dir.join(SERVICE_COMPOSE_OVERRIDE);
+        assert!(override_path.exists());
+        let contents = std::fs::read_to_string(&override_path).unwrap();
+
+        assert!(
+            contents.contains("openbao-agent-myapp:"),
+            "must define compose service"
+        );
+        assert!(
+            contents.contains("container_name: bootroot-openbao-agent-myapp"),
+            "must set container name"
+        );
+        assert!(
+            contents.contains("VAULT_ADDR=http://bootroot-openbao:8200"),
+            "must set VAULT_ADDR"
+        );
+        assert!(
+            contents.contains("depends_on:"),
+            "must depend on openbao when present in compose"
+        );
+        assert!(
+            contents.contains("bootroot_default"),
+            "must reference bootroot_default network"
+        );
+        assert!(
+            !contents.contains("VAULT_CACERT"),
+            "http must not set VAULT_CACERT"
+        );
+    }
+
+    #[test]
+    fn compose_override_includes_ca_env_for_https() {
+        let dir = tempdir().unwrap();
+        let secrets = dir.path().join("secrets");
+        std::fs::create_dir_all(&secrets).unwrap();
+
+        let compose_file = dir.path().join("docker-compose.yml");
+        std::fs::write(
+            &compose_file,
+            "services:\n  openbao:\n    image: openbao/openbao:latest\n",
+        )
+        .unwrap();
+
+        let svc_dir = secrets.join("openbao/services/myapp");
+        std::fs::create_dir_all(&svc_dir).unwrap();
+        std::fs::write(svc_dir.join(OPENBAO_AGENT_DOCKER_CONFIG_FILENAME), "").unwrap();
+
+        let messages = crate::i18n::test_messages();
+        write_service_agent_compose_override(
+            &compose_file,
+            &secrets,
+            &svc_dir,
+            "myapp",
+            "https://192.168.1.10:8200",
+            &messages,
+        )
+        .unwrap();
+
+        let contents = std::fs::read_to_string(svc_dir.join(SERVICE_COMPOSE_OVERRIDE)).unwrap();
+
+        assert!(
+            contents.contains("VAULT_ADDR=https://bootroot-openbao:8200"),
+            "must use https docker address"
+        );
+        assert!(
+            contents.contains("VAULT_CACERT="),
+            "https must set VAULT_CACERT"
+        );
+        assert!(
+            contents.contains("depends_on:"),
+            "must depend on openbao when present in compose"
+        );
+    }
+
+    #[test]
+    fn compose_override_keeps_original_addr_without_openbao_in_compose() {
+        let dir = tempdir().unwrap();
+        let secrets = dir.path().join("secrets");
+        std::fs::create_dir_all(&secrets).unwrap();
+
+        let compose_file = dir.path().join("docker-compose.yml");
+        std::fs::write(&compose_file, "services:\n  app:\n    image: app:latest\n").unwrap();
+
+        let svc_dir = secrets.join("openbao/services/myapp");
+        std::fs::create_dir_all(&svc_dir).unwrap();
+        std::fs::write(svc_dir.join(OPENBAO_AGENT_DOCKER_CONFIG_FILENAME), "").unwrap();
+
+        let messages = crate::i18n::test_messages();
+        write_service_agent_compose_override(
+            &compose_file,
+            &secrets,
+            &svc_dir,
+            "myapp",
+            "https://192.168.1.10:8200",
+            &messages,
+        )
+        .unwrap();
+
+        let contents = std::fs::read_to_string(svc_dir.join(SERVICE_COMPOSE_OVERRIDE)).unwrap();
+
+        assert!(
+            contents.contains("VAULT_ADDR=https://192.168.1.10:8200"),
+            "must keep original address when openbao not in compose"
+        );
+        assert!(
+            !contents.contains("depends_on:"),
+            "must not depend on openbao when not in compose"
+        );
+    }
+
+    #[test]
+    fn compose_override_no_version_field() {
+        let dir = tempdir().unwrap();
+        let secrets = dir.path().join("secrets");
+        std::fs::create_dir_all(&secrets).unwrap();
+
+        let compose_file = dir.path().join("docker-compose.yml");
+        std::fs::write(&compose_file, "services:\n  app:\n    image: app:latest\n").unwrap();
+
+        let svc_dir = secrets.join("openbao/services/test");
+        std::fs::create_dir_all(&svc_dir).unwrap();
+        std::fs::write(svc_dir.join(OPENBAO_AGENT_DOCKER_CONFIG_FILENAME), "").unwrap();
+
+        let messages = crate::i18n::test_messages();
+        write_service_agent_compose_override(
+            &compose_file,
+            &secrets,
+            &svc_dir,
+            "test",
+            "http://localhost:8200",
+            &messages,
+        )
+        .unwrap();
+
+        let contents = std::fs::read_to_string(svc_dir.join(SERVICE_COMPOSE_OVERRIDE)).unwrap();
+
+        assert!(
+            !contents.contains("version:"),
+            "must not include deprecated version field"
+        );
+    }
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -460,6 +460,11 @@ pub(crate) struct Strings {
     pub(crate) error_infra_tls_renew_failed: &'static str,
     pub(crate) prompt_rotate_infra_tls: &'static str,
     pub(crate) rotate_infra_tls_no_entries: &'static str,
+    pub(crate) error_service_agent_start_failed: &'static str,
+    pub(crate) error_service_not_docker: &'static str,
+    pub(crate) error_service_remote_bootstrap: &'static str,
+    pub(crate) error_service_agent_config_missing: &'static str,
+    pub(crate) service_agent_start_completed: &'static str,
 }
 
 pub(crate) struct Messages {

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -425,4 +425,9 @@ pub(super) static STRINGS: Strings = Strings {
     error_infra_tls_renew_failed: "Failed to renew infrastructure certificate: {name}",
     prompt_rotate_infra_tls: "Renew infrastructure certificates? [y/N]: ",
     rotate_infra_tls_no_entries: "No infrastructure certificates registered in state",
+    error_service_agent_start_failed: "bootroot service agent start failed",
+    error_service_not_docker: "Service deploy type is not docker: {value}",
+    error_service_remote_bootstrap: "Service uses remote-bootstrap delivery; local sidecar agent start is not supported: {value}",
+    error_service_agent_config_missing: "Docker agent config not found: {value}",
+    service_agent_start_completed: "bootroot service agent start: started bootroot-openbao-agent-{value}",
 };

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -425,4 +425,9 @@ pub(super) static STRINGS: Strings = Strings {
     error_infra_tls_renew_failed: "인프라 인증서 갱신에 실패했습니다: {name}",
     prompt_rotate_infra_tls: "인프라 인증서를 갱신하시겠습니까? [y/N]: ",
     rotate_infra_tls_no_entries: "state에 등록된 인프라 인증서가 없습니다",
+    error_service_agent_start_failed: "bootroot service agent start 실패",
+    error_service_not_docker: "서비스 배포 유형이 docker가 아닙니다: {value}",
+    error_service_remote_bootstrap: "서비스가 remote-bootstrap 전달 모드를 사용합니다. 로컬 사이드카 에이전트 시작은 지원되지 않습니다: {value}",
+    error_service_agent_config_missing: "Docker 에이전트 설정 파일을 찾을 수 없습니다: {value}",
+    service_agent_start_completed: "bootroot service agent start: bootroot-openbao-agent-{value} 시작됨",
 };

--- a/src/i18n/service.rs
+++ b/src/i18n/service.rs
@@ -857,4 +857,33 @@ impl Messages {
     pub(crate) fn service_update_no_changes(&self) -> &'static str {
         self.strings().service_update_no_changes
     }
+
+    pub(crate) fn error_service_agent_start_failed(&self) -> &'static str {
+        self.strings().error_service_agent_start_failed
+    }
+
+    pub(crate) fn error_service_not_docker(&self, value: &str) -> String {
+        format_template(self.strings().error_service_not_docker, &[("value", value)])
+    }
+
+    pub(crate) fn error_service_remote_bootstrap(&self, value: &str) -> String {
+        format_template(
+            self.strings().error_service_remote_bootstrap,
+            &[("value", value)],
+        )
+    }
+
+    pub(crate) fn error_service_agent_config_missing(&self, value: &str) -> String {
+        format_template(
+            self.strings().error_service_agent_config_missing,
+            &[("value", value)],
+        )
+    }
+
+    pub(crate) fn service_agent_start_completed(&self, value: &str) -> String {
+        format_template(
+            self.strings().service_agent_start_completed,
+            &[("value", value)],
+        )
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@ mod state;
 use clap::Parser;
 
 use crate::cli::args::{
-    Cli, CliCommand, InfraCommand, MonitoringCommand, OpenbaoCommand, ServiceCommand,
+    Cli, CliCommand, InfraCommand, MonitoringCommand, OpenbaoCommand, ServiceAgentCommand,
+    ServiceCommand,
 };
 use crate::i18n::Messages;
 
@@ -95,6 +96,10 @@ fn run(cli: Cli, messages: &Messages) -> Result<()> {
         CliCommand::Service(ServiceCommand::Update(args)) => {
             commands::service::run_service_update(&args, messages)
                 .with_context(|| messages.error_service_update_failed())?;
+        }
+        CliCommand::Service(ServiceCommand::Agent(ServiceAgentCommand::Start(args))) => {
+            commands::service::agent_start::run_service_agent_start(&args, messages)
+                .with_context(|| messages.error_service_agent_start_failed())?;
         }
         CliCommand::Verify(args) => commands::verify::run_verify(&args, messages)
             .with_context(|| messages.error_verify_failed())?,


### PR DESCRIPTION
## Summary

- Adds `bootroot service agent start <service>` subcommand with a `--compose-file` flag (default: `docker-compose.yml`).
- Writes a per-service compose override fragment to `secrets/openbao/services/<service>/docker-compose.override.yml` defining the `bootroot-openbao-agent-<service>` sidecar container with correct image, network (`bootroot_default`), and volume mounts.
- Invokes `docker compose -p bootroot -f <compose-file> -f <override-file> up -d` to bring up the sidecar, following the same compose-override pattern used by `bootroot init`.
- Supports TLS-enabled OpenBao by passing `VAULT_CACERT` when the address uses `https://`.
- Rejects services with `RemoteBootstrap` delivery mode, since managing remote sidecar agents is out of scope (#519).
- Idempotent: re-running when the container is already up is safe.

Closes #520

## Test plan

- [x] `bootroot service agent start <service>` starts the sidecar container using `docker-compose.yml`, attached to `bootroot_default`, which authenticates to OpenBao and renders the agent config
- [x] `--compose-file <path>` correctly uses the specified compose file
- [x] Running the command when the container is already running behaves idempotently
- [x] `bootroot rotate responder-hmac` completes without timeout when the sidecar container is running
- [x] TLS-enabled OpenBao: the container connects via `https://` and validates against the CA bundle
- [x] Unit tests pass: `cargo test agent_start`