### PR TITLE
Apply default renew_before guardrail in ca update (#554)

### DIFF
--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -1097,11 +1097,12 @@ in place before the next render cycle).
 - `--cert-duration`: new `defaultTLSCertDuration` value
   (e.g., `24h`, `48h`). Required.
 
-  `cert-duration` must exceed the `renew_before` value configured in
-  `agent.toml` on each agent host; otherwise newly issued certificates
-  will be flagged for immediate renewal. The control plane does not
-  have access to `agent.toml`, so this cross-validation is not
-  performed here — operators are responsible for ensuring consistency.
+  `cert-duration` must be strictly greater than the daemon's default
+  `renew_before` (16h); otherwise every newly issued certificate is
+  flagged for immediate renewal and the command fails validation. This
+  is the same conservative guardrail `bootroot init` applies. The
+  control plane does not read `agent.toml`, so per-agent
+  `renew_before` consistency remains the operator's responsibility.
 
 ### Behavior
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -1060,10 +1060,12 @@ OpenBao KV: `bootroot/responder/hmac`
 - `--cert-duration`: 새 `defaultTLSCertDuration` 값
   (예: `24h`, `48h`). 필수.
 
-  `cert-duration`은 각 agent 호스트의 `agent.toml`에 설정된
-  `renew_before`보다 커야 하며, 그렇지 않으면 새로 발급된 인증서가 즉시
-  갱신 대상으로 표시됩니다. 제어 노드는 `agent.toml`을 참조할 수 없으므로
-  이 교차 검증은 수행하지 않으며, 값의 일관성 보장은 운영자의 책임입니다.
+  `cert-duration`은 데몬의 기본 `renew_before`(16h)보다 엄격히 커야
+  하며, 그렇지 않으면 새로 발급된 모든 인증서가 즉시 갱신 대상으로
+  표시되고 명령이 검증에 실패합니다. `bootroot init`이 적용하는 것과
+  동일한 보수적 가드레일입니다. 제어 노드는 `agent.toml`을 참조하지
+  않으므로, 각 agent의 `renew_before`와의 정합성 보장은 여전히
+  운영자의 책임입니다.
 
 ### 동작
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -43,9 +43,11 @@ pub(crate) enum CliCommand {
 pub(crate) enum CaCommand {
     /// Updates step-ca `defaultTLSCertDuration`.
     ///
-    /// `cert-duration` must exceed the `renew_before` value configured
-    /// in `agent.toml` on each agent host; otherwise newly issued
-    /// certificates will be flagged for immediate renewal.
+    /// `cert-duration` must be strictly greater than the daemon's
+    /// default `renew_before` (16h) — the same conservative guardrail
+    /// `bootroot init` applies. The control plane does not read
+    /// `agent.toml`; ensuring per-agent `renew_before` consistency
+    /// remains the operator's responsibility.
     Update(CaUpdateArgs),
     /// Restarts the step-ca container so it picks up a configuration
     /// change such as a new `defaultTLSCertDuration`.
@@ -64,8 +66,10 @@ pub(crate) struct CaUpdateArgs {
 
     /// New `defaultTLSCertDuration` value (e.g. `24h`, `48h`).
     ///
-    /// Must exceed the `renew_before` value configured in `agent.toml`
-    /// on each agent host.
+    /// Must be strictly greater than the daemon's default
+    /// `renew_before` (16h) — otherwise every newly issued certificate
+    /// is flagged for immediate renewal. Per-agent `renew_before`
+    /// consistency is the operator's responsibility.
     #[arg(long)]
     pub(crate) cert_duration: String,
 }

--- a/src/commands/ca.rs
+++ b/src/commands/ca.rs
@@ -19,7 +19,7 @@ const READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 pub(crate) fn run_ca_update(args: &CaUpdateArgs, messages: &Messages) -> Result<()> {
-    bootroot::config::parse_cert_duration(&args.cert_duration)?;
+    bootroot::config::validate_cert_duration_vs_default_renew_before(&args.cert_duration)?;
 
     let secrets_dir = &args.secrets_dir.secrets_dir;
     let ca_json_path = secrets_dir.join("config").join("ca.json");
@@ -184,9 +184,42 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::cli::args::SecretsDirArgs;
 
     fn test_messages() -> Messages {
         crate::i18n::test_messages()
+    }
+
+    fn ca_update_args(secrets_dir: std::path::PathBuf, cert_duration: &str) -> CaUpdateArgs {
+        CaUpdateArgs {
+            secrets_dir: SecretsDirArgs { secrets_dir },
+            stepca_provisioner: "acme".to_string(),
+            cert_duration: cert_duration.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_run_ca_update_rejects_duration_below_default_renew_before() {
+        let dir = tempdir().unwrap();
+        // Files intentionally not created: validation must fail before any I/O.
+        let args = ca_update_args(dir.path().to_path_buf(), "1m");
+        let err = run_ca_update(&args, &test_messages()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("must exceed the default renew_before"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_run_ca_update_rejects_duration_equal_to_default_renew_before() {
+        let dir = tempdir().unwrap();
+        let args = ca_update_args(dir.path().to_path_buf(), "16h");
+        let err = run_ca_update(&args, &test_messages()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("must exceed the default renew_before")
+        );
     }
 
     fn sample_ctmpl() -> String {


### PR DESCRIPTION
## Summary

- `bootroot ca update --cert-duration` now applies the same conservative 16h default-based guardrail as `bootroot init --cert-duration` by calling `validate_cert_duration_vs_default_renew_before` instead of just `parse_cert_duration`. Both commands fail with the same error message when the supplied duration does not strictly exceed the daemon's default `renew_before`.
- Updated clap help in `src/cli/args.rs` and the EN/KO CLI docs to describe the new behavior, replacing the earlier wording that implied a hard cross-check against each agent's `agent.toml`. The note that per-agent `agent.toml` consistency remains the operator's responsibility is kept.
- Added unit tests covering `1m` and `16h` rejection paths on `run_ca_update`.

Closes #554

## Test plan

- [x] `bootroot ca update --cert-duration 1m` fails with the same error message as `bootroot init --cert-duration 1m`.
- [x] `bootroot ca update --cert-duration 16h` fails (must be strictly greater than the default 16h `renew_before`).
- [x] `bootroot ca update --cert-duration 24h` succeeds.
- [x] clap help (`src/cli/args.rs`), `docs/en/cli.md`, and `docs/ko/cli.md` describe the behavior consistently.
- [x] `cargo clippy --all-targets -- -D warnings` is clean.
- [x] `cargo test` passes, including the new `test_run_ca_update_rejects_duration_*` cases.