### PR TITLE
Auto-read admin DSN from ca.json in rotate db (#517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- `bootroot rotate db` now auto-reads the current PostgreSQL admin DSN
+  from `ca.json`'s `db.dataSource` field when `--db-admin-dsn` is
+  omitted. Previously operators had to copy the DSN out of `ca.json`
+  manually because the password in `.env`'s `POSTGRES_PASSWORD` diverges
+  from the live credential after `init --enable db-provision`. The flag
+  still overrides the discovered value when explicitly provided, and the
+  command falls through to the interactive prompt only when `ca.json` is
+  absent. A present-but-broken `ca.json` now fails fast instead of
+  prompting for a DSN that would likely be wrong. (Closes #517)
 - Added rotation cadence guidance to `service add`, `service update`,
   and `init` CLI output. `init` always prints the rotation-cadence
   note; `service add` and `service update` print it when

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -816,7 +816,12 @@ Per subcommand:
 
 #### `rotate db`
 
-- `--db-admin-dsn`: DB admin DSN (env `BOOTROOT_DB_ADMIN_DSN`)
+- `--db-admin-dsn`: DB admin DSN (env `BOOTROOT_DB_ADMIN_DSN`). Optional
+  when `ca.json` is present (auto-populated by `bootroot init --enable
+  db-provision`); bootroot reads the current admin DSN from
+  `ca.json`'s `db.dataSource` field. Pass the flag explicitly to
+  override, or provide it when `ca.json` is absent and the command would
+  otherwise prompt interactively.
 - `--db-password`: new DB password
   (optional, auto-generated if omitted, env `BOOTROOT_DB_PASSWORD`)
 - `--db-timeout-secs`: DB timeout in seconds (default `2`)

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -792,7 +792,12 @@ OpenBao와 통신해 값을 갱신합니다.
 
 #### `rotate db`
 
-- `--db-admin-dsn`: DB 관리자 DSN (환경 변수 `BOOTROOT_DB_ADMIN_DSN`)
+- `--db-admin-dsn`: DB 관리자 DSN (환경 변수 `BOOTROOT_DB_ADMIN_DSN`).
+  `ca.json`이 있으면(즉, `bootroot init --enable db-provision`으로 생성된
+  경우) 선택 사항입니다. bootroot가 `ca.json`의 `db.dataSource` 필드에서
+  현재 관리자 DSN을 자동으로 읽어옵니다. 값을 재정의하려면 플래그를 명시적
+  으로 지정하고, `ca.json`이 없고 대화형 프롬프트를 피하고 싶을 때도 직접
+  지정하세요.
 - `--db-password`: 새 DB 비밀번호
   (선택, 미지정 시 자동 생성, 환경 변수: `BOOTROOT_DB_PASSWORD`)
 - `--db-timeout-secs`: DB 점검 타임아웃(초, 기본값 `2`)

--- a/src/commands/rotate/db.rs
+++ b/src/commands/rotate/db.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io;
 use std::path::Path;
 use std::time::Duration;
 
@@ -27,7 +28,8 @@ pub(super) async fn rotate_db(
     confirm_action(messages.prompt_rotate_db(), auto_confirm, messages)?;
     ensure_postgres_localhost_binding(&ctx.compose_file, messages)?;
 
-    let admin_dsn = resolve_db_admin_dsn(args, messages)?;
+    let ca_json_path = ctx.paths.ca_json();
+    let admin_dsn = resolve_db_admin_dsn(args, &ca_json_path, messages)?;
     let admin = db::parse_db_dsn(&admin_dsn).with_context(|| messages.error_invalid_db_dsn())?;
     ensure_single_host_db_host(&admin.host, messages)?;
     let db_password = match &args.password {
@@ -35,7 +37,6 @@ pub(super) async fn rotate_db(
         None => bootroot::utils::generate_secret(SECRET_BYTES)
             .with_context(|| messages.error_generate_secret_failed())?,
     };
-    let ca_json_path = ctx.paths.ca_json();
     let current_dsn = read_ca_json_dsn(&ca_json_path, messages)?;
     let parsed = db::parse_db_dsn(&current_dsn).with_context(|| messages.error_invalid_db_dsn())?;
     ensure_single_host_db_host(&parsed.host, messages)?;
@@ -91,9 +92,22 @@ pub(super) async fn rotate_db(
     Ok(())
 }
 
-fn resolve_db_admin_dsn(args: &RotateDbArgs, messages: &Messages) -> Result<String> {
+fn resolve_db_admin_dsn(
+    args: &RotateDbArgs,
+    ca_json_path: &Path,
+    messages: &Messages,
+) -> Result<String> {
     if let Some(value) = &args.admin_dsn.admin_dsn {
         return Ok(value.clone());
+    }
+    // Only fall through to the interactive prompt when ca.json is
+    // definitively absent. Any other I/O failure (permission denied,
+    // unreadable parent, malformed contents, missing fields) is surfaced
+    // as a hard error so a broken environment does not silently prompt
+    // for a DSN that would likely be wrong — and cannot trigger the
+    // non-interactive EOF loop in `Prompt::prompt_with_validation`.
+    if let Some(dsn) = read_ca_json_dsn_if_present(ca_json_path, messages)? {
+        return Ok(dsn);
     }
     let mut input = std::io::stdin().lock();
     let mut output = std::io::stdout();
@@ -103,11 +117,24 @@ fn resolve_db_admin_dsn(args: &RotateDbArgs, messages: &Messages) -> Result<Stri
     })
 }
 
+fn read_ca_json_dsn_if_present(path: &Path, messages: &Messages) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(contents) => parse_ca_json_dsn(&contents, messages).map(Some),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(anyhow::Error::new(err)
+            .context(messages.error_read_file_failed(&path.display().to_string()))),
+    }
+}
+
 fn read_ca_json_dsn(path: &Path, messages: &Messages) -> Result<String> {
     let contents = fs::read_to_string(path)
         .with_context(|| messages.error_read_file_failed(&path.display().to_string()))?;
+    parse_ca_json_dsn(&contents, messages)
+}
+
+fn parse_ca_json_dsn(contents: &str, messages: &Messages) -> Result<String> {
     let value: serde_json::Value =
-        serde_json::from_str(&contents).context(messages.error_parse_ca_json_failed())?;
+        serde_json::from_str(contents).context(messages.error_parse_ca_json_failed())?;
     let db = value
         .get("db")
         .ok_or_else(|| anyhow::anyhow!(messages.error_ca_json_db_missing()))?;
@@ -131,6 +158,13 @@ mod tests {
     #[test]
     fn resolve_db_admin_dsn_uses_cli_arg() {
         let messages = test_messages();
+        let dir = tempdir().expect("tempdir");
+        let ca_json = dir.path().join("ca.json");
+        fs::write(
+            &ca_json,
+            r#"{"db":{"type":"postgresql","dataSource":"postgresql://step:other@postgres:5432/stepca"}}"#,
+        )
+        .expect("write ca.json");
         let args = RotateDbArgs {
             admin_dsn: DbAdminDsnArgs {
                 admin_dsn: Some("postgresql://admin:pass@127.0.0.1:15432/postgres".to_string()),
@@ -138,8 +172,95 @@ mod tests {
             password: None,
             timeout: DbTimeoutArgs { timeout_secs: 30 },
         };
-        let resolved = resolve_db_admin_dsn(&args, &messages).expect("resolve dsn");
+        let resolved = resolve_db_admin_dsn(&args, &ca_json, &messages).expect("resolve dsn");
         assert_eq!(resolved, "postgresql://admin:pass@127.0.0.1:15432/postgres");
+    }
+
+    #[test]
+    fn resolve_db_admin_dsn_reads_from_ca_json_when_flag_absent() {
+        let messages = test_messages();
+        let dir = tempdir().expect("tempdir");
+        let ca_json = dir.path().join("ca.json");
+        fs::write(
+            &ca_json,
+            r#"{"db":{"type":"postgresql","dataSource":"postgresql://step:current@postgres:5432/stepca?sslmode=disable"}}"#,
+        )
+        .expect("write ca.json");
+        let args = RotateDbArgs {
+            admin_dsn: DbAdminDsnArgs { admin_dsn: None },
+            password: None,
+            timeout: DbTimeoutArgs { timeout_secs: 30 },
+        };
+        let resolved = resolve_db_admin_dsn(&args, &ca_json, &messages).expect("resolve dsn");
+        assert_eq!(
+            resolved,
+            "postgresql://step:current@postgres:5432/stepca?sslmode=disable"
+        );
+    }
+
+    #[test]
+    fn resolve_db_admin_dsn_errors_when_ca_json_malformed() {
+        let messages = test_messages();
+        let dir = tempdir().expect("tempdir");
+        let ca_json = dir.path().join("ca.json");
+        fs::write(&ca_json, "not valid json").expect("write ca.json");
+        let args = RotateDbArgs {
+            admin_dsn: DbAdminDsnArgs { admin_dsn: None },
+            password: None,
+            timeout: DbTimeoutArgs { timeout_secs: 30 },
+        };
+        let err = resolve_db_admin_dsn(&args, &ca_json, &messages)
+            .expect_err("expected error on malformed ca.json");
+        assert!(
+            err.to_string().contains("ca.json")
+                || err
+                    .chain()
+                    .any(|cause| cause.to_string().contains("ca.json"))
+        );
+    }
+
+    #[test]
+    fn resolve_db_admin_dsn_errors_when_ca_json_unreadable() {
+        // Regression test for the `exists()` vs. `NotFound` distinction:
+        // a present-but-unreadable ca.json must surface as a hard error
+        // rather than falling through to the interactive prompt. We
+        // simulate an I/O failure other than NotFound by pointing at a
+        // directory entry, which makes `read_to_string` fail without
+        // returning `ErrorKind::NotFound`.
+        let messages = test_messages();
+        let dir = tempdir().expect("tempdir");
+        let ca_json = dir.path().join("ca.json");
+        fs::create_dir(&ca_json).expect("create ca.json as directory");
+        let args = RotateDbArgs {
+            admin_dsn: DbAdminDsnArgs { admin_dsn: None },
+            password: None,
+            timeout: DbTimeoutArgs { timeout_secs: 30 },
+        };
+        let err = resolve_db_admin_dsn(&args, &ca_json, &messages)
+            .expect_err("expected error when ca.json is unreadable");
+        assert!(
+            err.to_string().contains("ca.json")
+                || err
+                    .chain()
+                    .any(|cause| cause.to_string().contains("ca.json")),
+            "error should mention ca.json: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_db_admin_dsn_errors_when_ca_json_missing_data_source() {
+        let messages = test_messages();
+        let dir = tempdir().expect("tempdir");
+        let ca_json = dir.path().join("ca.json");
+        fs::write(&ca_json, r#"{"db":{"type":"postgresql"}}"#).expect("write ca.json");
+        let args = RotateDbArgs {
+            admin_dsn: DbAdminDsnArgs { admin_dsn: None },
+            password: None,
+            timeout: DbTimeoutArgs { timeout_secs: 30 },
+        };
+        let err = resolve_db_admin_dsn(&args, &ca_json, &messages)
+            .expect_err("expected error when dataSource missing");
+        assert!(err.to_string().contains("ca.json"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `bootroot rotate db` now reads the current PostgreSQL admin DSN from `ca.json`'s `db.dataSource` field when `--db-admin-dsn` is omitted, eliminating the manual copy step operators currently have to perform after `init --enable db-provision` diverges the password from `.env`'s `POSTGRES_PASSWORD`.
- Precedence: explicit `--db-admin-dsn` wins, then `ca.json`, then the interactive prompt (only when `ca.json` is definitively absent). Only an `ErrorKind::NotFound` on ca.json falls through to the prompt; any other I/O failure (permission denied, unreadable parent, malformed contents, missing `db.dataSource`) is a hard error so the command does not loop on non-interactive EOF with a DSN that would likely be wrong anyway.
- Updates English/Korean CLI docs and the CHANGELOG.

Closes #517

## Test plan

- [x] `bootroot rotate db` without `--db-admin-dsn` succeeds when `ca.json` contains a valid DSN. — covered by unit test `resolve_db_admin_dsn_reads_from_ca_json_when_flag_absent` (resolution returns the `ca.json` DSN, which is then passed to the unchanged rotation pipeline).
- [x] `bootroot rotate db --db-admin-dsn <explicit>` uses the provided value regardless of what `ca.json` contains. — covered by unit test `resolve_db_admin_dsn_uses_cli_arg` and by the Docker E2E (rotation) job which still drives rotation with an explicit `--db-admin-dsn`.
- [x] `ca.json` absent (db-provision not enabled) → falls through to the interactive prompt as before. — `read_ca_json_dsn_if_present` returns `Ok(None)` on `ErrorKind::NotFound`, and `resolve_db_admin_dsn` then invokes `Prompt::prompt_with_validation`, identical to the prior behavior.
- [x] `ca.json` present but malformed, unreadable, or missing `db.dataSource` → hard error with a clear message, no prompt loop. — covered by unit tests `resolve_db_admin_dsn_errors_when_ca_json_malformed`, `resolve_db_admin_dsn_errors_when_ca_json_unreadable` (non-NotFound I/O failure), and `resolve_db_admin_dsn_errors_when_ca_json_missing_data_source`.
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test resolve_db_admin_dsn`