### PR TITLE
Honor POSTGRES_HOST_PORT in rotate-db admin DSN

### DIFF
--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -1081,8 +1081,9 @@ run_rotations_with_verification() {
   if [ -z "${db_admin_dsn:-}" ]; then
     db_admin_dsn="postgresql://step:step-pass@127.0.0.1:${POSTGRES_HOST_PORT:-5432}/stepca?sslmode=disable"
   else
-    # Replace the Docker-internal host with localhost for host-side access.
-    db_admin_dsn="$(echo "$db_admin_dsn" | sed 's|@postgres:|@127.0.0.1:|')"
+    # Replace the Docker-internal host:port with the host-side mapping.
+    db_admin_dsn="$(echo "$db_admin_dsn" \
+      | sed "s|@postgres:5432|@127.0.0.1:${POSTGRES_HOST_PORT:-5432}|")"
   fi
   run_bootroot rotate \
     --compose-file "$COMPOSE_FILE" \


### PR DESCRIPTION
## Summary

- The rotate-db phase in `scripts/impl/run-local-lifecycle.sh` rewrote only the hostname when constructing the host-side admin DSN, leaving the port literal at 5432.
- On any developer host where 5432 is occupied by an unrelated postgres, the connection routed to the wrong database and rotate-db failed with `role "step" does not exist`, pointing away from the actual root cause.
- Extend the substitution to swap host and port together so `POSTGRES_HOST_PORT` is honored in the normal post-init path. The fallback branch already did this; only the substitution branch was inconsistent.

## Test plan

- [x] Ran `POSTGRES_HOST_PORT=5433 scripts/preflight/ci/e2e-matrix.sh --skip-hosts --fresh-secrets` on macOS Darwin with port 5432 occupied by an unrelated postgres. Before the patch: rotate-db fails with the misleading role error. After the patch: full local lifecycle, remote lifecycle, and rotation/recovery matrix all pass (verified during the #573 preflight session).
- [x] Ran `POSTGRES_HOST_PORT=5433 scripts/preflight/ci/e2e-extended.sh` on the same host. All six extended cases (scale-contention, failure-recovery, runner-timer, runner-cron, ca-key-recovery, infra-lifecycle) report `pass`.
- [x] CI matrix re-runs on the PR branch (port 5432 is free on GitHub runners, so the mapping is the identity 5432→5432 and the bug does not manifest there). All required checks pass: Quality Check, Unit & CLI Smoke, every Docker E2E arm (local / local-no-hosts and its four topology variants / remote / rotation), CodeQL, and Analyze (actions / python / rust).

Closes #579