### PR TITLE
Fix verify agent discovery and service agent start flag (#553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `POSTGRES_HOST_PORT` for the host-side translation. Only `sslmode`
   is preserved across translation; other query parameters are
   dropped. (Closes #542)
+- Fixed `bootroot verify` failing with "No such file or directory" when
+  `bootroot-agent` was not on `$PATH`. Verify now resolves the agent
+  binary by checking `--agent-binary <path>` first, then the directory
+  containing the running `bootroot` executable, and finally `$PATH`.
+  When none resolve, the error message names every candidate that was
+  tried. (Closes #553)
 - Fixed daemon-mode retries silently dropping CLI overrides (`--email`,
   `--ca-url`, `--http-responder-url`, `--http-responder-hmac`). The retry
   path reloaded the config file from disk without re-applying CLI-provided
@@ -192,6 +198,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Changed `bootroot service agent start` to take `--service-name <NAME>`
+  instead of a positional `<SERVICE_NAME>` argument, matching the other
+  per-service subcommands (`service add`, `service info`, `service update`).
+  The positional form is no longer accepted. (Closes #553)
 - `bootroot rotate db` now auto-reads the current PostgreSQL admin DSN
   from `ca.json`'s `db.dataSource` field when `--db-admin-dsn` is
   omitted. Previously operators had to copy the DSN out of `ca.json`

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -750,6 +750,9 @@ for those flags.
 
 - `--service-name`: service name identifier
 - `--agent-config`: bootroot-agent config path override (optional)
+- `--agent-binary`: path to the `bootroot-agent` binary (optional; when
+  omitted, bootroot first tries the directory containing the running
+  `bootroot` binary, then falls back to `$PATH`)
 - `--db-check`: verify DB connectivity and auth using ca.json DSN
 - `--db-timeout-secs`: DB connectivity timeout (seconds, default `2`)
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -726,6 +726,9 @@ bootroot-agent를 one-shot으로 실행해 발급을 검증합니다. 서비스 
 
 - `--service-name`: 서비스 이름 식별자
 - `--agent-config`: bootroot-agent 설정 경로 (선택, 기본은 등록된 값)
+- `--agent-binary`: `bootroot-agent` 바이너리 경로 (선택). 지정하지 않으면
+  실행 중인 `bootroot` 바이너리와 같은 디렉터리를 먼저 탐색하고,
+  없으면 `$PATH`에서 찾습니다.
 - `--db-check`: ca.json DSN으로 DB 연결/인증 점검
 - `--db-timeout-secs`: DB 연결 타임아웃(초, 기본값 `2`)
 

--- a/scripts/impl/run-baseline.sh
+++ b/scripts/impl/run-baseline.sh
@@ -253,10 +253,10 @@ run_verify_all() {
     log_phase "verify" "$node" "$service"
     (
       cd "$work_dir"
-      PATH="$work_dir/bin:$PATH" \
       "$BOOTROOT_BIN" verify \
         --service-name "$service" \
         --agent-config "$agent_config_path" \
+        --agent-binary "$work_dir/bin/bootroot-agent" \
         >/dev/null
     )
   done <"$SERVICES_TSV"

--- a/scripts/impl/run-harness-smoke.sh
+++ b/scripts/impl/run-harness-smoke.sh
@@ -197,11 +197,11 @@ PY
 run_verify() {
   (
     cd "$WORK_DIR"
-    PATH="$WORK_DIR/bin:$PATH" \
-      "$BOOTROOT_BIN" verify \
-        --service-name "$SERVICE_NAME" \
-        --agent-config "agent.toml" \
-        >/dev/null
+    "$BOOTROOT_BIN" verify \
+      --service-name "$SERVICE_NAME" \
+      --agent-config "agent.toml" \
+      --agent-binary "$WORK_DIR/bin/bootroot-agent" \
+      >/dev/null
   )
 }
 

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -416,10 +416,8 @@ verify_with_retry() {
   local service="$1"
   local agent_config="$2"
   local attempt
-  local agent_bin_dir
-  agent_bin_dir="$(dirname "$BOOTROOT_AGENT_BIN")"
   for attempt in $(seq 1 "$VERIFY_ATTEMPTS"); do
-    if PATH="${agent_bin_dir}:$PATH" run_bootroot_control verify --service-name "$service" --agent-config "$agent_config" >>"$RUN_LOG" 2>&1; then
+    if run_bootroot_control verify --service-name "$service" --agent-config "$agent_config" --agent-binary "$BOOTROOT_AGENT_BIN" >>"$RUN_LOG" 2>&1; then
       return 0
     fi
     if [ "$attempt" -eq "$VERIFY_ATTEMPTS" ]; then

--- a/scripts/impl/run-rotation-recovery.sh
+++ b/scripts/impl/run-rotation-recovery.sh
@@ -304,10 +304,10 @@ run_verify_all() {
     log_phase "verify" "$node" "$service" "$cycle" "$item"
     (
       cd "$work_dir"
-      PATH="$work_dir/bin:$PATH" \
       "$BOOTROOT_BIN" verify \
         --service-name "$service" \
         --agent-config "$agent_config_path" \
+        --agent-binary "$work_dir/bin/bootroot-agent" \
         >/dev/null
     )
   done <"$SERVICES_TSV"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -116,6 +116,7 @@ pub(crate) enum ServiceAgentCommand {
 #[derive(Args, Debug)]
 pub(crate) struct ServiceAgentStartArgs {
     /// Service name identifier
+    #[arg(long)]
     pub(crate) service_name: String,
 
     #[command(flatten)]
@@ -892,6 +893,10 @@ pub(crate) struct VerifyArgs {
     #[arg(long)]
     pub(crate) agent_config: Option<PathBuf>,
 
+    /// Path to the bootroot-agent binary (overrides auto-discovery)
+    #[arg(long)]
+    pub(crate) agent_binary: Option<PathBuf>,
+
     /// Verify DB connectivity and auth using ca.json DSN
     #[arg(long)]
     pub(crate) db_check: bool,
@@ -1598,7 +1603,14 @@ mod tests {
 
     #[test]
     fn test_cli_parses_service_agent_start() {
-        let cli = Cli::parse_from(["bootroot", "service", "agent", "start", "myapp"]);
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "agent",
+            "start",
+            "--service-name",
+            "myapp",
+        ]);
         match cli.command {
             CliCommand::Service(ServiceCommand::Agent(ServiceAgentCommand::Start(args))) => {
                 assert_eq!(args.service_name, "myapp");
@@ -1618,6 +1630,7 @@ mod tests {
             "service",
             "agent",
             "start",
+            "--service-name",
             "myapp",
             "--compose-file",
             "custom.yml",
@@ -1635,5 +1648,14 @@ mod tests {
     fn test_cli_service_agent_start_requires_service_name() {
         let result = Cli::try_parse_from(["bootroot", "service", "agent", "start"]);
         assert!(result.is_err(), "service-name should be required");
+    }
+
+    #[test]
+    fn test_cli_service_agent_start_rejects_positional() {
+        let result = Cli::try_parse_from(["bootroot", "service", "agent", "start", "myapp"]);
+        assert!(
+            result.is_err(),
+            "positional service name should be rejected"
+        );
     }
 }

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
@@ -9,6 +9,8 @@ use crate::cli::output::print_verify_plan;
 use crate::cli::prompt::Prompt;
 use crate::i18n::Messages;
 use crate::state::{DeployType, ServiceEntry, StateFile};
+
+const AGENT_BINARY_NAME: &str = "bootroot-agent";
 
 pub(crate) fn run_verify(args: &VerifyArgs, messages: &Messages) -> Result<()> {
     let state_path = StateFile::default_path();
@@ -29,7 +31,8 @@ pub(crate) fn run_verify(args: &VerifyArgs, messages: &Messages) -> Result<()> {
 
     print_verify_plan(&entry.service_name, agent_config, messages);
 
-    let status = Command::new("bootroot-agent")
+    let agent_binary = resolve_agent_binary(args.agent_binary.as_deref(), messages)?;
+    let status = Command::new(&agent_binary)
         .args([
             "--config",
             agent_config.to_string_lossy().as_ref(),
@@ -127,6 +130,64 @@ fn verify_db_connectivity(
     Ok(())
 }
 
+fn resolve_agent_binary(override_path: Option<&Path>, messages: &Messages) -> Result<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(path) = override_path {
+        candidates.push(path.display().to_string());
+        if path.is_file() {
+            return Ok(path.to_path_buf());
+        }
+    }
+
+    let sibling = match std::env::current_exe() {
+        Ok(exe) => exe.parent().map(|dir| dir.join(AGENT_BINARY_NAME)),
+        Err(_) => None,
+    };
+    if let Some(sibling_path) = sibling.as_ref() {
+        candidates.push(sibling_path.display().to_string());
+        if sibling_path.is_file() {
+            return Ok(sibling_path.clone());
+        }
+    }
+
+    let (found, path_candidates) = find_on_path(AGENT_BINARY_NAME);
+    for candidate in &path_candidates {
+        candidates.push(candidate.display().to_string());
+    }
+    if let Some(path) = found {
+        return Ok(path);
+    }
+    if path_candidates.is_empty() {
+        candidates.push(format!("$PATH (unset; searched for {AGENT_BINARY_NAME})"));
+    }
+
+    anyhow::bail!(messages.error_bootroot_agent_not_found(&candidates.join(", ")));
+}
+
+fn find_on_path(name: &str) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let mut checked = Vec::new();
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return (None, checked);
+    };
+    let mut found = None;
+    for dir in std::env::split_paths(&path_var) {
+        // POSIX treats an empty PATH entry (leading/trailing/doubled `:`) as
+        // the current working directory, so normalise before searching.
+        let search_dir = if dir.as_os_str().is_empty() {
+            PathBuf::from(".")
+        } else {
+            dir
+        };
+        let candidate = search_dir.join(name);
+        checked.push(candidate.clone());
+        if found.is_none() && candidate.is_file() {
+            found = Some(candidate);
+        }
+    }
+    (found, checked)
+}
+
 fn resolve_verify_service_name(args: &VerifyArgs, messages: &Messages) -> Result<String> {
     if let Some(value) = args.service_name.as_deref() {
         if value.trim().is_empty() {
@@ -212,5 +273,213 @@ fn expected_dns_name(entry: &ServiceEntry, messages: &Messages) -> Result<String
                 instance_id, entry.service_name, entry.hostname, entry.domain
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::write(path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[cfg(not(unix))]
+    fn write_executable(path: &Path) {
+        std::fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn resolve_agent_binary_prefers_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let explicit = dir.path().join("bootroot-agent");
+        write_executable(&explicit);
+
+        let resolved = resolve_agent_binary(Some(&explicit), &messages).unwrap();
+        assert_eq!(resolved, explicit);
+    }
+
+    #[test]
+    fn resolve_agent_binary_falls_back_to_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let path_entry = dir.path().to_path_buf();
+        let binary = path_entry.join(AGENT_BINARY_NAME);
+        write_executable(&binary);
+
+        let original_path = std::env::var_os("PATH");
+        // SAFETY: Serialized via ENV_LOCK so no other test mutates PATH concurrently.
+        unsafe {
+            std::env::set_var("PATH", path_entry.as_os_str());
+        }
+        let resolved = resolve_agent_binary(None, &messages);
+        // SAFETY: Same serialization guarantee as above.
+        unsafe {
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+
+        let resolved = resolved.unwrap();
+        assert_eq!(resolved, binary);
+    }
+
+    #[test]
+    fn resolve_agent_binary_error_names_candidates() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("no-such-agent");
+        let path_dir_a = dir.path().join("path-a");
+        let path_dir_b = dir.path().join("path-b");
+        std::fs::create_dir_all(&path_dir_a).unwrap();
+        std::fs::create_dir_all(&path_dir_b).unwrap();
+        let path_value = std::env::join_paths([&path_dir_a, &path_dir_b]).unwrap();
+
+        let original_path = std::env::var_os("PATH");
+        // SAFETY: Serialized via ENV_LOCK so no other test mutates PATH concurrently.
+        unsafe {
+            std::env::set_var("PATH", &path_value);
+        }
+        let err = resolve_agent_binary(Some(&missing), &messages).unwrap_err();
+        // SAFETY: Same serialization guarantee as above.
+        unsafe {
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&missing.display().to_string()),
+            "expected override path listed in error, got: {rendered}"
+        );
+        let expected_a = path_dir_a.join(AGENT_BINARY_NAME);
+        let expected_b = path_dir_b.join(AGENT_BINARY_NAME);
+        assert!(
+            rendered.contains(&expected_a.display().to_string()),
+            "expected first PATH candidate listed in error, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(&expected_b.display().to_string()),
+            "expected second PATH candidate listed in error, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn resolve_agent_binary_error_lists_empty_path_segment_as_cwd() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("no-such-agent");
+        let path_dir = dir.path().join("path-dir");
+        std::fs::create_dir_all(&path_dir).unwrap();
+        // Leading separator yields an empty segment, which POSIX treats as `.`.
+        let path_value = std::env::join_paths([PathBuf::new(), path_dir.clone()]).unwrap();
+
+        let original_path = std::env::var_os("PATH");
+        // SAFETY: Serialized via ENV_LOCK so no other test mutates PATH concurrently.
+        unsafe {
+            std::env::set_var("PATH", &path_value);
+        }
+        let err = resolve_agent_binary(Some(&missing), &messages).unwrap_err();
+        // SAFETY: Same serialization guarantee as above.
+        unsafe {
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+
+        let rendered = err.to_string();
+        let cwd_candidate = PathBuf::from(".").join(AGENT_BINARY_NAME);
+        assert!(
+            rendered.contains(&cwd_candidate.display().to_string()),
+            "expected empty PATH segment to surface as `{}` candidate, got: {rendered}",
+            cwd_candidate.display()
+        );
+        assert!(
+            rendered.contains(&path_dir.join(AGENT_BINARY_NAME).display().to_string()),
+            "expected non-empty PATH candidate listed in error, got: {rendered}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_agent_binary_uses_cwd_for_empty_path_segment() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let agent = dir.path().join(AGENT_BINARY_NAME);
+        write_executable(&agent);
+        let path_dir = dir.path().join("path-dir");
+        std::fs::create_dir_all(&path_dir).unwrap();
+        // Trailing separator yields an empty segment after the non-empty entry.
+        let path_value = std::env::join_paths([path_dir, PathBuf::new()]).unwrap();
+
+        let original_path = std::env::var_os("PATH");
+        let original_cwd = std::env::current_dir().unwrap();
+        // SAFETY: Serialized via ENV_LOCK; cwd and PATH restored below.
+        unsafe {
+            std::env::set_var("PATH", &path_value);
+        }
+        std::env::set_current_dir(dir.path()).unwrap();
+        let resolved = resolve_agent_binary(None, &messages);
+        std::env::set_current_dir(&original_cwd).unwrap();
+        // SAFETY: Same serialization guarantee as above.
+        unsafe {
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+
+        let resolved = resolved.expect("empty PATH segment should resolve via cwd");
+        // Relative candidate; resolution used the cwd we set above.
+        assert_eq!(resolved, PathBuf::from(".").join(AGENT_BINARY_NAME));
+        assert!(agent.is_file());
+    }
+
+    #[test]
+    fn resolve_agent_binary_error_handles_unset_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("no-such-agent");
+
+        let original_path = std::env::var_os("PATH");
+        // SAFETY: Serialized via ENV_LOCK so no other test mutates PATH concurrently.
+        unsafe {
+            std::env::remove_var("PATH");
+        }
+        let err = resolve_agent_binary(Some(&missing), &messages).unwrap_err();
+        // SAFETY: Same serialization guarantee as above.
+        unsafe {
+            if let Some(value) = original_path {
+                std::env::set_var("PATH", value);
+            }
+        }
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("$PATH"),
+            "expected unset $PATH noted in error, got: {rendered}"
+        );
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -179,6 +179,7 @@ pub(crate) struct Strings {
     pub(crate) error_docker_compose_failed: &'static str,
     pub(crate) error_docker_command_failed: &'static str,
     pub(crate) error_bootroot_agent_run_failed: &'static str,
+    pub(crate) error_bootroot_agent_not_found: &'static str,
     pub(crate) error_secrets_dir_resolve_failed: &'static str,
     pub(crate) error_rendered_file_timeout: &'static str,
     pub(crate) error_parse_ca_json_failed: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -139,6 +139,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_docker_compose_failed: "docker compose failed: {value}",
     error_docker_command_failed: "docker command failed: {value}",
     error_bootroot_agent_run_failed: "Failed to run bootroot-agent",
+    error_bootroot_agent_not_found: "bootroot-agent binary not found. Tried: {candidates}",
     error_secrets_dir_resolve_failed: "Failed to resolve secrets dir",
     error_parse_ca_json_failed: "Failed to parse ca.json",
     error_serialize_ca_json_failed: "Failed to serialize ca.json",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -139,6 +139,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_docker_compose_failed: "docker compose 실패: {value}",
     error_docker_command_failed: "docker 명령 실패: {value}",
     error_bootroot_agent_run_failed: "bootroot-agent 실행 실패",
+    error_bootroot_agent_not_found: "bootroot-agent 바이너리를 찾을 수 없습니다. 시도한 경로: {candidates}",
     error_secrets_dir_resolve_failed: "secrets dir 확인 실패",
     error_parse_ca_json_failed: "ca.json 파싱 실패",
     error_serialize_ca_json_failed: "ca.json 직렬화 실패",

--- a/src/i18n/service.rs
+++ b/src/i18n/service.rs
@@ -309,6 +309,13 @@ impl Messages {
         self.strings().error_bootroot_agent_run_failed
     }
 
+    pub(crate) fn error_bootroot_agent_not_found(&self, candidates: &str) -> String {
+        format_template(
+            self.strings().error_bootroot_agent_not_found,
+            &[("candidates", candidates)],
+        )
+    }
+
     pub(crate) fn error_secrets_dir_resolve_failed(&self) -> &'static str {
         self.strings().error_secrets_dir_resolve_failed
     }

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -927,13 +927,17 @@ async fn test_app_add_local_file_sets_verify_prerequisites() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake bootroot-agent");
-    let current_path = std::env::var("PATH").unwrap_or_default();
-    let path = format!("{}:{current_path}", bin_dir.display());
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let verify_output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", path)
-        .args(["verify", "--service-name", "edge-proxy"])
+        .args([
+            "verify",
+            "--service-name",
+            "edge-proxy",
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
+        ])
         .output()
         .expect("run verify");
     let stdout = String::from_utf8_lossy(&verify_output.stdout);

--- a/tests/bootroot_verify.rs
+++ b/tests/bootroot_verify.rs
@@ -32,19 +32,18 @@ fn test_verify_success() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             "edge-proxy",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .expect("run verify");
@@ -75,19 +74,18 @@ fn test_verify_docker_success() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             "web-app",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .expect("run verify");
@@ -116,19 +114,18 @@ fn test_verify_san_mismatch_fails() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             "edge-proxy",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .expect("run verify");
@@ -160,14 +157,15 @@ fn test_verify_prompts_for_service_name() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
-        .args(["verify"])
+        .args([
+            "verify",
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
@@ -210,14 +208,15 @@ fn test_verify_reprompts_on_empty_service_name() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
-        .args(["verify"])
+        .args([
+            "verify",
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
+        ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
@@ -271,13 +270,10 @@ fn test_verify_db_check_reports_auth_failure() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .env_remove("POSTGRES_HOST_PORT")
         .args([
             "verify",
@@ -285,6 +281,8 @@ fn test_verify_db_check_reports_auth_failure() {
             "edge-proxy",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
             "--db-check",
         ])
         .output()
@@ -339,13 +337,10 @@ fn test_verify_db_check_translates_compose_dsn_via_process_env() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .env("POSTGRES_HOST_PORT", port.to_string())
         .args([
             "verify",
@@ -353,6 +348,8 @@ fn test_verify_db_check_translates_compose_dsn_via_process_env() {
             "edge-proxy",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
             "--db-check",
         ])
         .output()
@@ -392,19 +389,18 @@ fn test_verify_missing_cert_fails() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             "edge-proxy",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .expect("run verify");
@@ -432,19 +428,18 @@ fn test_verify_empty_cert_fails() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             "edge-proxy",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .expect("run verify");
@@ -473,19 +468,18 @@ fn test_verify_empty_key_fails_docker() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 0).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             "web-app",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .expect("run verify");
@@ -493,6 +487,66 @@ fn test_verify_empty_key_fails_docker() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success());
     assert!(stderr.contains("Key file is empty"));
+}
+
+#[test]
+fn test_verify_resolves_sibling_agent_without_path_or_flag() {
+    // Regression test for the install-layout scenario: operators run a
+    // `bootroot` binary that ships next to `bootroot-agent` but neither
+    // the directory is on $PATH nor `--agent-binary` is supplied.
+    let temp_dir = tempdir().expect("create temp dir");
+    let agent_config = temp_dir.path().join("agent.toml");
+    fs::write(&agent_config, "# config").expect("write agent config");
+
+    let cert_path = temp_dir.path().join("certs").join("edge-proxy.crt");
+    let key_path = temp_dir.path().join("certs").join("edge-proxy.key");
+    fs::create_dir_all(cert_path.parent().unwrap()).expect("create cert dir");
+    write_cert_with_dns(
+        &cert_path,
+        &key_path,
+        "001.edge-proxy.edge-node-01.trusted.domain",
+    )
+    .expect("write cert");
+
+    write_state_with_app(temp_dir.path(), &agent_config, &cert_path, &key_path)
+        .expect("write state");
+
+    // Copy the real bootroot binary next to a fake bootroot-agent so that
+    // the copy's current_exe() resolves to the install-layout directory.
+    let install_dir = temp_dir.path().join("install");
+    fs::create_dir_all(&install_dir).expect("create install dir");
+    let bootroot_copy = install_dir.join("bootroot");
+    fs::copy(env!("CARGO_BIN_EXE_bootroot"), &bootroot_copy).expect("copy bootroot");
+    let mut perms = fs::metadata(&bootroot_copy)
+        .expect("stat bootroot copy")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&bootroot_copy, perms).expect("chmod bootroot copy");
+    write_fake_bootroot_agent(&install_dir, 0).expect("write fake agent");
+
+    // Scrub PATH so only the sibling fallback can succeed.
+    let empty_path = temp_dir.path().join("empty-path");
+    fs::create_dir_all(&empty_path).expect("create empty PATH dir");
+
+    let output = std::process::Command::new(&bootroot_copy)
+        .current_dir(temp_dir.path())
+        .env("PATH", &empty_path)
+        .args([
+            "verify",
+            "--service-name",
+            "edge-proxy",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+        ])
+        .output()
+        .expect("run verify");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(stdout.contains("bootroot verify: summary"));
+    assert!(stdout.contains("- service name: edge-proxy"));
+    assert!(stdout.contains("- result: ok"));
 }
 
 #[test]
@@ -517,19 +571,18 @@ fn test_verify_agent_failure_reports_error() {
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
     write_fake_bootroot_agent(&bin_dir, 1).expect("write fake agent");
-
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{}", bin_dir.display(), path);
+    let agent_binary = bin_dir.join("bootroot-agent");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(temp_dir.path())
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             "edge-proxy",
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .expect("run verify");

--- a/tests/e2e_remote_happy_path.rs
+++ b/tests/e2e_remote_happy_path.rs
@@ -344,17 +344,17 @@ fn write_fake_bootroot_agent(service_dir: &Path) -> anyhow::Result<()> {
 }
 
 fn run_verify(service_dir: &Path) -> anyhow::Result<()> {
-    let path = std::env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{path}", service_dir.join("bin").display());
+    let agent_binary = service_dir.join("bin").join("bootroot-agent");
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(service_dir)
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             SERVICE_NAME,
             "--agent-config",
             service_dir.join("agent.toml").to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .context("run verify")?;

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -499,17 +499,17 @@ fn run_rotate_secret_id_with_output(root: &Path, openbao_url: &str) -> std::proc
 }
 
 fn run_verify(root: &Path, agent_config: &Path) -> anyhow::Result<()> {
-    let path_env = env::var("PATH").unwrap_or_default();
-    let combined_path = format!("{}:{path_env}", root.join("bin").display());
+    let agent_binary = root.join("bin").join("bootroot-agent");
     let output = Command::new(env!("CARGO_BIN_EXE_bootroot"))
         .current_dir(root)
-        .env("PATH", combined_path)
         .args([
             "verify",
             "--service-name",
             SERVICE_NAME,
             "--agent-config",
             agent_config.to_string_lossy().as_ref(),
+            "--agent-binary",
+            agent_binary.to_string_lossy().as_ref(),
         ])
         .output()
         .context("run verify")?;


### PR DESCRIPTION
## Summary

Addresses the two UX gaps raised in #553.

### `bootroot verify` cannot locate `bootroot-agent`

`verify` previously spawned the agent with `Command::new("bootroot-agent")`, which consulted `$PATH` only. Release installs ship `bootroot` and `bootroot-agent` side-by-side, so operators running `bootroot` from the install dir without that dir on `$PATH` got a bare `No such file or directory (os error 2)`.

Resolution order is now:

1. `--agent-binary <path>` if provided
2. the directory containing `current_exe()`
3. `$PATH`

If none resolve, the error message names every candidate that was tried.

### `bootroot service agent start` now takes `--service-name`

It was the only per-service subcommand taking a positional `<SERVICE_NAME>` while its siblings (`service add`, `service info`, `service update`) use `--service-name`. Switched to the flag form outright — no dual-accept, the positional form errors out at parse time. This is a one-binary CLI with no external scripting contract to preserve.

Closes #553

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo test` passes (verify/service suites exercise the new resolution order and the flag form)
- [x] `bootroot verify` succeeds when `bootroot-agent` lives next to `bootroot` but is not on `$PATH`
- [x] `bootroot verify --agent-binary <path>` uses the explicit path
- [x] `bootroot verify` error lists every candidate tried when nothing resolves
- [x] `bootroot service agent start --service-name <NAME>` parses successfully
- [x] `bootroot service agent start <NAME>` (positional) is rejected by clap
- [x] `docs/en/cli.md` and `docs/ko/cli.md` render correctly

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title**

```text
Fix verify agent discovery and service agent start flag
```

**Body**

```text
`bootroot verify` previously spawned `bootroot-agent` with
`Command::new("bootroot-agent")`, which relies on `$PATH` only.
Release installs ship `bootroot` and `bootroot-agent` side-by-side,
so running `bootroot` from the install dir without that dir on
`$PATH` failed with a bare "No such file or directory". Resolve
the agent in order: `--agent-binary <path>` if provided, the
directory containing `current_exe()`, then `$PATH`. When nothing
resolves, the error names every candidate that was tried, and
POSIX empty PATH segments are normalised to the current working
directory.

`bootroot service agent start` was the only per-service subcommand
taking a positional `<SERVICE_NAME>` while its siblings (`service
add`, `service info`, `service update`) use `--service-name`.
Switch to the flag form outright — no dual-accept, the positional
form errors out at parse time.

Closes #553
```
<!-- agentcoop:squash-suggestion:end -->
