### PR TITLE
Wire local-file force-reissue --wait into CI matrix (#590)

### DIFF
--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -372,6 +372,8 @@ verify_service_with_retry() {
   done
 }
 
+# Daemon-deploy local-file path: drives `bootroot rotate force-reissue
+# --wait` end-to-end so the in-binary signal+wait code path runs in CI.
 force_reissue_for_service() {
   local service="$1"
   run_bootroot rotate \
@@ -387,13 +389,25 @@ force_reissue_for_service() {
     >>"$RUN_LOG" 2>&1
 }
 
+# Docker-deploy local-file path: web-app is registered with
+# --deploy-type docker --container-name web-app for service-add coverage,
+# but no real `web-app` container runs in this scenario.  The host
+# bootroot-agent owns the cert via the shared agent config, so deleting
+# the files and letting the daemon's missing-cert check pick them up is
+# the right reissue trigger here.  The `bootroot rotate force-reissue`
+# wait-path is exercised by the daemon-deploy edge-proxy call above.
+force_reissue_for_docker_service() {
+  local service="$1"
+  rm -f "$CERTS_DIR/${service}.crt" "$CERTS_DIR/${service}.key"
+}
+
 force_reissue_remote() {
   rm -f "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key"
 }
 
 force_reissue_all_services() {
   force_reissue_for_service "$EDGE_SERVICE"
-  force_reissue_for_service "$WEB_SERVICE"
+  force_reissue_for_docker_service "$WEB_SERVICE"
   force_reissue_remote
 }
 
@@ -772,7 +786,7 @@ scenario_3_partial_reissuance() {
   [ -f "$CERTS_DIR/${WEB_SERVICE}.crt" ] || fail "S3: web-app old cert should still exist"
 
   # Reissue remaining services
-  force_reissue_for_service "$WEB_SERVICE"
+  force_reissue_for_docker_service "$WEB_SERVICE"
   verify_service_with_retry "$WEB_SERVICE"
   run_remote_bootstrap
   force_reissue_remote

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -404,7 +404,11 @@ start_local_bootroot_agent_daemon() {
   [ -f "$AGENT_CONFIG_PATH" ] || fail "agent config missing at $AGENT_CONFIG_PATH"
   printf '[recovery] starting bootroot-agent daemon: --config %s\n' \
     "$AGENT_CONFIG_PATH" >>"$RUN_LOG"
-  "$BOOTROOT_AGENT_BIN" --config "$AGENT_CONFIG_PATH" \
+  # bootroot-agent uses tracing_subscriber::fmt::init(), whose default
+  # filter is ERROR.  The readiness probe below greps for an info-level
+  # message, so we have to opt into info output explicitly.
+  RUST_LOG="${RUST_LOG:-info}" \
+    "$BOOTROOT_AGENT_BIN" --config "$AGENT_CONFIG_PATH" \
     >>"$LOCAL_AGENT_DAEMON_LOG" 2>&1 &
   LOCAL_AGENT_DAEMON_PID=$!
   local attempt

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -365,7 +365,18 @@ verify_service_with_retry() {
 }
 
 force_reissue_for_service() {
-  rm -f "$CERTS_DIR/${1}.crt" "$CERTS_DIR/${1}.key"
+  local service="$1"
+  run_bootroot rotate \
+    --compose-file "$COMPOSE_FILE" \
+    --openbao-url "http://${STEPCA_HOST_IP}:8200" \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_ROTATE_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_ROTATE_SECRET_ID" \
+    --yes \
+    force-reissue \
+    --service-name "$service" \
+    --wait \
+    >>"$RUN_LOG" 2>&1
 }
 
 force_reissue_remote() {

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -64,6 +64,13 @@ RUNTIME_ROTATE_SECRET_ID=""
 SIDECAR_OBA_SERVICE="$EDGE_SERVICE"
 SIDECAR_OBA_CONTAINER="bootroot-openbao-agent-${SIDECAR_OBA_SERVICE}"
 CURRENT_PHASE="init"
+# PID of the long-running bootroot-agent daemon started for the local
+# services (edge-proxy + web-app share AGENT_CONFIG_PATH).  Required so
+# `bootroot rotate force-reissue --wait` can deliver SIGHUP to a real
+# process — without it, pkill -HUP exits 1 ("no processes matched") and
+# the rotate fails before the wait path runs.
+LOCAL_AGENT_DAEMON_PID=""
+LOCAL_AGENT_DAEMON_LOG="$ARTIFACT_DIR/bootroot-agent.log"
 # Pin POSTGRES_HOST_PORT for the compose stack: docker-compose.yml's
 # default moved from 5432 to 5433 in #588 §4c; the e2e harness
 # expects 5432 (CI runners free that port before the matrix), so
@@ -204,6 +211,7 @@ stop_service_sidecar_oba() {
 
 cleanup() {
   log_phase "cleanup"
+  stop_local_bootroot_agent_daemon
   capture_artifacts
   stop_service_sidecar_oba
   compose_down
@@ -387,6 +395,51 @@ force_reissue_all_services() {
   force_reissue_for_service "$EDGE_SERVICE"
   force_reissue_for_service "$WEB_SERVICE"
   force_reissue_remote
+}
+
+start_local_bootroot_agent_daemon() {
+  if [ -n "$LOCAL_AGENT_DAEMON_PID" ] && kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+    return 0
+  fi
+  [ -f "$AGENT_CONFIG_PATH" ] || fail "agent config missing at $AGENT_CONFIG_PATH"
+  printf '[recovery] starting bootroot-agent daemon: --config %s\n' \
+    "$AGENT_CONFIG_PATH" >>"$RUN_LOG"
+  "$BOOTROOT_AGENT_BIN" --config "$AGENT_CONFIG_PATH" \
+    >>"$LOCAL_AGENT_DAEMON_LOG" 2>&1 &
+  LOCAL_AGENT_DAEMON_PID=$!
+  local attempt
+  for attempt in $(seq 1 20); do
+    if ! kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+      tail -n 80 "$LOCAL_AGENT_DAEMON_LOG" >>"$RUN_LOG" 2>&1 || true
+      LOCAL_AGENT_DAEMON_PID=""
+      fail "bootroot-agent daemon exited during startup; see $LOCAL_AGENT_DAEMON_LOG"
+    fi
+    if grep -q "Profile .* daemon enabled" "$LOCAL_AGENT_DAEMON_LOG" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  tail -n 80 "$LOCAL_AGENT_DAEMON_LOG" >>"$RUN_LOG" 2>&1 || true
+  fail "bootroot-agent daemon failed to become ready; see $LOCAL_AGENT_DAEMON_LOG"
+}
+
+stop_local_bootroot_agent_daemon() {
+  if [ -z "$LOCAL_AGENT_DAEMON_PID" ]; then
+    return 0
+  fi
+  if kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+    kill "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null || true
+    local attempt
+    for attempt in $(seq 1 10); do
+      if ! kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.2
+    done
+    kill -9 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null || true
+  fi
+  wait "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null || true
+  LOCAL_AGENT_DAEMON_PID=""
 }
 
 run_verify_pair() {
@@ -838,11 +891,13 @@ main() {
 
   run_verify_pair "initial"
 
+  start_local_bootroot_agent_daemon
   scenario_1_phase3_failure
   scenario_2_phase4_failure
   scenario_3_partial_reissuance
   scenario_4_finalize_blocked
   scenario_5_trustsync_conflict
+  stop_local_bootroot_agent_daemon
 }
 
 main "$@"

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -908,7 +908,17 @@ run_verify_pair() {
 
 force_reissue_for_service() {
   local service="$1"
-  rm -f "$CERTS_DIR/${service}.crt" "$CERTS_DIR/${service}.key"
+  run_bootroot rotate \
+    --compose-file "$COMPOSE_FILE" \
+    --openbao-url "http://${STEPCA_HOST_IP}:8200" \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_ROTATE_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_ROTATE_SECRET_ID" \
+    --yes \
+    force-reissue \
+    --service-name "$service" \
+    --wait \
+    >>"$RUN_LOG" 2>&1
 }
 
 force_reissue_remote() {

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -936,7 +936,11 @@ start_local_bootroot_agent_daemon() {
   [ -f "$AGENT_CONFIG_PATH" ] || fail "agent config missing at $AGENT_CONFIG_PATH"
   printf '[lifecycle] starting bootroot-agent daemon: --config %s\n' \
     "$AGENT_CONFIG_PATH" >>"$RUN_LOG"
-  "$BOOTROOT_AGENT_BIN" --config "$AGENT_CONFIG_PATH" \
+  # bootroot-agent uses tracing_subscriber::fmt::init(), whose default
+  # filter is ERROR.  The readiness probe below greps for an info-level
+  # message, so we have to opt into info output explicitly.
+  RUST_LOG="${RUST_LOG:-info}" \
+    "$BOOTROOT_AGENT_BIN" --config "$AGENT_CONFIG_PATH" \
     >>"$LOCAL_AGENT_DAEMON_LOG" 2>&1 &
   LOCAL_AGENT_DAEMON_PID=$!
   # Give the daemon time to load config and install its SIGHUP handler;

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -134,6 +134,13 @@ EXTERNAL_OBA_NETWORK="${EXTERNAL_OBA_NETWORK:-oba-ext}"
 SIDECAR_ROTATE_LATENCY_LIMIT_SECS="${SIDECAR_ROTATE_LATENCY_LIMIT_SECS:-25}"
 HOST_DAEMON_RENDER_TIMEOUT_SECS="${HOST_DAEMON_RENDER_TIMEOUT_SECS:-75}"
 CURRENT_PHASE="init"
+# PID of the long-running bootroot-agent daemon started for the local
+# services (edge-proxy + web-app share AGENT_CONFIG_PATH).  Required so
+# `bootroot rotate force-reissue --wait` can deliver SIGHUP to a real
+# process — without it, pkill -HUP exits 1 ("no processes matched") and
+# the rotate fails before the wait path runs.
+LOCAL_AGENT_DAEMON_PID=""
+LOCAL_AGENT_DAEMON_LOG="$ARTIFACT_DIR/bootroot-agent.log"
 # Pin POSTGRES_HOST_PORT for the compose stack: docker-compose.yml's
 # default moved from 5432 to 5433 in #588 §4c; the e2e harness
 # expects 5432 (CI runners free that port before the matrix), so
@@ -565,6 +572,7 @@ cleanup_hosts() {
 cleanup() {
   log_phase "cleanup"
   cleanup_hosts
+  stop_local_bootroot_agent_daemon
   capture_artifacts
   stop_service_oba
   compose_down
@@ -921,6 +929,54 @@ force_reissue_for_service() {
     >>"$RUN_LOG" 2>&1
 }
 
+start_local_bootroot_agent_daemon() {
+  if [ -n "$LOCAL_AGENT_DAEMON_PID" ] && kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+    return 0
+  fi
+  [ -f "$AGENT_CONFIG_PATH" ] || fail "agent config missing at $AGENT_CONFIG_PATH"
+  printf '[lifecycle] starting bootroot-agent daemon: --config %s\n' \
+    "$AGENT_CONFIG_PATH" >>"$RUN_LOG"
+  "$BOOTROOT_AGENT_BIN" --config "$AGENT_CONFIG_PATH" \
+    >>"$LOCAL_AGENT_DAEMON_LOG" 2>&1 &
+  LOCAL_AGENT_DAEMON_PID=$!
+  # Give the daemon time to load config and install its SIGHUP handler;
+  # otherwise the first force_reissue may signal it before the handler
+  # is ready, masking the wait-path coverage we are trying to add.
+  local attempt
+  for attempt in $(seq 1 20); do
+    if ! kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+      tail -n 80 "$LOCAL_AGENT_DAEMON_LOG" >>"$RUN_LOG" 2>&1 || true
+      LOCAL_AGENT_DAEMON_PID=""
+      fail "bootroot-agent daemon exited during startup; see $LOCAL_AGENT_DAEMON_LOG"
+    fi
+    if grep -q "Profile .* daemon enabled" "$LOCAL_AGENT_DAEMON_LOG" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  tail -n 80 "$LOCAL_AGENT_DAEMON_LOG" >>"$RUN_LOG" 2>&1 || true
+  fail "bootroot-agent daemon failed to become ready; see $LOCAL_AGENT_DAEMON_LOG"
+}
+
+stop_local_bootroot_agent_daemon() {
+  if [ -z "$LOCAL_AGENT_DAEMON_PID" ]; then
+    return 0
+  fi
+  if kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+    kill "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null || true
+    local attempt
+    for attempt in $(seq 1 10); do
+      if ! kill -0 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.2
+    done
+    kill -9 "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null || true
+  fi
+  wait "$LOCAL_AGENT_DAEMON_PID" 2>/dev/null || true
+  LOCAL_AGENT_DAEMON_PID=""
+}
+
 force_reissue_remote() {
   rm -f "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.crt" "$REMOTE_CERTS_DIR/${REMOTE_SERVICE}.key"
 }
@@ -1235,7 +1291,9 @@ main() {
   run_remote_bootstrap
 
   run_verify_pair "initial"
+  start_local_bootroot_agent_daemon
   run_rotations_with_verification
+  stop_local_bootroot_agent_daemon
 
   log_phase "assert-openbao-audit-log"
   assert_openbao_audit_log

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -914,6 +914,8 @@ run_verify_pair() {
   snapshot_cert_meta "$REMOTE_SERVICE" "$label" "$REMOTE_CERTS_DIR"
 }
 
+# Daemon-deploy local-file path: drives `bootroot rotate force-reissue
+# --wait` end-to-end so the in-binary signal+wait code path runs in CI.
 force_reissue_for_service() {
   local service="$1"
   run_bootroot rotate \
@@ -927,6 +929,18 @@ force_reissue_for_service() {
     --service-name "$service" \
     --wait \
     >>"$RUN_LOG" 2>&1
+}
+
+# Docker-deploy local-file path: web-app is registered with
+# --deploy-type docker --container-name web-app for service-add coverage,
+# but no real `web-app` container runs in this scenario.  The host
+# bootroot-agent owns the cert via the shared agent config, so deleting
+# the files and letting the daemon's missing-cert check pick them up is
+# the right reissue trigger here.  The `bootroot rotate force-reissue`
+# wait-path is exercised by the daemon-deploy edge-proxy call above.
+force_reissue_for_docker_service() {
+  local service="$1"
+  rm -f "$CERTS_DIR/${service}.crt" "$CERTS_DIR/${service}.key"
 }
 
 start_local_bootroot_agent_daemon() {
@@ -987,7 +1001,7 @@ force_reissue_remote() {
 
 force_reissue_all_services() {
   force_reissue_for_service "$EDGE_SERVICE"
-  force_reissue_for_service "$WEB_SERVICE"
+  force_reissue_for_docker_service "$WEB_SERVICE"
   force_reissue_remote
 }
 


### PR DESCRIPTION
## Summary

Wires the `--delivery-mode local-file` `--wait` code path that shipped in #589 into the CI E2E matrix by replacing the `rm -f`-based `force_reissue_for_service` helper in `scripts/impl/run-local-lifecycle.sh` and `scripts/impl/run-ca-key-rotation-recovery.sh` with a real `bootroot rotate force-reissue --yes --wait` invocation for daemon-deployed services (edge-proxy).

The companion `force_reissue_for_docker_service` helper keeps the original `rm -f` behaviour for `web-app`, which is registered with `--deploy-type docker --container-name web-app` for service-add coverage even though no actual `web-app` container runs in this scenario. `bootroot rotate force-reissue` would otherwise try to restart the missing container and fail. The host bootroot-agent owns both certs via the shared agent config, so deleting `web-app`'s files and letting the daemon's missing-cert check pick them up is the right reissue trigger here. The `--wait` code path is still exercised end-to-end through the daemon-deploy edge-proxy path.

`force_reissue_remote` and the three standalone `rm -f` lines at `run-ca-key-rotation-recovery.sh:691`, `:733`, `:762` are left untouched — those intentionally simulate partial-migration / finalize-blocked / trust-sync-conflict states that Phase 6 must still detect.

Spawns a long-running `bootroot-agent` daemon against `AGENT_CONFIG_PATH` after the OBA template render and stops it from `cleanup`. `bootroot rotate force-reissue` calls `pkill -HUP -f <agent_config_path>` to nudge the daemon; until this commit the lifecycle and recovery scripts only ever invoked `bootroot-agent --oneshot` (via `bootroot verify`), so `pkill` matched no process and the rotate failed before the `--wait` path could run. `RUST_LOG=info` is set when launching the daemon so the readiness probe (which greps for an info-level log line) can match the default tracing-subscriber output.

Closes #590

## Test plan

- [x] `scripts/preflight/ci/e2e-matrix.sh` green (covers `run-local-lifecycle.sh` via `local-no-hosts`, `local-no-hosts-host-daemon`, `rotation` arms)
- [x] `scripts/preflight/ci/e2e-extended.sh` green (covers `run-ca-key-rotation-recovery.sh` via the `ca-key-recovery` case)
- [x] CI `Docker E2E (local-no-hosts)` and `Docker E2E (rotation)` jobs pass
- [x] CI `run-extended` `ca-key-recovery` case passes
- [x] Confirm `force_reissue_remote` and the three scenario-setup `rm -f` lines in `run-ca-key-rotation-recovery.sh` are unchanged