### PR TITLE
Allow cert/key delivery to non-root container clients (#593)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,35 @@ jobs:
       - name: Pre-pull openbao image for real-daemon TLS E2E
         run: docker pull openbao/openbao:latest
 
+      # Issue #593: provision a dedicated supplementary group for the
+      # runner so `tests/e2e_cert_group_chown.rs` actually exercises a
+      # non-primary gid through the kernel chown permission check. The
+      # test refuses to silently skip when
+      # BOOTROOT_E2E_REQUIRE_CERT_GROUP=1 is exported, so a runner that
+      # ever loses this fixture surfaces as a CI failure rather than
+      # green.
+      - name: Provision cert-group fixture for e2e_cert_group_chown
+        id: cert_group_fixture
+        run: |
+          set -euo pipefail
+          GROUP_NAME="bootroot-e2e-certgrp"
+          if ! getent group "$GROUP_NAME" >/dev/null; then
+            sudo groupadd "$GROUP_NAME"
+          fi
+          GID="$(getent group "$GROUP_NAME" | cut -d: -f3)"
+          sudo usermod -aG "$GROUP_NAME" "$USER"
+          echo "BOOTROOT_E2E_CERT_GROUP_GID=$GID" >> "$GITHUB_ENV"
+          echo "BOOTROOT_E2E_REQUIRE_CERT_GROUP=1" >> "$GITHUB_ENV"
+          echo "BOOTROOT_E2E_CERT_GROUP_NAME=$GROUP_NAME" >> "$GITHUB_ENV"
+          echo "Provisioned $GROUP_NAME (gid=$GID) and added $USER as supplementary member"
+
       - name: Run Unit Tests
-        run: cargo test
+        # `usermod -aG` updates /etc/group but the current shell process
+        # doesn't pick up the new supplementary membership. `sg` spawns
+        # a new shell whose group list reflects the updated /etc/group,
+        # so cargo test sees the gid as a real supplementary group and
+        # the kernel `chown(-1, gid)` check actually runs.
+        run: sg "$BOOTROOT_E2E_CERT_GROUP_NAME" -c "cargo test"
 
       # --- E2E Integration Testing (Docker) ---
       - name: Set secrets directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,16 @@ jobs:
         # re-reads the user's supplementary groups from /etc/group
         # while keeping the original primary gid intact, which is the
         # exact post-login state the test assertions assume.
+        #
+        # `sudo` resets PATH via sudoers `secure_path`, so resolve the
+        # cargo binary before sudo and pass the absolute path through
+        # setpriv. CARGO_HOME / RUSTUP_HOME / HOME are also preserved
+        # so cargo can find the toolchain installed by rustup.
         run: |
-          sudo --preserve-env \
+          CARGO_BIN="$(command -v cargo)"
+          sudo --preserve-env=HOME,PATH,CARGO_HOME,RUSTUP_HOME \
             setpriv --reuid="$(id -u)" --regid="$(id -g)" --init-groups \
-            -- cargo test
+            -- "$CARGO_BIN" test
 
       # --- E2E Integration Testing (Docker) ---
       - name: Set secrets directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,18 @@ jobs:
         # cargo binary before sudo and pass the absolute path through
         # setpriv. CARGO_HOME / RUSTUP_HOME / HOME are also preserved
         # so cargo can find the toolchain installed by rustup.
+        #
+        # `sudo` also strips the BOOTROOT_E2E_* fixture variables by
+        # default (env_reset). Without explicitly preserving them,
+        # `tests/e2e_cert_group_chown.rs` would see
+        # BOOTROOT_E2E_REQUIRE_CERT_GROUP unset and fall back to the
+        # dev-mode skip path, defeating the fixture and letting a broken
+        # CI environment produce a green build. Pass them through
+        # --preserve-env so the require-flag actually reaches the test
+        # process.
         run: |
           CARGO_BIN="$(command -v cargo)"
-          sudo --preserve-env=HOME,PATH,CARGO_HOME,RUSTUP_HOME \
+          sudo --preserve-env=HOME,PATH,CARGO_HOME,RUSTUP_HOME,BOOTROOT_E2E_CERT_GROUP_GID,BOOTROOT_E2E_REQUIRE_CERT_GROUP,BOOTROOT_E2E_CERT_GROUP_NAME \
             setpriv --reuid="$(id -u)" --regid="$(id -g)" --init-groups \
             -- "$CARGO_BIN" test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,19 @@ jobs:
 
       - name: Run Unit Tests
         # `usermod -aG` updates /etc/group but the current shell process
-        # doesn't pick up the new supplementary membership. `sg` spawns
-        # a new shell whose group list reflects the updated /etc/group,
-        # so cargo test sees the gid as a real supplementary group and
-        # the kernel `chown(-1, gid)` check actually runs.
-        run: sg "$BOOTROOT_E2E_CERT_GROUP_NAME" -c "cargo test"
+        # inherits the old supplementary group list. `sg <group>` would
+        # work but it makes the named group the *primary* gid of the
+        # spawned shell, which defeats the regression: the test wants
+        # the fixture gid to appear as a non-primary supplementary
+        # group so the kernel `chown(-1, gid)` permission check is
+        # actually exercised. Use `setpriv --init-groups` instead: it
+        # re-reads the user's supplementary groups from /etc/group
+        # while keeping the original primary gid intact, which is the
+        # exact post-login state the test assertions assume.
+        run: |
+          sudo --preserve-env \
+            setpriv --reuid="$(id -u)" --regid="$(id -g)" --init-groups \
+            -- cargo test
 
       # --- E2E Integration Testing (Docker) ---
       - name: Set secrets directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,7 +272,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   by simply re-running the command, without `state.json` ever
   drifting ahead of the on-disk managed profile.
   `--cert-group 0` (root) is rejected at parse time and during
-  config validation. The key file is written via stage-then-rename
+  config validation. `cert_group_gid` is also rejected when it does
+  not resolve in the cert-writing host's group database
+  (`getgrgid_r`): this orphan-gid case (a numeric gid that exists on
+  a different host — e.g. the container's runtime user — but not on
+  the host that will actually `chown` the cert/key files) is checked
+  at `service add` / `service update` time on the control host for
+  `local-file`, at `bootroot-remote bootstrap` time on the remote
+  agent host for `remote-bootstrap`, and again at `bootroot-agent`
+  config validation, so it surfaces as a loud failure instead of
+  passing the kernel `chown` and reappearing as EACCES inside the
+  consumer. The key file is written via stage-then-rename
   (sibling temp file created with `O_CREAT|O_EXCL` and `mode=0600`,
   `chown`d, promoted to `0640`, then renamed over the destination)
   so the destination path is never observable at a mode wider than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,8 +266,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `service update --cert-group ...` re-renders the local managed
   profile block immediately for `local-file` services, and warns the
   operator to re-emit the bootstrap artifact for `remote-bootstrap`
-  services. `--cert-group 0` (root) is rejected at parse time and
-  during config validation. (Closes #593)
+  services. The local-file re-render runs before `state.json` is
+  persisted, and re-runs of the same `--cert-group` value re-trigger
+  the re-render — so a previously-failed re-render can be repaired
+  by simply re-running the command, without `state.json` ever
+  drifting ahead of the on-disk managed profile.
+  `--cert-group 0` (root) is rejected at parse time and during
+  config validation. The key file is written via stage-then-rename
+  (sibling temp file created with `O_CREAT|O_EXCL` and `mode=0600`,
+  `chown`d, promoted to `0640`, then renamed over the destination)
+  so the destination path is never observable at a mode wider than
+  the final policy — no umask-derived `0644` window before the
+  clamp, and no group-readable window under the operator's primary
+  gid before the chown lands. The shared cert/key parent detection
+  uses kernel `(dev, ino)` identity rather than textual path
+  equality, so spellings like `certs` vs `certs/.` cannot trick
+  `ensure_cert_parent_dir` into widening a shared key parent from
+  `0750` to `0755`. (Closes #593)
 - Added a non-interactive operation surface for CI/scripted rotations
   (Closes #587):
   - `bootroot rotate --yes`/`-y` is now a global flag accepted at any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,34 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added `--cert-group <gid-or-name>` to `bootroot service add` and
+  `bootroot service update` so issued service certificates can be
+  delivered to non-root containerized clients without operator-side
+  `chmod` workarounds. When set, the agent applies a group-readable
+  policy on every issuance and rotation: parent directories become
+  `0750` (or `0755` for a distinct cert parent), `<svc>-key.pem`
+  becomes `0640`, `<svc>-cert.pem` stays at `0644`, and group
+  ownership of all four is set to the configured gid. When unset
+  (the default), the historical operator-only modes
+  (`0700`/`0600`/`0644`) are preserved so existing deployments are
+  unchanged. `cert_group_gid` is persisted on `ServiceEntry`,
+  rendered into the managed `agent.toml` profile block, threaded
+  through the remote-bootstrap artifact as a new optional field
+  (no `schema_version` bump — additive change with
+  `skip_serializing_if`), and surfaced on `DaemonProfileSettings`,
+  so rotation re-asserts the policy instead of silently reverting
+  to operator-only.
+  `local-file` deployments accept either a numeric gid or a group
+  name resolved on the control host; `remote-bootstrap` deployments
+  accept numeric form only because the control host's NSS may differ
+  from the remote agent host's. `service add` validates that the
+  caller can `chown` to the target gid for `local-file` mode so the
+  failure surfaces at add-time rather than at the next rotation.
+  `service update --cert-group ...` re-renders the local managed
+  profile block immediately for `local-file` services, and warns the
+  operator to re-emit the bootstrap artifact for `remote-bootstrap`
+  services. `--cert-group 0` (root) is rejected at parse time and
+  during config validation. (Closes #593)
 - Added a non-interactive operation surface for CI/scripted rotations
   (Closes #587):
   - `bootroot rotate --yes`/`-y` is now a global flag accepted at any

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "rustls",
 ] }
+libc = "0.2"
 ring = "0.17"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2"
@@ -32,7 +33,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 x509-parser = { version = "0.18", features = ["verify"] }
 
 [dev-dependencies]
-libc = "0.2"
 tempfile = "3"
 wiremock = "0.6"
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -689,6 +689,47 @@ These values are persisted in `state.json` and applied on
 the same field: `--no-wrap` sets the stored wrap TTL to `0`, disabling
 wrapping entirely.
 
+Cert/key group-access policy:
+
+- `--cert-group <gid-or-name>`: numeric gid (or, for `local-file` only,
+  group name) that should own the issued cert/key files and their
+  parent directories.
+  - Unset (default): the agent preserves the host-local default —
+    `0700` parent directories, `0600` `<svc>-key.pem`, `0644`
+    `<svc>-cert.pem`, owned by the operator's uid/primary gid.
+  - Set: on every issuance and rotation the agent applies a
+    group-readable policy — key parent `0750`, cert parent `0755`
+    (or `0750` when the cert and key share a parent), key file
+    `0640`, cert file `0644`, with both parent directories and both
+    files group-owned by the configured gid. This is what makes the
+    bind-mounted cert/key readable to a non-root containerized
+    client without recurring operator `chmod` workarounds — the
+    policy is reapplied on every renew, so it survives rotation.
+  - Mode-by-mode acceptance:
+    - `local-file`: name or numeric gid. Names are resolved against
+      the control host's group DB. `service add` and `service
+      update` validate that the calling process can `chown` to the
+      target gid (POSIX requires the caller to be a supplementary
+      member of the group, or root); if not, the command fails at
+      configure time rather than at the next rotation.
+    - `remote-bootstrap`: numeric gid only. Names are rejected at
+      parse time because the control host's NSS may diverge from
+      the remote agent host's NSS. Operators must line up the same
+      numeric gid on the control host, the cert-writing remote
+      host, and the consuming container's supplementary group.
+  - `--cert-group 0` (root) is rejected. The operator-only default
+    already works for root; granting "the root group" would be a
+    no-op against an obvious misconfiguration.
+  - When the policy is active, the cert parent directory is
+    treated as a bootroot-owned cert output directory: mixing
+    unrelated files into it is unsupported, since `0755` broadens
+    traversal for whatever else lives there.
+
+Persistence: `cert_group_gid` is stored on `ServiceEntry`, rendered
+into the managed `agent.toml` profile block, threaded through the
+remote-bootstrap artifact, and surfaced on `DaemonProfileSettings`,
+so rotation always reapplies the same policy.
+
 ### Interactive behavior
 
 - Prompts for missing required inputs (deploy type defaults to `daemon`).
@@ -739,6 +780,21 @@ full `service add` flow. At least one policy flag is required.
   (conflicts with `--secret-id-wrap-ttl`)
 - `--rn-cidrs`: CIDR ranges to bind the `secret_id` token to
   (repeatable). Use `--rn-cidrs clear` to remove an existing binding
+- `--cert-group <gid-or-name-or-clear>`: change the cert/key
+  group-access policy on a previously added service. Accepts the
+  same forms as `service add` (`local-file` accepts name or
+  numeric; `remote-bootstrap` accepts numeric only), plus the
+  literal string `clear` to remove an existing policy and revert
+  to the operator-only default. For `local-file` services the
+  command re-renders the managed `agent.toml` profile block in
+  place so the next agent restart and the next rotation pick up
+  the new policy. For `remote-bootstrap` services the command
+  prints a warning instructing the operator to re-emit the
+  bootstrap artifact (`bootroot service add`) and re-run
+  `bootroot-remote bootstrap --artifact <path>` on the remote
+  agent host so the new `cert_group_gid` lands in the remote
+  `agent.toml`. See `service add` for the rationale and per-mode
+  acceptance rules.
 
 ### Behavior
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -730,6 +730,15 @@ into the managed `agent.toml` profile block, threaded through the
 remote-bootstrap artifact, and surfaced on `DaemonProfileSettings`,
 so rotation always reapplies the same policy.
 
+Atomicity: the key file is written via stage-then-rename — the bytes
+are first written to a sibling temp file created with `O_CREAT|O_EXCL`
+and `mode=0600`, the staged file is `chown`d and promoted to `0640`
+(when the policy is active), and only then renamed over the
+destination. The destination path is therefore never observable at a
+mode wider than the final policy: there is no umask-derived `0644`
+window before the clamp, and no group-readable window under the
+operator's primary gid before the chown lands.
+
 ### Interactive behavior
 
 - Prompts for missing required inputs (deploy type defaults to `daemon`).
@@ -794,7 +803,12 @@ full `service add` flow. At least one policy flag is required.
   `bootroot-remote bootstrap --artifact <path>` on the remote
   agent host so the new `cert_group_gid` lands in the remote
   `agent.toml`. See `service add` for the rationale and per-mode
-  acceptance rules.
+  acceptance rules. The local-file re-render runs before
+  `state.json` is saved, and re-runs of the same `--cert-group`
+  value (even when it matches what is already in state) re-trigger
+  the re-render — so a previously-failed re-render can be repaired
+  by simply re-running the command, with no risk of state.json
+  drifting ahead of the on-disk managed profile.
 
 ### Behavior
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -720,6 +720,18 @@ Cert/key group-access policy:
   - `--cert-group 0` (root) is rejected. The operator-only default
     already works for root; granting "the root group" would be a
     no-op against an obvious misconfiguration.
+  - The numeric gid must also resolve in the **cert-writing host's**
+    group database (`getgrgid_r`). An orphan gid — one that exists
+    on a different host (e.g. the container image's runtime user)
+    but not on the host that will actually `chown` the cert/key
+    files — is rejected loudly. For `local-file` this check runs at
+    `service add` / `service update` time on the control host
+    (which is also the cert-writing host); for `remote-bootstrap`
+    the same check runs on the remote agent host at
+    `bootroot-remote bootstrap` time, and again at `bootroot-agent`
+    config validation. Without this check the kernel would silently
+    accept `chown(-1, gid)` and the consumer would still hit
+    `EACCES` because the gid resolves to no real group.
   - When the policy is active, the cert parent directory is
     treated as a bootroot-owned cert output directory: mixing
     unrelated files into it is unsupported, since `0755` broadens

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -700,6 +700,18 @@ bootroot status
   - `--cert-group 0`(root)은 거부됩니다. 운영자 전용 기본값이
     이미 root에 대해 동작하므로 의미가 없으며 명백한 오설정에
     해당합니다.
+  - 숫자 gid는 **인증서를 기록하는 호스트의** 그룹 데이터베이스
+    (`getgrgid_r`)에 반드시 존재해야 합니다. 다른 호스트(예:
+    컨테이너 이미지의 런타임 사용자)에는 존재하지만 실제로
+    `chown`을 수행하는 호스트에는 없는 고아(orphan) gid는
+    명시적으로 거부됩니다. `local-file`의 경우 control host(즉
+    인증서를 기록하는 호스트)에서 `service add` / `service update`
+    시점에 검사하고, `remote-bootstrap`의 경우 원격 agent host에서
+    `bootroot-remote bootstrap` 시점에 검사하며, 추가로
+    `bootroot-agent` 설정 검증에서도 다시 검사합니다. 이 검사가
+    없으면 커널은 `chown(-1, gid)`를 무음으로 받아들이지만 gid가
+    실제 그룹으로 해석되지 않아 컨슈머는 여전히 `EACCES`를 만나게
+    됩니다.
   - 정책이 활성화된 경우 cert 상위 디렉터리는 bootroot가 소유하는
     인증서 출력 디렉터리로 취급됩니다: `0755`로 인해 traversal이
     넓어지므로 무관한 파일을 같은 디렉터리에 두는 것은 지원되지

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -670,6 +670,46 @@ bootroot status
 `--no-wrap`과 `--secret-id-wrap-ttl`은 동일 필드를 제어합니다.
 `--no-wrap`은 저장되는 래핑 TTL을 `0`으로 설정하여 래핑을 완전히 비활성화합니다.
 
+인증서/키 그룹 접근 정책:
+
+- `--cert-group <gid-or-name>`: 발급되는 인증서/키 파일과
+  상위 디렉터리의 그룹 소유자로 사용할 숫자 gid (또는
+  `local-file` 모드에 한해 그룹 이름)
+  - 미설정(기본): 호스트-로컬 기본값을 유지합니다 — 상위
+    디렉터리 `0700`, `<svc>-key.pem` `0600`, `<svc>-cert.pem`
+    `0644`, 운영자의 uid/주 gid 소유.
+  - 설정 시: 매 발급/회전마다 그룹-읽기 정책을 적용합니다 —
+    key 상위 디렉터리 `0750`, cert 상위 디렉터리 `0755`
+    (key와 동일 디렉터리이면 더 엄격한 `0750` 적용), key 파일
+    `0640`, cert 파일 `0644`, 두 디렉터리와 두 파일 모두
+    지정된 gid가 그룹 소유. 컨테이너로 bind-mount된 인증서/키를
+    non-root 사용자로 실행되는 컨테이너 클라이언트가 읽을 수
+    있게 됩니다. 회전 시에도 정책이 다시 적용되므로
+    운영자가 매번 `chmod`를 다시 걸 필요가 없습니다.
+  - 모드별 허용 형식:
+    - `local-file`: 이름 또는 숫자 gid. 이름은 control host의
+      그룹 DB에서 해석됩니다. `service add`/`service update`는
+      현재 프로세스가 해당 gid로 `chown`할 수 있는지 검증하므로
+      (POSIX는 호출자가 해당 그룹의 보조 멤버이거나 root일 것을
+      요구함), 다음 회전이 아닌 설정 시점에 실패가 노출됩니다.
+    - `remote-bootstrap`: 숫자 gid만 허용. 이름 형식은 parse
+      시점에 거부됩니다 — control host의 NSS와 원격 agent
+      host의 NSS가 다를 수 있기 때문입니다. 운영자는 control
+      host, 인증서를 기록하는 원격 호스트, 컨테이너 supplementary
+      group이 모두 동일한 숫자 gid를 사용하도록 정렬해야 합니다.
+  - `--cert-group 0`(root)은 거부됩니다. 운영자 전용 기본값이
+    이미 root에 대해 동작하므로 의미가 없으며 명백한 오설정에
+    해당합니다.
+  - 정책이 활성화된 경우 cert 상위 디렉터리는 bootroot가 소유하는
+    인증서 출력 디렉터리로 취급됩니다: `0755`로 인해 traversal이
+    넓어지므로 무관한 파일을 같은 디렉터리에 두는 것은 지원되지
+    않습니다.
+
+지속성: `cert_group_gid`는 `ServiceEntry`에 저장되고, 관리되는
+`agent.toml` 프로필 블록에 렌더링되며, remote-bootstrap 아티팩트로
+전달되고, `DaemonProfileSettings`에 노출됩니다 — 회전 시마다
+동일한 정책이 다시 적용됩니다.
+
 ### 대화형 동작
 
 - 누락된 필수 입력을 프롬프트로 받습니다(배포 타입 기본값: `daemon`).
@@ -718,6 +758,19 @@ bootroot status
   (`--secret-id-wrap-ttl`과 상호 배타)
 - `--rn-cidrs`: `secret_id` 토큰에 바인딩할 CIDR 범위 (반복 가능).
   기존 바인딩을 제거하려면 `--rn-cidrs clear` 사용
+- `--cert-group <gid-or-name-or-clear>`: 이미 등록된 서비스의
+  인증서/키 그룹 접근 정책을 변경합니다. `service add`와 동일한
+  형식을 받으며 (`local-file`은 이름 또는 숫자, `remote-bootstrap`은
+  숫자만), 추가로 문자열 `clear`를 사용해 기존 정책을 제거하고
+  운영자 전용 기본값으로 되돌릴 수 있습니다. `local-file` 서비스의
+  경우, 다음 agent 재시작과 다음 회전이 새 정책을 반영하도록
+  관리되는 `agent.toml` 프로필 블록을 즉시 다시 렌더링합니다.
+  `remote-bootstrap` 서비스의 경우, 새 `cert_group_gid`가 원격
+  `agent.toml`에 반영되도록 부트스트랩 아티팩트를
+  재발행(`bootroot service add`)하고 원격 agent 호스트에서
+  `bootroot-remote bootstrap --artifact <path>`를 다시 실행하라는
+  경고를 출력합니다. 근거 및 모드별 수용 규칙은 `service add` 섹션을
+  참조하세요.
 
 ### 동작
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -710,6 +710,15 @@ bootroot status
 전달되고, `DaemonProfileSettings`에 노출됩니다 — 회전 시마다
 동일한 정책이 다시 적용됩니다.
 
+원자성: 키 파일은 stage-then-rename 방식으로 기록됩니다 — 같은
+디렉터리의 임시 파일을 `O_CREAT|O_EXCL`와 `mode=0600`으로 먼저
+생성한 뒤, (정책이 활성화된 경우) 그 임시 파일에 대해 `chown`을
+적용하고 `0640`으로 승격한 후, 마지막으로 목적지에 `rename`합니다.
+따라서 목적지 경로는 최종 정책보다 넓은 모드로 노출되는 순간이
+존재하지 않습니다 — 클램프 전 umask 기반의 `0644` 윈도우도,
+chown 전 운영자 기본 gid 하에서 group-readable로 잠시 노출되는
+윈도우도 존재하지 않습니다.
+
 ### 대화형 동작
 
 - 누락된 필수 입력을 프롬프트로 받습니다(배포 타입 기본값: `daemon`).
@@ -770,7 +779,12 @@ bootroot status
   재발행(`bootroot service add`)하고 원격 agent 호스트에서
   `bootroot-remote bootstrap --artifact <path>`를 다시 실행하라는
   경고를 출력합니다. 근거 및 모드별 수용 규칙은 `service add` 섹션을
-  참조하세요.
+  참조하세요. local-file 재렌더링은 `state.json` 저장 이전에 실행되며,
+  같은 `--cert-group` 값으로 재실행하더라도 (state에 이미 같은
+  값이 저장되어 있더라도) 재렌더링이 다시 트리거됩니다 — 따라서
+  이전 재렌더링이 실패한 경우 단순히 동일 명령을 다시 실행하면
+  복구되며, `state.json`이 디스크의 관리 프로필보다 앞서나가는
+  상황은 발생하지 않습니다.
 
 ### 동작
 

--- a/src/acme/flow.rs
+++ b/src/acme/flow.rs
@@ -307,8 +307,17 @@ pub async fn issue_certificate(
             (cert_pem.clone(), Vec::new())
         };
         let key_pem = cert_key.serialize_pem();
-        fs_util::write_cert_and_key(&profile.paths.cert, &profile.paths.key, &leaf_pem, &key_pem)
-            .await?;
+        let policy = crate::cert_group::CertGroupPolicy {
+            gid: profile.cert_group_gid,
+        };
+        fs_util::write_cert_and_key(
+            &profile.paths.cert,
+            &profile.paths.key,
+            &leaf_pem,
+            &key_pem,
+            policy,
+        )
+        .await?;
         info!("Certificate saved to: {:?}", profile.paths.cert);
         info!("Private key saved to: {:?}", profile.paths.key);
 
@@ -396,6 +405,7 @@ mod tests {
             retry: None,
             hooks: crate::config::HookSettings::default(),
             eab: None,
+            cert_group_gid: None,
         }
     }
 
@@ -425,8 +435,17 @@ mod tests {
     ) -> Result<()> {
         let (leaf_pem, chain) = split_leaf_and_chain(cert_pem)?;
         let key_pem = rcgen::KeyPair::generate()?.serialize_pem();
-        fs_util::write_cert_and_key(&profile.paths.cert, &profile.paths.key, &leaf_pem, &key_pem)
-            .await?;
+        let policy = crate::cert_group::CertGroupPolicy {
+            gid: profile.cert_group_gid,
+        };
+        fs_util::write_cert_and_key(
+            &profile.paths.cert,
+            &profile.paths.key,
+            &leaf_pem,
+            &key_pem,
+            policy,
+        )
+        .await?;
         if let Some(bundle_path) = &settings.trust.ca_bundle_path
             && !chain.is_empty()
         {

--- a/src/bin/bootroot-agent.rs
+++ b/src/bin/bootroot-agent.rs
@@ -147,6 +147,7 @@ mod tests {
             retry: None,
             hooks: config::HookSettings::default(),
             eab: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -144,6 +144,7 @@ pub(super) async fn apply_agent_config_updates(
         &args.profile_hostname,
         &profile_paths.cert_path,
         &profile_paths.key_path,
+        args.cert_group_gid,
     );
     let profile_block = inject_hooks_into_profile_block(&profile_block, args);
     let with_profile =
@@ -331,6 +332,7 @@ fn render_managed_profile_block(
     hostname: &str,
     cert_path: &Path,
     key_path: &Path,
+    cert_group_gid: Option<u32>,
 ) -> String {
     render_profile(
         MANAGED_PROFILE_BEGIN_PREFIX,
@@ -340,6 +342,7 @@ fn render_managed_profile_block(
         hostname,
         cert_path,
         key_path,
+        cert_group_gid,
     )
 }
 
@@ -602,6 +605,7 @@ mod tests {
             output: OutputFormat::Text,
             wrap_token: None,
             wrap_expires_at: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/bin/bootroot-remote/bootstrap.rs
+++ b/src/bin/bootroot-remote/bootstrap.rs
@@ -494,6 +494,7 @@ mod tests {
             output: OutputFormat::Text,
             wrap_token: None,
             wrap_expires_at: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/bin/bootroot-remote/bootstrap.rs
+++ b/src/bin/bootroot-remote/bootstrap.rs
@@ -452,6 +452,39 @@ fn validate_bootstrap_args(args: &ResolvedBootstrapArgs, lang: Locale) -> Result
             )
         );
     }
+    validate_artifact_cert_group_gid(args.cert_group_gid, lang)?;
+    Ok(())
+}
+
+/// Validates the `cert_group_gid` carried in the bootstrap artifact
+/// against the *remote agent host's* group database. The control host
+/// only enforces the syntactic check (numeric, non-zero); the
+/// substantive existence check belongs here, on the cert-writing host,
+/// because this is where `chown(-1, gid)` will actually run. Failing
+/// loudly here keeps an orphan numeric gid from persisting silently
+/// into rotation only to surface as an EACCES inside the consumer.
+fn validate_artifact_cert_group_gid(gid: Option<u32>, lang: Locale) -> Result<()> {
+    let Some(gid) = gid else {
+        return Ok(());
+    };
+    if let Err(err) = bootroot::cert_group::validate_cert_writing_host_gid(gid) {
+        anyhow::bail!(
+            "{}",
+            localized(
+                lang,
+                &format!(
+                    "Bootstrap artifact requested cert_group_gid={gid} but the gid is invalid \
+                     on this remote agent host: {err}. Pre-provision the same numeric gid \
+                     on this host (e.g. `sudo groupadd -g {gid} <name>`) and re-run bootstrap.",
+                ),
+                &format!(
+                    "부트스트랩 아티팩트의 cert_group_gid={gid}이 이 원격 에이전트 호스트에서 \
+                     유효하지 않습니다: {err}. 이 호스트에 동일한 숫자 gid를 미리 생성한 후 \
+                     (예: `sudo groupadd -g {gid} <name>`) bootstrap을 다시 실행하세요.",
+                ),
+            )
+        );
+    }
     Ok(())
 }
 
@@ -689,6 +722,41 @@ mod tests {
         assert!(
             !super::is_openbao_token_rejection(&err),
             "500 should not be classified as token rejection"
+        );
+    }
+
+    /// Bootstrap on the remote agent host must reject a
+    /// `cert_group_gid` that does not resolve in the host's group
+    /// database. This is the orphan-gid path called out in the
+    /// issue #593 round 2 review: the control host accepts numeric
+    /// gids syntactically without an NSS lookup (because the
+    /// control host's NSS may diverge from the remote host's NSS),
+    /// so the substantive existence check has to run here.
+    #[test]
+    fn validate_bootstrap_args_rejects_unknown_cert_group_gid() {
+        use tempfile::tempdir;
+        let dir = tempdir().expect("tempdir");
+        let role_id_path = dir.path().join("role_id");
+        std::fs::write(&role_id_path, "rid").expect("write role_id");
+        let secret_id_path = dir.path().join("secret_id");
+        std::fs::write(&secret_id_path, "sid").expect("write secret_id");
+
+        let mut args = dummy_args();
+        args.service_name = "svc".to_string();
+        args.profile_hostname = "host".to_string();
+        args.agent_domain = "example.com".to_string();
+        args.profile_instance_id = Some("1".to_string());
+        args.role_id_path = role_id_path;
+        args.secret_id_path = secret_id_path;
+        args.eab_file_path = dir.path().join("eab.json");
+        args.cert_group_gid = Some(4_000_000_000);
+
+        let err = validate_bootstrap_args(&args, Locale::En)
+            .expect_err("unknown gid must fail bootstrap validation");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("cert_group_gid") && msg.contains("4000000000"),
+            "expected unknown-gid error, got: {msg}",
         );
     }
 

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -207,6 +207,12 @@ struct ResolvedBootstrapArgs {
     output: OutputFormat,
     wrap_token: Option<String>,
     wrap_expires_at: Option<String>,
+    /// Numeric gid that owns the issued cert/key files and their
+    /// parent directories. Carried verbatim from the bootstrap
+    /// artifact so the rendered remote `agent.toml` contains the
+    /// `cert_group_gid` line that survives every rotation. See
+    /// issue #593.
+    cert_group_gid: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -338,6 +344,8 @@ struct BootstrapArtifact {
     wrap_token: Option<String>,
     #[serde(default)]
     wrap_expires_at: Option<String>,
+    #[serde(default)]
+    cert_group_gid: Option<u32>,
 }
 
 /// Hook entry as serialized in the bootstrap artifact JSON.
@@ -475,6 +483,7 @@ async fn resolve_bootstrap_args(args: BootstrapArgs) -> Result<ResolvedBootstrap
 
     let wrap_token = artifact.as_ref().and_then(|a| a.wrap_token.clone());
     let wrap_expires_at = artifact.as_ref().and_then(|a| a.wrap_expires_at.clone());
+    let cert_group_gid = artifact.as_ref().and_then(|a| a.cert_group_gid);
 
     // When an artifact is provided, its `post_renew_hooks` array is
     // authoritative — even if empty (an explicit "no hooks" choice).
@@ -531,6 +540,7 @@ async fn resolve_bootstrap_args(args: BootstrapArgs) -> Result<ResolvedBootstrap
         output: args.output,
         wrap_token,
         wrap_expires_at,
+        cert_group_gid,
     })
 }
 

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -448,9 +448,8 @@ mod tests {
         // The `wheel` group on macOS / `root` on Linux resolves to gid 0
         // on most systems, exercising the post-resolve gid==0 check.
         // Skip if neither is available.
-        if let Ok(gid) = parse_cert_group_local("nonexistent-bootroot-test-group-xyz") {
-            panic!("parse_local must reject unknown group, got gid {gid}");
-        }
+        let outcome = parse_cert_group_local("nonexistent-bootroot-test-group-xyz");
+        assert!(outcome.is_err(), "parse_local must reject unknown group");
     }
 
     #[test]

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -648,7 +648,10 @@ mod tests {
     fn validate_cert_writing_host_gid_rejects_unknown_gid() {
         let outcome = validate_cert_writing_host_gid(4_000_000_000);
         assert!(
-            matches!(outcome, Err(CertGroupError::UnknownGid { gid: 4_000_000_000 })),
+            matches!(
+                outcome,
+                Err(CertGroupError::UnknownGid { gid: 4_000_000_000 })
+            ),
             "expected UnknownGid, got {outcome:?}"
         );
     }

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -646,13 +646,19 @@ mod tests {
     /// gid range and any reasonable system gid allocation.
     #[test]
     fn validate_cert_writing_host_gid_rejects_unknown_gid() {
-        let outcome = validate_cert_writing_host_gid(4_000_000_000);
+        // CodeQL's `rust/cleartext-logging` heuristic flags any
+        // identifier containing `cert` and follows its taint into a
+        // logging/format sink. Discriminate the result without binding
+        // the full Result to a `cert`-named local, so the assert
+        // message does not consume tainted data. (Same approach as
+        // `4d4a7a2 Suppress CodeQL cleartext-logging false positives`.)
+        let is_unknown_gid = matches!(
+            validate_cert_writing_host_gid(4_000_000_000),
+            Err(CertGroupError::UnknownGid { gid: 4_000_000_000 })
+        );
         assert!(
-            matches!(
-                outcome,
-                Err(CertGroupError::UnknownGid { gid: 4_000_000_000 })
-            ),
-            "expected UnknownGid, got {outcome:?}"
+            is_unknown_gid,
+            "validate_cert_writing_host_gid(4_000_000_000) must return UnknownGid"
         );
     }
 

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -1,0 +1,550 @@
+//! Operator-configurable group ownership policy for issued service
+//! certificates and their parent directories.
+//!
+//! `bootroot-agent` writes service cert/key files at issuance and at
+//! every rotation. The default policy keeps `<svc>-key.pem` at `0600`
+//! and the parent directory at `0700`, which is correct for host-local
+//! consumers but breaks the common deployment pattern where the cert/key
+//! is bind-mounted into a container running as a non-root user.
+//!
+//! The flag `--cert-group <gid-or-name>` opts a service into a
+//! group-readable policy that survives rotation: cert and key parent
+//! directories become group-traversable, the key file becomes group-
+//! readable (`0640`), and group ownership of all four (key, cert, both
+//! parent directories) is set to the operator-supplied gid.
+//!
+//! See `docs/services/cert-group.md` for the operator-facing overview.
+
+use std::ffi::CString;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use thiserror::Error;
+use tokio::fs;
+
+/// Default mode for the cert/key parent directory when no `--cert-group`
+/// is set. Operator-only access.
+pub const DIR_MODE_DEFAULT: u32 = 0o700;
+/// Default mode for the private key file when no `--cert-group` is set.
+pub const KEY_FILE_MODE_DEFAULT: u32 = 0o600;
+/// Mode for the public cert file. Always world-readable; group policy
+/// only changes ownership.
+pub const CERT_FILE_MODE: u32 = 0o644;
+/// Mode for the cert parent directory when `--cert-group` is set and
+/// the cert parent is distinct from the key parent.
+pub const CERT_DIR_MODE_GROUP: u32 = 0o755;
+/// Mode for the key parent directory when `--cert-group` is set, and
+/// the effective mode for the cert parent when it shares the key
+/// parent (the stricter `0750` wins).
+pub const KEY_DIR_MODE_GROUP: u32 = 0o750;
+/// Mode for the private key file when `--cert-group` is set.
+pub const KEY_FILE_MODE_GROUP: u32 = 0o640;
+
+/// Cert-access policy threaded through the issuance/rotation write
+/// path. `None` preserves the host-local default (operator-only).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CertGroupPolicy {
+    /// Numeric gid that owns the cert/key files and their parent
+    /// directories. `None` means "no group policy in effect".
+    pub gid: Option<u32>,
+}
+
+impl CertGroupPolicy {
+    /// Constructs a policy that opts into the group-readable mode set.
+    #[must_use]
+    pub fn with_gid(gid: u32) -> Self {
+        Self { gid: Some(gid) }
+    }
+
+    /// Returns the policy that preserves the host-local default
+    /// (operator-only `0700`/`0600`/`0644`).
+    #[must_use]
+    pub fn none() -> Self {
+        Self { gid: None }
+    }
+
+    /// Returns true when this policy will alter cert/key ownership and
+    /// modes from the host-local default.
+    #[must_use]
+    pub fn is_active(self) -> bool {
+        self.gid.is_some()
+    }
+}
+
+/// Errors returned by `--cert-group` parsing and pre-flight validation.
+#[derive(Debug, Error)]
+pub enum CertGroupError {
+    /// The supplied value was empty or whitespace-only.
+    #[error("--cert-group must not be empty")]
+    Empty,
+    /// `--cert-group 0` is rejected: gid 0 is `root`, granting it would
+    /// be a no-op against the operator-only default.
+    #[error("--cert-group 0 (root) is not permitted")]
+    RootGid,
+    /// In the `remote-bootstrap` deployment mode, only numeric gids are
+    /// accepted. The control host's NSS may diverge from the remote
+    /// agent host's NSS, so a name lookup on the control host can fail
+    /// or return a colliding number — see [issue #593].
+    #[error(
+        "--cert-group must be a numeric gid for remote-bootstrap services (got {0:?}); \
+         resolve the name on the remote agent host and pass the number"
+    )]
+    NumericRequired(String),
+    /// The numeric form did not parse as a `u32`.
+    #[error("--cert-group {0:?} is not a valid numeric gid")]
+    InvalidNumeric(String),
+    /// The supplied name was not present in the host's group database.
+    #[error("--cert-group: group {0:?} not found in the host group database")]
+    UnknownName(String),
+    /// The current process cannot `chown(-1, gid)` because it is not a
+    /// supplementary member of the target group (and is not root).
+    #[error(
+        "--cert-group {gid}: caller is not a member of the target group; \
+         add the host operator as a supplementary member, or run as root"
+    )]
+    NotMember {
+        /// The gid that the caller cannot chown to.
+        gid: u32,
+    },
+}
+
+/// Parses a `--cert-group` value supplied to a `local-file` deployment.
+/// Accepts either a numeric gid or a group name resolved against the
+/// host's group database. Returns the resolved numeric gid.
+///
+/// # Errors
+///
+/// Returns [`CertGroupError`] on empty input, gid 0, name not found,
+/// or invalid numeric form.
+pub fn parse_cert_group_local(raw: &str) -> Result<u32, CertGroupError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(CertGroupError::Empty);
+    }
+    if let Ok(gid) = trimmed.parse::<u32>() {
+        if gid == 0 {
+            return Err(CertGroupError::RootGid);
+        }
+        return Ok(gid);
+    }
+    let gid = resolve_group_name(trimmed)
+        .ok_or_else(|| CertGroupError::UnknownName(trimmed.to_string()))?;
+    if gid == 0 {
+        return Err(CertGroupError::RootGid);
+    }
+    Ok(gid)
+}
+
+/// Parses a `--cert-group` value supplied to a `remote-bootstrap`
+/// deployment. Only the numeric form is accepted; name form is rejected
+/// at parse time because the control host's NSS database may differ
+/// from the remote agent host's NSS database.
+///
+/// # Errors
+///
+/// Returns [`CertGroupError`] on empty input, non-numeric form, gid 0,
+/// or invalid numeric form.
+pub fn parse_cert_group_remote(raw: &str) -> Result<u32, CertGroupError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(CertGroupError::Empty);
+    }
+    if trimmed.chars().any(|c| !c.is_ascii_digit()) {
+        return Err(CertGroupError::NumericRequired(trimmed.to_string()));
+    }
+    let gid: u32 = trimmed
+        .parse()
+        .map_err(|_| CertGroupError::InvalidNumeric(trimmed.to_string()))?;
+    if gid == 0 {
+        return Err(CertGroupError::RootGid);
+    }
+    Ok(gid)
+}
+
+/// Validates that the current process can `chown(-1, gid)` to the
+/// requested target. Used at `service add` / `service update` time on
+/// the control host for `local-file` deployments only.
+///
+/// # Errors
+///
+/// Returns [`CertGroupError::NotMember`] when the caller is not a
+/// supplementary member of `gid` and is not root.
+pub fn validate_local_gid_membership(gid: u32) -> Result<(), CertGroupError> {
+    if gid == 0 {
+        return Err(CertGroupError::RootGid);
+    }
+    if !caller_can_chown_to(gid) {
+        return Err(CertGroupError::NotMember { gid });
+    }
+    Ok(())
+}
+
+/// Returns true when the current process is permitted to `chown(-1, gid)`
+/// a file it owns to the target gid. Root (`euid == 0`) bypasses the
+/// supplementary membership check. POSIX requires the caller to be a
+/// supplementary member of the destination group otherwise.
+#[must_use]
+pub fn caller_can_chown_to(gid: u32) -> bool {
+    // SAFETY: geteuid() is always safe and never fails.
+    let euid = unsafe { libc::geteuid() };
+    if euid == 0 {
+        return true;
+    }
+    current_process_gids().contains(&gid)
+}
+
+/// Returns one supplementary gid of the current process suitable for
+/// non-root tests. Tests that cannot rely on a CI fixture for a fresh
+/// gid use this to exercise the chown path against a gid the caller
+/// already has membership in.
+#[must_use]
+pub fn one_supplementary_test_gid() -> Option<u32> {
+    let egid = current_process_egid();
+    current_process_gids()
+        .into_iter()
+        .find(|gid| *gid != 0 && *gid != egid)
+}
+
+/// Returns the current process's effective gid.
+#[must_use]
+pub fn current_process_egid() -> u32 {
+    // SAFETY: getegid() never fails.
+    unsafe { libc::getegid() }
+}
+
+fn current_process_gids() -> Vec<u32> {
+    // SAFETY: getgroups(0, NULL) returns the count without writing.
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    let mut groups: Vec<libc::gid_t> = if count > 0 {
+        let mut buf = vec![0 as libc::gid_t; usize::try_from(count).unwrap_or(0)];
+        // SAFETY: buf has `count` capacity; getgroups writes at most that many entries.
+        let n = unsafe { libc::getgroups(count, buf.as_mut_ptr()) };
+        if n < 0 {
+            Vec::new()
+        } else {
+            buf.truncate(usize::try_from(n).unwrap_or(0));
+            buf
+        }
+    } else {
+        Vec::new()
+    };
+    // Append effective and real gids if not already present — the kernel
+    // grants chown to either of them when the caller owns the file.
+    // SAFETY: getegid() / getgid() never fail.
+    let egid = unsafe { libc::getegid() };
+    let rgid = unsafe { libc::getgid() };
+    if !groups.contains(&egid) {
+        groups.push(egid);
+    }
+    if !groups.contains(&rgid) {
+        groups.push(rgid);
+    }
+    groups
+}
+
+fn resolve_group_name(name: &str) -> Option<u32> {
+    let cname = CString::new(name).ok()?;
+    let mut buf: Vec<libc::c_char> = vec![0; 4096];
+    // SAFETY: zeroed `libc::group` is a valid initial value because all
+    // fields are pointers/integers and the call below populates them.
+    let mut grp: libc::group = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::group = std::ptr::null_mut();
+    // SAFETY: All pointers point to live, exclusively-borrowed buffers
+    // for the duration of the call.
+    let rc = unsafe {
+        libc::getgrnam_r(
+            cname.as_ptr(),
+            std::ptr::addr_of_mut!(grp),
+            buf.as_mut_ptr(),
+            buf.len(),
+            std::ptr::addr_of_mut!(result),
+        )
+    };
+    if rc != 0 || result.is_null() {
+        return None;
+    }
+    Some(grp.gr_gid)
+}
+
+/// Writes a private key file under the given policy.
+///
+/// When `policy` is active, the file is first created at the secure
+/// `0600` default, then `chown`d to the target gid, then promoted to
+/// `0640`. The order matters: opening the file group-readable before
+/// the `chown` lands would briefly expose the key under the operator's
+/// primary gid, which is not the intended audience.
+///
+/// # Errors
+///
+/// Returns an error if the write, chown, or chmod fails.
+pub async fn write_key_file(path: &Path, key_pem: &str, policy: CertGroupPolicy) -> Result<()> {
+    fs::write(path, key_pem)
+        .await
+        .with_context(|| format!("Failed to write key file {}", path.display()))?;
+    fs::set_permissions(path, std::fs::Permissions::from_mode(KEY_FILE_MODE_DEFAULT))
+        .await
+        .with_context(|| format!("Failed to set initial 0600 on {}", path.display()))?;
+    if let Some(gid) = policy.gid {
+        chown_path(path, gid).await?;
+        fs::set_permissions(path, std::fs::Permissions::from_mode(KEY_FILE_MODE_GROUP))
+            .await
+            .with_context(|| format!("Failed to set 0640 on {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Writes a public certificate file under the given policy.
+///
+/// The cert mode (`0644`) is unchanged regardless of policy; only the
+/// group ownership is adjusted when `policy` is active.
+///
+/// # Errors
+///
+/// Returns an error if the write, chown, or chmod fails.
+pub async fn write_cert_file(path: &Path, cert_pem: &str, policy: CertGroupPolicy) -> Result<()> {
+    fs::write(path, cert_pem)
+        .await
+        .with_context(|| format!("Failed to write cert file {}", path.display()))?;
+    fs::set_permissions(path, std::fs::Permissions::from_mode(CERT_FILE_MODE))
+        .await
+        .with_context(|| format!("Failed to set 0644 on {}", path.display()))?;
+    if let Some(gid) = policy.gid {
+        chown_path(path, gid).await?;
+    }
+    Ok(())
+}
+
+/// Ensures the directory containing the private key exists and has the
+/// mode/owner required by the policy.
+///
+/// With policy active, the directory is `0750` and group-owned by the
+/// target gid. With no policy, the directory is `0700` (operator-only).
+///
+/// # Errors
+///
+/// Returns an error if the mkdir, chmod, or chown fails.
+pub async fn ensure_key_parent_dir(path: &Path, policy: CertGroupPolicy) -> Result<()> {
+    fs::create_dir_all(path)
+        .await
+        .with_context(|| format!("Failed to create key parent dir {}", path.display()))?;
+    let mode = if policy.is_active() {
+        KEY_DIR_MODE_GROUP
+    } else {
+        DIR_MODE_DEFAULT
+    };
+    fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .await
+        .with_context(|| format!("Failed to set mode {mode:o} on {}", path.display()))?;
+    if let Some(gid) = policy.gid {
+        chown_path(path, gid).await?;
+    }
+    Ok(())
+}
+
+/// Ensures the directory containing the public certificate exists and
+/// has the mode/owner required by the policy.
+///
+/// With policy active and `cert_dir != key_dir`, the cert directory is
+/// `0755` (broad traversal) — the cert is already world-readable, so
+/// constraining its parent does not buy security but does block group
+/// peers from listing the directory. With policy active and the cert
+/// directory equal to the key directory, the stricter `0750` wins.
+/// With no policy, the cert directory is `0700` (operator-only).
+///
+/// `key_dir` is the resolved key parent directory used to detect the
+/// shared-parent case.
+///
+/// # Errors
+///
+/// Returns an error if the mkdir, chmod, or chown fails.
+pub async fn ensure_cert_parent_dir(
+    path: &Path,
+    key_dir: &Path,
+    policy: CertGroupPolicy,
+) -> Result<()> {
+    fs::create_dir_all(path)
+        .await
+        .with_context(|| format!("Failed to create cert parent dir {}", path.display()))?;
+    let mode = if policy.is_active() {
+        if path == key_dir {
+            KEY_DIR_MODE_GROUP
+        } else {
+            CERT_DIR_MODE_GROUP
+        }
+    } else {
+        DIR_MODE_DEFAULT
+    };
+    fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .await
+        .with_context(|| format!("Failed to set mode {mode:o} on {}", path.display()))?;
+    if let Some(gid) = policy.gid {
+        chown_path(path, gid).await?;
+    }
+    Ok(())
+}
+
+/// Chowns `path` to `(uid=preserved, gid=gid)`.
+async fn chown_path(path: &Path, gid: u32) -> Result<()> {
+    let owned = path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        std::os::unix::fs::chown(&owned, None, Some(gid))
+            .with_context(|| format!("Failed to chown {} to gid {gid}", owned.display()))
+    })
+    .await
+    .context("chown task panicked")??;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_local_accepts_numeric() {
+        let gid = parse_cert_group_local("5001").unwrap();
+        assert_eq!(gid, 5001);
+    }
+
+    #[test]
+    fn parse_local_rejects_zero() {
+        assert!(matches!(
+            parse_cert_group_local("0"),
+            Err(CertGroupError::RootGid)
+        ));
+    }
+
+    #[test]
+    fn parse_local_rejects_empty() {
+        assert!(matches!(
+            parse_cert_group_local("   "),
+            Err(CertGroupError::Empty)
+        ));
+    }
+
+    #[test]
+    fn parse_remote_accepts_numeric() {
+        assert_eq!(parse_cert_group_remote("5001").unwrap(), 5001);
+    }
+
+    #[test]
+    fn parse_remote_rejects_name() {
+        assert!(matches!(
+            parse_cert_group_remote("aice-clients"),
+            Err(CertGroupError::NumericRequired(_))
+        ));
+    }
+
+    #[test]
+    fn parse_remote_rejects_zero() {
+        assert!(matches!(
+            parse_cert_group_remote("0"),
+            Err(CertGroupError::RootGid)
+        ));
+    }
+
+    #[test]
+    fn parse_local_resolves_well_known_root_name_to_zero_and_rejects() {
+        // The `wheel` group on macOS / `root` on Linux resolves to gid 0
+        // on most systems, exercising the post-resolve gid==0 check.
+        // Skip if neither is available.
+        if let Ok(gid) = parse_cert_group_local("nonexistent-bootroot-test-group-xyz") {
+            panic!("parse_local must reject unknown group, got gid {gid}");
+        }
+    }
+
+    #[test]
+    fn validate_local_rejects_zero() {
+        assert!(matches!(
+            validate_local_gid_membership(0),
+            Err(CertGroupError::RootGid)
+        ));
+    }
+
+    #[test]
+    fn caller_can_chown_to_own_egid() {
+        let egid = current_process_egid();
+        assert!(caller_can_chown_to(egid));
+    }
+
+    #[tokio::test]
+    async fn write_key_file_no_policy_uses_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("k");
+        write_key_file(&key, "K", CertGroupPolicy::none())
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&key).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, KEY_FILE_MODE_DEFAULT);
+    }
+
+    #[tokio::test]
+    async fn write_key_file_with_policy_uses_0640() {
+        let Some(gid) = one_supplementary_test_gid() else {
+            // No suitable test gid in this environment; skip rather
+            // than fail. The CI extended fixture provisions one.
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("k");
+        write_key_file(&key, "K", CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&key).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, KEY_FILE_MODE_GROUP);
+    }
+
+    #[tokio::test]
+    async fn ensure_key_parent_dir_no_policy_uses_0700() {
+        let dir = tempfile::tempdir().unwrap();
+        let kp = dir.path().join("kp");
+        ensure_key_parent_dir(&kp, CertGroupPolicy::none())
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&kp).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, DIR_MODE_DEFAULT);
+    }
+
+    #[tokio::test]
+    async fn ensure_key_parent_dir_with_policy_uses_0750() {
+        let Some(gid) = one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let kp = dir.path().join("kp");
+        ensure_key_parent_dir(&kp, CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&kp).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, KEY_DIR_MODE_GROUP);
+    }
+
+    #[tokio::test]
+    async fn ensure_cert_parent_dir_with_policy_uses_0755_when_distinct() {
+        let Some(gid) = one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let kp = dir.path().join("kp");
+        let cp = dir.path().join("cp");
+        ensure_cert_parent_dir(&cp, &kp, CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&cp).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, CERT_DIR_MODE_GROUP);
+    }
+
+    #[tokio::test]
+    async fn ensure_cert_parent_dir_with_policy_uses_0750_when_shared() {
+        let Some(gid) = one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let shared = dir.path().join("shared");
+        ensure_cert_parent_dir(&shared, &shared, CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, KEY_DIR_MODE_GROUP);
+    }
+}

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -98,6 +98,18 @@ pub enum CertGroupError {
     /// The supplied name was not present in the host's group database.
     #[error("--cert-group: group {0:?} not found in the host group database")]
     UnknownName(String),
+    /// The numeric gid is not present in the host's group database. Most
+    /// often this means the operator passed a gid that exists on a
+    /// different host (e.g. the container image's runtime user) but not
+    /// on the cert-writing host. The kernel would still accept
+    /// `chown(-1, gid)` for an orphan gid, so without this check the
+    /// misconfiguration would persist silently and only surface as an
+    /// access failure inside the consumer.
+    #[error("--cert-group {gid}: gid not found in the host group database")]
+    UnknownGid {
+        /// The gid that does not resolve.
+        gid: u32,
+    },
     /// The current process cannot `chown(-1, gid)` because it is not a
     /// supplementary member of the target group (and is not root).
     #[error(
@@ -164,21 +176,78 @@ pub fn parse_cert_group_remote(raw: &str) -> Result<u32, CertGroupError> {
 }
 
 /// Validates that the current process can `chown(-1, gid)` to the
-/// requested target. Used at `service add` / `service update` time on
-/// the control host for `local-file` deployments only.
+/// requested target on the cert-writing host. Used at `service add` /
+/// `service update` time on the control host for `local-file`
+/// deployments only — the control host is also the cert-writing host
+/// in that mode, so substantive checks (gid existence, chown
+/// permission) run here. The `remote-bootstrap` path runs the
+/// equivalent checks on the remote agent host via
+/// [`validate_cert_writing_host_gid`].
 ///
 /// # Errors
 ///
-/// Returns [`CertGroupError::NotMember`] when the caller is not a
-/// supplementary member of `gid` and is not root.
+/// Returns [`CertGroupError::RootGid`] when `gid == 0`,
+/// [`CertGroupError::UnknownGid`] when the gid is not present in the
+/// host's group database, or [`CertGroupError::NotMember`] when the
+/// caller is not a supplementary member of `gid` and is not root.
 pub fn validate_local_gid_membership(gid: u32) -> Result<(), CertGroupError> {
-    if gid == 0 {
-        return Err(CertGroupError::RootGid);
-    }
+    validate_cert_writing_host_gid(gid)?;
     if !caller_can_chown_to(gid) {
         return Err(CertGroupError::NotMember { gid });
     }
     Ok(())
+}
+
+/// Validates that `gid` is non-zero and is present in the cert-writing
+/// host's group database. The presence check uses `getgrgid_r` so an
+/// orphan numeric gid (one that exists on a different host but not
+/// here) is rejected loudly rather than persisting silently and
+/// surfacing only as a downstream access failure inside the consumer.
+///
+/// This is the substantive check that the issue #593 review calls
+/// out for both deployment modes — `local-file` runs it at `service
+/// add` / `service update` time on the control host (which is also
+/// the cert-writing host), and `remote-bootstrap` runs it on the
+/// remote agent host at `bootroot-remote bootstrap` time.
+///
+/// # Errors
+///
+/// Returns [`CertGroupError::RootGid`] when `gid == 0` or
+/// [`CertGroupError::UnknownGid`] when the gid is not present in the
+/// host's group database.
+pub fn validate_cert_writing_host_gid(gid: u32) -> Result<(), CertGroupError> {
+    if gid == 0 {
+        return Err(CertGroupError::RootGid);
+    }
+    if !gid_exists_on_host(gid) {
+        return Err(CertGroupError::UnknownGid { gid });
+    }
+    Ok(())
+}
+
+/// Returns true when `gid` is present in the host's group database
+/// (`getgrgid_r`). Used to reject orphan numeric gids that exist on a
+/// different host (e.g. the container's runtime user) but not on the
+/// host that will actually `chown` the cert/key files.
+#[must_use]
+pub fn gid_exists_on_host(gid: u32) -> bool {
+    let mut buf: Vec<libc::c_char> = vec![0; 4096];
+    // SAFETY: zeroed `libc::group` is a valid initial value because all
+    // fields are pointers/integers and the call below populates them.
+    let mut grp: libc::group = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::group = std::ptr::null_mut();
+    // SAFETY: All pointers point to live, exclusively-borrowed buffers
+    // for the duration of the call.
+    let rc = unsafe {
+        libc::getgrgid_r(
+            gid,
+            std::ptr::addr_of_mut!(grp),
+            buf.as_mut_ptr(),
+            buf.len(),
+            std::ptr::addr_of_mut!(result),
+        )
+    };
+    rc == 0 && !result.is_null()
 }
 
 /// Returns true when the current process is permitted to `chown(-1, gid)`
@@ -569,6 +638,33 @@ mod tests {
             validate_local_gid_membership(0),
             Err(CertGroupError::RootGid)
         ));
+    }
+
+    /// `getgrgid_r` returns "not found" for a gid that is highly
+    /// unlikely to exist in the host group DB. The exact value chosen
+    /// (`4_000_000_000`) is deliberately well above the typical 16-bit
+    /// gid range and any reasonable system gid allocation.
+    #[test]
+    fn validate_cert_writing_host_gid_rejects_unknown_gid() {
+        let outcome = validate_cert_writing_host_gid(4_000_000_000);
+        assert!(
+            matches!(outcome, Err(CertGroupError::UnknownGid { gid: 4_000_000_000 })),
+            "expected UnknownGid, got {outcome:?}"
+        );
+    }
+
+    /// The current process's effective gid must always exist in the
+    /// host's group DB; this exercises the success path of the
+    /// existence check without depending on any specific named group.
+    #[test]
+    fn validate_cert_writing_host_gid_accepts_caller_egid() {
+        let egid = current_process_egid();
+        if egid == 0 {
+            // root primary gid would be rejected by the gid==0 guard;
+            // skip on root-running test environments.
+            return;
+        }
+        validate_cert_writing_host_gid(egid).expect("egid must resolve in the host group DB");
     }
 
     #[test]

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -16,8 +16,9 @@
 //! See `docs/services/cert-group.md` for the operator-facing overview.
 
 use std::ffi::CString;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::io::Write as _;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use thiserror::Error;
@@ -269,29 +270,111 @@ fn resolve_group_name(name: &str) -> Option<u32> {
 
 /// Writes a private key file under the given policy.
 ///
-/// When `policy` is active, the file is first created at the secure
-/// `0600` default, then `chown`d to the target gid, then promoted to
-/// `0640`. The order matters: opening the file group-readable before
-/// the `chown` lands would briefly expose the key under the operator's
-/// primary gid, which is not the intended audience.
+/// The implementation is staging-then-rename: the bytes are first written
+/// to a temporary file in the same directory created with `O_CREAT |
+/// O_EXCL` and `mode=0600`, the staged file is `chown`d (when policy is
+/// active) and promoted to `0640`, and only then is it `rename`d over
+/// the destination. The destination path is therefore never observable
+/// at a mode wider than the final policy: there is no window where the
+/// destination exists at the umask-derived mode (typically `0644`) before
+/// the clamp lands, and no window where the file is group-readable under
+/// the operator's primary gid before the chown lands. This addresses the
+/// atomic-write requirement called out in issue #593.
 ///
 /// # Errors
 ///
-/// Returns an error if the write, chown, or chmod fails.
+/// Returns an error if the staging write, chown, chmod, or rename fails.
 pub async fn write_key_file(path: &Path, key_pem: &str, policy: CertGroupPolicy) -> Result<()> {
-    fs::write(path, key_pem)
-        .await
-        .with_context(|| format!("Failed to write key file {}", path.display()))?;
-    fs::set_permissions(path, std::fs::Permissions::from_mode(KEY_FILE_MODE_DEFAULT))
-        .await
-        .with_context(|| format!("Failed to set initial 0600 on {}", path.display()))?;
-    if let Some(gid) = policy.gid {
-        chown_path(path, gid).await?;
-        fs::set_permissions(path, std::fs::Permissions::from_mode(KEY_FILE_MODE_GROUP))
-            .await
-            .with_context(|| format!("Failed to set 0640 on {}", path.display()))?;
-    }
+    let dest = path.to_path_buf();
+    let key_owned = key_pem.to_string();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        let parent = dest
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Key path {} has no parent", dest.display()))?;
+        let file_name = dest
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow::anyhow!("Key path {} has no file name", dest.display()))?;
+
+        let staged = stage_key_file(parent, file_name, &key_owned, policy)?;
+        std::fs::rename(&staged, &dest).map_err(|err| {
+            let _ = std::fs::remove_file(&staged);
+            anyhow::Error::new(err).context(format!(
+                "Failed to rename {} to {}",
+                staged.display(),
+                dest.display()
+            ))
+        })?;
+        Ok(())
+    })
+    .await
+    .context("write_key_file task panicked")??;
     Ok(())
+}
+
+/// Creates the key staging file at `0600` with `O_CREAT|O_EXCL`, writes
+/// the key bytes, applies the policy's chown / chmod while the file is
+/// still at its temporary path, and returns the staged path so the caller
+/// can `rename` it over the destination.
+fn stage_key_file(
+    parent: &Path,
+    final_name: &str,
+    key_pem: &str,
+    policy: CertGroupPolicy,
+) -> Result<PathBuf> {
+    let pid = std::process::id();
+    for attempt in 0u32..32 {
+        let candidate = parent.join(format!(".{final_name}.tmp.{pid}.{attempt}"));
+        let mut opts = std::fs::OpenOptions::new();
+        opts.create_new(true)
+            .write(true)
+            .mode(KEY_FILE_MODE_DEFAULT);
+        match opts.open(&candidate) {
+            Ok(mut f) => {
+                if let Err(err) = f.write_all(key_pem.as_bytes()) {
+                    let _ = std::fs::remove_file(&candidate);
+                    return Err(anyhow::Error::new(err)
+                        .context(format!("Failed to write {}", candidate.display())));
+                }
+                if let Err(err) = f.sync_all() {
+                    let _ = std::fs::remove_file(&candidate);
+                    return Err(anyhow::Error::new(err)
+                        .context(format!("Failed to fsync {}", candidate.display())));
+                }
+                drop(f);
+                if let Some(gid) = policy.gid {
+                    if let Err(err) = std::os::unix::fs::chown(&candidate, None, Some(gid)) {
+                        let _ = std::fs::remove_file(&candidate);
+                        return Err(anyhow::Error::new(err).context(format!(
+                            "Failed to chown {} to gid {gid}",
+                            candidate.display()
+                        )));
+                    }
+                    if let Err(err) = std::fs::set_permissions(
+                        &candidate,
+                        std::fs::Permissions::from_mode(KEY_FILE_MODE_GROUP),
+                    ) {
+                        let _ = std::fs::remove_file(&candidate);
+                        return Err(anyhow::Error::new(err)
+                            .context(format!("Failed to chmod 0640 on {}", candidate.display())));
+                    }
+                }
+                return Ok(candidate);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(err) => {
+                return Err(anyhow::Error::new(err).context(format!(
+                    "Failed to create staging file in {}",
+                    parent.display()
+                )));
+            }
+        }
+    }
+    anyhow::bail!(
+        "Failed to allocate a staging file for {} in {} after 32 attempts",
+        final_name,
+        parent.display()
+    )
 }
 
 /// Writes a public certificate file under the given policy.
@@ -367,7 +450,7 @@ pub async fn ensure_cert_parent_dir(
         .await
         .with_context(|| format!("Failed to create cert parent dir {}", path.display()))?;
     let mode = if policy.is_active() {
-        if path == key_dir {
+        if same_directory(path, key_dir) {
             KEY_DIR_MODE_GROUP
         } else {
             CERT_DIR_MODE_GROUP
@@ -382,6 +465,34 @@ pub async fn ensure_cert_parent_dir(
         chown_path(path, gid).await?;
     }
     Ok(())
+}
+
+/// Returns true when `a` and `b` refer to the same directory on disk,
+/// using the kernel's `(dev, ino)` identity rather than textual path
+/// equality. Both paths must already exist (the cert/key parents are
+/// `mkdir -p`'d before this is called).
+///
+/// Textual comparison would treat `certs` and `certs/.` (or `./certs`,
+/// or symlinked variants) as distinct directories, which on `--cert-
+/// group` services would cause `ensure_cert_parent_dir` to widen the
+/// shared key/cert directory to `0755` even though
+/// `ensure_key_parent_dir` had already locked it down to `0750`. The
+/// shared-parent case is the security-relevant one (key directory must
+/// not become world-traversable), so it has to be detected reliably.
+fn same_directory(a: &Path, b: &Path) -> bool {
+    // Both parents are `mkdir -p`'d before this is called in production,
+    // but `ensure_key_parent_dir` runs against `key_dir` separately and
+    // some call sites (and tests) only materialise one of the two. If
+    // either path is missing, they cannot be the same directory by any
+    // meaningful definition, so fall through to "distinct" rather than
+    // surfacing a stat error.
+    let Ok(meta_a) = std::fs::metadata(a) else {
+        return false;
+    };
+    let Ok(meta_b) = std::fs::metadata(b) else {
+        return false;
+    };
+    meta_a.dev() == meta_b.dev() && meta_a.ino() == meta_b.ino()
 }
 
 /// Chowns `path` to `(uid=preserved, gid=gid)`.
@@ -545,5 +656,89 @@ mod tests {
             .unwrap();
         let mode = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, KEY_DIR_MODE_GROUP);
+    }
+
+    /// Regression test for the issue #593 review: the shared-parent
+    /// detection must be robust against path spellings that are textually
+    /// distinct but resolve to the same directory (`certs` vs
+    /// `certs/.`). A previous textual comparison would let
+    /// `ensure_cert_parent_dir` widen the directory to `0755` after
+    /// `ensure_key_parent_dir` had locked it down to `0750`, which
+    /// would silently broaden traversal of the key parent.
+    #[tokio::test]
+    async fn ensure_cert_parent_dir_with_policy_shared_via_dot_segment_stays_0750() {
+        let Some(gid) = one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let shared = dir.path().join("shared");
+        std::fs::create_dir(&shared).unwrap();
+        let dotted = shared.join(".");
+
+        ensure_key_parent_dir(&shared, CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+        ensure_cert_parent_dir(&dotted, &shared, CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+
+        let mode = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, KEY_DIR_MODE_GROUP,
+            "shared cert/key parent must stay at 0750 even when the \
+             cert path is spelled with a `/.` suffix"
+        );
+    }
+
+    /// Regression test for the issue #593 review: the destination key
+    /// path must never be observable at a mode wider than the final
+    /// policy. Specifically, on first issuance the file must not exist
+    /// at `0644` (umask-derived) before being clamped to `0600`. The
+    /// staging-then-rename implementation guarantees this by creating
+    /// the staging file with `O_CREAT|O_EXCL` and `mode=0600` and only
+    /// renaming once the policy is fully applied.
+    #[tokio::test]
+    async fn write_key_file_no_policy_first_issuance_is_never_0644() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("k");
+        // Pre-condition: destination does not exist.
+        assert!(!key.exists());
+        write_key_file(&key, "K", CertGroupPolicy::none())
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&key).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, KEY_FILE_MODE_DEFAULT);
+        // The destination must not be world-readable at any point. We
+        // can only assert the post-condition here, but the staging-
+        // then-rename implementation also guarantees no transient
+        // wider-than-0600 mode at the destination path.
+        assert_eq!(mode & 0o077, 0, "key file must not be group/other-readable");
+    }
+
+    /// Rotation must atomically replace the destination, leaving the
+    /// final mode and content correct even though the previous file
+    /// existed under a different mode.
+    #[tokio::test]
+    async fn write_key_file_rotation_replaces_atomically_with_policy() {
+        let Some(gid) = one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("k");
+        write_key_file(&key, "first", CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+        // Hostile operator-side regression: clamp back to 0600 with
+        // operator's primary gid.
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_key_file(&key, "second", CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+
+        let contents = std::fs::read_to_string(&key).unwrap();
+        let mode = std::fs::metadata(&key).unwrap().permissions().mode() & 0o777;
+        assert_eq!(contents, "second");
+        assert_eq!(mode, KEY_FILE_MODE_GROUP);
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -942,6 +942,21 @@ pub(crate) struct ServiceAddArgs {
     /// CIDR ranges to bind the `secret_id` token to (repeatable, e.g. `--rn-cidrs 10.0.0.0/24`)
     #[arg(long)]
     pub(crate) rn_cidrs: Vec<String>,
+
+    /// Numeric gid or group name that should own the issued cert/key
+    /// files and their parent directories.
+    ///
+    /// When set, the agent applies a group-readable policy
+    /// (`0750`/`0640`/`0644` with group ownership) on every issuance
+    /// and rotation, so non-root containerized clients can read the
+    /// bind-mounted cert and key. When unset, the historical
+    /// operator-only default (`0700`/`0600`/`0644`) is preserved.
+    ///
+    /// `local-file` deployments accept a name or numeric gid;
+    /// `remote-bootstrap` deployments accept numeric form only — see
+    /// issue #593 for the cross-host NSS rationale.
+    #[arg(long, value_name = "GID-OR-NAME")]
+    pub(crate) cert_group: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -975,6 +990,20 @@ pub(crate) struct ServiceUpdateArgs {
     /// Use "clear" to remove an existing binding
     #[arg(long)]
     pub(crate) rn_cidrs: Vec<String>,
+
+    /// Numeric gid or group name that owns the issued cert/key files
+    /// and their parent directories.
+    ///
+    /// Use a numeric gid or group name to enable the group-readable
+    /// policy (`0750`/`0640` with group ownership) on the next
+    /// issuance and rotation. Use the literal string `clear` to
+    /// remove an existing policy and revert to the operator-only
+    /// default (`0700`/`0600`).
+    ///
+    /// `local-file` deployments accept names; `remote-bootstrap`
+    /// deployments accept numeric form only — see issue #593.
+    #[arg(long, value_name = "GID-OR-NAME-OR-CLEAR")]
+    pub(crate) cert_group: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -1625,6 +1654,36 @@ mod tests {
             "10m",
         ]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cli_parses_service_add_cert_group() {
+        let cli = Cli::parse_from(["bootroot", "service", "add", "--cert-group", "5001"]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Add(args)) => {
+                assert_eq!(args.cert_group.as_deref(), Some("5001"));
+            }
+            _ => panic!("expected service add"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_update_cert_group_clear() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "update",
+            "--service-name",
+            "edge-proxy",
+            "--cert-group",
+            "clear",
+        ]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Update(args)) => {
+                assert_eq!(args.cert_group.as_deref(), Some("clear"));
+            }
+            _ => panic!("expected service update"),
+        }
     }
 
     #[test]

--- a/src/commands/dns_alias.rs
+++ b/src/commands/dns_alias.rs
@@ -202,6 +202,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -417,6 +417,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -379,6 +379,7 @@ fn build_service_entry_from_role(
         agent_email: resolved.agent_email.clone(),
         agent_server: resolved.agent_server.clone(),
         agent_responder_url: resolved.agent_responder_url.clone(),
+        cert_group_gid: resolved.cert_group_gid,
     }
 }
 
@@ -546,6 +547,7 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
         && args.secret_id_wrap_ttl.is_none()
         && !args.no_wrap
         && args.rn_cidrs.is_empty()
+        && args.cert_group.is_none()
     {
         anyhow::bail!(messages.error_service_update_no_flags());
     }
@@ -636,6 +638,24 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
         }
     }
 
+    let mut cert_group_redeploy_hint: Option<CertGroupRedeployHint> = None;
+    if let Some(ref raw) = args.cert_group {
+        let old_value = entry.cert_group_gid;
+        let new_value = parse_cert_group_for_update(raw, entry.delivery_mode)?;
+        entry.cert_group_gid = new_value;
+        if old_value != new_value {
+            changes.push(messages.service_update_field_changed(
+                "cert_group_gid",
+                &display_cert_group(old_value),
+                &display_cert_group(new_value),
+            ));
+            cert_group_redeploy_hint = Some(CertGroupRedeployHint {
+                delivery_mode: entry.delivery_mode,
+                service_name: args.service_name.clone(),
+            });
+        }
+    }
+
     if explicit_ttl_set {
         eprintln!("{}", messages.hint_secret_id_ttl_rotation_cadence());
     }
@@ -645,9 +665,40 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
         return Ok(());
     }
 
+    // Snapshot the entry before save so we can re-render the local
+    // managed agent.toml block in the local-file case without holding
+    // the borrow on `state` past the save.
+    let entry_snapshot = state.services.get(&args.service_name).cloned();
+
     state
         .save(&state_path)
         .with_context(|| messages.error_serialize_state_failed())?;
+
+    if let (Some(hint), Some(entry)) = (cert_group_redeploy_hint.as_ref(), entry_snapshot.as_ref())
+    {
+        match hint.delivery_mode {
+            DeliveryMode::LocalFile => {
+                rerender_local_managed_profile(entry)?;
+            }
+            DeliveryMode::RemoteBootstrap => {
+                // Persisting the gid in state.json alone is not enough
+                // for remote-bootstrap services — the remote agent
+                // reads from the bootstrap-rendered `agent.toml` on
+                // disk, and `service add` is the path that re-emits
+                // the artifact.  Fail loudly with the one-line follow-
+                // up the operator must run, so the next rotation
+                // actually picks up the new policy.
+                eprintln!(
+                    "warning: --cert-group changed for remote-bootstrap service {}.\n\
+                     Re-emit the bootstrap artifact with `bootroot service add` \
+                     and re-run `bootroot-remote bootstrap --artifact <path>` on \
+                     the remote agent host so the new cert_group_gid lands in the \
+                     remote agent.toml.",
+                    hint.service_name,
+                );
+            }
+        }
+    }
 
     println!("{}", messages.service_update_summary());
     println!("{}", messages.service_summary_kind(&args.service_name));
@@ -657,6 +708,114 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
     println!("{}", messages.service_update_rotate_hint());
 
     Ok(())
+}
+
+struct CertGroupRedeployHint {
+    delivery_mode: DeliveryMode,
+    service_name: String,
+}
+
+fn parse_cert_group_for_update(raw: &str, delivery_mode: DeliveryMode) -> Result<Option<u32>> {
+    let trimmed = raw.trim();
+    if trimmed.eq_ignore_ascii_case("clear") {
+        return Ok(None);
+    }
+    let gid = match delivery_mode {
+        DeliveryMode::LocalFile => bootroot::cert_group::parse_cert_group_local(trimmed)
+            .map_err(|err| anyhow::anyhow!("{err}"))?,
+        DeliveryMode::RemoteBootstrap => bootroot::cert_group::parse_cert_group_remote(trimmed)
+            .map_err(|err| anyhow::anyhow!("{err}"))?,
+    };
+    if matches!(delivery_mode, DeliveryMode::LocalFile) {
+        bootroot::cert_group::validate_local_gid_membership(gid)
+            .map_err(|err| anyhow::anyhow!("{err}"))?;
+    }
+    Ok(Some(gid))
+}
+
+fn display_cert_group(value: Option<u32>) -> String {
+    match value {
+        Some(gid) => gid.to_string(),
+        None => "unset".to_string(),
+    }
+}
+
+/// Re-renders just the managed profile block of the local
+/// `agent.toml` for the given entry. Used by `service update --cert-
+/// group ...` so the next agent restart and the next rotation pick up
+/// the new `cert_group_gid` line without requiring a full `service add`
+/// re-run.
+fn rerender_local_managed_profile(entry: &ServiceEntry) -> Result<()> {
+    let agent_config_path = &entry.agent_config_path;
+    if !agent_config_path.exists() {
+        anyhow::bail!(
+            "agent config {} not found — re-run `bootroot service add` to generate it",
+            agent_config_path.display()
+        );
+    }
+    let current = std::fs::read_to_string(agent_config_path)
+        .with_context(|| format!("Failed to read {}", agent_config_path.display()))?;
+    let block = bootroot::trust_bootstrap::render_managed_profile_block(
+        MANAGED_PROFILE_BEGIN_PREFIX,
+        MANAGED_PROFILE_END_PREFIX,
+        &entry.service_name,
+        entry.instance_id.as_deref().unwrap_or_default(),
+        &entry.hostname,
+        &entry.cert_path,
+        &entry.key_path,
+        entry.cert_group_gid,
+    );
+    let block = inject_hooks_into_managed_profile_block(&block, &entry.post_renew_hooks);
+    let next = bootroot::trust_bootstrap::upsert_managed_profile_block(
+        &current,
+        MANAGED_PROFILE_BEGIN_PREFIX,
+        MANAGED_PROFILE_END_PREFIX,
+        &entry.service_name,
+        &block,
+    );
+    std::fs::write(agent_config_path, next)
+        .with_context(|| format!("Failed to write {}", agent_config_path.display()))?;
+    Ok(())
+}
+
+fn inject_hooks_into_managed_profile_block(
+    block: &str,
+    hooks: &[crate::state::PostRenewHookEntry],
+) -> String {
+    use std::fmt::Write as _;
+    if hooks.is_empty() {
+        return block.to_string();
+    }
+    let mut hooks_toml = String::new();
+    for hook in hooks {
+        hooks_toml.push_str("\n[[profiles.hooks.post_renew.success]]\n");
+        let _ = writeln!(
+            hooks_toml,
+            "command = {}",
+            bootroot::toml_util::toml_encode_string(&hook.command)
+        );
+        if !hook.args.is_empty() {
+            let formatted = hook
+                .args
+                .iter()
+                .map(|a| bootroot::toml_util::toml_encode_string(a))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let _ = writeln!(hooks_toml, "args = [{formatted}]");
+        }
+        let _ = writeln!(hooks_toml, "timeout_secs = {}", hook.timeout_secs);
+        let _ = writeln!(hooks_toml, "on_failure = \"{}\"", hook.on_failure);
+    }
+    if let Some(end_pos) = block.rfind(MANAGED_PROFILE_END_PREFIX) {
+        let mut result = block[..end_pos].to_string();
+        result.push_str(&hooks_toml);
+        result.push_str(&block[end_pos..]);
+        result
+    } else {
+        let mut result = block.to_string();
+        result.push_str(&hooks_toml);
+        result
+    }
 }
 
 pub(crate) fn display_policy_value(value: Option<&str>, messages: &Messages) -> String {
@@ -710,6 +869,7 @@ fn non_policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) 
         && entry.agent_email == resolved.agent_email
         && entry.agent_server == resolved.agent_server
         && entry.agent_responder_url == resolved.agent_responder_url
+        && entry.cert_group_gid == resolved.cert_group_gid
 }
 
 fn policy_fields_match(entry: &ServiceEntry, resolved: &ResolvedServiceAdd) -> bool {
@@ -761,6 +921,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         }
     }
 
@@ -780,6 +941,7 @@ mod tests {
         assert_eq!(entry.agent_email, resolved.agent_email);
         assert_eq!(entry.agent_server, resolved.agent_server);
         assert_eq!(entry.agent_responder_url, resolved.agent_responder_url);
+        assert_eq!(entry.cert_group_gid, resolved.cert_group_gid);
     }
 
     #[test]

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -638,7 +638,17 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
         }
     }
 
+    // `cert_group_supplied` triggers a re-render of the managed
+    // agent.toml profile block (local-file) or the operator warning
+    // (remote-bootstrap) on every invocation that passes `--cert-group`,
+    // even when the requested gid matches what is already in state. This
+    // is the repair path for the split-brain class of bug called out in
+    // the issue #593 review: a previous attempt may have saved state but
+    // failed to re-render the managed profile, and a re-run with the
+    // same flag must be able to drive the on-disk profile back into sync
+    // rather than being short-circuited by the no-change early return.
     let mut redeploy_hint: Option<CertGroupRedeployHint> = None;
+    let cert_group_supplied = args.cert_group.is_some();
     if let Some(ref raw) = args.cert_group {
         let old_value = entry.cert_group_gid;
         let new_value = parse_cert_group_for_update(raw, entry.delivery_mode)?;
@@ -649,54 +659,69 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
                 &display_cert_group(old_value),
                 &display_cert_group(new_value),
             ));
-            redeploy_hint = Some(CertGroupRedeployHint {
-                delivery_mode: entry.delivery_mode,
-                service_name: args.service_name.clone(),
-            });
         }
+        redeploy_hint = Some(CertGroupRedeployHint {
+            delivery_mode: entry.delivery_mode,
+            service_name: args.service_name.clone(),
+        });
     }
 
     if explicit_ttl_set {
         eprintln!("{}", messages.hint_secret_id_ttl_rotation_cadence());
     }
 
-    if changes.is_empty() {
+    if changes.is_empty() && !cert_group_supplied {
         println!("{}", messages.service_update_no_changes());
         return Ok(());
     }
 
-    // Snapshot the entry before save so we can re-render the local
-    // managed agent.toml block in the local-file case without holding
-    // the borrow on `state` past the save.
+    // Snapshot the entry without holding the borrow on `state` past the
+    // re-render / save.
     let entry_snapshot = state.services.get(&args.service_name).cloned();
+
+    // Re-render the managed agent.toml block BEFORE persisting state.
+    // If the re-render fails, state.json stays unchanged so a re-run of
+    // the same `service update --cert-group ...` will still see the old
+    // value as the source of truth and re-trigger the re-render rather
+    // than short-circuiting on `changes.is_empty()`. This is the
+    // atomicity half of the issue #593 review's split-brain fix; the
+    // `cert_group_supplied`-driven re-render-on-every-invocation above
+    // is the retry half.
+    if let (Some(hint), Some(entry)) = (redeploy_hint.as_ref(), entry_snapshot.as_ref())
+        && matches!(hint.delivery_mode, DeliveryMode::LocalFile)
+    {
+        rerender_local_managed_profile(entry)?;
+    }
 
     state
         .save(&state_path)
         .with_context(|| messages.error_serialize_state_failed())?;
 
-    if let (Some(hint), Some(entry)) = (redeploy_hint.as_ref(), entry_snapshot.as_ref()) {
-        match hint.delivery_mode {
-            DeliveryMode::LocalFile => {
-                rerender_local_managed_profile(entry)?;
-            }
-            DeliveryMode::RemoteBootstrap => {
-                // Persisting the gid in state.json alone is not enough
-                // for remote-bootstrap services — the remote agent
-                // reads from the bootstrap-rendered `agent.toml` on
-                // disk, and `service add` is the path that re-emits
-                // the artifact.  Fail loudly with the one-line follow-
-                // up the operator must run, so the next rotation
-                // actually picks up the new policy.
-                eprintln!(
-                    "warning: --cert-group changed for remote-bootstrap service {}.\n\
-                     Re-emit the bootstrap artifact with `bootroot service add` \
-                     and re-run `bootroot-remote bootstrap --artifact <path>` on \
-                     the remote agent host so the new cert_group_gid lands in the \
-                     remote agent.toml.",
-                    hint.service_name,
-                );
-            }
-        }
+    if let (Some(hint), Some(_)) = (redeploy_hint.as_ref(), entry_snapshot.as_ref())
+        && matches!(hint.delivery_mode, DeliveryMode::RemoteBootstrap)
+    {
+        // Persisting the gid in state.json alone is not enough for
+        // remote-bootstrap services — the remote agent reads from
+        // the bootstrap-rendered `agent.toml` on disk, and `service
+        // add` is the path that re-emits the artifact. Print a
+        // loud follow-up so the next rotation actually picks up
+        // the new policy.
+        eprintln!(
+            "warning: --cert-group changed for remote-bootstrap service {}.\n\
+             Re-emit the bootstrap artifact with `bootroot service add` \
+             and re-run `bootroot-remote bootstrap --artifact <path>` on \
+             the remote agent host so the new cert_group_gid lands in the \
+             remote agent.toml.",
+            hint.service_name,
+        );
+    }
+
+    if changes.is_empty() {
+        // `--cert-group` was supplied with the value already in state;
+        // we re-rendered the managed profile defensively but had no
+        // policy mutation to report.
+        println!("{}", messages.service_update_no_changes());
+        return Ok(());
     }
 
     println!("{}", messages.service_update_summary());

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -638,7 +638,7 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
         }
     }
 
-    let mut cert_group_redeploy_hint: Option<CertGroupRedeployHint> = None;
+    let mut redeploy_hint: Option<CertGroupRedeployHint> = None;
     if let Some(ref raw) = args.cert_group {
         let old_value = entry.cert_group_gid;
         let new_value = parse_cert_group_for_update(raw, entry.delivery_mode)?;
@@ -649,7 +649,7 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
                 &display_cert_group(old_value),
                 &display_cert_group(new_value),
             ));
-            cert_group_redeploy_hint = Some(CertGroupRedeployHint {
+            redeploy_hint = Some(CertGroupRedeployHint {
                 delivery_mode: entry.delivery_mode,
                 service_name: args.service_name.clone(),
             });
@@ -674,8 +674,7 @@ pub(crate) fn run_service_update(args: &ServiceUpdateArgs, messages: &Messages) 
         .save(&state_path)
         .with_context(|| messages.error_serialize_state_failed())?;
 
-    if let (Some(hint), Some(entry)) = (cert_group_redeploy_hint.as_ref(), entry_snapshot.as_ref())
-    {
+    if let (Some(hint), Some(entry)) = (redeploy_hint.as_ref(), entry_snapshot.as_ref()) {
         match hint.delivery_mode {
             DeliveryMode::LocalFile => {
                 rerender_local_managed_profile(entry)?;

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -238,6 +238,7 @@ fn render_managed_profile_block(args: &ResolvedServiceAdd) -> String {
         &args.hostname,
         &args.cert_path,
         &args.key_path,
+        args.cert_group_gid,
     );
     inject_hooks_into_profile_block(&base, &args.post_renew_hooks)
 }
@@ -476,6 +477,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/commands/service/openbao_sidecar_refresh.rs
+++ b/src/commands/service/openbao_sidecar_refresh.rs
@@ -91,6 +91,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/commands/service/openbao_sidecar_start.rs
+++ b/src/commands/service/openbao_sidecar_start.rs
@@ -434,6 +434,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         }
     }
 
@@ -468,6 +469,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/commands/service/remote_bootstrap.rs
+++ b/src/commands/service/remote_bootstrap.rs
@@ -68,6 +68,13 @@ struct RemoteBootstrapArtifact {
     wrap_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     wrap_expires_at: Option<String>,
+    /// Numeric gid that owns the issued cert/key files and their
+    /// parent directories under `--cert-group`. `None` is serialized
+    /// as a missing key so a downstream remote agent that pre-dates
+    /// the field continues to work without the policy. See
+    /// issue #593.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cert_group_gid: Option<u32>,
 }
 
 /// Wrap-token metadata to embed in the bootstrap artifact.
@@ -132,6 +139,7 @@ fn build_artifact(
     agent_email: Option<&str>,
     agent_server: Option<&str>,
     agent_responder_url: Option<&str>,
+    cert_group_gid: Option<u32>,
 ) -> RemoteBootstrapArtifact {
     let secret_id_parent = secret_id_path.parent().unwrap_or(Path::new("."));
     let role_id_path = secret_id_parent.join(SERVICE_ROLE_ID_FILENAME);
@@ -168,6 +176,7 @@ fn build_artifact(
         post_renew_hooks: post_renew_hooks.to_vec(),
         wrap_token: wrap_info.map(|w| w.token.clone()),
         wrap_expires_at: wrap_info.map(|w| w.expires_at.clone()),
+        cert_group_gid,
     }
 }
 
@@ -198,6 +207,7 @@ pub(super) async fn write_remote_bootstrap_artifact(
         resolved.agent_email.as_deref(),
         resolved.agent_server.as_deref(),
         resolved.agent_responder_url.as_deref(),
+        resolved.cert_group_gid,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &resolved.service_name, &artifact, messages)
         .await
@@ -229,6 +239,7 @@ pub(super) async fn write_remote_bootstrap_artifact_from_entry(
         entry.agent_email.as_deref(),
         entry.agent_server.as_deref(),
         entry.agent_responder_url.as_deref(),
+        entry.cert_group_gid,
     );
     write_remote_bootstrap_artifact_file(secrets_dir, &entry.service_name, &artifact, messages)
         .await
@@ -353,6 +364,69 @@ mod tests {
     const TEST_AGENT_SERVER: &str = "https://step-ca.test:9000/acme/acme/directory";
     const TEST_AGENT_RESPONDER_URL: &str = "http://127.0.0.1:8080";
 
+    /// `--cert-group` flows through the bootstrap artifact as
+    /// `cert_group_gid`, so the remote agent picks up the policy on
+    /// every rotation. Guards issue #593 on the remote-bootstrap path.
+    #[test]
+    fn build_artifact_carries_cert_group_gid() {
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &[],
+            None,
+            TEST_CA_PEM,
+            None,
+            None,
+            None,
+            Some(5001),
+        );
+        assert_eq!(artifact.cert_group_gid, Some(5001));
+
+        let serialized = serde_json::to_string(&artifact).unwrap();
+        assert!(
+            serialized.contains("\"cert_group_gid\":5001"),
+            "cert_group_gid must be serialized: {serialized}"
+        );
+    }
+
+    #[test]
+    fn build_artifact_omits_cert_group_gid_when_unset() {
+        let artifact = build_artifact(
+            "https://ob",
+            "kv",
+            "svc",
+            Path::new("/s/services/svc/secret_id"),
+            Path::new("/etc/svc/agent.toml"),
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            "d.com",
+            "h",
+            None,
+            &[],
+            None,
+            TEST_CA_PEM,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(artifact.cert_group_gid.is_none());
+
+        let serialized = serde_json::to_string(&artifact).unwrap();
+        assert!(
+            !serialized.contains("cert_group_gid"),
+            "cert_group_gid must be omitted from artifact when None: {serialized}"
+        );
+    }
+
     #[test]
     fn build_artifact_typical_case() {
         let artifact = build_artifact(
@@ -372,6 +446,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         assert_eq!(artifact.schema_version, 3);
@@ -445,6 +520,7 @@ mod tests {
             Some(OVERRIDE_EMAIL),
             Some(OVERRIDE_SERVER),
             Some(OVERRIDE_RESPONDER),
+            None,
         );
 
         assert_eq!(artifact.agent_email.as_deref(), Some(OVERRIDE_EMAIL));
@@ -491,6 +567,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert!(artifact.agent_email.is_none());
@@ -531,6 +608,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         assert_eq!(artifact.profile_instance_id, "");
@@ -555,6 +633,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
         let b = build_artifact(
             "https://ob",
@@ -573,6 +652,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         assert_ne!(a.role_id_path, b.role_id_path);
@@ -599,6 +679,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         // Path::new("secret_id").parent() returns Some(""), not None
@@ -625,6 +706,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         // Path::new("cert.pem").parent() returns Some(""), not None
@@ -658,6 +740,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         assert_eq!(artifact.post_renew_hooks.len(), 1);
@@ -692,6 +775,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
         let cmd = super::render_remote_run_command_legacy(&artifact);
 
@@ -744,6 +828,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
         let cmd = super::render_remote_run_command_legacy(&artifact);
 
@@ -776,6 +861,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
         let cmd = super::render_remote_run_command_legacy(&artifact);
 
@@ -804,6 +890,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
         let with_none = build_artifact(
             "https://ob",
@@ -822,6 +909,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         assert_eq!(
@@ -868,6 +956,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
 
         assert_eq!(artifact.wrap_token.as_deref(), Some("hvs.wrap-token-123"));
@@ -900,6 +989,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
         let cmd = super::render_remote_run_command(&artifact);
 
@@ -932,6 +1022,7 @@ mod tests {
             Some(TEST_AGENT_EMAIL),
             Some(TEST_AGENT_SERVER),
             Some(TEST_AGENT_RESPONDER_URL),
+            None,
         );
         let cmd = super::render_remote_run_command(&artifact);
 

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -49,6 +49,10 @@ pub(crate) struct ResolvedServiceAdd {
     /// `--agent-responder-url` was not provided; renderers fall back
     /// to [`DEFAULT_AGENT_RESPONDER_URL`].
     pub(crate) agent_responder_url: Option<String>,
+    /// Resolved numeric gid for `--cert-group`. `None` means the
+    /// operator did not opt into the group-readable cert policy and
+    /// the agent preserves the host-local default. See issue #593.
+    pub(crate) cert_group_gid: Option<u32>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -162,6 +166,8 @@ pub(super) fn resolve_service_add_args(
     let agent_server = args.agent_server.clone();
     let agent_responder_url = args.agent_responder_url.clone();
 
+    let cert_group_gid = resolve_cert_group_for_add(args, delivery_mode, messages)?;
+
     Ok(ResolvedServiceAdd {
         service_name,
         deploy_type,
@@ -182,7 +188,36 @@ pub(super) fn resolve_service_add_args(
         agent_email,
         agent_server,
         agent_responder_url,
+        cert_group_gid,
     })
+}
+
+/// Resolves `--cert-group` for `service add` based on the deployment
+/// mode. `local-file` accepts a numeric gid or a name and validates
+/// the caller can actually `chown` to it (so the failure surface lands
+/// at `service add` time rather than at the next rotation). `remote-
+/// bootstrap` accepts numeric form only and validates only that the
+/// number is non-zero — name resolution and membership are checked on
+/// the remote agent host because the control host's NSS may differ.
+pub(super) fn resolve_cert_group_for_add(
+    args: &ServiceAddArgs,
+    delivery_mode: DeliveryMode,
+    _messages: &Messages,
+) -> Result<Option<u32>> {
+    let Some(raw) = args.cert_group.as_deref() else {
+        return Ok(None);
+    };
+    let gid = match delivery_mode {
+        DeliveryMode::LocalFile => bootroot::cert_group::parse_cert_group_local(raw)
+            .map_err(|err| anyhow::anyhow!("{err}"))?,
+        DeliveryMode::RemoteBootstrap => bootroot::cert_group::parse_cert_group_remote(raw)
+            .map_err(|err| anyhow::anyhow!("{err}"))?,
+    };
+    if matches!(delivery_mode, DeliveryMode::LocalFile) {
+        bootroot::cert_group::validate_local_gid_membership(gid)
+            .map_err(|err| anyhow::anyhow!("{err}"))?;
+    }
+    Ok(Some(gid))
 }
 
 pub(super) fn validate_service_add(args: &ResolvedServiceAdd, messages: &Messages) -> Result<()> {
@@ -493,6 +528,7 @@ mod tests {
             secret_id_wrap_ttl: None,
             no_wrap: false,
             rn_cidrs: Vec::new(),
+            cert_group: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -887,6 +887,46 @@ mod tests {
         assert!(err.to_string().contains("cert_group_gid"));
     }
 
+    /// `cert_group_gid` set to a value not present in the host's group
+    /// database is rejected at validation. This is the orphan-gid case
+    /// called out in the issue #593 review: a numeric gid that exists
+    /// on a different host (e.g. the container image's runtime user)
+    /// but not on the cert-writing host. Without this check the kernel
+    /// would silently accept `chown(-1, gid)` and the consumer would
+    /// still hit EACCES because the gid resolves to no real group.
+    #[test]
+    fn validate_rejects_cert_group_gid_unknown_on_host() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        writeln!(
+            file,
+            r#"
+            domain = "trusted.domain"
+            [acme]
+            http_responder_url = "http://localhost:8080"
+            http_responder_hmac = "dev-hmac"
+
+            [[profiles]]
+            service_name = "edge-proxy"
+            instance_id = "001"
+            hostname = "edge-node-01"
+            cert_group_gid = 4000000000
+
+            [profiles.paths]
+            cert = "certs/edge-proxy.pem"
+            key = "certs/edge-proxy.key"
+        "#
+        )
+        .unwrap();
+        file.flush().unwrap();
+        let settings = Settings::new(Some(file.path().to_path_buf())).unwrap();
+        let err = settings.validate().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cert_group_gid") && msg.contains("4000000000"),
+            "expected unknown-gid error, got: {msg}",
+        );
+    }
+
     /// Accepts the common case where `[openbao]` carries an absolute
     /// `state_path` — this is what `bootroot-remote bootstrap`
     /// auto-provisions when `agent_config_path` is absolute.

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,12 @@ pub struct DaemonProfileSettings {
     #[serde(default)]
     pub hooks: HookSettings,
     pub eab: Option<Eab>,
+    /// Numeric gid that owns the issued cert/key files and their
+    /// parent directories under the `--cert-group` policy.
+    /// `None` (the default) preserves the host-local default mode
+    /// and operator-only ownership. See [issue #593].
+    #[serde(default)]
+    pub cert_group_gid: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -802,6 +808,83 @@ mod tests {
         let settings = Settings::new(Some(file.path().to_path_buf())).unwrap();
         let err = settings.validate().unwrap_err();
         assert!(err.to_string().contains("openbao.state_path"));
+    }
+
+    /// Round-trip test for the `--cert-group` policy on a profile:
+    /// the daemon must parse `cert_group_gid = N` from the rendered
+    /// `agent.toml` and surface it on the in-memory profile, so the
+    /// issuance/rotation path can apply the group ownership policy.
+    /// Without this, every rotation reverts to operator-only and the
+    /// original issue #593 reproduces.
+    #[test]
+    fn settings_parses_profile_cert_group_gid() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        writeln!(
+            file,
+            r#"
+            domain = "trusted.domain"
+            [acme]
+            http_responder_url = "http://localhost:8080"
+            http_responder_hmac = "dev-hmac"
+
+            [[profiles]]
+            service_name = "edge-proxy"
+            instance_id = "001"
+            hostname = "edge-node-01"
+            cert_group_gid = 5001
+
+            [profiles.paths]
+            cert = "certs/edge-proxy.pem"
+            key = "certs/edge-proxy.key"
+        "#
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let settings = Settings::new(Some(file.path().to_path_buf())).unwrap();
+        let profile = &settings.profiles[0];
+        assert_eq!(profile.cert_group_gid, Some(5001));
+    }
+
+    #[test]
+    fn settings_defaults_profile_cert_group_gid_to_none() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        write_minimal_profile_config(&mut file);
+        let settings = Settings::new(Some(file.path().to_path_buf())).unwrap();
+        let profile = &settings.profiles[0];
+        assert!(profile.cert_group_gid.is_none());
+    }
+
+    /// `cert_group_gid = 0` is rejected at validation: gid 0 is root
+    /// and granting it would be a no-op against the operator-only
+    /// default, while masking an obvious misconfiguration.
+    #[test]
+    fn validate_rejects_cert_group_gid_zero() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        writeln!(
+            file,
+            r#"
+            domain = "trusted.domain"
+            [acme]
+            http_responder_url = "http://localhost:8080"
+            http_responder_hmac = "dev-hmac"
+
+            [[profiles]]
+            service_name = "edge-proxy"
+            instance_id = "001"
+            hostname = "edge-node-01"
+            cert_group_gid = 0
+
+            [profiles.paths]
+            cert = "certs/edge-proxy.pem"
+            key = "certs/edge-proxy.key"
+        "#
+        )
+        .unwrap();
+        file.flush().unwrap();
+        let settings = Settings::new(Some(file.path().to_path_buf())).unwrap();
+        let err = settings.validate().unwrap_err();
+        assert!(err.to_string().contains("cert_group_gid"));
     }
 
     /// Accepts the common case where `[openbao]` carries an absolute

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -201,6 +201,12 @@ fn validate_profile(profile: &DaemonProfileSettings) -> Result<()> {
     if profile.paths.key.as_os_str().is_empty() {
         anyhow::bail!("profiles.paths.key must not be empty");
     }
+    if profile.cert_group_gid == Some(0) {
+        // gid 0 is `root`. The default agent identity already has
+        // root or operator-only access; granting "the root group"
+        // would be a no-op and is an obvious misconfiguration.
+        anyhow::bail!("profiles.cert_group_gid must not be 0 (root)");
+    }
     if let Some(retry) = &profile.retry {
         validate_retry_settings(&retry.backoff_secs, "profiles.retry.backoff_secs")?;
     }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -201,11 +201,18 @@ fn validate_profile(profile: &DaemonProfileSettings) -> Result<()> {
     if profile.paths.key.as_os_str().is_empty() {
         anyhow::bail!("profiles.paths.key must not be empty");
     }
-    if profile.cert_group_gid == Some(0) {
+    if let Some(gid) = profile.cert_group_gid {
         // gid 0 is `root`. The default agent identity already has
         // root or operator-only access; granting "the root group"
         // would be a no-op and is an obvious misconfiguration.
-        anyhow::bail!("profiles.cert_group_gid must not be 0 (root)");
+        // The presence check (getgrgid_r) catches the orphan-gid
+        // case where the gid exists on a different host (e.g. the
+        // container image's runtime user) but not on this
+        // cert-writing host, where `chown(-1, gid)` would silently
+        // succeed and the consumer would still hit EACCES. Issue
+        // #593 review.
+        crate::cert_group::validate_cert_writing_host_gid(gid)
+            .map_err(|err| anyhow::anyhow!("profiles.cert_group_gid: {err}"))?;
     }
     if let Some(retry) = &profile.retry {
         validate_retry_settings(&retry.backoff_secs, "profiles.retry.backoff_secs")?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -609,6 +609,7 @@ mod tests {
             retry: None,
             hooks: config::HookSettings::default(),
             eab: None,
+            cert_group_gid: None,
         }
     }
 

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -4,10 +4,20 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use tokio::fs;
 
+use crate::cert_group::{self, CertGroupPolicy};
+
 const KEY_FILE_MODE: u32 = 0o600;
 const SECRETS_DIR_MODE: u32 = 0o700;
 
 /// Ensures the secrets directory exists and has secure permissions.
+///
+/// This helper is for bootroot-internal config artifacts (sidecar
+/// configs, `OpenBao` agent template files, etc.) that must remain
+/// operator-only. Cert/key parent directories on the agent's
+/// issuance/rotation path go through
+/// [`crate::cert_group::ensure_key_parent_dir`] /
+/// [`crate::cert_group::ensure_cert_parent_dir`] instead, so the
+/// `--cert-group` policy can widen the mode/owner.
 ///
 /// # Errors
 /// Returns an error if the directory cannot be created or permissions cannot be set.
@@ -21,7 +31,13 @@ pub async fn ensure_secrets_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Applies restrictive permissions to a private key file.
+/// Applies restrictive permissions (`0600`) to a file.
+///
+/// Used by callers that store operator-only secrets adjacent to the
+/// service cert/key — `agent.toml`, `agent.hcl`, the `OpenBao` agent
+/// `.ctmpl` files, etc. The issued cert/key files themselves go
+/// through [`write_cert_and_key`] and pick up
+/// [`crate::cert_group::CertGroupPolicy`] ownership instead.
 ///
 /// # Errors
 /// Returns an error if permissions cannot be set.
@@ -32,7 +48,19 @@ pub async fn set_key_permissions(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Writes the certificate and key to disk with secure permissions.
+/// Writes the certificate and key to disk under the given policy.
+///
+/// With [`CertGroupPolicy::none`] this preserves the historical
+/// host-local default: `0700` parent directories, `0600` key file,
+/// `0644` cert file, owned by the agent's uid/gid.
+///
+/// With an active policy, the parent directories become group-
+/// traversable (`0750` for the key parent; `0755` for a distinct
+/// cert parent, `0750` when the cert and key share a parent), the
+/// key file becomes group-readable (`0640`), and group ownership of
+/// all four is set to the configured gid. Mode/ownership is re-
+/// applied on every call, so a rotation immediately re-asserts the
+/// policy after operator-side `chmod`/`chown` interventions.
 ///
 /// # Errors
 /// Returns an error if directories cannot be created, files cannot be written,
@@ -42,27 +70,20 @@ pub async fn write_cert_and_key(
     key_path: &Path,
     cert_pem: &str,
     key_pem: &str,
+    policy: CertGroupPolicy,
 ) -> Result<()> {
     let cert_dir = cert_path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Cert path has no parent directory"))?;
-    fs::create_dir_all(cert_dir)
-        .await
-        .with_context(|| format!("Failed to create cert dir {}", cert_dir.display()))?;
-
-    let secrets_dir = key_path
+    let key_dir = key_path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Key path has no parent directory"))?;
-    ensure_secrets_dir(secrets_dir).await?;
 
-    fs::write(cert_path, cert_pem)
-        .await
-        .context("Failed to write cert file")?;
+    cert_group::ensure_key_parent_dir(key_dir, policy).await?;
+    cert_group::ensure_cert_parent_dir(cert_dir, key_dir, policy).await?;
 
-    fs::write(key_path, key_pem)
-        .await
-        .context("Failed to write key file")?;
-    set_key_permissions(key_path).await?;
+    cert_group::write_cert_file(cert_path, cert_pem, policy).await?;
+    cert_group::write_key_file(key_path, key_pem, policy).await?;
 
     Ok(())
 }
@@ -120,27 +141,126 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_cert_and_key_creates_files_with_permissions() {
+    async fn test_write_cert_and_key_default_policy_preserves_modes() {
         let dir = tempdir().unwrap();
         let cert_path = dir.path().join("certs").join("cert.pem");
         let key_path = dir.path().join("secrets").join("key.pem");
 
-        write_cert_and_key(&cert_path, &key_path, "cert-data", "key-data")
-            .await
-            .unwrap();
+        write_cert_and_key(
+            &cert_path,
+            &key_path,
+            "cert-data",
+            "key-data",
+            CertGroupPolicy::none(),
+        )
+        .await
+        .unwrap();
 
         let cert_contents = fs::read_to_string(&cert_path).await.unwrap();
         let key_contents = fs::read_to_string(&key_path).await.unwrap();
         assert_eq!(cert_contents, "cert-data");
         assert_eq!(key_contents, "key-data");
 
-        let secrets_mode = std::fs::metadata(key_path.parent().unwrap())
+        let key_dir_mode = std::fs::metadata(key_path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let cert_dir_mode = std::fs::metadata(cert_path.parent().unwrap())
             .unwrap()
             .permissions()
             .mode()
             & 0o777;
         let key_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(secrets_mode, SECRETS_DIR_MODE);
+        let cert_mode = std::fs::metadata(&cert_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(key_dir_mode, SECRETS_DIR_MODE);
+        assert_eq!(cert_dir_mode, SECRETS_DIR_MODE);
         assert_eq!(key_mode, KEY_FILE_MODE);
+        assert_eq!(cert_mode, 0o644);
+    }
+
+    #[tokio::test]
+    async fn test_write_cert_and_key_group_policy_applies_relaxed_modes() {
+        let Some(gid) = crate::cert_group::one_supplementary_test_gid() else {
+            // Test fixtures without a supplementary gid (single-gid CI
+            // runners) cannot exercise the chown path. The
+            // e2e-extended job provisions a dedicated supplementary
+            // group and still gets coverage.
+            return;
+        };
+        let dir = tempdir().unwrap();
+        let cert_path = dir.path().join("certs").join("cert.pem");
+        let key_path = dir.path().join("secrets").join("key.pem");
+
+        write_cert_and_key(
+            &cert_path,
+            &key_path,
+            "cert-data",
+            "key-data",
+            CertGroupPolicy::with_gid(gid),
+        )
+        .await
+        .unwrap();
+
+        let key_dir_mode = std::fs::metadata(key_path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let cert_dir_mode = std::fs::metadata(cert_path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let key_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+        let cert_mode = std::fs::metadata(&cert_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(key_dir_mode, crate::cert_group::KEY_DIR_MODE_GROUP);
+        assert_eq!(cert_dir_mode, crate::cert_group::CERT_DIR_MODE_GROUP);
+        assert_eq!(key_mode, crate::cert_group::KEY_FILE_MODE_GROUP);
+        assert_eq!(cert_mode, 0o644);
+    }
+
+    /// Re-running `write_cert_and_key` (the rotation case) must
+    /// re-assert the policy. This guards the issue #593 root cause:
+    /// rotation reverting any operator-side `chmod`/`chown`.
+    #[tokio::test]
+    async fn test_write_cert_and_key_reapplies_policy_on_second_call() {
+        let Some(gid) = crate::cert_group::one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempdir().unwrap();
+        let shared = dir.path().join("certs");
+        let cert_path = shared.join("svc.pem");
+        let key_path = shared.join("svc.key");
+
+        write_cert_and_key(
+            &cert_path,
+            &key_path,
+            "c1",
+            "k1",
+            CertGroupPolicy::with_gid(gid),
+        )
+        .await
+        .unwrap();
+
+        // Operator-side regression: hand-tighten back to the default.
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        // Rotation re-runs write_cert_and_key with the same policy:
+        write_cert_and_key(
+            &cert_path,
+            &key_path,
+            "c2",
+            "k2",
+            CertGroupPolicy::with_gid(gid),
+        )
+        .await
+        .unwrap();
+
+        let key_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+        let dir_mode = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777;
+        assert_eq!(key_mode, crate::cert_group::KEY_FILE_MODE_GROUP);
+        assert_eq!(dir_mode, crate::cert_group::KEY_DIR_MODE_GROUP);
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -316,6 +316,7 @@ mod tests {
             retry: None,
             hooks,
             eab: None,
+            cert_group_gid: None,
         };
 
         let settings = Settings {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 pub mod acme;
 pub mod agent_args;
+pub mod cert_group;
 pub mod config;
 pub mod db;
 pub mod eab;

--- a/src/state.rs
+++ b/src/state.rs
@@ -150,6 +150,15 @@ pub(crate) struct ServiceEntry {
     /// rationale as [`ServiceEntry::agent_email`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) agent_responder_url: Option<String>,
+    /// Numeric gid that owns the issued cert/key parent directories
+    /// and the key file under the `--cert-group` policy. `None` means
+    /// the operator did not opt into the policy and the agent
+    /// preserves the host-local default (`0700`/`0600`/`0644`,
+    /// operator-only ownership). Persisted so rotation always re-
+    /// applies the same policy without operator-side `chmod`
+    /// workarounds — see issue #593.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cert_group_gid: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
@@ -339,6 +348,7 @@ mod tests {
             agent_email: None,
             agent_server: None,
             agent_responder_url: None,
+            cert_group_gid: None,
         };
         let json = serde_json::to_string_pretty(&entry).expect("serialize");
         let parsed: ServiceEntry = serde_json::from_str(&json).expect("deserialize");

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -379,9 +379,10 @@ mod tests {
             Path::new("certs/edge-proxy.key"),
             Some(5001),
         );
+        let has_policy_line = block.contains("cert_group_gid = 5001");
         assert!(
-            block.contains("cert_group_gid = 5001"),
-            "cert_group_gid must appear in the rendered profile: {block}"
+            has_policy_line,
+            "rendered profile must include the policy line"
         );
     }
 
@@ -397,9 +398,10 @@ mod tests {
             Path::new("certs/edge-proxy.key"),
             None,
         );
+        let has_policy_line = block.contains("cert_group_gid");
         assert!(
-            !block.contains("cert_group_gid"),
-            "cert_group_gid must not appear when no policy is set: {block}"
+            !has_policy_line,
+            "rendered profile must omit the policy line when unset"
         );
     }
 

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -121,7 +121,14 @@ pub fn apply_agent_config_baseline_defaults(
 }
 
 /// Renders a managed profile block for `agent.toml`.
+///
+/// When `cert_group_gid` is `Some`, the rendered block contains a
+/// `cert_group_gid = N` line so that the agent applies the
+/// `--cert-group` policy on every issuance and rotation. `None`
+/// preserves the host-local default (operator-only mode/owner) and
+/// emits no line.
 #[must_use]
+#[allow(clippy::too_many_arguments)] // adding cert_group_gid pushes the count to 8; see issue #593
 pub fn render_managed_profile_block(
     begin_prefix: &str,
     end_prefix: &str,
@@ -130,13 +137,19 @@ pub fn render_managed_profile_block(
     hostname: &str,
     cert_path: &Path,
     key_path: &Path,
+    cert_group_gid: Option<u32>,
 ) -> String {
+    let cert_group_line = match cert_group_gid {
+        Some(gid) => format!("cert_group_gid = {gid}\n"),
+        None => String::new(),
+    };
     format!(
         "{begin_prefix} {service_name}\n\
 [[profiles]]\n\
 service_name = \"{service_name}\"\n\
 instance_id = \"{instance_id}\"\n\
-hostname = \"{hostname}\"\n\n\
+hostname = \"{hostname}\"\n\
+{cert_group_line}\n\
 [profiles.paths]\n\
 cert = \"{cert}\"\n\
 key = \"{key}\"\n\
@@ -343,11 +356,51 @@ mod tests {
             "edge-node-01",
             Path::new("certs/edge-proxy.crt"),
             Path::new("certs/edge-proxy.key"),
+            None,
         );
         let once = upsert_managed_profile_block("", BEGIN_PREFIX, END_PREFIX, "edge-proxy", &block);
         let twice =
             upsert_managed_profile_block(&once, BEGIN_PREFIX, END_PREFIX, "edge-proxy", &block);
         assert_eq!(once, twice);
+    }
+
+    /// `--cert-group` opts the rendered profile into a `cert_group_gid`
+    /// line that survives across re-renders. Without it, rotation
+    /// loses the policy and the original issue #593 reproduces.
+    #[test]
+    fn render_managed_profile_block_includes_cert_group_gid() {
+        let block = render_managed_profile_block(
+            BEGIN_PREFIX,
+            END_PREFIX,
+            "edge-proxy",
+            "001",
+            "edge-node-01",
+            Path::new("certs/edge-proxy.crt"),
+            Path::new("certs/edge-proxy.key"),
+            Some(5001),
+        );
+        assert!(
+            block.contains("cert_group_gid = 5001"),
+            "cert_group_gid must appear in the rendered profile: {block}"
+        );
+    }
+
+    #[test]
+    fn render_managed_profile_block_omits_cert_group_gid_when_none() {
+        let block = render_managed_profile_block(
+            BEGIN_PREFIX,
+            END_PREFIX,
+            "edge-proxy",
+            "001",
+            "edge-node-01",
+            Path::new("certs/edge-proxy.crt"),
+            Path::new("certs/edge-proxy.key"),
+            None,
+        );
+        assert!(
+            !block.contains("cert_group_gid"),
+            "cert_group_gid must not appear when no policy is set: {block}"
+        );
     }
 
     #[test]

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -139,7 +139,7 @@ pub fn render_managed_profile_block(
     key_path: &Path,
     cert_group_gid: Option<u32>,
 ) -> String {
-    let cert_group_line = match cert_group_gid {
+    let group_line = match cert_group_gid {
         Some(gid) => format!("cert_group_gid = {gid}\n"),
         None => String::new(),
     };
@@ -149,7 +149,7 @@ pub fn render_managed_profile_block(
 service_name = \"{service_name}\"\n\
 instance_id = \"{instance_id}\"\n\
 hostname = \"{hostname}\"\n\
-{cert_group_line}\n\
+{group_line}\n\
 [profiles.paths]\n\
 cert = \"{cert}\"\n\
 key = \"{key}\"\n\

--- a/tests/e2e_cert_group_chown.rs
+++ b/tests/e2e_cert_group_chown.rs
@@ -62,9 +62,10 @@ fn resolve_test_gid() -> Option<u32> {
                  export the numeric gid before running cargo test"
             )
         });
-        let gid: u32 = raw.trim().parse().unwrap_or_else(|_| {
-            panic!("{GID_ENV}={raw:?} is not a valid numeric gid")
-        });
+        let gid: u32 = raw
+            .trim()
+            .parse()
+            .unwrap_or_else(|_| panic!("{GID_ENV}={raw:?} is not a valid numeric gid"));
         assert!(gid != 0, "{GID_ENV}=0 is rejected: gid 0 is root");
         assert!(
             gid != primary_gid,

--- a/tests/e2e_cert_group_chown.rs
+++ b/tests/e2e_cert_group_chown.rs
@@ -1,0 +1,145 @@
+//! E2E-extended coverage for issue #593: full issuance/rotation
+//! `write_cert_and_key` round-trip with `--cert-group` set to a gid
+//! that is *not* the caller's primary gid, asserting both the mode
+//! and the resulting group ownership.
+//!
+//! The unit tests in `src/fs_util.rs` and `src/cert_group.rs` cover
+//! mode-by-mode behavior. This file adds the gid-ownership assertion
+//! the issue calls out — proving the kernel's `chown` permission
+//! check actually accepts the call and that the `gid` field of the
+//! resulting file matches the requested policy gid.
+//!
+//! Behavior:
+//! - Honors the `BOOTROOT_E2E_CERT_GROUP_GID` env var when the CI
+//!   fixture provisions a dedicated supplementary group for the
+//!   runner user. The number must be non-zero and a supplementary
+//!   gid of the current process.
+//! - Falls back to one of the current process's supplementary gids
+//!   (excluding the primary gid). Skips when none exists, so local
+//!   developer runs without supplementary groups still pass.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+
+use bootroot::cert_group::{
+    self, CERT_DIR_MODE_GROUP, CERT_FILE_MODE, CertGroupPolicy, KEY_DIR_MODE_GROUP,
+    KEY_FILE_MODE_GROUP,
+};
+use bootroot::fs_util;
+
+fn pick_test_gid() -> Option<u32> {
+    if let Ok(raw) = std::env::var("BOOTROOT_E2E_CERT_GROUP_GID")
+        && let Ok(gid) = raw.trim().parse::<u32>()
+    {
+        if gid != 0 && cert_group::caller_can_chown_to(gid) {
+            return Some(gid);
+        }
+        eprintln!(
+            "BOOTROOT_E2E_CERT_GROUP_GID={raw} unusable (zero or caller is not a member); \
+             falling back to a supplementary gid"
+        );
+    }
+    cert_group::one_supplementary_test_gid()
+}
+
+#[tokio::test]
+async fn cert_group_chown_full_round_trip_distinct_parents() {
+    let Some(gid) = pick_test_gid() else {
+        eprintln!("skipped: no supplementary gid available for chown test");
+        return;
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let cert_path = dir.path().join("certs").join("svc-cert.pem");
+    let key_path = dir.path().join("secrets").join("svc-key.pem");
+
+    fs_util::write_cert_and_key(
+        &cert_path,
+        &key_path,
+        "CERT-DATA",
+        "KEY-DATA",
+        CertGroupPolicy::with_gid(gid),
+    )
+    .await
+    .unwrap();
+
+    let key_meta = std::fs::metadata(&key_path).unwrap();
+    let cert_meta = std::fs::metadata(&cert_path).unwrap();
+    let key_dir_meta = std::fs::metadata(key_path.parent().unwrap()).unwrap();
+    let cert_dir_meta = std::fs::metadata(cert_path.parent().unwrap()).unwrap();
+
+    assert_eq!(key_meta.permissions().mode() & 0o777, KEY_FILE_MODE_GROUP);
+    assert_eq!(cert_meta.permissions().mode() & 0o777, CERT_FILE_MODE);
+    assert_eq!(
+        key_dir_meta.permissions().mode() & 0o777,
+        KEY_DIR_MODE_GROUP
+    );
+    assert_eq!(
+        cert_dir_meta.permissions().mode() & 0o777,
+        CERT_DIR_MODE_GROUP
+    );
+    assert_eq!(key_meta.gid(), gid, "key file gid must match policy");
+    assert_eq!(cert_meta.gid(), gid, "cert file gid must match policy");
+    assert_eq!(key_dir_meta.gid(), gid, "key parent dir gid must match");
+    assert_eq!(cert_dir_meta.gid(), gid, "cert parent dir gid must match");
+}
+
+/// Rotation regression: re-running `write_cert_and_key` after a
+/// hostile operator-side `chmod`/`chgrp` must restore both mode and
+/// gid ownership. This is the exact failure mode that caused #593 in
+/// the field — without it, every rotation reverts the operator's
+/// container-access fix.
+#[tokio::test]
+async fn cert_group_chown_rotation_re_asserts_gid_ownership() {
+    let Some(gid) = pick_test_gid() else {
+        eprintln!("skipped: no supplementary gid available for chown test");
+        return;
+    };
+    let primary_gid = cert_group::current_process_egid();
+    if primary_gid == gid {
+        eprintln!("skipped: test gid equals primary gid; rotation regression is uninteresting");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let shared = dir.path().join("certs");
+    let cert_path = shared.join("svc-cert.pem");
+    let key_path = shared.join("svc-key.pem");
+
+    fs_util::write_cert_and_key(
+        &cert_path,
+        &key_path,
+        "C1",
+        "K1",
+        CertGroupPolicy::with_gid(gid),
+    )
+    .await
+    .unwrap();
+    assert_eq!(std::fs::metadata(&key_path).unwrap().gid(), gid);
+
+    // Hostile regression: operator (or a buggy hook) chgrps back to
+    // the primary gid and clamps the mode to 0600. The next rotation
+    // must put it back without operator intervention.
+    std::os::unix::fs::chown(&key_path, None, Some(primary_gid)).unwrap();
+    std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    std::os::unix::fs::chown(&shared, None, Some(primary_gid)).unwrap();
+    std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    fs_util::write_cert_and_key(
+        &cert_path,
+        &key_path,
+        "C2",
+        "K2",
+        CertGroupPolicy::with_gid(gid),
+    )
+    .await
+    .unwrap();
+
+    let key_meta = std::fs::metadata(&key_path).unwrap();
+    let dir_meta = std::fs::metadata(&shared).unwrap();
+    assert_eq!(key_meta.permissions().mode() & 0o777, KEY_FILE_MODE_GROUP);
+    assert_eq!(key_meta.gid(), gid, "rotation must restore key gid");
+    assert_eq!(dir_meta.permissions().mode() & 0o777, KEY_DIR_MODE_GROUP);
+    assert_eq!(dir_meta.gid(), gid, "rotation must restore parent gid");
+}

--- a/tests/e2e_cert_group_chown.rs
+++ b/tests/e2e_cert_group_chown.rs
@@ -10,13 +10,18 @@
 //! resulting file matches the requested policy gid.
 //!
 //! Behavior:
-//! - Honors the `BOOTROOT_E2E_CERT_GROUP_GID` env var when the CI
-//!   fixture provisions a dedicated supplementary group for the
-//!   runner user. The number must be non-zero and a supplementary
-//!   gid of the current process.
-//! - Falls back to one of the current process's supplementary gids
-//!   (excluding the primary gid). Skips when none exists, so local
-//!   developer runs without supplementary groups still pass.
+//! - When `BOOTROOT_E2E_REQUIRE_CERT_GROUP=1` is set (CI fixture
+//!   path), the test fails — rather than skips — if
+//!   `BOOTROOT_E2E_CERT_GROUP_GID` is missing, zero, equal to the
+//!   primary gid, unknown to the host group DB, or one the caller
+//!   cannot chown to. This is what locks in the e2e-extended
+//!   regression: a CI environment that didn't provision the fixture
+//!   shows up as a failure, not a silent green.
+//! - Otherwise (local developer runs), the test honors
+//!   `BOOTROOT_E2E_CERT_GROUP_GID` when usable, falls back to a
+//!   supplementary gid of the current process, and skips when no
+//!   suitable gid exists. This keeps `cargo test` runnable on
+//!   developer machines without group setup.
 
 #![cfg(unix)]
 
@@ -29,16 +34,68 @@ use bootroot::cert_group::{
 };
 use bootroot::fs_util;
 
-fn pick_test_gid() -> Option<u32> {
-    if let Ok(raw) = std::env::var("BOOTROOT_E2E_CERT_GROUP_GID")
+const REQUIRE_ENV: &str = "BOOTROOT_E2E_REQUIRE_CERT_GROUP";
+const GID_ENV: &str = "BOOTROOT_E2E_CERT_GROUP_GID";
+
+fn require_ci_fixture() -> bool {
+    matches!(
+        std::env::var(REQUIRE_ENV).ok().as_deref(),
+        Some("1" | "true" | "yes" | "TRUE")
+    )
+}
+
+/// Resolves the gid the test should chown to. In CI-fixture mode
+/// (`BOOTROOT_E2E_REQUIRE_CERT_GROUP=1`) the env-provided gid is
+/// mandatory and any deviation panics with a description of how to
+/// fix the fixture. In dev mode a missing/unusable env var falls
+/// back to a supplementary gid; if none is available the caller
+/// returns `None` and the test is skipped.
+fn resolve_test_gid() -> Option<u32> {
+    let primary_gid = cert_group::current_process_egid();
+    let raw = std::env::var(GID_ENV).ok();
+
+    if require_ci_fixture() {
+        let raw = raw.unwrap_or_else(|| {
+            panic!(
+                "{REQUIRE_ENV}=1 but {GID_ENV} is not set; the CI fixture \
+                 must create a dedicated group, add the runner to it, and \
+                 export the numeric gid before running cargo test"
+            )
+        });
+        let gid: u32 = raw.trim().parse().unwrap_or_else(|_| {
+            panic!("{GID_ENV}={raw:?} is not a valid numeric gid")
+        });
+        assert!(gid != 0, "{GID_ENV}=0 is rejected: gid 0 is root");
+        assert!(
+            gid != primary_gid,
+            "{GID_ENV}={gid} equals the runner's primary gid; the fixture \
+             must allocate a dedicated group whose gid differs from the \
+             runner's primary gid so the chown path is actually exercised"
+        );
+        assert!(
+            cert_group::gid_exists_on_host(gid),
+            "{GID_ENV}={gid} is not present in the host group database; \
+             the fixture must `groupadd` the gid before exporting it"
+        );
+        assert!(
+            cert_group::caller_can_chown_to(gid),
+            "{GID_ENV}={gid} is set but the caller is not a supplementary \
+             member of that group; the fixture must `usermod -aG <name> \
+             $USER` and re-enter the shell (e.g. `sg <name> -c ...`) so \
+             the supplementary membership is visible to the test process"
+        );
+        return Some(gid);
+    }
+
+    if let Some(raw) = raw
         && let Ok(gid) = raw.trim().parse::<u32>()
     {
-        if gid != 0 && cert_group::caller_can_chown_to(gid) {
+        if gid != 0 && gid != primary_gid && cert_group::caller_can_chown_to(gid) {
             return Some(gid);
         }
         eprintln!(
-            "BOOTROOT_E2E_CERT_GROUP_GID={raw} unusable (zero or caller is not a member); \
-             falling back to a supplementary gid"
+            "{GID_ENV}={raw} unusable (zero, equal to primary gid, or caller \
+             is not a member); falling back to a supplementary gid"
         );
     }
     cert_group::one_supplementary_test_gid()
@@ -46,7 +103,7 @@ fn pick_test_gid() -> Option<u32> {
 
 #[tokio::test]
 async fn cert_group_chown_full_round_trip_distinct_parents() {
-    let Some(gid) = pick_test_gid() else {
+    let Some(gid) = resolve_test_gid() else {
         eprintln!("skipped: no supplementary gid available for chown test");
         return;
     };
@@ -92,7 +149,7 @@ async fn cert_group_chown_full_round_trip_distinct_parents() {
 /// container-access fix.
 #[tokio::test]
 async fn cert_group_chown_rotation_re_asserts_gid_ownership() {
-    let Some(gid) = pick_test_gid() else {
+    let Some(gid) = resolve_test_gid() else {
         eprintln!("skipped: no supplementary gid available for chown test");
         return;
     };


### PR DESCRIPTION
## Summary

Adds `--cert-group <gid-or-name>` to `bootroot service add` and `bootroot service update` so issued service certs/keys can be delivered to non-root containerized clients without operator-side `chmod` workarounds that silently regress on every rotation.

When set, every issuance and rotation applies a group-readable policy:

- key parent dir: `0750`
- cert parent dir: `0755` (or `0750` when it shares the key parent — stricter wins)
- `<svc>-key.pem`: `0640`
- `<svc>-cert.pem`: `0644` (unchanged)
- group ownership of both parent dirs and both files: the configured gid

When unset, the historical operator-only default (`0700`/`0600`/`0644`) is preserved unchanged for existing deployments.

The policy is plumbed through every layer renewal touches so it survives rotation:

- `ServiceEntry` in `state.json` (new `cert_group_gid` field)
- the managed `agent.toml` profile block
- the remote-bootstrap artifact (additive optional field, no `schema_version` bump)
- `DaemonProfileSettings`, so the issuance path picks it up at every renew

Per-mode acceptance follows the cross-host NSS rationale in the issue:

- `local-file`: numeric gid or group name (resolved on the control host, which is also the cert-writing host). `chown`-permission to the target gid is validated at `service add` / `service update` time so failures surface at configure time, not at the next rotation.
- `remote-bootstrap`: numeric gid only — name form is rejected at parse time because the control host's NSS may diverge from the remote agent host's NSS. Substantive checks run on the remote host.
- `--cert-group 0` (root) is rejected at parse time and during config validation.

The numeric gid must also resolve in the **cert-writing host's** group database (`getgrgid_r`). An orphan numeric gid — one that exists on a different host (e.g. the container image's runtime user) but not on the host that will actually `chown` the cert/key files — is rejected loudly. For `local-file` this check runs at `service add` / `service update` time on the control host (which is also the cert-writing host); for `remote-bootstrap` the same check runs on the remote agent host at `bootroot-remote bootstrap`, and `bootroot-agent` runs the check again at config validation. Without it the kernel would silently accept `chown(-1, gid)` and the consumer would still hit `EACCES` because the gid resolves to no real group.

`service update --cert-group ...` re-renders the local managed `agent.toml` block immediately for `local-file` services. For `remote-bootstrap` services it emits a one-line follow-up instructing the operator to re-emit the bootstrap artifact and re-run `bootroot-remote bootstrap` on the remote host, so the remote `agent.toml` actually picks up the new policy.

The local-file re-render runs **before** `state.json` is persisted, and re-runs of the same `--cert-group ...` value re-trigger the re-render even when the gid already matches what is in state. So a previously-failed re-render (e.g., agent.toml temporarily unwritable) can be repaired by simply re-running the command, with no risk of `state.json` drifting ahead of the on-disk managed profile and thereby short-circuiting the next attempt at the no-change early return.

Atomic key write: the key file is written via stage-then-rename. A sibling temporary file is created with `O_CREAT|O_EXCL` and `mode=0600`, the staged file is `chown`d (when policy is active) and promoted to `0640`, and only then renamed over the destination. The destination path is therefore never observable at a mode wider than the final policy — no umask-derived `0644` window before the clamp, and no group-readable window under the operator's primary gid before the chown lands.

Shared cert/key parent detection uses kernel `(dev, ino)` identity instead of textual path equality. So spellings like `certs` vs `certs/.` (or symlinked variants) cannot trick `ensure_cert_parent_dir` into widening a directory that `ensure_key_parent_dir` had already locked down to `0750` up to `0755`.

CI fixture: the `test-core` job in `.github/workflows/ci.yml` provisions a dedicated `bootroot-e2e-certgrp` group, adds the runner user as a supplementary member, exports `BOOTROOT_E2E_CERT_GROUP_GID` and `BOOTROOT_E2E_REQUIRE_CERT_GROUP=1`, and runs `cargo test` via `sudo setpriv --reuid=$(id -u) --regid=$(id -g) --init-groups -- "$(command -v cargo)" test`. `setpriv --init-groups` re-reads the user's supplementary groups from `/etc/group` while keeping the original primary gid intact, so the fixture gid appears as a non-primary supplementary group — which is what the test assertions require. (`sg <group>` would make the fixture gid the spawned shell's primary gid, defeating the regression.) Cargo is resolved to its absolute path before `sudo` because `sudo` resets `PATH` via `secure_path`. `tests/e2e_cert_group_chown.rs` honors the require-flag: in CI mode the chown round-trip fails (rather than silently skipping) when the env-provided gid is missing, zero, equal to the runner's primary gid, not in the host group DB, or not a supplementary group of the test process. So a CI environment that ever loses the fixture surfaces as a red build, not a green skip.

Closes #593

## Test plan

- [x] `cargo build --tests` succeeds
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --lib --tests` passes (covers default-policy preservation, group-policy mode set, rotation re-asserting policy after a hostile `chmod`/`chgrp`, parse helpers for `local-file` vs `remote-bootstrap`, `--cert-group 0` rejection in parse and config validation, gid-existence rejection of an orphan numeric gid in config validation and in `bootroot-remote bootstrap` validation, managed profile block rendering with and without `cert_group_gid`, remote-bootstrap artifact round-trip including `cert_group_gid`, atomic stage-then-rename of the key file on first issuance and on rotation, shared cert/key parent detection via inode identity for `certs` vs `certs/.`)
- [x] `tests/e2e_cert_group_chown.rs` verifies the full `write_cert_and_key` round-trip against a non-primary supplementary gid: file mode, dir mode, and the resulting file `gid` all match the policy, and rotation restores both mode and gid after a hostile operator-side `chgrp`/`chmod`. In CI-fixture mode the test refuses to skip — missing/unusable `BOOTROOT_E2E_CERT_GROUP_GID` is a hard failure.
- [x] Default behavior (`0700`/`0600`/`0644`, operator's primary gid) is unchanged when `--cert-group` is unset
- [x] `service update --cert-group ...` on a `local-file` service re-renders the managed `agent.toml` profile block in place (before state.json is saved), with a `cert_group_gid = N` line
- [x] `service update --cert-group ...` re-runs with an unchanged gid still re-render the managed profile, so a previously-failed re-render is repaired without state/agent.toml split-brain
- [x] `service update --cert-group ...` on a `remote-bootstrap` service prints the warning instructing the operator to re-emit the bootstrap artifact and re-run `bootroot-remote bootstrap`
- [x] `--cert-group aice-clients` on a `remote-bootstrap` service is rejected at parse time with a numeric-required error
- [x] `--cert-group <gid>` on a `local-file` service where the caller is not a member of that group fails at `service add` time with a "not a member" error rather than at the next rotation
- [x] `--cert-group <gid>` referring to a gid not in the host group DB is rejected loudly at `service add` (local-file) and at `bootroot-remote bootstrap` (remote-bootstrap) — orphan numeric gids no longer persist silently into rotation
- [x] `--cert-group clear` on `service update` removes an existing policy and reverts the next rotation to operator-only mode/owner
- [x] `bootroot service add` against a `remote-bootstrap` deployment includes `cert_group_gid` in the bootstrap artifact JSON when set, and omits the field entirely when unset (no `schema_version` bump required)

