### PR TITLE
Reject path-like sighup reload targets (#543)

### DIFF
--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -588,6 +588,20 @@ entries in the generated `agent.toml` profile:
 - `docker-restart` + target `my-container` — `docker restart my-container`
 - `none` — no hook
 
+For the `sighup` preset, `--reload-target` must be a plain process
+name (matched against `comm`, i.e. the basename of `argv[0]`;
+Linux truncates `comm` to 15 characters). Path-like targets
+containing `/` are rejected at `service add` time because the
+preset invokes `pkill -HUP <name>` without `-f` and would
+otherwise silently fail to match. For path-based matching, use
+the low-level flags to opt into `pkill -f` explicitly:
+
+```
+--post-renew-command pkill \
+--post-renew-arg -HUP --post-renew-arg -f \
+--post-renew-arg <your-path>
+```
+
 Post-renew hook flags (low-level):
 
 - `--post-renew-command`: hook command to run after successful renewal

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -596,7 +596,7 @@ preset invokes `pkill -HUP <name>` without `-f` and would
 otherwise silently fail to match. For path-based matching, use
 the low-level flags to opt into `pkill -f` explicitly:
 
-```
+```text
 --post-renew-command pkill \
 --post-renew-arg -HUP --post-renew-arg -f \
 --post-renew-arg <your-path>

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -572,6 +572,20 @@ bootroot status
 - `docker-restart` + 대상 `my-container` — `docker restart my-container`
 - `none` — 훅 없음
 
+`sighup` 프리셋의 `--reload-target`은 일반 프로세스 이름이어야 합니다
+(`comm` 필드, 즉 `argv[0]`의 basename에 매칭되며 Linux에서는
+15자로 잘립니다). 프리셋은 `-f` 없이 `pkill -HUP <name>`을
+실행하므로 `/`가 포함된 경로 형태의 값은 `service add` 단계에서
+거부됩니다. 그렇지 않으면 런타임에 매칭이 조용히 실패합니다.
+경로 기반 매칭이 필요하면 저수준 플래그로 `pkill -f`를
+명시적으로 사용해야 합니다:
+
+```
+--post-renew-command pkill \
+--post-renew-arg -HUP --post-renew-arg -f \
+--post-renew-arg <your-path>
+```
+
 갱신 후 훅 플래그(저수준):
 
 - `--post-renew-command`: 갱신 성공 후 실행할 훅 명령

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -580,7 +580,7 @@ bootroot status
 경로 기반 매칭이 필요하면 저수준 플래그로 `pkill -f`를
 명시적으로 사용해야 합니다:
 
-```
+```text
 --post-renew-command pkill \
 --post-renew-arg -HUP --post-renew-arg -f \
 --post-renew-arg <your-path>

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -365,6 +365,16 @@ fn resolve_reload_preset(
             let name = target.ok_or_else(|| {
                 anyhow::anyhow!("--reload-style sighup requires --reload-target <process-name>")
             })?;
+            if name.contains('/') {
+                anyhow::bail!(
+                    "--reload-target for sighup preset must be a process name, not a path.\n\
+                     Got: {name}\n\
+                     For path-based matching, use the low-level flags:\n    \
+                     --post-renew-command pkill \\\n    \
+                     --post-renew-arg -HUP --post-renew-arg -f \\\n    \
+                     --post-renew-arg <your-path>"
+                );
+            }
             Ok(vec![PostRenewHookEntry {
                 command: "pkill".to_string(),
                 args: vec!["-HUP".to_string(), name.to_string()],
@@ -559,6 +569,42 @@ mod tests {
         assert_eq!(hooks.len(), 1);
         assert_eq!(hooks[0].command, "pkill");
         assert_eq!(hooks[0].args, vec!["-HUP", "myproc"]);
+    }
+
+    #[test]
+    fn resolve_hooks_sighup_preset_rejects_path_like_target() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Sighup);
+        args.reload_target = Some("review/target/release/review".to_string());
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("must be a process name, not a path"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("review/target/release/review"),
+            "error should echo offending value: {msg}"
+        );
+        assert!(
+            msg.contains("--post-renew-arg -f"),
+            "error should point to low-level fallback: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_hooks_sighup_preset_rejects_absolute_path_target() {
+        let mut args = empty_args();
+        args.reload_style = Some(ReloadStyle::Sighup);
+        args.reload_target = Some("/usr/local/bin/myapp".to_string());
+
+        let err = resolve_post_renew_hooks(&args).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("must be a process name, not a path"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `sighup` reload preset expands to `pkill -HUP <target>` without `-f`, so `pkill` matches against `comm` (basename of argv[0], truncated to 15 chars on Linux) rather than the full command line. Path-like values such as `review/target/release/review` silently fail to match at runtime — the agent just logs `exit status: 1` and the service never gets SIGHUP.

- Validate `--reload-target` at `service add` resolve time: reject any value containing `/` when `--reload-style sighup` is selected, with an error message that points operators at the low-level `--post-renew-*` flags for path-based matching.
- Add unit tests covering both relative (`review/target/release/review`) and absolute (`/usr/local/bin/myapp`) rejection paths, alongside the existing positive case.
- Document the constraint in `docs/en/cli.md` and `docs/ko/cli.md`, explaining that the preset matches `comm` and that path-based matching requires the low-level flags with `-f`.

Closes #543

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes.
- [x] `cargo test --bin bootroot resolve_hooks_sighup` passes (covers preset expansion, path-like rejection, and absolute-path rejection).
- [x] `bootroot service add --reload-style sighup --reload-target review/target/release/review ...` fails at resolve time with the documented error and suggestion to use `--post-renew-arg -f`.
- [x] `bootroot service add --reload-style sighup --reload-target review ...` still succeeds and produces a `pkill -HUP review` hook.
- [x] Rendered `docs/en/cli.md` and `docs/ko/cli.md` note the `comm`-matching behavior and the low-level fallback for path-based matching.

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title**

```text
Reject path-like sighup reload targets
```

**Body**

```text
The `sighup` reload preset expanded to `pkill -HUP <target>`
without `-f`, so `pkill` matched against `comm` (basename of
argv[0], truncated to 15 characters on Linux) rather than the
full command line. Passing a path-like value such as
`review/target/release/review` silently failed to match at
runtime: the agent logged `exit status: 1` and the service never
received SIGHUP.

Validate `--reload-target` at `service add` resolve time and
reject any value containing `/` when `--reload-style sighup` is
selected. The error message points operators at the low-level
`--post-renew-*` flags for path-based matching, where `-f` can
be opted into deliberately.

Document the constraint in `docs/en/cli.md` and `docs/ko/cli.md`,
noting that the preset matches `comm` and that path-based
matching requires the low-level flags.

Closes #543
```
<!-- agentcoop:squash-suggestion:end -->
