### PR TITLE
Signal bootroot-agent docker container by recorded name (#552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   specific "No such container/object" response to the migration
   hint; other inspect failures (e.g. daemon unreachable, permission
   denied) surface verbatim as `docker command failed: …` so the
-  real problem is not masked. (Closes #552)
+  real problem is not masked. If the actual `docker restart` itself
+  fails after the inspect succeeds, the error now names the real
+  container (e.g. `docker restart my-nginx failed with status: …`)
+  instead of the removed hardcoded `bootroot-agent` label, so
+  operators can identify the signaled container from the failure
+  output. (Closes #552)
 - Fixed `bootroot init` storing the host-side PostgreSQL port in the
   step-ca DSN written to OpenBao KV / `ca.json` when
   `POSTGRES_HOST_PORT` differed from `5432`, and fixed `bootroot rotate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   hardcoded `bootroot-agent-<service>` prefix, and the `service add`
   docker snippet recommends a long-running daemon container
   (`docker run -d --restart unless-stopped`, without `--oneshot`) so
-  `docker restart` is a meaningful signal-renewal action. (Closes #552)
+  `docker restart` is a meaningful signal-renewal action. Services
+  that were registered before this fix and created a one-shot sidecar
+  (the old `docker run --rm ... --oneshot` snippet) will see a
+  dedicated error at rotate time naming the missing container and
+  pointing operators at the new long-running snippet; see
+  `docs/en/operations.md` for migration steps. (Closes #552)
 - Fixed `bootroot init` storing the host-side PostgreSQL port in the
   step-ca DSN written to OpenBao KV / `ca.json` when
   `POSTGRES_HOST_PORT` differed from `5432`, and fixed `bootroot rotate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   (the old `docker run --rm ... --oneshot` snippet) will see a
   dedicated error at rotate time naming the missing container and
   pointing operators at the new long-running snippet; see
-  `docs/en/operations.md` for migration steps. (Closes #552)
+  `docs/en/operations.md` for migration steps. The pre-flight
+  `docker container inspect` captures stderr and only maps the
+  specific "No such container/object" response to the migration
+  hint; other inspect failures (e.g. daemon unreachable, permission
+  denied) surface verbatim as `docker command failed: …` so the
+  real problem is not masked. (Closes #552)
 - Fixed `bootroot init` storing the host-side PostgreSQL port in the
   step-ca DSN written to OpenBao KV / `ca.json` when
   `POSTGRES_HOST_PORT` differed from `5432`, and fixed `bootroot rotate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot rotate ca-key` Phase 5 failing against services
+  registered with `--deploy-type docker` and a custom
+  `--container-name`. The restart target now reads
+  `entry.container_name` from `state.json` rather than assuming a
+  hardcoded `bootroot-agent-<service>` prefix, and the `service add`
+  docker snippet recommends a long-running daemon container
+  (`docker run -d --restart unless-stopped`, without `--oneshot`) so
+  `docker restart` is a meaningful signal-renewal action. (Closes #552)
 - Fixed `bootroot init` storing the host-side PostgreSQL port in the
   step-ca DSN written to OpenBao KV / `ca.json` when
   `POSTGRES_HOST_PORT` differed from `5432`, and fixed `bootroot rotate

--- a/docs/en/cli-examples.md
+++ b/docs/en/cli-examples.md
@@ -461,8 +461,9 @@ docker run --rm \
 ```
 
 ```bash
-docker run --rm \
+docker run -d \
   --name web-app \
+  --restart unless-stopped \
   -v /srv/bootroot/agent.toml:/app/agent.toml:ro \
   -v /srv/bootroot/certs:/app/certs \
   <bootroot-agent-image> \

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -416,3 +416,38 @@ bootroot rotate force-reissue --service-name edge-proxy --yes
 For local services (daemon/docker), the command signals bootroot-agent after
 deleting the files. For remote services, it prints a hint to run
 `bootroot-remote bootstrap` on the service host.
+
+## Migrating existing docker-deploy services to a long-running sidecar
+
+Before the fix for issue #552, `bootroot service add --deploy-type docker`
+printed a sidecar snippet that ran bootroot-agent as a one-shot container
+(`docker run --rm ... bootroot-agent --config /app/agent.toml --oneshot`).
+Such containers exited immediately after the initial issuance. For those
+installs, `bootroot rotate ca-key` Phase 5 cannot signal renewal because
+there is no container to `docker restart`, and the rotation fails with
+`No such container: <container_name>`.
+
+Recreate the sidecar as a long-running daemon, keeping the same
+`--container-name` recorded in `state.json`:
+
+```bash
+# Remove the old one-shot sidecar if anything is still lingering.
+docker rm -f <container_name> 2>/dev/null || true
+
+# Print the current recommended snippet for an existing registration
+# without modifying state.
+bootroot service add --print-only \
+  --deploy-type docker \
+  --service-name <service> \
+  --container-name <container_name> \
+  ... other flags as originally registered ...
+```
+
+Run the printed `docker run -d --restart unless-stopped ...` command. The
+container will stay `Up` after startup and across host reboots, so
+`docker restart <container_name>` (issued by Phase 5 of
+`bootroot rotate ca-key`) becomes a meaningful signal-renewal action.
+
+If you try to rotate first, Phase 5 now fails fast with a dedicated error
+that names the missing container and points at this procedure instead of
+the generic `exit status: 1` from the old code path.

--- a/docs/ko/cli-examples.md
+++ b/docs/ko/cli-examples.md
@@ -456,8 +456,9 @@ docker run --rm \
 ```
 
 ```bash
-docker run --rm \
+docker run -d \
   --name web-app \
+  --restart unless-stopped \
   -v /srv/bootroot/agent.toml:/app/agent.toml:ro \
   -v /srv/bootroot/certs:/app/certs \
   <bootroot-agent-image> \

--- a/docs/ko/operations.md
+++ b/docs/ko/operations.md
@@ -394,3 +394,37 @@ bootroot rotate force-reissue --service-name edge-proxy --yes
 로컬 서비스(daemon/docker)의 경우 파일 삭제 후 bootroot-agent에 시그널을
 보냅니다. 원격 서비스의 경우 서비스 머신에서 `bootroot-remote bootstrap`을
 실행하라는 안내를 출력합니다.
+
+## 기존 도커 배포 서비스를 장기 실행 사이드카로 마이그레이션
+
+이슈 #552 수정 전에 `bootroot service add --deploy-type docker`가 출력하던
+사이드카 스니펫은 bootroot-agent를 일회성 컨테이너
+(`docker run --rm ... bootroot-agent --config /app/agent.toml --oneshot`)로
+실행했습니다. 이 컨테이너는 초기 발급 직후 종료되므로, 해당 설정으로
+등록된 서비스는 `bootroot rotate ca-key` Phase 5에서 `docker restart`할
+컨테이너가 존재하지 않아 `No such container: <container_name>` 오류로
+실패합니다.
+
+`state.json`에 기록된 `--container-name`을 유지한 채, 사이드카를 장기 실행
+데몬으로 재생성하세요:
+
+```bash
+# 과거 일회성 사이드카가 남아 있다면 먼저 제거합니다.
+docker rm -f <container_name> 2>/dev/null || true
+
+# state.json 변경 없이 현재 권장 스니펫만 출력합니다.
+bootroot service add --print-only \
+  --deploy-type docker \
+  --service-name <service> \
+  --container-name <container_name> \
+  ... (기존 등록과 동일한 나머지 플래그) ...
+```
+
+출력된 `docker run -d --restart unless-stopped ...` 명령을 실행하면 호스트
+재부팅 후에도 컨테이너가 `Up` 상태로 유지되고, `bootroot rotate ca-key`
+Phase 5가 호출하는 `docker restart <container_name>`이 의미 있는 시그널-
+갱신 동작이 됩니다.
+
+마이그레이션 없이 회전을 먼저 실행하면, Phase 5가 사라진 컨테이너 이름을
+표시하고 위 절차를 안내하는 전용 오류 메시지로 즉시 중단됩니다(이전의
+`exit status: 1`과 달리 원인이 명확히 드러납니다).

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -433,8 +433,9 @@ fn print_docker_snippet(entry: &ServiceEntry, messages: &Messages) {
         .parent()
         .unwrap_or(std::path::Path::new("."));
     println!("{}", messages.service_snippet_docker_title());
-    println!("docker run --rm \\");
+    println!("docker run -d \\");
     println!("  --name {container} \\");
+    println!("  --restart unless-stopped \\");
     println!("  -v {config_path}:/app/agent.toml:ro \\");
     // codeql[rust/cleartext-logging]: output is a filesystem path used in a run snippet.
     println!(
@@ -442,7 +443,7 @@ fn print_docker_snippet(entry: &ServiceEntry, messages: &Messages) {
         cert_dir = cert_parent.display()
     );
     println!("  <bootroot-agent-image> \\");
-    println!("  bootroot-agent --config /app/agent.toml --oneshot");
+    println!("  bootroot-agent --config /app/agent.toml");
 }
 
 fn print_trust_snippet(entry: &ServiceEntry, trusted: &[String], messages: &Messages) {

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -28,7 +28,6 @@ pub(super) const ROOT_CA_COMMON_NAME: &str = "Bootroot Root CA";
 pub(super) const INTERMEDIATE_CA_COMMON_NAME: &str = "Bootroot Intermediate CA";
 pub(super) const RENDERED_FILE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 pub(super) const RENDERED_FILE_TIMEOUT: Duration = Duration::from_mins(1);
-pub(super) const BOOTROOT_AGENT_CONTAINER_PREFIX: &str = "bootroot-agent";
 pub(super) const OPENBAO_RECOVERY_SCOPE_UNSEAL_KEYS: &str = "unseal-keys";
 pub(super) const OPENBAO_RECOVERY_SCOPE_ROOT_TOKEN: &str = "root-token";
 pub(super) const OPENBAO_ROOT_ROTATION_INCOMPLETE_ERROR: &str =

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -240,6 +240,7 @@ pub(super) mod test_support {
     static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
     pub(super) const TEST_DOCKER_ARGS_ENV: &str = "BOOTROOT_TEST_DOCKER_ARGS";
     pub(super) const TEST_DOCKER_EXIT_ENV: &str = "BOOTROOT_TEST_DOCKER_EXIT";
+    pub(super) const TEST_DOCKER_STDERR_ENV: &str = "BOOTROOT_TEST_DOCKER_STDERR";
 
     pub(super) struct ScopedEnvVar {
         key: &'static str,
@@ -280,6 +281,9 @@ pub(super) mod test_support {
         let script = r#"#!/bin/sh
 set -eu
 printf '%s\n' "$@" > "${BOOTROOT_TEST_DOCKER_ARGS:?missing log path}"
+if [ -n "${BOOTROOT_TEST_DOCKER_STDERR:-}" ]; then
+  printf '%s' "${BOOTROOT_TEST_DOCKER_STDERR}" 1>&2
+fi
 if [ -n "${BOOTROOT_TEST_DOCKER_EXIT:-}" ]; then
   exit "${BOOTROOT_TEST_DOCKER_EXIT}"
 fi

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -191,6 +191,9 @@ pub(super) fn signal_bootroot_agent(entry: &ServiceEntry, messages: &Messages) -
                 .as_deref()
                 .filter(|name| !name.is_empty())
                 .ok_or_else(|| anyhow::anyhow!(messages.error_service_container_name_required()))?;
+            if !docker_container_exists(container, messages)? {
+                anyhow::bail!(messages.error_bootroot_agent_container_missing(container));
+            }
             run_docker(
                 &["restart", container],
                 "docker restart bootroot-agent",
@@ -199,6 +202,16 @@ pub(super) fn signal_bootroot_agent(entry: &ServiceEntry, messages: &Messages) -
         }
         crate::state::DeployType::Daemon => signal_bootroot_agent_daemon(entry, messages),
     }
+}
+
+fn docker_container_exists(container: &str, messages: &Messages) -> Result<bool> {
+    let status = std::process::Command::new("docker")
+        .args(["container", "inspect", container])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .with_context(|| messages.error_command_run_failed("docker container inspect"))?;
+    Ok(status.success())
 }
 
 #[cfg(unix)]
@@ -480,5 +493,48 @@ mod tests {
         let err = signal_bootroot_agent(&entry, &test_messages())
             .expect_err("missing container_name must fail fast");
         assert!(err.to_string().contains("container_name"));
+    }
+
+    #[test]
+    fn signal_bootroot_agent_docker_reports_missing_container_with_hint() {
+        use super::super::test_support::{
+            ScopedEnvVar, TEST_DOCKER_ARGS_ENV, TEST_DOCKER_EXIT_ENV, env_lock, path_with_prepend,
+            write_fake_docker_script,
+        };
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir(&bin_dir).expect("create bin dir");
+        let docker_path = bin_dir.join("docker");
+        write_fake_docker_script(&docker_path);
+
+        let args_log = dir.path().join("docker_args.log");
+        let _lock = env_lock();
+        let _path = ScopedEnvVar::set("PATH", path_with_prepend(&bin_dir));
+        let _args = ScopedEnvVar::set(TEST_DOCKER_ARGS_ENV, args_log.as_os_str());
+        let _exit = ScopedEnvVar::set(TEST_DOCKER_EXIT_ENV, "1");
+
+        let mut entry = make_service_entry("nginx-docker", DeliveryMode::LocalFile);
+        entry.container_name = Some("my-nginx".to_string());
+
+        let err = signal_bootroot_agent(&entry, &test_messages())
+            .expect_err("missing container must fail with tailored hint");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("my-nginx"),
+            "error should reference the missing container: {msg}"
+        );
+        assert!(
+            msg.contains("docker run -d") && msg.contains("--restart unless-stopped"),
+            "error should recommend recreating the sidecar as a long-running daemon: {msg}"
+        );
+
+        let logged = std::fs::read_to_string(&args_log).expect("read logged args");
+        let args: Vec<&str> = logged.lines().collect();
+        assert_eq!(
+            args,
+            vec!["container", "inspect", "my-nginx"],
+            "rotate must stop at the pre-flight inspect and not invoke docker restart"
+        );
     }
 }

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -191,27 +191,51 @@ pub(super) fn signal_bootroot_agent(entry: &ServiceEntry, messages: &Messages) -
                 .as_deref()
                 .filter(|name| !name.is_empty())
                 .ok_or_else(|| anyhow::anyhow!(messages.error_service_container_name_required()))?;
-            if !docker_container_exists(container, messages)? {
-                anyhow::bail!(messages.error_bootroot_agent_container_missing(container));
+            match inspect_docker_container(container, messages)? {
+                DockerInspectOutcome::Found => run_docker(
+                    &["restart", container],
+                    "docker restart bootroot-agent",
+                    messages,
+                ),
+                DockerInspectOutcome::Missing => {
+                    anyhow::bail!(messages.error_bootroot_agent_container_missing(container))
+                }
             }
-            run_docker(
-                &["restart", container],
-                "docker restart bootroot-agent",
-                messages,
-            )
         }
         crate::state::DeployType::Daemon => signal_bootroot_agent_daemon(entry, messages),
     }
 }
 
-fn docker_container_exists(container: &str, messages: &Messages) -> Result<bool> {
-    let status = std::process::Command::new("docker")
+#[derive(Debug, PartialEq, Eq)]
+enum DockerInspectOutcome {
+    Found,
+    Missing,
+}
+
+fn inspect_docker_container(container: &str, messages: &Messages) -> Result<DockerInspectOutcome> {
+    let output = std::process::Command::new("docker")
         .args(["container", "inspect", container])
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
+        .output()
         .with_context(|| messages.error_command_run_failed("docker container inspect"))?;
-    Ok(status.success())
+    if output.status.success() {
+        return Ok(DockerInspectOutcome::Found);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_no_such_container_stderr(&stderr) {
+        return Ok(DockerInspectOutcome::Missing);
+    }
+    anyhow::bail!(messages.error_docker_command_failed(stderr.trim()));
+}
+
+// Docker reports an absent container with either
+// "Error response from daemon: No such container: <name>" or
+// "Error: No such object: <name>"; any other stderr (daemon not reachable,
+// permission denied, TLS errors, …) is an unrelated failure that must
+// surface to the operator unchanged instead of being misattributed to the
+// #552 one-shot migration path.
+fn is_no_such_container_stderr(stderr: &str) -> bool {
+    stderr.contains("No such container") || stderr.contains("No such object")
 }
 
 #[cfg(unix)]
@@ -498,8 +522,8 @@ mod tests {
     #[test]
     fn signal_bootroot_agent_docker_reports_missing_container_with_hint() {
         use super::super::test_support::{
-            ScopedEnvVar, TEST_DOCKER_ARGS_ENV, TEST_DOCKER_EXIT_ENV, env_lock, path_with_prepend,
-            write_fake_docker_script,
+            ScopedEnvVar, TEST_DOCKER_ARGS_ENV, TEST_DOCKER_EXIT_ENV, TEST_DOCKER_STDERR_ENV,
+            env_lock, path_with_prepend, write_fake_docker_script,
         };
 
         let dir = tempdir().expect("tempdir");
@@ -513,6 +537,10 @@ mod tests {
         let _path = ScopedEnvVar::set("PATH", path_with_prepend(&bin_dir));
         let _args = ScopedEnvVar::set(TEST_DOCKER_ARGS_ENV, args_log.as_os_str());
         let _exit = ScopedEnvVar::set(TEST_DOCKER_EXIT_ENV, "1");
+        let _stderr = ScopedEnvVar::set(
+            TEST_DOCKER_STDERR_ENV,
+            "Error response from daemon: No such container: my-nginx\n",
+        );
 
         let mut entry = make_service_entry("nginx-docker", DeliveryMode::LocalFile);
         entry.container_name = Some("my-nginx".to_string());
@@ -536,5 +564,70 @@ mod tests {
             vec!["container", "inspect", "my-nginx"],
             "rotate must stop at the pre-flight inspect and not invoke docker restart"
         );
+    }
+
+    #[test]
+    fn signal_bootroot_agent_docker_surfaces_non_absence_inspect_failure() {
+        use super::super::test_support::{
+            ScopedEnvVar, TEST_DOCKER_ARGS_ENV, TEST_DOCKER_EXIT_ENV, TEST_DOCKER_STDERR_ENV,
+            env_lock, path_with_prepend, write_fake_docker_script,
+        };
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir(&bin_dir).expect("create bin dir");
+        let docker_path = bin_dir.join("docker");
+        write_fake_docker_script(&docker_path);
+
+        let args_log = dir.path().join("docker_args.log");
+        let _lock = env_lock();
+        let _path = ScopedEnvVar::set("PATH", path_with_prepend(&bin_dir));
+        let _args = ScopedEnvVar::set(TEST_DOCKER_ARGS_ENV, args_log.as_os_str());
+        let _exit = ScopedEnvVar::set(TEST_DOCKER_EXIT_ENV, "1");
+        let daemon_stderr = "Cannot connect to the Docker daemon at \
+                             unix:///var/run/docker.sock. Is the docker daemon running?";
+        let _stderr = ScopedEnvVar::set(TEST_DOCKER_STDERR_ENV, daemon_stderr);
+
+        let mut entry = make_service_entry("nginx-docker", DeliveryMode::LocalFile);
+        entry.container_name = Some("my-nginx".to_string());
+
+        let err = signal_bootroot_agent(&entry, &test_messages())
+            .expect_err("non-absence inspect failures must propagate verbatim");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Cannot connect to the Docker daemon"),
+            "error should preserve docker's own stderr: {msg}"
+        );
+        assert!(
+            !msg.contains("docker run -d"),
+            "must not recommend the #552 migration hint for unrelated docker failures: {msg}"
+        );
+        assert!(
+            !msg.contains("one-shot") && !msg.contains("bootroot-agent docker container not found"),
+            "must not use the missing-container i18n template for unrelated docker failures: {msg}"
+        );
+
+        let logged = std::fs::read_to_string(&args_log).expect("read logged args");
+        let args: Vec<&str> = logged.lines().collect();
+        assert_eq!(
+            args,
+            vec!["container", "inspect", "my-nginx"],
+            "rotate must stop at the pre-flight inspect"
+        );
+    }
+
+    #[test]
+    fn is_no_such_container_stderr_recognizes_known_absence_messages() {
+        assert!(is_no_such_container_stderr(
+            "Error response from daemon: No such container: foo\n"
+        ));
+        assert!(is_no_such_container_stderr("Error: No such object: foo\n"));
+        assert!(!is_no_such_container_stderr(
+            "Cannot connect to the Docker daemon at unix:///var/run/docker.sock"
+        ));
+        assert!(!is_no_such_container_stderr(
+            "permission denied while trying to connect to the Docker daemon socket"
+        ));
+        assert!(!is_no_such_container_stderr(""));
     }
 }

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -94,7 +94,7 @@ pub(super) fn temp_secret_path(path: &Path) -> PathBuf {
 
 pub(super) fn restart_container(container: &str, messages: &Messages) -> Result<()> {
     let args = ["restart", container];
-    run_docker(&args, "docker restart", messages)
+    run_docker(&args, &format!("docker restart {container}"), messages)
 }
 
 pub(super) fn restart_compose_service(
@@ -192,11 +192,7 @@ pub(super) fn signal_bootroot_agent(entry: &ServiceEntry, messages: &Messages) -
                 .filter(|name| !name.is_empty())
                 .ok_or_else(|| anyhow::anyhow!(messages.error_service_container_name_required()))?;
             match inspect_docker_container(container, messages)? {
-                DockerInspectOutcome::Found => run_docker(
-                    &["restart", container],
-                    "docker restart bootroot-agent",
-                    messages,
-                ),
+                DockerInspectOutcome::Found => restart_container(container, messages),
                 DockerInspectOutcome::Missing => {
                     anyhow::bail!(messages.error_bootroot_agent_container_missing(container))
                 }
@@ -629,5 +625,54 @@ mod tests {
             "permission denied while trying to connect to the Docker daemon socket"
         ));
         assert!(!is_no_such_container_stderr(""));
+    }
+
+    #[test]
+    fn signal_bootroot_agent_docker_restart_failure_names_container() {
+        use super::super::test_support::{
+            ScopedEnvVar, TEST_DOCKER_ARGS_ENV, env_lock, path_with_prepend,
+        };
+        #[cfg(unix)]
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir(&bin_dir).expect("create bin dir");
+        let docker_path = bin_dir.join("docker");
+        // Succeed on `container inspect`, fail on `restart` so the error
+        // context (which must name the actual container) is the one the
+        // operator sees.
+        let script = r#"#!/bin/sh
+set -eu
+printf '%s\n' "$@" >> "${BOOTROOT_TEST_DOCKER_ARGS:?missing log path}"
+if [ "$1" = "restart" ]; then
+  exit 1
+fi
+exit 0
+"#;
+        std::fs::write(&docker_path, script).expect("write fake docker");
+        #[cfg(unix)]
+        std::fs::set_permissions(&docker_path, std::fs::Permissions::from_mode(0o700))
+            .expect("chmod fake docker");
+
+        let args_log = dir.path().join("docker_args.log");
+        let _lock = env_lock();
+        let _path = ScopedEnvVar::set("PATH", path_with_prepend(&bin_dir));
+        let _args = ScopedEnvVar::set(TEST_DOCKER_ARGS_ENV, args_log.as_os_str());
+
+        let mut entry = make_service_entry("nginx-docker", DeliveryMode::LocalFile);
+        entry.container_name = Some("my-nginx".to_string());
+
+        let err = signal_bootroot_agent(&entry, &test_messages())
+            .expect_err("docker restart failure must propagate");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("my-nginx"),
+            "restart failure must name the actual container, got: {msg}"
+        );
+        assert!(
+            !msg.contains("bootroot-agent"),
+            "restart failure must not reference the removed hardcoded prefix, got: {msg}"
+        );
     }
 }

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -186,13 +186,13 @@ fn reload_openbao_agent_daemon(_entry: &ServiceEntry, messages: &Messages) -> Re
 pub(super) fn signal_bootroot_agent(entry: &ServiceEntry, messages: &Messages) -> Result<()> {
     match entry.deploy_type {
         crate::state::DeployType::Docker => {
-            let container = format!(
-                "{}-{}",
-                super::BOOTROOT_AGENT_CONTAINER_PREFIX,
-                entry.service_name
-            );
+            let container = entry
+                .container_name
+                .as_deref()
+                .filter(|name| !name.is_empty())
+                .ok_or_else(|| anyhow::anyhow!(messages.error_service_container_name_required()))?;
             run_docker(
-                &["restart", &container],
+                &["restart", container],
                 "docker restart bootroot-agent",
                 messages,
             )
@@ -441,5 +441,44 @@ mod tests {
             !args_log.exists(),
             "docker should not have been invoked for a remote service"
         );
+    }
+
+    #[test]
+    fn signal_bootroot_agent_docker_uses_entry_container_name() {
+        use super::super::test_support::{
+            ScopedEnvVar, TEST_DOCKER_ARGS_ENV, env_lock, path_with_prepend,
+            write_fake_docker_script,
+        };
+
+        let dir = tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir(&bin_dir).expect("create bin dir");
+        let docker_path = bin_dir.join("docker");
+        write_fake_docker_script(&docker_path);
+
+        let args_log = dir.path().join("docker_args.log");
+        let _lock = env_lock();
+        let _path = ScopedEnvVar::set("PATH", path_with_prepend(&bin_dir));
+        let _args = ScopedEnvVar::set(TEST_DOCKER_ARGS_ENV, args_log.as_os_str());
+
+        let mut entry = make_service_entry("nginx-docker", DeliveryMode::LocalFile);
+        entry.container_name = Some("my-nginx".to_string());
+
+        signal_bootroot_agent(&entry, &test_messages())
+            .expect("should invoke docker restart against entry.container_name");
+
+        let logged = std::fs::read_to_string(&args_log).expect("read logged args");
+        let args: Vec<&str> = logged.lines().collect();
+        assert_eq!(args, vec!["restart", "my-nginx"]);
+    }
+
+    #[test]
+    fn signal_bootroot_agent_docker_requires_container_name() {
+        let entry = make_service_entry("nginx-docker", DeliveryMode::LocalFile);
+        assert!(entry.container_name.is_none());
+
+        let err = signal_bootroot_agent(&entry, &test_messages())
+            .expect_err("missing container_name must fail fast");
+        assert!(err.to_string().contains("container_name"));
     }
 }

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -629,11 +629,12 @@ mod tests {
 
     #[test]
     fn signal_bootroot_agent_docker_restart_failure_names_container() {
+        #[cfg(unix)]
+        use std::os::unix::fs::PermissionsExt;
+
         use super::super::test_support::{
             ScopedEnvVar, TEST_DOCKER_ARGS_ENV, env_lock, path_with_prepend,
         };
-        #[cfg(unix)]
-        use std::os::unix::fs::PermissionsExt;
 
         let dir = tempdir().expect("tempdir");
         let bin_dir = dir.path().join("bin");

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -180,6 +180,7 @@ pub(crate) struct Strings {
     pub(crate) error_docker_command_failed: &'static str,
     pub(crate) error_bootroot_agent_run_failed: &'static str,
     pub(crate) error_bootroot_agent_not_found: &'static str,
+    pub(crate) error_bootroot_agent_container_missing: &'static str,
     pub(crate) error_secrets_dir_resolve_failed: &'static str,
     pub(crate) error_rendered_file_timeout: &'static str,
     pub(crate) error_parse_ca_json_failed: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -140,6 +140,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_docker_command_failed: "docker command failed: {value}",
     error_bootroot_agent_run_failed: "Failed to run bootroot-agent",
     error_bootroot_agent_not_found: "bootroot-agent binary not found. Tried: {candidates}",
+    error_bootroot_agent_container_missing: "bootroot-agent docker container not found: {container}. If this service was registered before issue #552 was fixed, the sidecar was likely a one-shot container that exited after initial issuance. Recreate it as a long-running daemon named `{container}` using the snippet printed by `bootroot service add --print-only --deploy-type docker --container-name {container} ...` (docker run -d --restart unless-stopped, no --oneshot), then retry `bootroot rotate ca-key`.",
     error_secrets_dir_resolve_failed: "Failed to resolve secrets dir",
     error_parse_ca_json_failed: "Failed to parse ca.json",
     error_serialize_ca_json_failed: "Failed to serialize ca.json",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -140,6 +140,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_docker_command_failed: "docker 명령 실패: {value}",
     error_bootroot_agent_run_failed: "bootroot-agent 실행 실패",
     error_bootroot_agent_not_found: "bootroot-agent 바이너리를 찾을 수 없습니다. 시도한 경로: {candidates}",
+    error_bootroot_agent_container_missing: "bootroot-agent 도커 컨테이너를 찾을 수 없습니다: {container}. 이슈 #552 수정 이전에 등록된 서비스라면 초기 발급 후 종료되는 일회성 컨테이너였을 가능성이 높습니다. `bootroot service add --print-only --deploy-type docker --container-name {container} ...`가 출력하는 새 스니펫(`docker run -d --restart unless-stopped`, `--oneshot` 없음)으로 `{container}`를 장기 실행 데몬으로 재생성한 뒤 `bootroot rotate ca-key`를 다시 실행하세요.",
     error_secrets_dir_resolve_failed: "secrets dir 확인 실패",
     error_parse_ca_json_failed: "ca.json 파싱 실패",
     error_serialize_ca_json_failed: "ca.json 직렬화 실패",

--- a/src/i18n/service.rs
+++ b/src/i18n/service.rs
@@ -316,6 +316,13 @@ impl Messages {
         )
     }
 
+    pub(crate) fn error_bootroot_agent_container_missing(&self, container: &str) -> String {
+        format_template(
+            self.strings().error_bootroot_agent_container_missing,
+            &[("container", container)],
+        )
+    }
+
     pub(crate) fn error_secrets_dir_resolve_failed(&self) -> &'static str {
         self.strings().error_secrets_dir_resolve_failed
     }

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -575,9 +575,11 @@ async fn test_app_add_prints_docker_snippet() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success());
-    assert!(stdout.contains("docker run --rm"));
+    assert!(stdout.contains("docker run -d"));
+    assert!(stdout.contains("--restart unless-stopped"));
     assert!(stdout.contains("--name edge-proxy"));
     assert!(stdout.contains("/app/agent.toml"));
+    assert!(!stdout.contains("--oneshot"));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- `bootroot rotate ca-key` Phase 5 now reads the Docker container name from `entry.container_name` (persisted by `service add --container-name`) instead of assuming a `bootroot-agent-<service>` prefix, so `docker restart` targets the container the operator actually created.
- Missing `container_name` for a docker-deployed service now surfaces the existing `error_service_container_name_required` message instead of silently constructing an invalid name.
- Added a pre-flight `docker container inspect` before Phase 5's restart so docker sidecars registered under the old `--oneshot` snippet (and therefore removed after initial issuance) fail with a dedicated i18n error (`error_bootroot_agent_container_missing`, en + ko) that names the missing container and points operators at the long-running `docker run -d --restart unless-stopped ...` snippet from the current `service add` output. The inspect call now captures stderr and only maps the specific `No such container` / `No such object` responses to that migration hint; any other docker failure (daemon unreachable, permission denied, TLS error, socket problems) is reported verbatim through the existing `docker command failed: …` template so the real problem is never hidden behind the #552 recreate-the-sidecar guidance.
- Phase 5's actual `docker restart` now routes through the shared `restart_container` helper, whose failure context was updated to include the real container name (e.g. `docker restart my-nginx failed with status: …`). Previously the error string was the stale hardcoded `"docker restart bootroot-agent"`, which was the original bug's blast radius bleeding into the error path. Every other caller of `restart_container` (`rotate responder-hmac`, `rotate db`, `rotate stepca-password`, cleanup paths) now also gets the container name in their restart-failure context, not just `docker restart`.
- The `service add` docker sidecar snippet (and both locale examples) now recommends a long-running daemon (`docker run -d --restart unless-stopped`, no `--oneshot`) so `docker restart` is a meaningful signal-renewal action consistent with how rotate interacts with it.
- Added a **Migrating existing docker-deploy services to a long-running sidecar** section to `docs/en/operations.md` and `docs/ko/operations.md` walking operators through removing a stale one-shot sidecar and re-running `bootroot service add --print-only --container-name <same_name>` to get the new long-running snippet without mutating `state.json`.
- Removed the now-unused `BOOTROOT_AGENT_CONTAINER_PREFIX` constant.

Closes #552

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Unit test `signal_bootroot_agent_docker_uses_entry_container_name` verifies `docker restart` is invoked with `entry.container_name` (the pre-flight inspect is also exercised but leaves the final logged args as `["restart", "my-nginx"]`)
- [x] Unit test `signal_bootroot_agent_docker_requires_container_name` verifies the missing-container-name error path
- [x] Unit test `signal_bootroot_agent_docker_reports_missing_container_with_hint` drives the fake docker to exit non-zero with `No such container: my-nginx` on stderr, asserts the error names the missing container and includes the recreation hint (`docker run -d` + `--restart unless-stopped`), and verifies rotate stops at the inspect call (no `docker restart` is attempted)
- [x] Unit test `signal_bootroot_agent_docker_surfaces_non_absence_inspect_failure` drives the fake docker to exit non-zero with `Cannot connect to the Docker daemon …` on stderr and asserts the error (a) preserves that stderr verbatim, (b) does not mention `docker run -d` / the one-shot migration path, and (c) does not use the missing-container i18n template — the unrelated failure must not be misattributed to the #552 recovery path
- [x] Unit test `signal_bootroot_agent_docker_restart_failure_names_container` drives the fake docker to succeed on `container inspect` and fail on `restart`, then asserts the surfaced error names `my-nginx` and does **not** contain the old hardcoded `bootroot-agent` label — pinning the context-string fix
- [x] Unit test `is_no_such_container_stderr_recognizes_known_absence_messages` pins the stderr classifier (matches `No such container` and `No such object`, rejects daemon / permission errors and empty stderr)
- [x] Updated `test_app_add_prints_docker_snippet` asserts `docker run -d`, `--restart unless-stopped`, and absence of `--oneshot`
- [x] `cargo test --bin bootroot` → 507 passed; `cargo test --test bootroot_rotate` → 44 passed; `cargo test --test bootroot_service` → 40 passed
- [x] Manual: `bootroot service add --deploy-type docker --container-name my-nginx ...` followed by `bootroot rotate ca-key` restarts `my-nginx` in Phase 5 — covered by the unit test that invokes `signal_bootroot_agent` against a docker `ServiceEntry` and asserts `docker restart <entry.container_name>` is the exact command issued (the same helper Phase 5 calls). Full end-to-end with a live Vault was not run locally.
- [x] Manual: running the updated docker snippet produces a container that survives `docker restart` (no `--oneshot` / `--rm` exit) — verified locally: `bootroot service add --print-only --deploy-type docker --container-name my-nginx ...` prints `docker run -d --name my-nginx --restart unless-stopped ...`, and a container started with those flags stays `Up` after `docker restart`.

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title**

```text
Signal bootroot-agent docker container by recorded name
```

**Body**

```text
bootroot rotate ca-key Phase 5 now reads the docker container name
from entry.container_name (persisted by service add
--container-name) instead of a hardcoded bootroot-agent-<service>
prefix, so docker restart targets the container the operator
actually created. Missing container_name for a docker-deployed
service now surfaces the existing
error_service_container_name_required message instead of silently
constructing an invalid name.

A pre-flight docker container inspect runs before the restart.
Sidecars registered under the old --oneshot snippet (which exited
after initial issuance) fail with a dedicated error that names
the missing container and points operators at the long-running
"docker run -d --restart unless-stopped" snippet. The inspect
call captures stderr and only maps the specific "No such
container" / "No such object" responses to that migration hint;
any other docker failure (daemon unreachable, permission denied,
TLS error) is reported verbatim so the real problem is not hidden
behind the recreate-the-sidecar guidance.

Phase 5's docker restart now routes through the shared
restart_container helper, whose failure context includes the real
container name (e.g. "docker restart my-nginx failed with
status: ..."). Every caller of restart_container (rotate
responder-hmac, rotate db, rotate stepca-password, cleanup paths)
benefits from the same context fix, replacing the stale hardcoded
"docker restart bootroot-agent" label.

The service add docker sidecar snippet and both locale examples
now recommend a long-running daemon ("docker run -d --restart
unless-stopped", no --oneshot) so docker restart is a meaningful
signal-renewal action. A new "Migrating existing docker-deploy
services to a long-running sidecar" section in
docs/en/operations.md and docs/ko/operations.md walks operators
through removing a stale one-shot sidecar and re-running
"bootroot service add --print-only --container-name <same_name>"
to get the new snippet without mutating state.json. The unused
BOOTROOT_AGENT_CONTAINER_PREFIX constant is removed.

Closes #552
```
<!-- agentcoop:squash-suggestion:end -->
