### PR TITLE
Assert OpenBao audit log production in Docker E2E (#536)

### DIFF
--- a/scripts/impl/lib/audit-log.sh
+++ b/scripts/impl/lib/audit-log.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+# Shared assertions for the OpenBao file-audit backend.
+#
+# Sourced by lifecycle harnesses to verify, against the real OpenBao
+# container, that the declarative `audit { type = "file" ... }` stanza
+# in `openbao/openbao.hcl` actually produces an audit log at runtime
+# and that the log captures representative AppRole login + KV read
+# events. Callers must define a `fail` function that aborts the
+# harness with a message; this helper invokes it on any failed check.
+
+OPENBAO_AUDIT_CONTAINER_DEFAULT="bootroot-openbao"
+OPENBAO_AUDIT_LOG_PATH_DEFAULT="/openbao/audit/audit.log"
+
+# Asserts that the OpenBao file-audit backend wrote a non-empty
+# audit log containing at least one `"type":"response"` entry for
+# `auth/approle/login` and one for a `secret/data/...` KV read.
+#
+# The KV check requires `"operation":"read"` in addition to a
+# `secret/data/...` path so that KV *writes* emitted by the harness
+# (e.g. seeding runtime secrets) cannot alone satisfy the assertion.
+assert_openbao_audit_log() {
+  local container="${1:-$OPENBAO_AUDIT_CONTAINER_DEFAULT}"
+  local path="${2:-$OPENBAO_AUDIT_LOG_PATH_DEFAULT}"
+
+  if ! docker exec "$container" test -s "$path"; then
+    fail "openbao audit log missing or empty: ${container}:${path}"
+  fi
+
+  if ! docker exec "$container" sh -c \
+      "grep -F '\"type\":\"response\"' '$path' | grep -F '\"path\":\"auth/approle/login\"' >/dev/null"; then
+    fail "openbao audit log missing AppRole login response entry: ${container}:${path}"
+  fi
+
+  if ! docker exec "$container" sh -c \
+      "grep -F '\"type\":\"response\"' '$path' | grep -F '\"operation\":\"read\"' | grep -E '\"path\":\"secret/data/' >/dev/null"; then
+    fail "openbao audit log missing KV read response entry (operation=read on secret/data/...): ${container}:${path}"
+  fi
+}

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ROOT_DIR"
+
+# shellcheck source=lib/audit-log.sh
+. "$SCRIPT_DIR/lib/audit-log.sh"
 
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-local-lifecycle-$(date +%s)}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/docker-compose.yml}"
@@ -798,6 +802,10 @@ main() {
 
   run_verify_pair "initial"
   run_rotations_with_verification
+
+  log_phase "assert-openbao-audit-log"
+  assert_openbao_audit_log
+
   write_manifest
 }
 

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ROOT_DIR"
+
+# shellcheck source=lib/audit-log.sh
+. "$SCRIPT_DIR/lib/audit-log.sh"
 
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-remote-lifecycle-$(date +%s)}"
 COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/docker-compose.yml}"
@@ -623,6 +627,9 @@ main() {
   run_verify_pair "after-responder-hmac"
   assert_fingerprint_changed "$SERVICE_NAME" "after-trust-sync" "after-responder-hmac"
   assert_fingerprint_changed "$SERVICE_NAME_2" "after-trust-sync" "after-responder-hmac"
+
+  log_phase "assert-openbao-audit-log"
+  assert_openbao_audit_log
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Add `scripts/impl/lib/audit-log.sh` with a shared `assert_openbao_audit_log` helper that `docker exec`s into `bootroot-openbao` and checks that `/openbao/audit/audit.log` exists, is non-empty, and contains at least one `"type":"response"` entry for both `auth/approle/login` and a KV **read** (`"operation":"read"` + `"path":"secret/data/..."`). The `operation` discriminator prevents harness-generated KV writes from alone satisfying the assertion.
- Wire the helper into both `run-local-lifecycle.sh` and `run-remote-lifecycle.sh` as a final `assert-openbao-audit-log` phase, so the `test-docker-e2e-matrix` job fails if the file audit backend is silently broken.
- Closes the #510 acceptance gap that #524 explicitly deferred (real-stack assertion that the declarative `audit { type = "file" ... }` stanza actually produces log entries at runtime).

No production code changes; this is a test-only harness addition.

Closes #536
Part of #507

## Test plan

- [x] `scripts/preflight/ci/e2e-matrix.sh` passes locally (both local and remote lifecycle harnesses exercise the new assertion after their normal lifecycle runs). — Covered by the CI `test-docker-e2e-matrix` jobs (all four variants: `local-hosts`, `local-no-hosts`, `remote-hosts`, `remote-no-hosts`, plus `rotation`), which run the same harness scripts with the new assertion.
- [x] Introducing a regression (e.g. removing the `audit` stanza from `openbao/openbao.hcl` or the `openbao-audit` volume from `docker-compose.yml`) causes both harnesses to fail with a clear `openbao audit log missing or empty` / `missing AppRole login response entry` / `missing KV read response entry` message.
- [x] A pure-write regression (KV writes only, no reads) trips the tightened KV assertion, because the helper now requires `"operation":"read"` in addition to a `secret/data/...` path.
- [x] `test-docker-e2e-matrix` CI job is green on the PR.
- [x] The assertion logic lives only in `scripts/impl/lib/audit-log.sh`; neither harness duplicates the check body.