### PR TITLE
Set deterministic compose env in E2E baseline/smoke

### DIFF
--- a/scripts/impl/run-baseline.sh
+++ b/scripts/impl/run-baseline.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+# docker-compose.yml interpolates the entire file regardless of which
+# services are targeted or which profiles are active, so required vars
+# referenced by gated services (e.g. grafana) must still be defined.
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-step-pass}"
+export GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
+
 DEFAULT_SCENARIO_FILE="$ROOT_DIR/tests/e2e/docker_harness/scenarios/scenario-a-single-node-mixed.json"
 SCENARIO_FILE="${SCENARIO_FILE:-$DEFAULT_SCENARIO_FILE}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-baseline-$(date +%s)}"

--- a/scripts/impl/run-harness-smoke.sh
+++ b/scripts/impl/run-harness-smoke.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+# docker-compose.yml interpolates the entire file regardless of which
+# services are targeted or which profiles are active, so required vars
+# referenced by gated services (e.g. grafana) must still be defined.
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-step-pass}"
+export GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
+
 SCENARIO_ID="${SCENARIO_ID:-docker-harness-smoke}"
 PROJECT_NAME="${PROJECT_NAME:-bootroot-e2e-smoke-$$}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-smoke-$PROJECT_NAME}"


### PR DESCRIPTION
## Summary

- Export `POSTGRES_PASSWORD` and `GRAFANA_ADMIN_PASSWORD` with safe E2E defaults at the top of `scripts/impl/run-baseline.sh` and `scripts/impl/run-harness-smoke.sh` so every `docker compose` invocation in those scripts (up / ps / logs / down) sees a consistent environment.
- Fixes the `e2e-extended.yml` workflow failure where the `scale-contention` case aborted at `docker compose up` with `required variable GRAFANA_ADMIN_PASSWORD is missing a value`.

## Why

`docker-compose.yml` interpolates the entire file regardless of which services are targeted or which profiles are active. After commit a4170bf turned `GRAFANA_ADMIN_PASSWORD` into a hard requirement via `${GRAFANA_ADMIN_PASSWORD:?...}`, any compose call without that variable fails immediately, even when grafana / grafana-public are profile-gated and not part of `COMPOSE_SERVICES`.

`scripts/impl/run-rotation-recovery.sh` already writes a deterministic `.env`, so `failure-recovery` and `ca-key-recovery` kept passing. The baseline and harness-smoke scripts did not, so:

- `scale-contention` (which runs first, via `run-baseline.sh`) failed every time.
- `runner-cron` / `runner-timer` (via `run-harness-smoke.sh`) only passed because `failure-recovery` had already seeded `.env` earlier in the same job. Reordering would have broken them too.

The compose security policy of refusing weak defaults in production stays intact; the defaults only apply inside the E2E scripts, before invoking compose.

Closes #585

## Test plan

- [x] `scripts/impl/run-baseline.sh` runs to completion without a pre-existing `.env` (verified via the GitHub Actions runner, which has no pre-existing `.env` and exercises this path through the `scale-contention` extended case)
- [x] `scripts/impl/run-extended-suite.sh` reaches all extended cases without compose interpolation errors (run [25264024867](https://github.com/aicers/bootroot/actions/runs/25264024867) green; all five cases pass)
- [x] `e2e-extended.yml` workflow_dispatch run goes green on this branch (run [25264024867](https://github.com/aicers/bootroot/actions/runs/25264024867))
- [x] CI `Quality Check`, `Unit & CLI Smoke`, and `Docker E2E` matrix jobs pass on the PR ([runs](https://github.com/aicers/bootroot/pull/586/checks))