### PR TITLE
Add non-interactive flags for init save-unseal-keys prompt (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `bootroot init` now accepts `--save-unseal-keys` and
+  `--no-save-unseal-keys` to non-interactively answer the
+  "Save unseal keys to file for automatic unseal? [y/N]" prompt,
+  which was the last remaining interactive prompt on the public `init`
+  surface. `--save-unseal-keys` writes the freshly generated keys to
+  `<secrets_dir>/openbao/unseal-keys.txt` (mode `0600`) without
+  prompting; `--no-save-unseal-keys` skips both the on-disk save and
+  the cleartext-echo fallback, and requires `--summary-json <path>`
+  (enforced at clap parse time) so the keys are captured in the 0600
+  summary JSON instead of being lost. The two flags are mutually
+  exclusive. When neither flag is set the interactive prompt (default
+  `N`) is preserved, so operators see no behavior change. Reinit's
+  internal auto-save path (`args.reinit_mode`) is unaffected.
+  (Closes #603)
+
 ### Security
 
 - Bumped `rustls-webpki` from 0.103.10 to 0.103.12 to address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,7 +253,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   exclusive. When neither flag is set the interactive prompt (default
   `N`) is preserved, so operators see no behavior change. Reinit's
   internal auto-save path (`args.reinit_mode`) is unaffected.
-  (Closes #603)
+  `bootroot init` also now runs the same `--summary-json` and
+  `--root-token-output` preflight that `bootroot reinit` does, before
+  any OpenBao work starts, so a bad output destination fails fast
+  instead of being discovered post-init with the freshly issued root
+  token and unseal keys already minted (recreating the partial-init
+  trap `--no-save-unseal-keys` is designed to avoid through the
+  summary-json recovery channel). (Closes #603)
 - New `bootroot reinit` recovery command that atomically wipes
   OpenBao-owned state and re-runs init while preserving step-ca CA
   material, `password.txt`, PostgreSQL state, operator-authored compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Added
-
-- `bootroot init` now accepts `--save-unseal-keys` and
-  `--no-save-unseal-keys` to non-interactively answer the
-  "Save unseal keys to file for automatic unseal? [y/N]" prompt,
-  which was the last remaining interactive prompt on the public `init`
-  surface. `--save-unseal-keys` writes the freshly generated keys to
-  `<secrets_dir>/openbao/unseal-keys.txt` (mode `0600`) without
-  prompting; `--no-save-unseal-keys` skips both the on-disk save and
-  the cleartext-echo fallback, and requires `--summary-json <path>`
-  (enforced at clap parse time) so the keys are captured in the 0600
-  summary JSON instead of being lost. The two flags are mutually
-  exclusive. When neither flag is set the interactive prompt (default
-  `N`) is preserved, so operators see no behavior change. Reinit's
-  internal auto-save path (`args.reinit_mode`) is unaffected.
-  (Closes #603)
-
 ### Security
 
 - Bumped `rustls-webpki` from 0.103.10 to 0.103.12 to address
@@ -257,6 +240,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `bootroot init` now accepts `--save-unseal-keys` and
+  `--no-save-unseal-keys` to non-interactively answer the
+  "Save unseal keys to file for automatic unseal? [y/N]" prompt,
+  which was the last remaining interactive prompt on the public `init`
+  surface. `--save-unseal-keys` writes the freshly generated keys to
+  `<secrets_dir>/openbao/unseal-keys.txt` (mode `0600`) without
+  prompting; `--no-save-unseal-keys` skips both the on-disk save and
+  the cleartext-echo fallback, and requires `--summary-json <path>`
+  (enforced at clap parse time) so the keys are captured in the 0600
+  summary JSON instead of being lost. The two flags are mutually
+  exclusive. When neither flag is set the interactive prompt (default
+  `N`) is preserved, so operators see no behavior change. Reinit's
+  internal auto-save path (`args.reinit_mode`) is unaffected.
+  (Closes #603)
 - New `bootroot reinit` recovery command that atomically wipes
   OpenBao-owned state and re-runs init while preserving step-ca CA
   material, `password.txt`, PostgreSQL state, operator-authored compose

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -264,7 +264,14 @@ Input priority is **CLI flags > environment variables > prompts/defaults**.
 - `--skip <phase,...>`: skip optional phases (comma-separated).
   Values: `responder-check`
 - `--summary-json`: write init summary as machine-readable JSON
-  (it may include sensitive fields such as `root_token`)
+  (it may include sensitive fields such as `root_token`). The path is
+  preflight-checked before any OpenBao work begins: init refuses to
+  start if the path is a directory, an unwritable existing file, a
+  world-/group-readable existing file, or sits under an uncreatable or
+  read-only parent. This avoids the partial-init trap in which init
+  completes against OpenBao and only then fails to write the summary,
+  leaving the freshly issued root token and unseal keys captured
+  nowhere.
 - `--root-token`: OpenBao root token (environment variable:
   `OPENBAO_ROOT_TOKEN`). Required for normal apply mode. Optional in preview
   mode (`--print-only`/`--dry-run`), but required if you want trust preview

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -327,6 +327,19 @@ Input priority is **CLI flags > environment variables > prompts/defaults**.
 - `--no-eab`: skip the EAB prompt and persist no EAB credentials.
   Conflicts with `--eab-kid`/`--eab-hmac`. Recommended for OSS
   step-ca and CI flows that never use EAB (#588 §3b).
+- `--save-unseal-keys`: skip the "Save unseal keys to file?" prompt and
+  persist the freshly generated unseal keys to
+  `<secrets_dir>/openbao/unseal-keys.txt` (mode `0600`). Equivalent to
+  answering `y` at the prompt. Conflicts with `--no-save-unseal-keys`
+  (#603).
+- `--no-save-unseal-keys`: skip the "Save unseal keys to file?" prompt
+  and do NOT persist the keys to that on-disk path. Requires
+  `--summary-json <path>` so the freshly generated keys are captured in
+  the 0600 summary file; without it the keys would be lost and would
+  brick the next OpenBao restart. Under this flag the cleartext-echo
+  fallback is also suppressed (the keys are already in the summary
+  JSON, and echoing would leak them into CI logs). Conflicts with
+  `--save-unseal-keys` (#603).
 
 If a previous `init` failed mid-flight and rolled back, OpenBao may
 remain initialised in its volume while bootroot has no usable root

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -259,7 +259,13 @@ OpenBao 초기화/언실/정책/AppRole 구성, step-ca 초기화, 시크릿 등
 - `--skip <phase,...>`: 선택 단계 건너뛰기(쉼표 구분).
   값: `responder-check`
 - `--summary-json`: init 요약을 머신 파싱용 JSON 파일로 저장
-  (민감 필드 포함 가능: 예 `root_token`)
+  (민감 필드 포함 가능: 예 `root_token`). OpenBao 작업을 시작하기
+  전에 경로를 사전 점검합니다. 경로가 디렉터리이거나, 기존 파일이
+  쓰기 불가/그룹·기타 권한 노출 상태이거나, 부모 디렉터리가
+  생성·쓰기 불가인 경우 init은 어떤 작업도 시작하지 않고
+  중단됩니다. 이는 init이 OpenBao 초기화를 마친 뒤에야 요약 파일
+  쓰기가 실패해 새로 발행된 root token과 unseal key가 어디에도
+  남지 않는 부분 초기화 함정을 방지합니다.
 - `--root-token`: OpenBao root token (환경 변수: `OPENBAO_ROOT_TOKEN`).
   기본 실행에서는 필수입니다. preview 모드(`--print-only`/`--dry-run`)에서는
   선택이며, trust 프리뷰를 보려면 지정해야 합니다.

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -317,6 +317,19 @@ OpenBao 초기화/언실/정책/AppRole 구성, step-ca 초기화, 시크릿 등
 - `--no-eab`: EAB 프롬프트를 생략하고 EAB 자격증명을 KV에 기록하지
   않습니다. `--eab-kid`/`--eab-hmac`과 함께 사용할 수 없습니다.
   OSS step-ca 및 EAB를 사용하지 않는 CI 흐름에 권장됩니다(#588 §3b).
+- `--save-unseal-keys`: "Save unseal keys to file?" 프롬프트를
+  건너뛰고 새로 생성된 unseal 키를
+  `<secrets_dir>/openbao/unseal-keys.txt`에 모드 `0600`으로
+  저장합니다. 프롬프트에 `y`를 입력한 것과 동등합니다.
+  `--no-save-unseal-keys`와 함께 사용할 수 없습니다(#603).
+- `--no-save-unseal-keys`: "Save unseal keys to file?" 프롬프트를
+  건너뛰고 키를 위 경로에 저장하지 않습니다. 새로 생성된 키가
+  0600 요약 파일에 포착되도록 `--summary-json <path>`가 함께
+  필요합니다. 그렇지 않으면 키가 손실되어 다음 OpenBao 재시작이
+  실패합니다. 이 플래그에서는 운영자가 저장을 거부했을 때 키를
+  stdout으로 평문 출력하는 경로도 함께 억제되어(요약 JSON에
+  이미 들어 있고, CI 로그로 유출될 위험을 차단) 출력되지 않습니다.
+  `--save-unseal-keys`와 함께 사용할 수 없습니다(#603).
 
 이전 `init`이 중간에 실패하고 롤백되었다면 OpenBao는 볼륨에 초기화된
 상태로 남아 있는 반면 bootroot에는 사용 가능한 root token이 없을 수

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -698,6 +698,15 @@ pub(crate) enum InitSkipPhase {
     ResponderCheck,
 }
 
+// Each boolean flag corresponds to an explicit, per-prompt
+// non-interactive opt-out on the `init` surface (`--no-eab`,
+// `--save-unseal-keys`, `--no-save-unseal-keys`, plus the internal
+// `reinit_mode`).  Per the project pattern (#588 §3b), `init` uses
+// per-prompt explicit flags rather than a global `--yes`, so refactoring
+// them into a single state enum would obscure the clap-level mutual
+// exclusivity (`conflicts_with`) and `requires = "summary_json"`
+// constraints that this surface relies on.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Args, Debug)]
 pub(crate) struct InitArgs {
     #[command(flatten)]
@@ -801,6 +810,23 @@ pub(crate) struct InitArgs {
     /// and for CI flows that never use EAB.
     #[arg(long = "no-eab", conflicts_with_all = ["eab_kid", "eab_hmac"])]
     pub(crate) no_eab: bool,
+
+    /// Skip the save-unseal-keys prompt and persist the freshly
+    /// generated unseal keys to `<secrets_dir>/openbao/unseal-keys.txt`
+    /// (mode `0600`).  Equivalent to answering `y` at the prompt.
+    #[arg(long = "save-unseal-keys", conflicts_with = "no_save_unseal_keys")]
+    pub(crate) save_unseal_keys: bool,
+
+    /// Skip the save-unseal-keys prompt and do NOT persist the keys to
+    /// the on-disk path.  Requires `--summary-json <path>` so the freshly
+    /// generated keys are captured in the 0600 summary file; without it
+    /// the keys would be lost and would brick the next `OpenBao` restart.
+    #[arg(
+        long = "no-save-unseal-keys",
+        requires = "summary_json",
+        conflicts_with = "save_unseal_keys"
+    )]
+    pub(crate) no_save_unseal_keys: bool,
 
     /// Internal: invoked from `bootroot reinit`.  Suppresses overwrite
     /// prompts for files that the reinit caller has already decided to
@@ -1329,6 +1355,85 @@ mod tests {
         match cli.command {
             CliCommand::Init(args) => {
                 assert_eq!(args.summary_json, Some(PathBuf::from("init-summary.json")));
+            }
+            _ => panic!("expected init"),
+        }
+    }
+
+    /// `--save-unseal-keys` parses to the matching flag and leaves
+    /// `--no-save-unseal-keys` unset.
+    #[test]
+    fn test_cli_parses_init_save_unseal_keys() {
+        let cli = Cli::parse_from(["bootroot", "init", "--save-unseal-keys"]);
+        match cli.command {
+            CliCommand::Init(args) => {
+                assert!(args.save_unseal_keys);
+                assert!(!args.no_save_unseal_keys);
+            }
+            _ => panic!("expected init"),
+        }
+    }
+
+    /// `--no-save-unseal-keys` requires `--summary-json`; with both set
+    /// the parse succeeds.
+    #[test]
+    fn test_cli_parses_init_no_save_unseal_keys_with_summary_json() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "init",
+            "--no-save-unseal-keys",
+            "--summary-json",
+            "init-summary.json",
+        ]);
+        match cli.command {
+            CliCommand::Init(args) => {
+                assert!(args.no_save_unseal_keys);
+                assert!(!args.save_unseal_keys);
+                assert_eq!(args.summary_json, Some(PathBuf::from("init-summary.json")));
+            }
+            _ => panic!("expected init"),
+        }
+    }
+
+    /// Clap must reject `--no-save-unseal-keys` without `--summary-json`
+    /// at parse time so the operator does not waste a full init cycle
+    /// before discovering the bad combination.
+    #[test]
+    fn test_cli_rejects_no_save_unseal_keys_without_summary_json() {
+        let result = Cli::try_parse_from(["bootroot", "init", "--no-save-unseal-keys"]);
+        assert!(
+            result.is_err(),
+            "--no-save-unseal-keys without --summary-json must be rejected at parse time"
+        );
+    }
+
+    /// Clap must reject the mutually exclusive `--save-unseal-keys` and
+    /// `--no-save-unseal-keys` combination at parse time.
+    #[test]
+    fn test_cli_rejects_save_and_no_save_unseal_keys_together() {
+        let result = Cli::try_parse_from([
+            "bootroot",
+            "init",
+            "--save-unseal-keys",
+            "--no-save-unseal-keys",
+            "--summary-json",
+            "init-summary.json",
+        ]);
+        assert!(
+            result.is_err(),
+            "--save-unseal-keys and --no-save-unseal-keys must be mutually exclusive"
+        );
+    }
+
+    /// Default `init` (no save-unseal-keys flag) leaves both fields
+    /// false — the prompt path stays unchanged for interactive operators.
+    #[test]
+    fn test_cli_init_default_save_unseal_keys_flags_unset() {
+        let cli = Cli::parse_from(["bootroot", "init"]);
+        match cli.command {
+            CliCommand::Init(args) => {
+                assert!(!args.save_unseal_keys);
+                assert!(!args.no_save_unseal_keys);
             }
             _ => panic!("expected init"),
         }

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -500,6 +500,8 @@ pub(super) mod test_support {
             eab_kid: None,
             eab_hmac: None,
             no_eab: false,
+            save_unseal_keys: false,
+            no_save_unseal_keys: false,
             reinit_mode: false,
             root_token_output: None,
         }

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -1373,8 +1373,7 @@ mod tests {
             .expect_err("bad --summary-json must be rejected at preflight");
         let msg = err.to_string();
         assert!(
-            msg.contains(&bad_path.display().to_string())
-                || msg.to_lowercase().contains("summary"),
+            msg.contains(&bad_path.display().to_string()) || msg.to_lowercase().contains("summary"),
             "preflight error must reference the summary-json path or label, got: {msg}",
         );
     }

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -127,10 +127,17 @@ pub(crate) async fn run_init(args: &InitArgs, messages: &Messages) -> Result<()>
             // acceptance criteria require `reinit --yes` to write the
             // fresh keys automatically with no further interaction.
             if summary.init_response && !summary.unseal_keys.is_empty() {
+                let decision = if args.reinit_mode || args.save_unseal_keys {
+                    SaveUnsealKeysDecision::Save
+                } else if args.no_save_unseal_keys {
+                    SaveUnsealKeysDecision::DoNotSave
+                } else {
+                    SaveUnsealKeysDecision::Prompt
+                };
                 maybe_save_unseal_keys(
                     &args.secrets_dir.secrets_dir,
                     &summary.unseal_keys,
-                    args.reinit_mode,
+                    decision,
                     messages,
                 )
                 .await?;
@@ -723,14 +730,33 @@ async fn run_init_inner(
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SaveUnsealKeysDecision {
+    /// Neither flag set and not in reinit mode — ask the operator.
+    Prompt,
+    /// `reinit_mode` or `--save-unseal-keys` — write to disk without
+    /// prompting.
+    Save,
+    /// `--no-save-unseal-keys` — skip persistence AND suppress the
+    /// cleartext-echo fallback (operator has captured the keys via
+    /// `--summary-json`, which clap enforces at parse time).
+    DoNotSave,
+}
+
 async fn maybe_save_unseal_keys(
     secrets_dir: &Path,
     keys: &[String],
-    auto_save: bool,
+    decision: SaveUnsealKeysDecision,
     messages: &Messages,
 ) -> Result<()> {
     use super::prompts::prompt_yes_no;
-    let save = auto_save || prompt_yes_no(messages.prompt_save_unseal_keys(), messages)?;
+    let save = match decision {
+        SaveUnsealKeysDecision::Save => true,
+        SaveUnsealKeysDecision::DoNotSave => false,
+        SaveUnsealKeysDecision::Prompt => {
+            prompt_yes_no(messages.prompt_save_unseal_keys(), messages)?
+        }
+    };
     if save {
         let path =
             crate::commands::openbao_unseal::save_unseal_keys(secrets_dir, keys, messages).await?;
@@ -738,9 +764,12 @@ async fn maybe_save_unseal_keys(
             "{}",
             messages.openbao_unseal_keys_saved(&path.display().to_string())
         );
-    } else {
-        // User declined saving — display the keys in cleartext so they
-        // can be copied for manual safekeeping.
+    } else if matches!(decision, SaveUnsealKeysDecision::Prompt) {
+        // User declined saving at the prompt — display the keys in
+        // cleartext so they can be copied for manual safekeeping.  Under
+        // `--no-save-unseal-keys` the keys are already captured in the
+        // 0600 summary JSON (clap enforces `requires = "summary_json"`),
+        // so echoing them here would leak into CI logs — skip it.
         eprintln!("{}", messages.openbao_unseal_keys_not_saved_warning());
         for (idx, key) in keys.iter().enumerate() {
             println!("{}", messages.summary_unseal_key(idx + 1, key));
@@ -1190,7 +1219,7 @@ mod tests {
         std::fs::create_dir_all(&secrets).unwrap();
         let keys = vec!["key-1".to_string(), "key-2".to_string()];
         let messages = test_messages();
-        maybe_save_unseal_keys(&secrets, &keys, true, &messages)
+        maybe_save_unseal_keys(&secrets, &keys, SaveUnsealKeysDecision::Save, &messages)
             .await
             .expect("auto-save must not prompt");
         let path = secrets.join("openbao").join("unseal-keys.txt");
@@ -1198,6 +1227,56 @@ mod tests {
         assert!(body.contains("key-1") && body.contains("key-2"));
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "unseal keys file must be 0600, got {mode:o}");
+    }
+
+    /// `SaveUnsealKeysDecision::Save` (driven by `--save-unseal-keys`)
+    /// writes the on-disk unseal-keys file with mode `0600` and skips
+    /// the prompt, matching the reinit-mode write path.
+    #[tokio::test]
+    async fn maybe_save_unseal_keys_save_decision_writes_without_prompting() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let secrets = dir.path().join("secrets");
+        std::fs::create_dir_all(&secrets).unwrap();
+        let keys = vec!["key-a".to_string(), "key-b".to_string()];
+        let messages = test_messages();
+        maybe_save_unseal_keys(&secrets, &keys, SaveUnsealKeysDecision::Save, &messages)
+            .await
+            .expect("--save-unseal-keys decision must not prompt");
+        let path = secrets.join("openbao").join("unseal-keys.txt");
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("key-a") && body.contains("key-b"));
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "unseal keys file must be 0600, got {mode:o}");
+    }
+
+    /// `SaveUnsealKeysDecision::DoNotSave` (driven by
+    /// `--no-save-unseal-keys`) must skip the prompt AND skip the
+    /// on-disk write.  Operators that pass `--no-save-unseal-keys` rely
+    /// on `--summary-json` to capture the keys; the canonical
+    /// `<secrets_dir>/openbao/unseal-keys.txt` must not appear.
+    #[tokio::test]
+    async fn maybe_save_unseal_keys_do_not_save_skips_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let secrets = dir.path().join("secrets");
+        std::fs::create_dir_all(&secrets).unwrap();
+        let keys = vec!["key-x".to_string(), "key-y".to_string()];
+        let messages = test_messages();
+        maybe_save_unseal_keys(
+            &secrets,
+            &keys,
+            SaveUnsealKeysDecision::DoNotSave,
+            &messages,
+        )
+        .await
+        .expect("--no-save-unseal-keys decision must not prompt");
+        let path = secrets.join("openbao").join("unseal-keys.txt");
+        assert!(
+            !path.exists(),
+            "--no-save-unseal-keys must not write {}",
+            path.display()
+        );
     }
 
     /// `write_root_token_file` persists the token with mode `0600`.

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -60,6 +60,24 @@ pub(crate) async fn run_init(args: &InitArgs, messages: &Messages) -> Result<()>
     bootroot::config::validate_cert_duration_vs_default_renew_before(&args.cert_duration)?;
     eprintln!("{}", messages.hint_secret_id_ttl_rotation_cadence());
 
+    // Validate optional secret-bearing output destinations *before* any
+    // OpenBao work begins.  Both files are written only after
+    // `run_init_inner` returns: an unwritable destination would otherwise
+    // fail post-init, after OpenBao has been initialised but before
+    // `print_init_summary` / `maybe_save_unseal_keys` run, recreating
+    // the partial-init trap with the freshly issued root token and
+    // unseal keys captured nowhere.  Reinit already gates the same paths
+    // at its own preflight; this mirrors that for the direct `init`
+    // surface.  Critical for `--no-save-unseal-keys`, whose only capture
+    // channel is the summary JSON, but the same ordering issue applies
+    // to `--save-unseal-keys` and to bare `--summary-json`/`--root-token-output`.
+    if let Some(out) = args.summary_json.as_deref() {
+        crate::commands::reinit::validate_summary_json_output_path(out, messages)?;
+    }
+    if let Some(out) = args.root_token_output.as_deref() {
+        crate::commands::reinit::validate_root_token_output_path(out, messages)?;
+    }
+
     ensure_all_services_localhost_binding(&args.compose.compose_file, messages)?;
 
     // Check whether a non-loopback OpenBao bind intent is stored in
@@ -1322,6 +1340,67 @@ mod tests {
         assert_eq!(
             mode, 0o600,
             "root token file must be created atomically with 0600 under any umask, got {mode:o}"
+        );
+    }
+
+    /// Closes #603 Reviewer Round 1: `run_init` must validate
+    /// `--summary-json` *before* any `OpenBao` work begins.  Without this,
+    /// a bad summary destination would fail inside
+    /// `write_init_summary_json` after `run_init_inner` succeeds, leaving
+    /// the freshly issued root token + unseal keys captured nowhere —
+    /// the exact partial-init trap `--no-save-unseal-keys` is designed
+    /// to avoid via the summary-json recovery channel.  The validator is
+    /// the same one reinit uses; this test asserts it fires from the
+    /// init surface too.
+    #[tokio::test]
+    async fn run_init_rejects_bad_summary_json_before_any_work() {
+        let dir = tempfile::tempdir().unwrap();
+        // A directory standing in for the summary-json path: any write
+        // attempt would fail, but the preflight catches it first.
+        let bad_path = dir.path().join("not-a-file");
+        std::fs::create_dir_all(&bad_path).unwrap();
+
+        let mut args = default_init_args();
+        args.summary_json = Some(bad_path.clone());
+        // Point compose_file at a non-existent path so that if the
+        // preflight did NOT fire first, the test would fail with a
+        // different (compose-file) error.  The summary-json validator
+        // runs earlier and emits its own diagnostic.
+        args.compose.compose_file = dir.path().join("does-not-exist.yml");
+
+        let err = run_init(&args, &test_messages())
+            .await
+            .expect_err("bad --summary-json must be rejected at preflight");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&bad_path.display().to_string())
+                || msg.to_lowercase().contains("summary"),
+            "preflight error must reference the summary-json path or label, got: {msg}",
+        );
+    }
+
+    /// Same guarantee for `--root-token-output`: the preflight must fire
+    /// before any `OpenBao` work so a bad token-output destination cannot
+    /// fail post-init with the freshly issued root token already minted.
+    #[tokio::test]
+    async fn run_init_rejects_bad_root_token_output_before_any_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad_path = dir.path().join("not-a-file");
+        std::fs::create_dir_all(&bad_path).unwrap();
+
+        let mut args = default_init_args();
+        args.root_token_output = Some(bad_path.clone());
+        args.compose.compose_file = dir.path().join("does-not-exist.yml");
+
+        let err = run_init(&args, &test_messages())
+            .await
+            .expect_err("bad --root-token-output must be rejected at preflight");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&bad_path.display().to_string())
+                || msg.to_lowercase().contains("root token")
+                || msg.to_lowercase().contains("root-token"),
+            "preflight error must reference the root-token-output path or label, got: {msg}",
         );
     }
 

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -409,7 +409,7 @@ fn remove_file_if_exists(path: &Path, messages: &Messages) -> Result<()> {
 /// 4. The parent directory must accept new files.  We create the parent
 ///    if missing and probe with a uniquely named marker so read-only
 ///    parents and uncreatable ancestors are caught here.
-fn validate_root_token_output_path(path: &Path, messages: &Messages) -> Result<()> {
+pub(crate) fn validate_root_token_output_path(path: &Path, messages: &Messages) -> Result<()> {
     let display = path.display().to_string();
 
     if path.exists() {
@@ -501,7 +501,7 @@ fn validate_root_token_output_path(path: &Path, messages: &Messages) -> Result<(
 /// content lands in the pre-existing file's permission bits first, and
 /// a `0644` destination would briefly expose root token + unseal keys
 /// to other users on the host between the write and the chmod.
-fn validate_summary_json_output_path(path: &Path, messages: &Messages) -> Result<()> {
+pub(crate) fn validate_summary_json_output_path(path: &Path, messages: &Messages) -> Result<()> {
     let display = path.display().to_string();
 
     if path.exists() {

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -846,6 +846,8 @@ fn init_args_for_reinit(
         eab_kid: None,
         eab_hmac: None,
         no_eab: args.no_eab,
+        save_unseal_keys: false,
+        no_save_unseal_keys: false,
         reinit_mode: true,
         root_token_output: args.root_token_output.clone(),
     })


### PR DESCRIPTION
## Summary

Adds two new flags to `bootroot init` to non-interactively answer the "Save unseal keys to file for automatic unseal? [y/N]" prompt — the last remaining interactive prompt on the public `init` surface.

- `--save-unseal-keys`: skip the prompt and persist the freshly generated unseal keys to `<secrets_dir>/openbao/unseal-keys.txt` (mode `0600`). Equivalent to answering `y`.
- `--no-save-unseal-keys`: skip the prompt and do NOT persist the keys to that path. Requires `--summary-json <path>` (enforced at clap parse time) so the keys are captured in the 0600 summary file instead of being lost. Also suppresses the cleartext-echo fallback so the keys don't leak into CI job logs.

The two flags are mutually exclusive (`conflicts_with`). When neither is set, the existing interactive prompt (default `N`) is preserved, so operators see no behavior change. Per the precedent set by #588 §3b (`--no-eab`), `init` uses per-prompt explicit flags rather than a global `--yes`.

Internally, `maybe_save_unseal_keys` now takes a `SaveUnsealKeysDecision` enum (`Prompt` / `Save` / `DoNotSave`) computed at the call site from `reinit_mode` plus the two new flags, replacing the old `auto_save: bool` parameter. Reinit's internal auto-save path is unaffected: the `reinit` wrapper continues to construct `InitArgs` with both new flags `false` and `reinit_mode: true`.

### Reviewer Round 1 follow-up

`run_init` now runs the same `--summary-json` and `--root-token-output` preflight that `bootroot reinit` does, before any OpenBao work begins. Without this, a bad summary-json or root-token-output destination would fail post-init — after OpenBao was already initialised but before `print_init_summary` / `maybe_save_unseal_keys` ran — recreating the partial-init trap that `--no-save-unseal-keys` is designed to avoid via the summary-json recovery channel. The same fix also closes the equivalent gap for `--save-unseal-keys` (whose post-init flow was short-circuited the same way) and for bare `--summary-json` / `--root-token-output` invocations. The two preflight helpers (`validate_summary_json_output_path`, `validate_root_token_output_path`) are reused from `commands::reinit` to keep behaviour identical across both surfaces.

Closes #603

## Test plan

- [x] `cargo test` passes the new clap parse-time assertions:
  - [x] `--save-unseal-keys` parses and sets the matching field
  - [x] `--no-save-unseal-keys --summary-json <path>` parses
  - [x] `--no-save-unseal-keys` without `--summary-json` is rejected
  - [x] `--save-unseal-keys --no-save-unseal-keys` together is rejected
  - [x] Default `init` leaves both fields false
- [x] `cargo test` passes the orchestrator unit tests:
  - [x] `SaveUnsealKeysDecision::Save` writes `secrets_dir/openbao/unseal-keys.txt` at mode `0600` without prompting
  - [x] `SaveUnsealKeysDecision::DoNotSave` skips both the prompt and the on-disk write
  - [x] Existing `reinit_mode` auto-save path still writes (regression coverage via `maybe_save_unseal_keys_auto_save_writes_without_prompting`)
  - [x] `run_init_rejects_bad_summary_json_before_any_work` — bad `--summary-json` destination is rejected at preflight before any OpenBao work
  - [x] `run_init_rejects_bad_root_token_output_before_any_work` — bad `--root-token-output` destination is rejected at preflight before any OpenBao work
- [ ] Manual end-to-end: `bootroot init --enable auto-generate --no-eab --no-save-unseal-keys --summary-json /tmp/init.json` returns 0 without stdin input, `/tmp/init.json` contains a non-empty `unseal_keys` array at 0600, no `unseal-keys.txt` is present under `secrets_dir/openbao/`, and stdout does not contain any of the unseal keys verbatim (with `--enable show-secrets` unset)
- [ ] Manual end-to-end: `bootroot init … --save-unseal-keys` writes `<secrets_dir>/openbao/unseal-keys.txt` at mode `0600` without prompting
- [ ] Manual regression: `bootroot reinit --yes` continues to write unseal keys without prompting (reinit's `auto_save` path through `reinit_mode`)
- [ ] Interactive operators (neither flag set) still see the existing prompt with default-N
- [x] `cargo clippy` is clean
- [x] CHANGELOG and both CLI docs (`docs/en/cli.md`, `docs/ko/cli.md`) reflect the new flags and the `--summary-json` preflight on `init`

Manual end-to-end items above remain unchecked because local Docker bring-up was blocked by a stuck `127.0.0.1:8200` listener held by Docker Desktop (a known preflight flake recorded in repo memory). The underlying call paths they cover are exercised by the three `maybe_save_unseal_keys_*` unit tests (Save / DoNotSave / reinit auto-save), the two new `run_init_rejects_bad_*_before_any_work` preflight tests, and the five clap parse-time tests; all 14 Docker E2E matrix jobs pass on this branch. CLI parse-time rejection of bad combinations was also verified by invoking the built binary directly (`--no-save-unseal-keys` without `--summary-json` and `--save-unseal-keys --no-save-unseal-keys` both rejected at parse time with the expected clap error).