### PR TITLE
Add Docker-backed E2E recovery tests for reinit (#600)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,12 @@ jobs:
             artifact: ci-rotation
             oba_deployment: ""
             oba_topology: ""
+          - label: reinit-recovery
+            script: run-reinit-recovery.sh
+            resolution: ""
+            artifact: ci-reinit-recovery
+            oba_deployment: ""
+            oba_topology: ""
     steps:
       - uses: actions/checkout@v6
 
@@ -439,7 +445,7 @@ jobs:
         run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run E2E scenario (lifecycle)
-        if: matrix.scenario.label != 'rotation'
+        if: matrix.scenario.label != 'rotation' && matrix.scenario.label != 'reinit-recovery'
         run: |
           ARTIFACT_DIR="$(pwd)/tmp/e2e/${{ matrix.scenario.artifact }}-${GITHUB_RUN_ID}"
           # Host-daemon arm has to wait for OpenBao Agent's
@@ -488,6 +494,26 @@ jobs:
           BOOTROOT_BIN="$(pwd)/target/debug/bootroot" \
           BOOTROOT_REMOTE_BIN="$(pwd)/target/debug/bootroot-remote" \
           ./scripts/impl/run-rotation-recovery.sh
+
+      - name: Run E2E scenario (reinit recovery)
+        if: matrix.scenario.label == 'reinit-recovery'
+        run: |
+          ARTIFACT_DIR="$(pwd)/tmp/e2e/${{ matrix.scenario.artifact }}-${GITHUB_RUN_ID}"
+          ARTIFACT_DIR="$ARTIFACT_DIR" \
+          COMPOSE_PROJECT_NAME="bootroot-e2e-ci-reinit-${GITHUB_RUN_ID}" \
+          SECRETS_DIR="$(pwd)/secrets" \
+          BOOTROOT_BIN="$(pwd)/target/debug/bootroot" \
+          ./scripts/impl/run-reinit-recovery.sh || {
+            echo "reinit-recovery failed"
+            [ -f "$ARTIFACT_DIR/phases.log" ] && cat "$ARTIFACT_DIR/phases.log" || true
+            [ -f "$ARTIFACT_DIR/run.log" ] && tail -n 200 "$ARTIFACT_DIR/run.log" || true
+            [ -f "$ARTIFACT_DIR/init.raw.log" ] && tail -n 200 "$ARTIFACT_DIR/init.raw.log" || true
+            for f in "$ARTIFACT_DIR"/reinit-*.raw.log; do
+              [ -f "$f" ] && { echo "--- $(basename "$f") ---"; tail -n 120 "$f"; } || true
+            done
+            [ -f "$ARTIFACT_DIR/compose-logs.log" ] && tail -n 200 "$ARTIFACT_DIR/compose-logs.log" || true
+            exit 1
+          }
 
       - name: Upload Artifacts
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot reinit`'s `infra up` pass racing the OpenBao listener
+  after the volume wipe and bailing with
+  `OpenBao init status check failed: Connection refused`. Docker
+  reports `bootroot-openbao` as Started before the OpenBao process has
+  bound its listener — on the TLS-enabled non-loopback bind exercised
+  by reinit-recovery, the listener typically takes several seconds to
+  accept connections. `run_infra_up`'s unseal helpers
+  (`auto_unseal_openbao` and `maybe_interactive_unseal`) now poll
+  `/v1/sys/seal-status` until the API answers before issuing the first
+  `is_initialized()` call. The same helpers also resolve the
+  `secrets_dir` from `state.json` and build their `OpenBaoClient` via
+  `with_local_trust`, so the post-recreate readiness probe runs over
+  the same step-ca-anchored trust store as the rest of the reinit
+  flow. (Part of #600)
 - Fixed `bootroot service add` and `bootroot init`'s second pass (the
   one reinit runs after wiping OpenBao) failing the TLS handshake with
   `UnknownIssuer` against a TLS-enabled OpenBao bind. The CLI's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Docker-backed E2E recovery harness for `bootroot reinit`
+  (`scripts/impl/run-reinit-recovery.sh`, driven by
+  `tests/docker_e2e_reinit_recovery.rs` and wired into the CI matrix
+  and the extended suite). Drives a real partial-init OpenBao stack
+  through all three #598 failure modes — stuck after
+  `clean --openbao-only`, initialized-OpenBao-without-root-token, and
+  rsync-clone stale local state — and asserts the recovery contracts
+  after each scenario: step-ca root/intermediate fingerprint unchanged,
+  `secrets/password.txt` not overwritten, non-loopback OpenBao bind
+  preserved (compose override survives, intent persists in the
+  rewritten `state.json`, post-reinit OpenBao listens on the same
+  bind), and the rewritten state's service registry is empty. (Closes
+  #600, Closes #598)
 - `bootroot init` now accepts `--save-unseal-keys` and
   `--no-save-unseal-keys` to non-interactively answer the
   "Save unseal keys to file for automatic unseal? [y/N]" prompt,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot init`'s second pass (the one `reinit` runs after wiping
+  OpenBao) recreating the OpenBao container without its
+  `openbao-exposed` compose override and dropping the non-loopback
+  host-port publish mid-flow. `apply_openbao_agent_compose_override`,
+  `apply_responder_compose_override`, and the inline
+  responder TLS compose-up all invoked `docker compose up -d` without
+  `--no-deps`, so compose re-evaluated the openbao dependency against
+  a merged config that lacked the exposed override and recreated the
+  container to the loopback bind. The next KV call (e.g.
+  `write_ca_trust_fingerprints_with_retry`) against
+  `https://<bind>:8200` then failed with `Connection refused`, blowing
+  up reinit-recovery's scenario A. All three call sites now pass
+  `--no-deps`; openbao is left alone, retaining the bind it was
+  brought up with by `reinit`'s `infra up` step. (Part of #600)
 - Fixed `bootroot reinit`'s `infra up` pass racing the OpenBao listener
   after the volume wipe and bailing with
   `OpenBao init status check failed: Connection refused`. Docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot service add` and `bootroot init`'s second pass (the
+  one reinit runs after wiping OpenBao) failing the TLS handshake with
+  `UnknownIssuer` against a TLS-enabled OpenBao bind. The CLI's
+  `OpenBaoClient` constructor used webpki-roots only, so the step-ca
+  private root that signs the OpenBao server cert was not trusted.
+  Added `OpenBaoClient::with_local_trust(url, secrets_dir)`, which
+  auto-anchors verification to `<secrets_dir>/certs/root_ca.crt` when
+  the URL is `https://...` and the bundle exists, and falls back to the
+  default client for HTTP (the pre-TLS loopback path) and for HTTPS
+  endpoints with no local bundle (externally-trusted CAs). Wired into
+  `service add`'s apply, preview, and remote-idempotent paths and into
+  the init orchestrator so the post-TLS operator surface stops
+  blackholing on the new `--openbao-bind` + `--openbao-tls-required`
+  topology the reinit-recovery E2E exercises. (Part of #600)
 - Fixed `bootroot service add` leaving the per-service OpenBao Agent
   sidecar unable to render its `agent.toml` when no EAB is configured
   (e.g., `bootroot init --no-eab`, bundled OSS step-ca). The sidecar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,18 +85,24 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `OpenBaoClient` constructor used webpki-roots only, so the step-ca
   private root that signs the OpenBao server cert was not trusted.
   Added `OpenBaoClient::with_local_trust(url, secrets_dir)`, which
-  auto-anchors verification to `<secrets_dir>/certs/root_ca.crt` (and
-  to `<secrets_dir>/certs/intermediate_ca.crt` when present) when the
+  augments the default Mozilla webpki trust store with
+  `<secrets_dir>/certs/root_ca.crt` (and
+  `<secrets_dir>/certs/intermediate_ca.crt` when present) when the
   URL is `https://...` and the bundle exists, and falls back to the
   default client for HTTP (the pre-TLS loopback path) and for HTTPS
-  endpoints with no local bundle (externally-trusted CAs). The
-  intermediate must be added as a trust anchor because the OpenBao
-  TLS server cert is issued by `step certificate create` as a single
-  leaf (no chain), so without the intermediate in the trust store
-  rustls cannot bridge leaf → intermediate → root and the handshake
-  still fails with `UnknownIssuer`. Wired into `service add`'s apply,
-  preview, and remote-idempotent paths and into the init orchestrator
-  so the post-TLS operator surface stops blackholing on the new
+  endpoints with no local bundle (externally-trusted CAs). The local
+  PEM is appended to the webpki root store rather than replacing it,
+  so an externally-managed (publicly-trusted) HTTPS `OpenBao` URL
+  reachable through the same state-backed code path keeps verifying
+  against the public CA even after `init` has populated
+  `<secrets_dir>/certs/`. The intermediate must be added as a trust
+  anchor because the OpenBao TLS server cert is issued by `step
+  certificate create` as a single leaf (no chain), so without the
+  intermediate in the trust store rustls cannot bridge
+  leaf → intermediate → root and the handshake still fails with
+  `UnknownIssuer`. Wired into `service add`'s apply, preview, and
+  remote-idempotent paths and into the init orchestrator so the
+  post-TLS operator surface stops blackholing on the new
   `--openbao-bind` + `--openbao-tls-required` topology the
   reinit-recovery E2E exercises. `bootroot rotate` (every non-
   `infra-cert` subcommand) and `bootroot status` now go through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   preview, and remote-idempotent paths and into the init orchestrator
   so the post-TLS operator surface stops blackholing on the new
   `--openbao-bind` + `--openbao-tls-required` topology the
-  reinit-recovery E2E exercises. (Part of #600)
+  reinit-recovery E2E exercises. `bootroot rotate` (every non-
+  `infra-cert` subcommand) and `bootroot status` now go through the
+  same constructor — they used `OpenBaoClient::new` and would have
+  failed with `UnknownIssuer` against the same post-reinit topology.
+  The reinit-recovery E2E asserts the regression by running
+  `bootroot status --openbao-url https://<bind>` after each scenario.
+  (Part of #600)
 - Fixed `bootroot service add` leaving the per-service OpenBao Agent
   sidecar unable to render its `agent.toml` when no EAB is configured
   (e.g., `bootroot init --no-eab`, bundled OSS step-ca). The sidecar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,14 +57,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `OpenBaoClient` constructor used webpki-roots only, so the step-ca
   private root that signs the OpenBao server cert was not trusted.
   Added `OpenBaoClient::with_local_trust(url, secrets_dir)`, which
-  auto-anchors verification to `<secrets_dir>/certs/root_ca.crt` when
-  the URL is `https://...` and the bundle exists, and falls back to the
+  auto-anchors verification to `<secrets_dir>/certs/root_ca.crt` (and
+  to `<secrets_dir>/certs/intermediate_ca.crt` when present) when the
+  URL is `https://...` and the bundle exists, and falls back to the
   default client for HTTP (the pre-TLS loopback path) and for HTTPS
-  endpoints with no local bundle (externally-trusted CAs). Wired into
-  `service add`'s apply, preview, and remote-idempotent paths and into
-  the init orchestrator so the post-TLS operator surface stops
-  blackholing on the new `--openbao-bind` + `--openbao-tls-required`
-  topology the reinit-recovery E2E exercises. (Part of #600)
+  endpoints with no local bundle (externally-trusted CAs). The
+  intermediate must be added as a trust anchor because the OpenBao
+  TLS server cert is issued by `step certificate create` as a single
+  leaf (no chain), so without the intermediate in the trust store
+  rustls cannot bridge leaf → intermediate → root and the handshake
+  still fails with `UnknownIssuer`. Wired into `service add`'s apply,
+  preview, and remote-idempotent paths and into the init orchestrator
+  so the post-TLS operator surface stops blackholing on the new
+  `--openbao-bind` + `--openbao-tls-required` topology the
+  reinit-recovery E2E exercises. (Part of #600)
 - Fixed `bootroot service add` leaving the per-service OpenBao Agent
   sidecar unable to render its `agent.toml` when no EAB is configured
   (e.g., `bootroot init --no-eab`, bundled OSS step-ca). The sidecar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "webpki-root-certs",
  "wiremock",
  "x509-parser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio-rustls = "0.26"
 toml_edit = "0.25"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+webpki-root-certs = "1"
 x509-parser = { version = "0.18", features = ["verify"] }
 
 [dev-dependencies]

--- a/scripts/impl/run-extended-suite.sh
+++ b/scripts/impl/run-extended-suite.sh
@@ -16,6 +16,7 @@ TIMEOUT_SECS_ROTATION="${TIMEOUT_SECS_ROTATION:-90}"
 TIMEOUT_SECS_RUNNER="${TIMEOUT_SECS_RUNNER:-45}"
 TIMEOUT_SECS_LIFECYCLE="${TIMEOUT_SECS_LIFECYCLE:-600}"
 TIMEOUT_SECS_CA_KEY_RECOVERY="${TIMEOUT_SECS_CA_KEY_RECOVERY:-600}"
+TIMEOUT_SECS_REINIT_RECOVERY="${TIMEOUT_SECS_REINIT_RECOVERY:-900}"
 MAX_CYCLES_RUNNER="${MAX_CYCLES_RUNNER:-4}"
 INTERVAL_SECS_RUNNER="${INTERVAL_SECS_RUNNER:-1}"
 
@@ -108,6 +109,15 @@ case_ca_key_recovery() {
   "$ROOT_DIR/scripts/impl/run-ca-key-rotation-recovery.sh"
 }
 
+case_reinit_recovery() {
+  local case_dir="$ARTIFACT_DIR/reinit-recovery"
+  ARTIFACT_DIR="$case_dir" \
+  COMPOSE_PROJECT_NAME="${PROJECT_PREFIX}-reinit-$$" \
+  TIMEOUT_SECS="$TIMEOUT_SECS_REINIT_RECOVERY" \
+  BOOTROOT_BIN="$BOOTROOT_BIN" \
+  "$ROOT_DIR/scripts/impl/run-reinit-recovery.sh"
+}
+
 case_runner_cron() {
   local case_dir="$ARTIFACT_DIR/runner-cron"
   ARTIFACT_DIR="$case_dir" \
@@ -155,6 +165,13 @@ main() {
   fi
 
   if line="$(run_case "ca-key-recovery" case_ca_key_recovery)"; then
+    lines+=("$line")
+  else
+    lines+=("$line")
+    overall_status="fail"
+  fi
+
+  if line="$(run_case "reinit-recovery" case_reinit_recovery)"; then
     lines+=("$line")
   else
     lines+=("$line")

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -69,7 +69,10 @@ EXPOSED_OVERRIDE_PATH="$SECRETS_DIR/openbao/docker-compose.openbao-exposed.yml"
 OPENBAO_REPO_DIR="$ROOT_DIR/openbao"
 OPENBAO_REPO_HCL="$OPENBAO_REPO_DIR/openbao.hcl"
 OPENBAO_REPO_CONFIG_DIR="$OPENBAO_REPO_DIR/config"
+OPENBAO_REPO_TLS_DIR="$OPENBAO_REPO_DIR/tls"
 OPENBAO_HCL_SNAPSHOT="$ARTIFACT_DIR/openbao.hcl.pristine"
+OPENBAO_CONFIG_SNAPSHOT="$ARTIFACT_DIR/openbao-config.pristine"
+OPENBAO_TLS_SNAPSHOT="$ARTIFACT_DIR/openbao-tls.pristine"
 EDGE_SERVICE="edge-proxy"
 EDGE_HOSTNAME="edge-node-01"
 DOMAIN="trusted.domain"
@@ -168,15 +171,25 @@ cleanup() {
 # `bootroot init --openbao-bind --openbao-tls-required` rewrites the
 # repo-level `openbao/openbao.hcl` (mounted into the container as
 # `:ro`) to a TLS-enabled listener and drops the issued server cert
-# under `openbao/config/tls/`.  Both paths persist after the script
-# exits, so the next consumer of the same checkout (e.g. the
-# extended suite's `infra-lifecycle` case, which runs after this
-# one) inherits a TLS-bound config while its own `init` talks
-# plaintext.  Restore the snapshot and scrub the TLS cert files so
-# the checkout is left in its pre-run state.
+# under `openbao/tls/server.{crt,key}` (mode 0644 on the key — see
+# `set_openbao_readable_permissions`).  `init` also leaves the
+# auxiliary `openbao/config/` tree behind on some code paths.  Both
+# locations persist after the script exits, so the next consumer of
+# the same checkout (e.g. the extended suite's `infra-lifecycle`
+# case, which runs after this one) inherits a TLS-bound config
+# while its own `init` talks plaintext, and an untracked
+# world-readable private key gets left in the workspace.  Restore
+# `openbao.hcl` and either restore or scrub the `openbao/{tls,config}`
+# trees so the checkout is left exactly in its pre-run state.
 snapshot_repo_openbao_config() {
   if [ -f "$OPENBAO_REPO_HCL" ]; then
     cp "$OPENBAO_REPO_HCL" "$OPENBAO_HCL_SNAPSHOT"
+  fi
+  if [ -d "$OPENBAO_REPO_CONFIG_DIR" ]; then
+    cp -a "$OPENBAO_REPO_CONFIG_DIR" "$OPENBAO_CONFIG_SNAPSHOT"
+  fi
+  if [ -d "$OPENBAO_REPO_TLS_DIR" ]; then
+    cp -a "$OPENBAO_REPO_TLS_DIR" "$OPENBAO_TLS_SNAPSHOT"
   fi
 }
 
@@ -185,6 +198,13 @@ restore_repo_openbao_config() {
     cp "$OPENBAO_HCL_SNAPSHOT" "$OPENBAO_REPO_HCL"
   fi
   rm -rf "$OPENBAO_REPO_CONFIG_DIR"
+  if [ -d "$OPENBAO_CONFIG_SNAPSHOT" ]; then
+    cp -a "$OPENBAO_CONFIG_SNAPSHOT" "$OPENBAO_REPO_CONFIG_DIR"
+  fi
+  rm -rf "$OPENBAO_REPO_TLS_DIR"
+  if [ -d "$OPENBAO_TLS_SNAPSHOT" ]; then
+    cp -a "$OPENBAO_TLS_SNAPSHOT" "$OPENBAO_REPO_TLS_DIR"
+  fi
 }
 
 # Use the public sys/seal-status endpoint (always available, even

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -173,6 +173,32 @@ wait_for_openbao_listening() {
   fail "OpenBao did not become reachable at $url"
 }
 
+unseal_openbao_from_summary() {
+  local url="$1"
+  # `bootroot init` always uses Shamir threshold=2; the summary JSON
+  # does not record the threshold so feed the first two keys.
+  local threshold=2
+  local i
+  for i in $(seq 0 $((threshold - 1))); do
+    local key
+    key="$(jq -r ".unseal_keys[$i] // empty" "$INIT_SUMMARY_JSON")"
+    [ -n "$key" ] || fail "missing unseal key $i in $INIT_SUMMARY_JSON"
+    curl -kSs -m 5 -X PUT "${url}/v1/sys/unseal" \
+      -d "{\"key\":\"${key}\"}" >/dev/null
+  done
+  local attempt
+  for attempt in $(seq 1 "$OPENBAO_READY_ATTEMPTS"); do
+    local sealed
+    sealed="$(curl -kSs -m 3 "${url}/v1/sys/seal-status" \
+      | jq -r '.sealed // "true"' 2>/dev/null || echo "true")"
+    if [ "$sealed" = "false" ]; then
+      return 0
+    fi
+    sleep "$OPENBAO_READY_DELAY_SECS"
+  done
+  fail "OpenBao did not unseal within timeout at $url"
+}
+
 wait_for_postgres_admin() {
   local host_port="${POSTGRES_HOST_PORT:-5432}"
   local admin_user="${POSTGRES_USER:-step}"
@@ -365,6 +391,12 @@ run_bootstrap_init() {
   # post-TLS URL first; otherwise the bootstrap races and fails with
   # `Connection refused`.
   wait_for_openbao_listening "https://${OPENBAO_BIND_ADDR}"
+
+  # The TLS post-processing step recreates the OpenBao container, which
+  # comes back sealed; `init` does not auto-unseal afterwards.  Without
+  # this `service add` would fail with "Vault is sealed" on AppRole
+  # login.  Replay the unseal keys captured in the bootstrap summary.
+  unseal_openbao_from_summary "https://${OPENBAO_BIND_ADDR}"
 
   log_phase "bootstrap-service-add"
   run_bootroot service add \

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -221,12 +221,16 @@ unseal_openbao_from_summary() {
   done
   local attempt
   for attempt in $(seq 1 "$OPENBAO_READY_ATTEMPTS"); do
-    local sealed
-    sealed="$(docker exec -e BAO_ADDR="https://127.0.0.1:8200" \
+    # `bao status` exits 0 when unsealed, 2 when sealed-but-reachable.
+    # Use the exit code directly: jq's `//` alternative operator treats
+    # boolean `false` as nullish, so `.sealed // "true"` would return
+    # "true" for both sealed and unsealed states and the loop would
+    # never break.
+    local status_rc=0
+    docker exec -e BAO_ADDR="https://127.0.0.1:8200" \
       -e BAO_SKIP_VERIFY=true "$container" \
-      bao status -format=json 2>/dev/null \
-      | jq -r '.sealed // "true"' 2>/dev/null || echo "true")"
-    if [ "$sealed" = "false" ]; then
+      bao status -format=json >/dev/null 2>&1 || status_rc=$?
+    if [ "$status_rc" = "0" ]; then
       return 0
     fi
     sleep "$OPENBAO_READY_DELAY_SECS"

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -357,6 +357,15 @@ run_bootstrap_init() {
   [ -n "$RUNTIME_SERVICE_ADD_ROLE_ID" ] || fail "failed to parse runtime_service_add role_id"
   [ -n "$RUNTIME_SERVICE_ADD_SECRET_ID" ] || fail "failed to parse runtime_service_add secret_id"
 
+  # `bootroot init` returns as soon as `docker compose up -d openbao`
+  # reports the recreated container as Started, but OpenBao itself
+  # needs a couple of seconds to bind the TLS listener on the new
+  # `https://${OPENBAO_BIND_ADDR}` endpoint.  `service add` does not
+  # retry the AppRole login, so fire a readiness probe against the
+  # post-TLS URL first; otherwise the bootstrap races and fails with
+  # `Connection refused`.
+  wait_for_openbao_listening "https://${OPENBAO_BIND_ADDR}"
+
   log_phase "bootstrap-service-add"
   run_bootroot service add \
     --service-name "$EDGE_SERVICE" --deploy-type daemon --delivery-mode local-file \

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -145,6 +145,13 @@ ensure_prerequisites() {
 capture_artifacts() {
   compose ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
   compose logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+  # Container-level OpenBao state, captured straight from inside the
+  # container so the diagnostic is unaffected by host networking flakes
+  # that may have caused the failure in the first place.
+  docker port "$OPENBAO_CONTAINER_NAME" >"$ARTIFACT_DIR/openbao-port.log" 2>&1 || true
+  docker exec -e BAO_ADDR="https://127.0.0.1:8200" -e BAO_SKIP_VERIFY=true \
+    "$OPENBAO_CONTAINER_NAME" bao status -format=json \
+    >"$ARTIFACT_DIR/openbao-bao-status.log" 2>&1 || true
 }
 
 cleanup() {
@@ -173,8 +180,31 @@ wait_for_openbao_listening() {
   fail "OpenBao did not become reachable at $url"
 }
 
+# Unseals via `docker exec` against the in-container CLI so the helper
+# does not depend on the host-published port being routable.  The
+# `--openbao-bind` flow publishes OpenBao on a non-loopback host IP
+# (docker0 gateway by default), and CI runners have occasionally
+# proven unreliable about reaching that host IP between port
+# rebinds during `init`'s TLS recreate.  Talking to OpenBao from
+# inside the container sidesteps that flake entirely.
 unseal_openbao_from_summary() {
-  local url="$1"
+  local container="${OPENBAO_CONTAINER_NAME}"
+  # Wait for the OpenBao API inside the container to become responsive
+  # before submitting unseal keys.  `init`'s TLS recreate leaves the
+  # container Started before the OpenBao process is fully listening.
+  # `bao status` exits 0 when unsealed and 2 when sealed-but-reachable;
+  # both states mean the listener is up and the unseal call is safe.
+  local probe_attempt
+  for probe_attempt in $(seq 1 "$OPENBAO_READY_ATTEMPTS"); do
+    local probe_rc=0
+    docker exec -e BAO_ADDR="https://127.0.0.1:8200" \
+      -e BAO_SKIP_VERIFY=true "$container" \
+      bao status -format=json >/dev/null 2>&1 || probe_rc=$?
+    if [ "$probe_rc" = "0" ] || [ "$probe_rc" = "2" ]; then
+      break
+    fi
+    sleep "$OPENBAO_READY_DELAY_SECS"
+  done
   # `bootroot init` always uses Shamir threshold=2; the summary JSON
   # does not record the threshold so feed the first two keys.
   local threshold=2
@@ -183,20 +213,25 @@ unseal_openbao_from_summary() {
     local key
     key="$(jq -r ".unseal_keys[$i] // empty" "$INIT_SUMMARY_JSON")"
     [ -n "$key" ] || fail "missing unseal key $i in $INIT_SUMMARY_JSON"
-    curl -kSs -m 5 -X PUT "${url}/v1/sys/unseal" \
-      -d "{\"key\":\"${key}\"}" >/dev/null
+    if ! docker exec -e BAO_ADDR="https://127.0.0.1:8200" \
+        -e BAO_SKIP_VERIFY=true "$container" \
+        bao operator unseal "$key" >/dev/null 2>>"$RUN_LOG"; then
+      fail "bao operator unseal failed (key $i)"
+    fi
   done
   local attempt
   for attempt in $(seq 1 "$OPENBAO_READY_ATTEMPTS"); do
     local sealed
-    sealed="$(curl -kSs -m 3 "${url}/v1/sys/seal-status" \
+    sealed="$(docker exec -e BAO_ADDR="https://127.0.0.1:8200" \
+      -e BAO_SKIP_VERIFY=true "$container" \
+      bao status -format=json 2>/dev/null \
       | jq -r '.sealed // "true"' 2>/dev/null || echo "true")"
     if [ "$sealed" = "false" ]; then
       return 0
     fi
     sleep "$OPENBAO_READY_DELAY_SECS"
   done
-  fail "OpenBao did not unseal within timeout at $url"
+  fail "OpenBao did not unseal within timeout via docker exec"
 }
 
 wait_for_postgres_admin() {
@@ -383,20 +418,21 @@ run_bootstrap_init() {
   [ -n "$RUNTIME_SERVICE_ADD_ROLE_ID" ] || fail "failed to parse runtime_service_add role_id"
   [ -n "$RUNTIME_SERVICE_ADD_SECRET_ID" ] || fail "failed to parse runtime_service_add secret_id"
 
-  # `bootroot init` returns as soon as `docker compose up -d openbao`
-  # reports the recreated container as Started, but OpenBao itself
-  # needs a couple of seconds to bind the TLS listener on the new
-  # `https://${OPENBAO_BIND_ADDR}` endpoint.  `service add` does not
-  # retry the AppRole login, so fire a readiness probe against the
-  # post-TLS URL first; otherwise the bootstrap races and fails with
-  # `Connection refused`.
-  wait_for_openbao_listening "https://${OPENBAO_BIND_ADDR}"
-
   # The TLS post-processing step recreates the OpenBao container, which
   # comes back sealed; `init` does not auto-unseal afterwards.  Without
   # this `service add` would fail with "Vault is sealed" on AppRole
   # login.  Replay the unseal keys captured in the bootstrap summary.
-  unseal_openbao_from_summary "https://${OPENBAO_BIND_ADDR}"
+  # Talks to OpenBao via `docker exec` so the unseal does not race
+  # against the host-side port publish coming back up after the
+  # recreate.
+  unseal_openbao_from_summary
+
+  # `service add` connects to OpenBao via state.openbao_url, which
+  # `bootroot init` set to `https://${OPENBAO_BIND_ADDR}`.  Make sure
+  # the host-published port is actually reachable before invoking the
+  # next bootroot command; otherwise the AppRole login fails with
+  # `Connection refused` rather than a clear diagnostic.
+  wait_for_openbao_listening "https://${OPENBAO_BIND_ADDR}"
 
   log_phase "bootstrap-service-add"
   run_bootroot service add \

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -311,19 +311,15 @@ assert_post_reinit_contracts() {
   fi
   wait_for_openbao_listening "https://${OPENBAO_BIND_ADDR}"
 
-  # 4. Service registry intentionally empty.
-  local svc_count approles policies
+  # 4. Service registry intentionally empty.  The system-level
+  # `approles` and `policies` maps are repopulated by every `init`
+  # with the bootroot infrastructure AppRoles/policies (bootroot_agent,
+  # responder, stepca, runtime_service_add, runtime_rotate), so only
+  # the user-facing `services` map is expected to be empty.
+  local svc_count
   svc_count="$(jq -r '.services | length' "$WORKSPACE_DIR/state.json")"
-  approles="$(jq -r '.approles | length' "$WORKSPACE_DIR/state.json")"
-  policies="$(jq -r '.policies | length' "$WORKSPACE_DIR/state.json")"
   if [ "$svc_count" != "0" ]; then
     fail "[$label] post-reinit services registry is not empty (count=$svc_count)"
-  fi
-  if [ "$approles" != "0" ]; then
-    fail "[$label] post-reinit approles registry is not empty (count=$approles)"
-  fi
-  if [ "$policies" != "0" ]; then
-    fail "[$label] post-reinit policies registry is not empty (count=$policies)"
   fi
 }
 

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -66,6 +66,10 @@ OPENBAO_BIND_HOST_DEFAULT="172.17.0.1"
 OPENBAO_BIND_HOST="${OPENBAO_BIND_HOST:-$OPENBAO_BIND_HOST_DEFAULT}"
 OPENBAO_BIND_ADDR="${OPENBAO_BIND_ADDR:-${OPENBAO_BIND_HOST}:8200}"
 EXPOSED_OVERRIDE_PATH="$SECRETS_DIR/openbao/docker-compose.openbao-exposed.yml"
+OPENBAO_REPO_DIR="$ROOT_DIR/openbao"
+OPENBAO_REPO_HCL="$OPENBAO_REPO_DIR/openbao.hcl"
+OPENBAO_REPO_CONFIG_DIR="$OPENBAO_REPO_DIR/config"
+OPENBAO_HCL_SNAPSHOT="$ARTIFACT_DIR/openbao.hcl.pristine"
 EDGE_SERVICE="edge-proxy"
 EDGE_HOSTNAME="edge-node-01"
 DOMAIN="trusted.domain"
@@ -158,6 +162,29 @@ cleanup() {
   log_phase "cleanup"
   capture_artifacts
   compose_down
+  restore_repo_openbao_config
+}
+
+# `bootroot init --openbao-bind --openbao-tls-required` rewrites the
+# repo-level `openbao/openbao.hcl` (mounted into the container as
+# `:ro`) to a TLS-enabled listener and drops the issued server cert
+# under `openbao/config/tls/`.  Both paths persist after the script
+# exits, so the next consumer of the same checkout (e.g. the
+# extended suite's `infra-lifecycle` case, which runs after this
+# one) inherits a TLS-bound config while its own `init` talks
+# plaintext.  Restore the snapshot and scrub the TLS cert files so
+# the checkout is left in its pre-run state.
+snapshot_repo_openbao_config() {
+  if [ -f "$OPENBAO_REPO_HCL" ]; then
+    cp "$OPENBAO_REPO_HCL" "$OPENBAO_HCL_SNAPSHOT"
+  fi
+}
+
+restore_repo_openbao_config() {
+  if [ -f "$OPENBAO_HCL_SNAPSHOT" ]; then
+    cp "$OPENBAO_HCL_SNAPSHOT" "$OPENBAO_REPO_HCL"
+  fi
+  rm -rf "$OPENBAO_REPO_CONFIG_DIR"
 }
 
 # Use the public sys/seal-status endpoint (always available, even
@@ -577,6 +604,7 @@ main() {
   ensure_prerequisites
   ensure_bind_host_available
   compose_down
+  snapshot_repo_openbao_config
 
   log_phase "bootstrap-install"
   write_agent_config

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -463,6 +463,15 @@ run_bootstrap_init() {
 run_reinit() {
   local tag="$1"
   log_phase "reinit-${tag}"
+  # `--skip responder-check` mirrors the bootstrap `init` invocation
+  # above: this harness drives `bootroot` from the host CLI and the
+  # responder admin endpoint defaults to `http://bootroot-http01:8080`
+  # — a Docker-network DNS name that is not resolvable from the host.
+  # The bootstrap path overrides the URL to `http://localhost:8080`
+  # (and also skips the check); `bootroot reinit` does not accept
+  # `--responder-url`, so we propagate the skip instead.  Without it
+  # reinit's second init pass dies with `error sending request for url
+  # (http://bootroot-http01:8080/admin/http01)`.
   if ! BOOTROOT_LANG=en run_bootroot reinit \
     --yes \
     --no-eab \
@@ -470,6 +479,7 @@ run_reinit() {
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$ARTIFACT_DIR/reinit-summary-${tag}.json" \
     --enable auto-generate,show-secrets \
+    --skip responder-check \
     >"$ARTIFACT_DIR/reinit-${tag}.raw.log" 2>&1; then
     {
       echo "bootroot reinit failed (tag=${tag}, raw tail):"

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -325,7 +325,13 @@ run_bootstrap_init() {
   wait_for_openbao_listening "http://127.0.0.1:8200"
 
   log_phase "bootstrap-init"
-  if ! BOOTROOT_LANG=en run_bootroot init \
+  # `infra install` writes state.json (to capture the openbao_bind_addr
+  # intent) before init runs, so init's overwrite-state prompt fires
+  # under default-yes-no semantics.  Pipe `y` answers to clear that
+  # prompt (and any future ca.json / password.txt overwrite prompts
+  # that may appear on rerun) so the bootstrap pass stays
+  # non-interactive.
+  if ! printf 'y\ny\ny\n' | BOOTROOT_LANG=en run_bootroot init \
     --compose-file "$COMPOSE_FILE" \
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$INIT_SUMMARY_JSON" \

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -81,6 +81,7 @@ DEFAULT_STEPCA_PASSWORD="reinit-recovery"
 RUNTIME_SERVICE_ADD_ROLE_ID=""
 RUNTIME_SERVICE_ADD_SECRET_ID=""
 CURRENT_PHASE="bootstrap"
+REPO_OPENBAO_SNAPSHOT_TAKEN=0
 
 # Pin POSTGRES_HOST_PORT for the compose stack: docker-compose.yml's
 # default moved from 5432 to 5433 in #588 §4c; the harness expects
@@ -191,9 +192,19 @@ snapshot_repo_openbao_config() {
   if [ -d "$OPENBAO_REPO_TLS_DIR" ]; then
     cp -a "$OPENBAO_REPO_TLS_DIR" "$OPENBAO_TLS_SNAPSHOT"
   fi
+  # Mark the snapshot as taken so the EXIT trap's restore step is a
+  # no-op when the script fails before this point (e.g. prerequisite
+  # checks or bind-host availability) — otherwise the unconditional
+  # `rm -rf` below would delete any pre-existing operator-owned
+  # `openbao/config` or `openbao/tls` tree in the checkout without
+  # having a snapshot to replay.
+  REPO_OPENBAO_SNAPSHOT_TAKEN=1
 }
 
 restore_repo_openbao_config() {
+  if [ "$REPO_OPENBAO_SNAPSHOT_TAKEN" != "1" ]; then
+    return 0
+  fi
   if [ -f "$OPENBAO_HCL_SNAPSHOT" ]; then
     cp "$OPENBAO_HCL_SNAPSHOT" "$OPENBAO_REPO_HCL"
   fi

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -348,6 +348,25 @@ assert_post_reinit_contracts() {
   if [ "$svc_count" != "0" ]; then
     fail "[$label] post-reinit services registry is not empty (count=$svc_count)"
   fi
+
+  # 5. State-backed operator commands talk TLS to the non-loopback
+  # bind without UnknownIssuer.  `bootroot status` constructs its
+  # `OpenBaoClient` against the supplied `--openbao-url` but anchors
+  # the rustls trust store on the local step-ca bundle via
+  # `with_local_trust`.  Regression guard for #600 review round 1:
+  # before the fix, status (and rotate) used `OpenBaoClient::new`,
+  # which ships only webpki-roots and therefore fails the handshake
+  # against the step-ca-signed OpenBao server cert post-reinit.
+  if ! run_bootroot status \
+    --compose-file "$COMPOSE_FILE" \
+    --openbao-url "https://${OPENBAO_BIND_ADDR}" \
+    >"$ARTIFACT_DIR/status-${label}.log" 2>&1; then
+    {
+      echo "bootroot status failed after reinit (label=${label}, tail):"
+      tail -n 80 "$ARTIFACT_DIR/status-${label}.log" || true
+    } >>"$RUN_LOG"
+    fail "[$label] bootroot status against https://${OPENBAO_BIND_ADDR} failed after reinit"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docker-backed E2E recovery harness for `bootroot reinit` (#600).
+#
+# Builds a real partial-init OpenBao state on Docker, then drives
+# `bootroot reinit --yes` against three #598-derived failure modes
+# and asserts the recovery contracts every time:
+#
+#   - step-ca root/intermediate fingerprint unchanged before vs. after
+#   - secrets/password.txt not overwritten
+#   - non-loopback OpenBao bind survives (compose override survives,
+#     intent persists in rewritten state.json, post-reinit OpenBao
+#     listens on the bind, the second init pass reaches it)
+#   - service registry intentionally empty after reinit
+#
+# The scenarios are chained against a single bootstrap so the full
+# recovery sequence can be observed end-to-end:
+#
+#   scenario-a  stuck after `bootroot clean --openbao-only`
+#   scenario-b  initialized-OpenBao-without-root-token (operator
+#               lost summary-json; OpenBao volume still initialised)
+#   scenario-c  stale-local-state-only rsync-clone (OpenBao volume
+#               wiped manually; state.json + secrets/ survive)
+#
+# After each scenario reinit must recover and the four contracts
+# above must hold against the snapshot taken at bootstrap time.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-reinit-recovery-$(date +%s)}"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+COMPOSE_FILE="${COMPOSE_FILE:-$ROOT_DIR/docker-compose.yml}"
+COMPOSE_TEST_FILE="${COMPOSE_TEST_FILE:-$ROOT_DIR/docker-compose.test.yml}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$ARTIFACT_DIR/workspace}"
+SECRETS_DIR="${SECRETS_DIR:-$ROOT_DIR/secrets}"
+AGENT_CONFIG_PATH="${AGENT_CONFIG_PATH:-$WORKSPACE_DIR/agent.toml}"
+CERTS_DIR="${CERTS_DIR:-$WORKSPACE_DIR/certs}"
+BOOTROOT_BIN="${BOOTROOT_BIN:-$ROOT_DIR/target/debug/bootroot}"
+INFRA_READY_ATTEMPTS="${INFRA_READY_ATTEMPTS:-40}"
+INFRA_READY_DELAY_SECS="${INFRA_READY_DELAY_SECS:-3}"
+OPENBAO_READY_ATTEMPTS="${OPENBAO_READY_ATTEMPTS:-40}"
+OPENBAO_READY_DELAY_SECS="${OPENBAO_READY_DELAY_SECS:-2}"
+
+PHASE_LOG="$ARTIFACT_DIR/phases.log"
+RUN_LOG="$ARTIFACT_DIR/run.log"
+INIT_LOG="$ARTIFACT_DIR/init.log"
+INIT_RAW_LOG="$ARTIFACT_DIR/init.raw.log"
+INIT_SUMMARY_JSON="$ARTIFACT_DIR/init-summary.json"
+SNAPSHOT_DIR="$ARTIFACT_DIR/snapshots"
+
+OPENBAO_CONTAINER_NAME="bootroot-openbao"
+# Non-loopback bind exercised by the harness.  Defaults to the docker
+# bridge gateway because every host that can run this harness already
+# has the `docker0` interface (created by docker the moment it starts)
+# and the address is non-loopback for the purposes of
+# `validate_openbao_bind` / `validate_openbao_advertise_addr`.  A
+# specific (non-wildcard) bind sidesteps the
+# `--openbao-advertise-addr` requirement that wildcard binds carry,
+# and `client_url_from_bind_addr` returns the bind as-is so the
+# second init pass reaches OpenBao through the same address the
+# preserved compose override publishes on.
+OPENBAO_BIND_HOST_DEFAULT="172.17.0.1"
+OPENBAO_BIND_HOST="${OPENBAO_BIND_HOST:-$OPENBAO_BIND_HOST_DEFAULT}"
+OPENBAO_BIND_ADDR="${OPENBAO_BIND_ADDR:-${OPENBAO_BIND_HOST}:8200}"
+EXPOSED_OVERRIDE_PATH="$SECRETS_DIR/openbao/docker-compose.openbao-exposed.yml"
+EDGE_SERVICE="edge-proxy"
+EDGE_HOSTNAME="edge-node-01"
+DOMAIN="trusted.domain"
+INSTANCE_ID="001"
+DEFAULT_STEPCA_PASSWORD="reinit-recovery"
+RUNTIME_SERVICE_ADD_ROLE_ID=""
+RUNTIME_SERVICE_ADD_SECRET_ID=""
+CURRENT_PHASE="bootstrap"
+
+# Pin POSTGRES_HOST_PORT for the compose stack: docker-compose.yml's
+# default moved from 5432 to 5433 in #588 §4c; the harness expects
+# 5432 (CI runners free that port before the matrix) so pin it
+# explicitly here to keep compose port mapping aligned with admin
+# probes and the host-side admin DSN.
+export POSTGRES_HOST_PORT="${POSTGRES_HOST_PORT:-5432}"
+export POSTGRES_HOST="127.0.0.1"
+export POSTGRES_PORT="$POSTGRES_HOST_PORT"
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+log_phase() {
+  local phase="$1"
+  CURRENT_PHASE="$phase"
+  local now
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"ts":"%s","phase":"%s"}\n' "$now" "$phase" >>"$PHASE_LOG"
+}
+
+fail() {
+  local message="$1"
+  printf '[fatal][%s] %s\n' "$CURRENT_PHASE" "$message" >>"$RUN_LOG" 2>/dev/null || true
+  echo "[reinit-recovery][${CURRENT_PHASE}] $message" >&2
+  exit 1
+}
+
+on_error() {
+  local line="$1"
+  echo "[reinit-recovery] failed at phase=${CURRENT_PHASE} line=${line}" >&2
+  echo "[reinit-recovery] artifact dir: ${ARTIFACT_DIR}" >&2
+  if [ -f "$RUN_LOG" ]; then
+    echo "--- run.log (tail) ---" >&2
+    tail -n 120 "$RUN_LOG" >&2 || true
+  fi
+  if [ -f "$INIT_RAW_LOG" ]; then
+    echo "--- init.raw.log (tail) ---" >&2
+    tail -n 80 "$INIT_RAW_LOG" >&2 || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Docker / compose helpers
+# ---------------------------------------------------------------------------
+
+compose() {
+  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
+}
+
+compose_down() {
+  compose down -v --remove-orphans >/dev/null 2>&1 || true
+}
+
+run_bootroot() {
+  ( cd "$WORKSPACE_DIR" && "$BOOTROOT_BIN" "$@" )
+}
+
+ensure_prerequisites() {
+  command -v docker >/dev/null 2>&1 || fail "docker is required"
+  docker compose version >/dev/null 2>&1 || fail "docker compose is required"
+  command -v jq >/dev/null 2>&1 || fail "jq is required"
+  command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+  command -v curl >/dev/null 2>&1 || fail "curl is required"
+  [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
+}
+
+capture_artifacts() {
+  compose ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
+  compose logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+}
+
+cleanup() {
+  log_phase "cleanup"
+  capture_artifacts
+  compose_down
+}
+
+# Use the public sys/seal-status endpoint (always available, even
+# when OpenBao is sealed) so the readiness probe does not require a
+# valid root token.  Works over both http and https because the
+# probe always uses the host-published HTTP port — TLS for
+# non-loopback binds is layered on later by `init`'s certificate
+# issuance, after this probe.
+wait_for_openbao_listening() {
+  local url="$1"
+  local attempt
+  for attempt in $(seq 1 "$OPENBAO_READY_ATTEMPTS"); do
+    local code
+    code="$(curl -kSs -o /dev/null -w '%{http_code}' -m 3 "$url/v1/sys/seal-status" || true)"
+    if [ -n "$code" ] && [ "$code" != "000" ]; then
+      return 0
+    fi
+    sleep "$OPENBAO_READY_DELAY_SECS"
+  done
+  fail "OpenBao did not become reachable at $url"
+}
+
+wait_for_postgres_admin() {
+  local host_port="${POSTGRES_HOST_PORT:-5432}"
+  local admin_user="${POSTGRES_USER:-step}"
+  local attempt
+  for attempt in $(seq 1 "$INFRA_READY_ATTEMPTS"); do
+    if docker exec bootroot-postgres pg_isready -U "$admin_user" -d postgres >/dev/null 2>&1 &&
+      bash -lc ": >/dev/tcp/127.0.0.1/${host_port}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$INFRA_READY_DELAY_SECS"
+  done
+  fail "postgres admin endpoint did not become reachable"
+}
+
+# ---------------------------------------------------------------------------
+# Snapshot helpers
+# ---------------------------------------------------------------------------
+
+snapshot_pre_reinit() {
+  local label="$1"
+  local dir="$SNAPSHOT_DIR/$label"
+  mkdir -p "$dir"
+  cp "$SECRETS_DIR/password.txt" "$dir/password.txt"
+  openssl x509 -in "$SECRETS_DIR/certs/root_ca.crt" -noout -fingerprint -sha256 \
+    >"$dir/root_ca.fingerprint"
+  openssl x509 -in "$SECRETS_DIR/certs/intermediate_ca.crt" -noout -fingerprint -sha256 \
+    >"$dir/intermediate_ca.fingerprint"
+  cp "$WORKSPACE_DIR/state.json" "$dir/state.json"
+  if [ -f "$EXPOSED_OVERRIDE_PATH" ]; then
+    cp "$EXPOSED_OVERRIDE_PATH" "$dir/docker-compose.openbao-exposed.yml"
+  fi
+}
+
+assert_post_reinit_contracts() {
+  local label="$1"
+  local dir="$SNAPSHOT_DIR/$label"
+
+  # 1. step-ca CA fingerprints unchanged.
+  local before_root after_root
+  before_root="$(cat "$dir/root_ca.fingerprint")"
+  after_root="$(openssl x509 -in "$SECRETS_DIR/certs/root_ca.crt" -noout -fingerprint -sha256)"
+  if [ "$before_root" != "$after_root" ]; then
+    fail "[$label] root_ca.crt fingerprint changed across reinit (before='$before_root' after='$after_root')"
+  fi
+  local before_int after_int
+  before_int="$(cat "$dir/intermediate_ca.fingerprint")"
+  after_int="$(openssl x509 -in "$SECRETS_DIR/certs/intermediate_ca.crt" -noout -fingerprint -sha256)"
+  if [ "$before_int" != "$after_int" ]; then
+    fail "[$label] intermediate_ca.crt fingerprint changed across reinit"
+  fi
+
+  # 2. password.txt unchanged (byte-for-byte).
+  if ! cmp -s "$dir/password.txt" "$SECRETS_DIR/password.txt"; then
+    fail "[$label] secrets/password.txt was overwritten across reinit"
+  fi
+
+  # 3. Non-loopback bind survives.
+  [ -f "$EXPOSED_OVERRIDE_PATH" ] \
+    || fail "[$label] expected compose override $EXPOSED_OVERRIDE_PATH to survive reinit"
+  local bind
+  bind="$(jq -r '.openbao_bind_addr // empty' "$WORKSPACE_DIR/state.json")"
+  if [ "$bind" != "$OPENBAO_BIND_ADDR" ]; then
+    fail "[$label] post-reinit state.json openbao_bind_addr='$bind' expected '$OPENBAO_BIND_ADDR'"
+  fi
+  # No advertise_addr was set at install time (specific bind, not
+  # wildcard) so the post-reinit state should also leave it empty.
+  local advertise
+  advertise="$(jq -r '.openbao_advertise_addr // empty' "$WORKSPACE_DIR/state.json")"
+  if [ -n "$advertise" ]; then
+    fail "[$label] post-reinit state.json openbao_advertise_addr should be empty, got '$advertise'"
+  fi
+  wait_for_openbao_listening "https://${OPENBAO_BIND_ADDR}"
+
+  # 4. Service registry intentionally empty.
+  local svc_count approles policies
+  svc_count="$(jq -r '.services | length' "$WORKSPACE_DIR/state.json")"
+  approles="$(jq -r '.approles | length' "$WORKSPACE_DIR/state.json")"
+  policies="$(jq -r '.policies | length' "$WORKSPACE_DIR/state.json")"
+  if [ "$svc_count" != "0" ]; then
+    fail "[$label] post-reinit services registry is not empty (count=$svc_count)"
+  fi
+  if [ "$approles" != "0" ]; then
+    fail "[$label] post-reinit approles registry is not empty (count=$approles)"
+  fi
+  if [ "$policies" != "0" ]; then
+    fail "[$label] post-reinit policies registry is not empty (count=$policies)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+write_agent_config() {
+  mkdir -p "$(dirname "$AGENT_CONFIG_PATH")" "$CERTS_DIR"
+  cat >"$AGENT_CONFIG_PATH" <<EOF
+email = "admin@example.com"
+server = "https://localhost:9000/acme/acme/directory"
+domain = "${DOMAIN}"
+
+[acme]
+directory_fetch_attempts = 10
+directory_fetch_base_delay_secs = 1
+directory_fetch_max_delay_secs = 10
+poll_attempts = 15
+poll_interval_secs = 2
+http_responder_url = "http://localhost:8080"
+http_responder_hmac = "dev-hmac"
+http_responder_timeout_secs = 5
+http_responder_token_ttl_secs = 300
+EOF
+}
+
+reset_workspace() {
+  # Wipe the workspace's state file so the bootstrap init starts from
+  # a clean slate; preserve $SECRETS_DIR which holds Postgres/step-ca
+  # material refreshed below.
+  rm -f "$WORKSPACE_DIR/state.json"
+  rm -rf "$SECRETS_DIR/config" "$SECRETS_DIR/certs" "$SECRETS_DIR/db" \
+    "$SECRETS_DIR/secrets" "$SECRETS_DIR/openbao" \
+    "$SECRETS_DIR/password.txt" "$SECRETS_DIR/password.txt.new"
+  rm -f "$ROOT_DIR/.env"
+}
+
+ensure_bind_host_available() {
+  # Verify the configured non-loopback bind host actually exists on
+  # this machine; otherwise compose will refuse to publish the port
+  # and reinit will look broken when the real cause is a missing
+  # docker0 interface.
+  if ! ip -4 -o addr show 2>/dev/null | awk '{print $4}' | sed 's|/.*||' \
+      | grep -qx "$OPENBAO_BIND_HOST"; then
+    fail "non-loopback bind host $OPENBAO_BIND_HOST is not assigned to any local interface (set OPENBAO_BIND_HOST to an address that is)"
+  fi
+}
+
+install_infra_with_bind() {
+  reset_workspace
+  run_bootroot infra install \
+    --compose-file "$COMPOSE_FILE" \
+    --openbao-bind "$OPENBAO_BIND_ADDR" \
+    --openbao-tls-required >>"$RUN_LOG" 2>&1
+}
+
+run_bootstrap_init() {
+  wait_for_postgres_admin
+  # The very first init pass talks to the loopback URL because TLS has
+  # not been issued for the bind yet.  `infra install --openbao-bind`
+  # writes openbao.hcl as plaintext; `init` will switch it to TLS after
+  # issuing the OpenBao server cert.
+  wait_for_openbao_listening "http://127.0.0.1:8200"
+
+  log_phase "bootstrap-init"
+  if ! BOOTROOT_LANG=en run_bootroot init \
+    --compose-file "$COMPOSE_FILE" \
+    --secrets-dir "$SECRETS_DIR" \
+    --summary-json "$INIT_SUMMARY_JSON" \
+    --enable auto-generate,show-secrets,db-provision \
+    --stepca-password "$DEFAULT_STEPCA_PASSWORD" \
+    --http-hmac "dev-hmac" \
+    --no-eab \
+    --save-unseal-keys \
+    --db-user "step" \
+    --db-name "stepca" \
+    --responder-url "http://localhost:8080" \
+    --skip responder-check >"$INIT_RAW_LOG" 2>&1; then
+    {
+      echo "bootroot init failed (raw tail):"
+      tail -n 200 "$INIT_RAW_LOG" || true
+    } >>"$RUN_LOG"
+    fail "bootroot init failed"
+  fi
+  sed 's/^\(root token: \).*/\1<redacted>/' "$INIT_RAW_LOG" >"$INIT_LOG"
+
+  RUNTIME_SERVICE_ADD_ROLE_ID="$(jq -r '.approles[] | select(.label == "runtime_service_add") | .role_id // empty' "$INIT_SUMMARY_JSON")"
+  RUNTIME_SERVICE_ADD_SECRET_ID="$(jq -r '.approles[] | select(.label == "runtime_service_add") | .secret_id // empty' "$INIT_SUMMARY_JSON")"
+  [ -n "$RUNTIME_SERVICE_ADD_ROLE_ID" ] || fail "failed to parse runtime_service_add role_id"
+  [ -n "$RUNTIME_SERVICE_ADD_SECRET_ID" ] || fail "failed to parse runtime_service_add secret_id"
+
+  log_phase "bootstrap-service-add"
+  run_bootroot service add \
+    --service-name "$EDGE_SERVICE" --deploy-type daemon --delivery-mode local-file \
+    --hostname "$EDGE_HOSTNAME" --domain "$DOMAIN" \
+    --agent-config "$AGENT_CONFIG_PATH" \
+    --cert-path "$CERTS_DIR/${EDGE_SERVICE}.crt" \
+    --key-path "$CERTS_DIR/${EDGE_SERVICE}.key" \
+    --instance-id "$INSTANCE_ID" \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_SERVICE_ADD_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_SERVICE_ADD_SECRET_ID" >>"$RUN_LOG" 2>&1
+
+  # Sanity: the bootstrap state.json must carry the service we just
+  # added, so the empty-registry assertion after reinit proves the
+  # registry actually shrank rather than starting empty.
+  local pre_svc_count
+  pre_svc_count="$(jq -r '.services | length' "$WORKSPACE_DIR/state.json")"
+  if [ "$pre_svc_count" -lt 1 ]; then
+    fail "bootstrap state.json should contain at least one registered service (got $pre_svc_count)"
+  fi
+}
+
+run_reinit() {
+  local tag="$1"
+  log_phase "reinit-${tag}"
+  if ! BOOTROOT_LANG=en run_bootroot reinit \
+    --yes \
+    --no-eab \
+    --compose-file "$COMPOSE_FILE" \
+    --secrets-dir "$SECRETS_DIR" \
+    --summary-json "$ARTIFACT_DIR/reinit-summary-${tag}.json" \
+    --enable auto-generate,show-secrets \
+    >"$ARTIFACT_DIR/reinit-${tag}.raw.log" 2>&1; then
+    {
+      echo "bootroot reinit failed (tag=${tag}, raw tail):"
+      tail -n 200 "$ARTIFACT_DIR/reinit-${tag}.raw.log" || true
+    } >>"$RUN_LOG"
+    fail "bootroot reinit failed (tag=${tag})"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Scenario A: stuck after `bootroot clean --openbao-only`
+# ---------------------------------------------------------------------------
+
+scenario_a_stuck_after_clean() {
+  log_phase "scenario-a-clean-openbao-only"
+  snapshot_pre_reinit "scenario-a"
+  run_bootroot clean --openbao-only -y \
+    --compose-file "$COMPOSE_FILE" >>"$RUN_LOG" 2>&1
+  if docker inspect "$OPENBAO_CONTAINER_NAME" >/dev/null 2>&1; then
+    fail "[scenario-a] expected $OPENBAO_CONTAINER_NAME to be removed by clean --openbao-only"
+  fi
+  run_reinit "scenario-a"
+  assert_post_reinit_contracts "scenario-a"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario B: initialized-OpenBao-without-root-token
+# ---------------------------------------------------------------------------
+#
+# After a previous init the OpenBao volume is initialised but the
+# operator has lost the only on-disk channel to the root token (the
+# summary-json the bootstrap wrote).  state.json never carries the
+# root token, so dropping summary-json + unseal-keys.txt is sufficient
+# to put the deployment into the partial-init trap reinit recovers
+# from: `init` would refuse with "already initialised but no root
+# token available", and the operator has no way forward except wiping
+# OpenBao.  Reinit's atomic wipe + re-init is exactly that recovery.
+
+scenario_b_initialized_without_root_token() {
+  log_phase "scenario-b-no-root-token"
+  snapshot_pre_reinit "scenario-b"
+  # Confirm the starting state actually has an initialised OpenBao —
+  # the previous scenario's reinit must have left it that way.
+  local init_status
+  init_status="$(curl -kSs -m 3 "https://${OPENBAO_BIND_ADDR}/v1/sys/init" \
+    | jq -r '.initialized // empty' 2>/dev/null || true)"
+  if [ "$init_status" != "true" ]; then
+    fail "[scenario-b] expected OpenBao to be initialised before dropping the root-token channel"
+  fi
+  rm -f "$INIT_SUMMARY_JSON" "$SECRETS_DIR/openbao/unseal-keys.txt"
+  run_reinit "scenario-b"
+  assert_post_reinit_contracts "scenario-b"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario C: stale-local-state-only (rsync clone)
+# ---------------------------------------------------------------------------
+#
+# Simulates the rsync-clone-to-new-host case: state.json + secrets/
+# exist (rsynced from the original host) but the destination's
+# OpenBao volume is fresh.  We model the "destination OpenBao is
+# fresh" half by removing the container and its data volume
+# manually, then bringing the container back up with `docker
+# compose up openbao` so reinit sees an uninitialised OpenBao
+# alongside the carried-over local state.
+
+scenario_c_rsync_clone_stale_state() {
+  log_phase "scenario-c-rsync-clone"
+  snapshot_pre_reinit "scenario-c"
+  # Remove the container + named volume out-of-band so the carried-over
+  # state.json keeps pointing at a "previous-host" OpenBao that no
+  # longer exists locally — the canonical rsync-clone trap.
+  docker rm -f "$OPENBAO_CONTAINER_NAME" >/dev/null 2>&1 || true
+  local project_basename
+  project_basename="$(basename "$ROOT_DIR" | tr -c 'a-zA-Z0-9_-' '_' | tr '[:upper:]' '[:lower:]')"
+  # `docker compose` derives the project name from the work-dir
+  # basename when COMPOSE_PROJECT_NAME is unset; the volume is named
+  # <project>_openbao-data.  Honour COMPOSE_PROJECT_NAME when set so
+  # the harness can run under a custom project.
+  local project="${COMPOSE_PROJECT_NAME:-$project_basename}"
+  for vol in "${project}_openbao-data" "${project}_openbao-audit"; do
+    docker volume rm "$vol" >/dev/null 2>&1 || true
+  done
+  run_reinit "scenario-c"
+  assert_post_reinit_contracts "scenario-c"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  mkdir -p "$ARTIFACT_DIR" "$WORKSPACE_DIR" "$CERTS_DIR" "$SNAPSHOT_DIR"
+  : >"$PHASE_LOG"
+  : >"$RUN_LOG"
+  trap cleanup EXIT
+  trap 'on_error $LINENO' ERR
+
+  ensure_prerequisites
+  ensure_bind_host_available
+  compose_down
+
+  log_phase "bootstrap-install"
+  write_agent_config
+  install_infra_with_bind
+  run_bootstrap_init
+
+  scenario_a_stuck_after_clean
+  scenario_b_initialized_without_root_token
+  scenario_c_rsync_clone_stale_state
+
+  log_phase "done"
+}
+
+main "$@"

--- a/scripts/preflight/ci/e2e-matrix.sh
+++ b/scripts/preflight/ci/e2e-matrix.sh
@@ -219,6 +219,13 @@ BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
 BOOTROOT_REMOTE_BIN="$ROOT_DIR/target/debug/bootroot-remote" \
 "$ROOT_DIR/scripts/impl/run-rotation-recovery.sh"
 
+echo "[ci-local-e2e] run reinit recovery (issue #600)"
+ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-reinit-recovery-${RUN_ID}" \
+COMPOSE_PROJECT_NAME="bootroot-e2e-ci-reinit-${RUN_ID}" \
+SECRETS_DIR="$ROOT_DIR/secrets" \
+BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
+"$ROOT_DIR/scripts/impl/run-reinit-recovery.sh"
+
 echo "[ci-local-e2e] done"
 echo "[ci-local-e2e] artifacts:"
 echo "  - $ROOT_DIR/tmp/e2e/ci-local-no-hosts-${RUN_ID}"
@@ -229,3 +236,4 @@ echo "  - $ROOT_DIR/tmp/e2e/ci-local-hosts-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-remote-no-hosts-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-remote-hosts-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-rotation-${RUN_ID}"
+echo "  - $ROOT_DIR/tmp/e2e/ci-reinit-recovery-${RUN_ID}"

--- a/src/commands/guardrails.rs
+++ b/src/commands/guardrails.rs
@@ -356,7 +356,7 @@ pub(crate) fn write_http01_exposed_override(
         "\
 services:
   bootroot-http01:
-    ports: !reset
+    ports: !override
       - \"{bind_addr}:8080\"
 "
     );
@@ -927,8 +927,11 @@ fn validate_cert_chain_to_stepca_root(secrets_dir: &Path, cert_bytes: &[u8]) -> 
 /// Generates the compose override file that exposes `OpenBao` on a
 /// non-loopback address.
 ///
-/// The override uses Docker Compose `!reset` to replace the base port
-/// mapping with the operator-specified bind address.
+/// The override uses Docker Compose `!override` to replace the base port
+/// mapping with the operator-specified bind address.  `!reset` looks
+/// equivalent at first glance but discards the new value and removes
+/// the attribute entirely — leaving the container with no host-side
+/// publish at all (verified against Compose v2.x).
 ///
 /// # Errors
 ///
@@ -949,7 +952,7 @@ pub(crate) fn write_openbao_exposed_override(
         "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"{bind_addr}:8200\"
 "
     );
@@ -1109,7 +1112,7 @@ fn has_unsafe_port_binding_for_service(compose: &str, service_key: &str) -> bool
             continue;
         }
 
-        // Match `ports:` with optional YAML tags like `!reset`.
+        // Match `ports:` with optional YAML tags like `!override`.
         if !in_ports && (trimmed == "ports:" || trimmed.starts_with("ports: ")) {
             let rest = trimmed.strip_prefix("ports:").unwrap_or("").trim();
             if let Some(values) = parse_inline_yaml_port_values(rest) {
@@ -1144,11 +1147,11 @@ fn has_unsafe_port_binding_for_service(compose: &str, service_key: &str) -> bool
 /// Extracts port values from an inline YAML array on a `ports:` line.
 ///
 /// Handles forms like `ports: ["5432"]`, `ports: ["0.0.0.0:5432:5432"]`,
-/// and `ports: !reset ["5432"]`.  Returns `None` when the remainder does
+/// and `ports: !override ["5432"]`.  Returns `None` when the remainder does
 /// not contain an inline array.
 fn parse_inline_yaml_port_values(rest: &str) -> Option<Vec<String>> {
     let s = rest.trim();
-    // Skip optional YAML tags (e.g., `!reset`).
+    // Skip optional YAML tags (e.g., `!override`).
     let s = if let Some(after_tag) = s.strip_prefix('!') {
         after_tag
             .split_once(char::is_whitespace)
@@ -1864,7 +1867,7 @@ listener "tcp" {
         assert!(path.exists());
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("192.168.1.10:8200:8200"));
-        assert!(content.contains("!reset"));
+        assert!(content.contains("!override"));
     }
 
     #[test]
@@ -1902,11 +1905,11 @@ listener "tcp" {
     }
 
     #[test]
-    fn detects_unsafe_port_binding_with_reset_tag() {
+    fn detects_unsafe_port_binding_with_override_tag() {
         let compose = "\
 services:
   postgres:
-    ports: !reset
+    ports: !override
       - \"0.0.0.0:5432:5432\"
 ";
         assert!(has_unsafe_port_binding_for_service(compose, "postgres:"));
@@ -1924,7 +1927,7 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"192.168.1.10:8200:8200\"
   postgres:
     ports: [\"5432\"]
@@ -1945,10 +1948,10 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"192.168.1.10:8200:8200\"
   postgres:
-    ports: !reset
+    ports: !override
       - \"0.0.0.0:5432:5432\"
 ",
         )
@@ -1967,7 +1970,7 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"192.168.1.10:8200:8200\"
 ",
         )
@@ -1986,7 +1989,7 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"192.168.1.10:8200:8200\"
 ",
         )
@@ -2010,7 +2013,7 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"0.0.0.0:8200:8200\"
 ",
         )
@@ -2032,7 +2035,7 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"192.168.1.10:9200:8200\"
 ",
         )
@@ -2052,7 +2055,7 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
 ",
         )
         .unwrap();
@@ -2071,7 +2074,7 @@ services:
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"[fd12::1]:8200:8200\"
 ",
         )
@@ -2533,7 +2536,7 @@ listener "tcp" {
             "\
 services:
   bootroot-http01:
-    ports: !reset
+    ports: !override
       - \"192.168.1.10:8080:8080\"
   openbao:
     ports:

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -1,6 +1,7 @@
 use std::io::IsTerminal;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use bootroot::openbao::OpenBaoClient;
@@ -32,6 +33,17 @@ const DEFAULT_GRAFANA_ADMIN_PASSWORD: &str = "admin";
 const DEFAULT_POSTGRES_USER: &str = "step";
 const DEFAULT_POSTGRES_DB: &str = "stepca";
 const UNSEAL_KEYS_PATH: &str = "secrets/openbao/unseal-keys.txt";
+
+/// Total budget for the post-`docker compose up -d` wait that gives the
+/// `OpenBao` listener time to bind before the unseal helpers issue their
+/// first API call.  Docker reports the container `Started` as soon as
+/// the entrypoint runs — for a TLS-enabled non-loopback bind (the
+/// reinit-recovery path), several seconds typically elapse before the
+/// kernel accepts a TCP connection on the published port.  Mirrors the
+/// `OPENBAO_READY_ATTEMPTS * OPENBAO_READY_DELAY_SECS` budget used by
+/// `scripts/impl/run-reinit-recovery.sh`'s `wait_for_openbao_listening`.
+const OPENBAO_API_WAIT_ATTEMPTS: u32 = 60;
+const OPENBAO_API_WAIT_DELAY: Duration = Duration::from_millis(500);
 
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Result<()> {
@@ -132,12 +144,30 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
             None
         }
     });
+    // Resolve the secrets_dir from state when present so the unseal
+    // helpers can anchor TLS trust on the step-ca root/intermediate
+    // bundle.  Without this, the rustls client built by
+    // `OpenBaoClient::new` rejects the step-ca-signed OpenBao server
+    // cert with `UnknownIssuer` on the reinit-recovery path where
+    // OpenBao listens on `https://<non-loopback>:8200`.
+    let effective_secrets_dir = resolve_effective_secrets_dir(&state_path, compose_dir);
     if let Some(path) = unseal_file.as_deref() {
-        auto_unseal_openbao(path, &effective_openbao_url, messages).await?;
+        auto_unseal_openbao(
+            path,
+            &effective_openbao_url,
+            effective_secrets_dir.as_deref(),
+            messages,
+        )
+        .await?;
     } else {
         // No key file found — check if OpenBao is sealed and prompt
         // interactively so `infra up` works without --openbao-unseal-from-file.
-        maybe_interactive_unseal(&effective_openbao_url, messages).await?;
+        maybe_interactive_unseal(
+            &effective_openbao_url,
+            effective_secrets_dir.as_deref(),
+            messages,
+        )
+        .await?;
     }
 
     let readiness = collect_readiness(
@@ -570,11 +600,88 @@ pub(crate) fn ensure_init_prereqs_ready(compose_file: &Path, messages: &Messages
     Ok(())
 }
 
-async fn auto_unseal_openbao(path: &Path, openbao_url: &str, messages: &Messages) -> Result<()> {
+/// Returns the absolute path of the `secrets_dir` recorded in
+/// `state.json` when present.  Used so the unseal helpers can build an
+/// `OpenBao` client anchored on the step-ca root/intermediate bundle
+/// for the non-loopback TLS path.  Returns `None` when the state file
+/// is absent or fails to parse — the caller then falls back to the
+/// default `OpenBaoClient::new`, which is the right choice for the
+/// fresh-install plaintext-loopback flow that has no bundle on disk
+/// yet.
+fn resolve_effective_secrets_dir(state_path: &Path, compose_dir: &Path) -> Option<PathBuf> {
+    if !state_path.exists() {
+        return None;
+    }
+    let state = StateFile::load(state_path).ok()?;
+    let secrets_dir = state.secrets_dir();
+    if secrets_dir.is_absolute() {
+        Some(secrets_dir.to_path_buf())
+    } else {
+        Some(compose_dir.join(secrets_dir))
+    }
+}
+
+/// Builds an [`OpenBaoClient`] for the unseal helpers.  When a
+/// `secrets_dir` is supplied, prefers [`OpenBaoClient::with_local_trust`]
+/// so the rustls trust store includes the step-ca root and intermediate
+/// bundles — required to verify the `OpenBao` server cert issued by
+/// step-ca on the non-loopback TLS path.  Falls back to
+/// [`OpenBaoClient::new`] for the plaintext-loopback / fresh-install
+/// path where no bundle exists yet.
+fn build_openbao_client(
+    openbao_url: &str,
+    secrets_dir: Option<&Path>,
+    messages: &Messages,
+) -> Result<OpenBaoClient> {
+    if let Some(dir) = secrets_dir {
+        OpenBaoClient::with_local_trust(openbao_url, dir)
+            .with_context(|| messages.error_openbao_client_create_failed())
+    } else {
+        OpenBaoClient::new(openbao_url)
+            .with_context(|| messages.error_openbao_client_create_failed())
+    }
+}
+
+/// Polls `sys/seal-status` until the `OpenBao` listener responds or the
+/// budget is exhausted.  Any successful HTTP response (sealed or
+/// unsealed, initialized or not) proves the listener is up, so the
+/// caller can proceed with `is_initialized()` / `seal_status()` /
+/// `unseal()` without racing the post-recreate startup.
+///
+/// On the final attempt, propagates the underlying transport error so
+/// the operator sees the real cause (e.g. TLS handshake failure with
+/// `UnknownIssuer` when the trust bundle is wrong) rather than a
+/// generic "API never became reachable" message.
+async fn wait_for_openbao_api_reachable(client: &OpenBaoClient, messages: &Messages) -> Result<()> {
+    for attempt in 0..OPENBAO_API_WAIT_ATTEMPTS {
+        match client.seal_status().await {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                if attempt + 1 == OPENBAO_API_WAIT_ATTEMPTS {
+                    return Err(err).with_context(|| messages.error_openbao_seal_status_failed());
+                }
+            }
+        }
+        tokio::time::sleep(OPENBAO_API_WAIT_DELAY).await;
+    }
+    unreachable!("loop above returns on every iteration")
+}
+
+async fn auto_unseal_openbao(
+    path: &Path,
+    openbao_url: &str,
+    secrets_dir: Option<&Path>,
+    messages: &Messages,
+) -> Result<()> {
     println!("{}", messages.warning_openbao_unseal_from_file());
     let keys = read_unseal_keys_from_file(path, messages)?;
-    let client = OpenBaoClient::new(openbao_url)
-        .with_context(|| messages.error_openbao_client_create_failed())?;
+    let client = build_openbao_client(openbao_url, secrets_dir, messages)?;
+
+    // `docker compose up -d` returns once the container is Started, not
+    // when the OpenBao listener is bound.  Poll a public endpoint until
+    // the API answers so the immediately-following `is_initialized()`
+    // does not race the listener and fail with `Connection refused`.
+    wait_for_openbao_api_reachable(&client, messages).await?;
 
     // An uninitialized instance always reports sealed=true but has
     // no unseal keys yet.  A stale key file from a previous run
@@ -609,9 +716,17 @@ async fn auto_unseal_openbao(path: &Path, openbao_url: &str, messages: &Messages
 /// Skips the prompt when `OpenBao` has not been initialized yet (fresh
 /// `infra install`) or when stdin is not a terminal (CI / scripted
 /// usage).
-async fn maybe_interactive_unseal(openbao_url: &str, messages: &Messages) -> Result<()> {
-    let client = OpenBaoClient::new(openbao_url)
-        .with_context(|| messages.error_openbao_client_create_failed())?;
+async fn maybe_interactive_unseal(
+    openbao_url: &str,
+    secrets_dir: Option<&Path>,
+    messages: &Messages,
+) -> Result<()> {
+    let client = build_openbao_client(openbao_url, secrets_dir, messages)?;
+
+    // See `auto_unseal_openbao` — the OpenBao listener can be slower
+    // than `docker compose up -d` returning, so wait for the API to
+    // answer before the first `is_initialized()` call.
+    wait_for_openbao_api_reachable(&client, messages).await?;
 
     // An uninitialized instance always reports sealed=true but has
     // no unseal keys, so prompting is nonsensical.
@@ -1287,6 +1402,62 @@ pub(crate) fn docker_output(args: &[&str], messages: &Messages) -> Result<String
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_effective_secrets_dir_returns_none_without_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        assert!(resolve_effective_secrets_dir(&state_path, dir.path()).is_none());
+    }
+
+    #[test]
+    fn resolve_effective_secrets_dir_returns_absolute_when_state_uses_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let abs_secrets = dir.path().join("custom-secrets");
+        let state = StateFile {
+            openbao_url: "http://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+            secrets_dir: Some(abs_secrets.clone()),
+            policies: std::collections::BTreeMap::new(),
+            approles: std::collections::BTreeMap::new(),
+            services: std::collections::BTreeMap::new(),
+            openbao_bind_addr: None,
+            openbao_advertise_addr: None,
+            http01_admin_bind_addr: None,
+            http01_admin_advertise_addr: None,
+            infra_certs: std::collections::BTreeMap::new(),
+        };
+        state.save(&state_path).unwrap();
+        assert_eq!(
+            resolve_effective_secrets_dir(&state_path, dir.path()),
+            Some(abs_secrets)
+        );
+    }
+
+    #[test]
+    fn resolve_effective_secrets_dir_joins_relative_path_with_compose_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let state = StateFile {
+            openbao_url: "http://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+            secrets_dir: Some(PathBuf::from("secrets")),
+            policies: std::collections::BTreeMap::new(),
+            approles: std::collections::BTreeMap::new(),
+            services: std::collections::BTreeMap::new(),
+            openbao_bind_addr: None,
+            openbao_advertise_addr: None,
+            http01_admin_bind_addr: None,
+            http01_admin_advertise_addr: None,
+            infra_certs: std::collections::BTreeMap::new(),
+        };
+        state.save(&state_path).unwrap();
+        assert_eq!(
+            resolve_effective_secrets_dir(&state_path, dir.path()),
+            Some(dir.path().join("secrets"))
+        );
+    }
 
     #[test]
     fn test_is_image_archive_extensions() {

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -2051,7 +2051,7 @@ mod tests {
             "\
 services:
   openbao:
-    ports: !reset
+    ports: !override
       - \"0.0.0.0:8200:8200\"
 ",
         )
@@ -3190,7 +3190,7 @@ tls_key_path = \"/app/bootroot-http01/tls/server.key\"
         std::fs::create_dir_all(&override_dir).unwrap();
         std::fs::write(
             override_dir.join(HTTP01_EXPOSED_COMPOSE_OVERRIDE_NAME),
-            "services:\n  bootroot-http01:\n    ports: !reset\n      - \"192.168.1.10:8080:8080\"\n",
+            "services:\n  bootroot-http01:\n    ports: !override\n      - \"192.168.1.10:8080:8080\"\n",
         )
         .unwrap();
 

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -34,7 +34,7 @@ const DEFAULT_POSTGRES_DB: &str = "stepca";
 const UNSEAL_KEYS_PATH: &str = "secrets/openbao/unseal-keys.txt";
 
 #[allow(clippy::too_many_lines)]
-pub(crate) fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Result<()> {
+pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Result<()> {
     ensure_all_services_localhost_binding(&args.compose_file.compose_file, messages)?;
 
     // Check for stored OpenBao non-loopback bind intent.
@@ -133,11 +133,11 @@ pub(crate) fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Result<()
         }
     });
     if let Some(path) = unseal_file.as_deref() {
-        auto_unseal_openbao(path, &effective_openbao_url, messages)?;
+        auto_unseal_openbao(path, &effective_openbao_url, messages).await?;
     } else {
         // No key file found — check if OpenBao is sealed and prompt
         // interactively so `infra up` works without --openbao-unseal-from-file.
-        maybe_interactive_unseal(&effective_openbao_url, messages)?;
+        maybe_interactive_unseal(&effective_openbao_url, messages).await?;
     }
 
     let readiness = collect_readiness(
@@ -570,41 +570,37 @@ pub(crate) fn ensure_init_prereqs_ready(compose_file: &Path, messages: &Messages
     Ok(())
 }
 
-fn auto_unseal_openbao(path: &Path, openbao_url: &str, messages: &Messages) -> Result<()> {
+async fn auto_unseal_openbao(path: &Path, openbao_url: &str, messages: &Messages) -> Result<()> {
     println!("{}", messages.warning_openbao_unseal_from_file());
     let keys = read_unseal_keys_from_file(path, messages)?;
-    let runtime = tokio::runtime::Runtime::new()
-        .with_context(|| messages.error_runtime_init_failed("infra up"))?;
-    runtime.block_on(async {
-        let client = OpenBaoClient::new(openbao_url)
-            .with_context(|| messages.error_openbao_client_create_failed())?;
+    let client = OpenBaoClient::new(openbao_url)
+        .with_context(|| messages.error_openbao_client_create_failed())?;
 
-        // An uninitialized instance always reports sealed=true but has
-        // no unseal keys yet.  A stale key file from a previous run
-        // would cause an unseal error, so skip gracefully.
-        if !client
-            .is_initialized()
-            .await
-            .with_context(|| messages.error_openbao_init_status_failed())?
-        {
-            return Ok(());
-        }
+    // An uninitialized instance always reports sealed=true but has
+    // no unseal keys yet.  A stale key file from a previous run
+    // would cause an unseal error, so skip gracefully.
+    if !client
+        .is_initialized()
+        .await
+        .with_context(|| messages.error_openbao_init_status_failed())?
+    {
+        return Ok(());
+    }
 
-        for key in &keys {
-            client
-                .unseal(key)
-                .await
-                .with_context(|| messages.error_openbao_unseal_failed())?;
-        }
-        let status = client
-            .seal_status()
+    for key in &keys {
+        client
+            .unseal(key)
             .await
-            .with_context(|| messages.error_openbao_seal_status_failed())?;
-        if status.sealed {
-            anyhow::bail!(messages.error_openbao_sealed());
-        }
-        Ok(())
-    })
+            .with_context(|| messages.error_openbao_unseal_failed())?;
+    }
+    let status = client
+        .seal_status()
+        .await
+        .with_context(|| messages.error_openbao_seal_status_failed())?;
+    if status.sealed {
+        anyhow::bail!(messages.error_openbao_sealed());
+    }
+    Ok(())
 }
 
 /// Checks whether `OpenBao` is sealed and, if so, prompts the user
@@ -613,52 +609,48 @@ fn auto_unseal_openbao(path: &Path, openbao_url: &str, messages: &Messages) -> R
 /// Skips the prompt when `OpenBao` has not been initialized yet (fresh
 /// `infra install`) or when stdin is not a terminal (CI / scripted
 /// usage).
-fn maybe_interactive_unseal(openbao_url: &str, messages: &Messages) -> Result<()> {
-    let runtime = tokio::runtime::Runtime::new()
-        .with_context(|| messages.error_runtime_init_failed("infra up"))?;
-    runtime.block_on(async {
-        let client = OpenBaoClient::new(openbao_url)
-            .with_context(|| messages.error_openbao_client_create_failed())?;
+async fn maybe_interactive_unseal(openbao_url: &str, messages: &Messages) -> Result<()> {
+    let client = OpenBaoClient::new(openbao_url)
+        .with_context(|| messages.error_openbao_client_create_failed())?;
 
-        // An uninitialized instance always reports sealed=true but has
-        // no unseal keys, so prompting is nonsensical.
-        if !client
-            .is_initialized()
+    // An uninitialized instance always reports sealed=true but has
+    // no unseal keys, so prompting is nonsensical.
+    if !client
+        .is_initialized()
+        .await
+        .with_context(|| messages.error_openbao_init_status_failed())?
+    {
+        return Ok(());
+    }
+
+    let status = client
+        .seal_status()
+        .await
+        .with_context(|| messages.error_openbao_seal_status_failed())?;
+    if !status.sealed {
+        return Ok(());
+    }
+
+    if !std::io::stdin().is_terminal() {
+        eprintln!("{}", messages.warning_openbao_sealed_non_interactive());
+        return Ok(());
+    }
+
+    let keys = prompt_unseal_keys_interactive(status.t, messages)?;
+    for key in &keys {
+        client
+            .unseal(key)
             .await
-            .with_context(|| messages.error_openbao_init_status_failed())?
-        {
-            return Ok(());
-        }
-
-        let status = client
-            .seal_status()
-            .await
-            .with_context(|| messages.error_openbao_seal_status_failed())?;
-        if !status.sealed {
-            return Ok(());
-        }
-
-        if !std::io::stdin().is_terminal() {
-            eprintln!("{}", messages.warning_openbao_sealed_non_interactive());
-            return Ok(());
-        }
-
-        let keys = prompt_unseal_keys_interactive(status.t, messages)?;
-        for key in &keys {
-            client
-                .unseal(key)
-                .await
-                .with_context(|| messages.error_openbao_unseal_failed())?;
-        }
-        let final_status = client
-            .seal_status()
-            .await
-            .with_context(|| messages.error_openbao_seal_status_failed())?;
-        if final_status.sealed {
-            anyhow::bail!(messages.error_openbao_sealed());
-        }
-        Ok(())
-    })
+            .with_context(|| messages.error_openbao_unseal_failed())?;
+    }
+    let final_status = client
+        .seal_status()
+        .await
+        .with_context(|| messages.error_openbao_seal_status_failed())?;
+    if final_status.sealed {
+        anyhow::bail!(messages.error_openbao_sealed());
+    }
+    Ok(())
 }
 
 /// Returns the `OpenBao` exposed compose override path when a

--- a/src/commands/init/steps/http01_admin_tls.rs
+++ b/src/commands/init/steps/http01_admin_tls.rs
@@ -45,10 +45,8 @@ pub(in crate::commands::init) fn issue_http01_admin_tls_cert(
         .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
     let user_arg = format!("{}:{}", meta.uid(), meta.gid());
 
-    let san_arg = sans.join(",");
-
     let intermediate_cert = format!("/home/step/{CA_CERTS_DIR}/{CA_INTERMEDIATE_CERT_FILENAME}");
-    let args: Vec<&str> = vec![
+    let mut args: Vec<&str> = vec![
         "run",
         "--user",
         &user_arg,
@@ -72,12 +70,21 @@ pub(in crate::commands::init) fn issue_http01_admin_tls_cert(
         "/home/step/password.txt",
         "--no-password",
         "--insecure",
-        "--san",
-        &san_arg,
+    ];
+    // `step certificate create --san` accepts a single value per flag
+    // and must be repeated per SAN; comma-joining yields one literal
+    // SAN whose DnsName is the joined string (failing hostname
+    // verification for every individual name).  step infers DNS vs IP
+    // from the value shape.
+    for san in sans {
+        args.push("--san");
+        args.push(san);
+    }
+    args.extend([
         "--not-after",
         HTTP01_ADMIN_TLS_DEFAULT_NOT_AFTER,
         "--force",
-    ];
+    ]);
 
     run_docker(
         &args,

--- a/src/commands/init/steps/http01_admin_tls.rs
+++ b/src/commands/init/steps/http01_admin_tls.rs
@@ -80,11 +80,7 @@ pub(in crate::commands::init) fn issue_http01_admin_tls_cert(
         args.push("--san");
         args.push(san);
     }
-    args.extend([
-        "--not-after",
-        HTTP01_ADMIN_TLS_DEFAULT_NOT_AFTER,
-        "--force",
-    ]);
+    args.extend(["--not-after", HTTP01_ADMIN_TLS_DEFAULT_NOT_AFTER, "--force"]);
 
     run_docker(
         &args,

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -758,6 +758,17 @@ pub(super) fn apply_openbao_agent_compose_override(
 ) -> Result<()> {
     let compose_str = compose_file.to_string_lossy();
     let override_str = override_path.to_string_lossy();
+    // `--no-deps` is load-bearing: the agent override does not include
+    // the `openbao-exposed` compose file, so without it `compose up`
+    // would re-evaluate the openbao dependency against `-f main -f
+    // agent` (no host-port publish) versus the running container's
+    // `-f main -f openbao-exposed` config (non-loopback publish) and
+    // recreate openbao to the merged config, dropping its non-loopback
+    // bind.  Subsequent KV calls against the bind URL then fail with
+    // `Connection refused`.  Reinit's second init pass is the canonical
+    // trip: infra-up starts openbao with the preserved exposed
+    // override, and the agent compose-up here recreates it back to
+    // loopback unless we tell compose to ignore the dependency.
     let args = [
         "compose",
         "-f",
@@ -766,6 +777,7 @@ pub(super) fn apply_openbao_agent_compose_override(
         &*override_str,
         "up",
         "-d",
+        "--no-deps",
         OPENBAO_AGENT_STEPCA_SERVICE,
         OPENBAO_AGENT_RESPONDER_SERVICE,
     ];

--- a/src/commands/init/steps/openbao_tls.rs
+++ b/src/commands/init/steps/openbao_tls.rs
@@ -104,6 +104,11 @@ pub(in crate::commands::init) fn write_openbao_hcl_with_tls(
     messages: &Messages,
 ) -> Result<()> {
     let hcl_path = compose_dir.join(OPENBAO_HCL_PATH);
+    // The `audit` stanza must match the canonical openbao/openbao.hcl shipped
+    // with the repo. OpenBao >= 2.5 requires audit devices to be declared in
+    // the server configuration rather than enabled via the API, and `init`
+    // verifies that a file audit backend is present (see
+    // `OpenBaoClient::verify_audit_file`).
     let content = format!(
         r#"storage "file" {{
   path = "/openbao/file"
@@ -130,6 +135,14 @@ listener "tcp" {{
 telemetry {{
   prometheus_retention_time = "30s"
   disable_hostname = true
+}}
+
+audit {{
+  type = "file"
+  path = "file"
+  options {{
+    file_path = "/openbao/audit/audit.log"
+  }}
 }}
 
 disable_mlock = true
@@ -236,6 +249,11 @@ pub(crate) fn write_openbao_hcl_plaintext(compose_dir: &Path, messages: &Message
     if !hcl_path.exists() {
         return Ok(());
     }
+    // The `audit` stanza must match the canonical openbao/openbao.hcl shipped
+    // with the repo. OpenBao >= 2.5 requires audit devices to be declared in
+    // the server configuration rather than enabled via the API, and `init`
+    // verifies that a file audit backend is present (see
+    // `OpenBaoClient::verify_audit_file`).
     let content = r#"storage "file" {
   path = "/openbao/file"
 }
@@ -260,6 +278,14 @@ listener "tcp" {
 telemetry {
   prometheus_retention_time = "30s"
   disable_hostname = true
+}
+
+audit {
+  type = "file"
+  path = "file"
+  options {
+    file_path = "/openbao/audit/audit.log"
+  }
 }
 
 disable_mlock = true
@@ -430,6 +456,10 @@ mod tests {
         assert!(!api_block.contains("tls_disable"));
         // Telemetry listener should still have tls_disable.
         assert!(content.contains("tls_disable = 1"));
+        // File audit backend must be declared so init's
+        // `verify_audit_file` succeeds after the TLS rewrite.
+        assert!(content.contains("audit {"));
+        assert!(content.contains("file_path = \"/openbao/audit/audit.log\""));
     }
 
     #[test]
@@ -453,6 +483,10 @@ mod tests {
             tls_disable_count, 2,
             "both listeners must have tls_disable = 1"
         );
+        // Plaintext rewrite must preserve the file audit backend so init
+        // can run after a subsequent `--openbao-bind` reinstall cycle.
+        assert!(content.contains("audit {"));
+        assert!(content.contains("file_path = \"/openbao/audit/audit.log\""));
     }
 
     #[test]

--- a/src/commands/init/steps/openbao_tls.rs
+++ b/src/commands/init/steps/openbao_tls.rs
@@ -16,9 +16,11 @@ use crate::state::{InfraCertEntry, ReloadStrategy, StateFile};
 /// Issues an `OpenBao` TLS server certificate signed by the local
 /// step-ca intermediate CA.
 ///
-/// Writes the certificate to `compose_dir/openbao/tls/server.{crt,key}`
-/// with `0600` permissions.  `step certificate create` runs via Docker
-/// (no step CLI required on the host).
+/// Writes the certificate to `compose_dir/openbao/tls/server.{crt,key}`.
+/// `step certificate create` runs via Docker (no step CLI required on
+/// the host).  After provisioning, the files are set to `0644` so the
+/// `OpenBao` container's `openbao` user can read them (see
+/// `set_openbao_readable_permissions` for the rationale).
 pub(in crate::commands::init) fn issue_openbao_tls_cert(
     compose_dir: &Path,
     secrets_dir: &Path,
@@ -84,13 +86,38 @@ pub(in crate::commands::init) fn issue_openbao_tls_cert(
     )
     .with_context(|| messages.error_openbao_tls_provision_failed())?;
 
-    set_key_permissions_sync(&key_path)?;
-    set_key_permissions_sync(&cert_path)?;
+    set_openbao_readable_permissions(&cert_path, &key_path)?;
 
     println!(
         "{}",
         messages.info_openbao_tls_provisioned(&cert_path.display().to_string())
     );
+    Ok(())
+}
+
+/// Sets cert + key to modes the `OpenBao` container can read.
+///
+/// `docker-compose.yml` mounts `./openbao` as `:ro`, so the `OpenBao`
+/// image's standard entrypoint cannot chown its config dir to the
+/// `openbao` user — the chown silently fails and the container then
+/// fails to load the TLS material with `permission denied`.  The
+/// `step` CLI writes the cert and key as the runner UID with mode
+/// `0600`, which the `openbao` user inside the container can not
+/// read.
+///
+/// Loosen the modes so the openbao user can read the files via the
+/// "other" permission bits.  The cert is public (`0644`).  The key
+/// is set to `0644` too because the openbao user is in neither the
+/// runner's primary group nor any shared group, so `0640` would not
+/// help.  The host is a single-tenant operator host (the only other
+/// reader is root, who can read anything anyway); the key never
+/// leaves this directory and is renewed on a 30-day cadence, so the
+/// expanded read scope is acceptable in this deployment model.
+fn set_openbao_readable_permissions(cert_path: &Path, key_path: &Path) -> Result<()> {
+    std::fs::set_permissions(cert_path, std::fs::Permissions::from_mode(0o644))
+        .with_context(|| format!("Failed to set permissions on {}", cert_path.display()))?;
+    std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o644))
+        .with_context(|| format!("Failed to set permissions on {}", key_path.display()))?;
     Ok(())
 }
 
@@ -297,11 +324,6 @@ ui = true
 
     println!("{}", messages.info_openbao_hcl_tls_reverted());
     Ok(())
-}
-
-fn set_key_permissions_sync(path: &Path) -> Result<()> {
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("Failed to set permissions on {}", path.display()))
 }
 
 /// Re-issues an existing `OpenBao` infrastructure certificate.

--- a/src/commands/init/steps/openbao_tls.rs
+++ b/src/commands/init/steps/openbao_tls.rs
@@ -45,10 +45,8 @@ pub(in crate::commands::init) fn issue_openbao_tls_cert(
         .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
     let user_arg = format!("{}:{}", meta.uid(), meta.gid());
 
-    let san_arg = sans.join(",");
-
     let intermediate_cert = format!("/home/step/{CA_CERTS_DIR}/{CA_INTERMEDIATE_CERT_FILENAME}");
-    let args: Vec<&str> = vec![
+    let mut args: Vec<&str> = vec![
         "run",
         "--user",
         &user_arg,
@@ -72,12 +70,18 @@ pub(in crate::commands::init) fn issue_openbao_tls_cert(
         "/home/step/password.txt",
         "--no-password",
         "--insecure",
-        "--san",
-        &san_arg,
-        "--not-after",
-        OPENBAO_TLS_DEFAULT_NOT_AFTER,
-        "--force",
     ];
+    // `step certificate create --san` accepts a single value and must
+    // be repeated per SAN; comma-joining yields one literal SAN whose
+    // DnsName is the joined string (e.g. "openbao.internal,localhost,
+    // bootroot-openbao,172.17.0.1"), which fails hostname verification
+    // for every individual name.  step also infers DNS vs IP from the
+    // value shape, so passing IP literals via --san produces IP SANs.
+    for san in sans {
+        args.push("--san");
+        args.push(san);
+    }
+    args.extend(["--not-after", OPENBAO_TLS_DEFAULT_NOT_AFTER, "--force"]);
 
     run_docker(
         &args,

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -544,6 +544,15 @@ async fn run_init_inner(
             let compose_str = args.compose.compose_file.to_string_lossy();
             let config_override_str = override_path.to_string_lossy();
             let exposed_override_str = exposed_override.to_string_lossy();
+            // `--no-deps` is load-bearing here for the same reason as
+            // `apply_responder_compose_override` and
+            // `apply_openbao_agent_compose_override`: this compose
+            // invocation does not include the `openbao-exposed`
+            // override, so without it compose would recreate the
+            // openbao dependency to the merged config and drop its
+            // non-loopback host-port publish.  Reinit-recovery's
+            // second init pass would then lose access to the bind URL
+            // mid-flow.
             let up_args = [
                 "compose",
                 "-f",
@@ -554,6 +563,7 @@ async fn run_init_inner(
                 &*exposed_override_str,
                 "up",
                 "-d",
+                "--no-deps",
                 RESPONDER_SERVICE_NAME,
             ];
             run_docker(

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -89,11 +89,9 @@ pub(crate) async fn run_init(args: &InitArgs, messages: &Messages) -> Result<()>
     // Only check openbao + postgres; step-ca may not be bootstrapped yet.
     ensure_init_prereqs_ready(&args.compose.compose_file, messages)?;
 
-    let mut client = OpenBaoClient::with_local_trust(
-        &args.openbao.openbao_url,
-        &args.secrets_dir.secrets_dir,
-    )
-    .with_context(|| messages.error_openbao_client_create_failed())?;
+    let mut client =
+        OpenBaoClient::with_local_trust(&args.openbao.openbao_url, &args.secrets_dir.secrets_dir)
+            .with_context(|| messages.error_openbao_client_create_failed())?;
     client
         .health_check()
         .await

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -89,8 +89,11 @@ pub(crate) async fn run_init(args: &InitArgs, messages: &Messages) -> Result<()>
     // Only check openbao + postgres; step-ca may not be bootstrapped yet.
     ensure_init_prereqs_ready(&args.compose.compose_file, messages)?;
 
-    let mut client = OpenBaoClient::new(&args.openbao.openbao_url)
-        .with_context(|| messages.error_openbao_client_create_failed())?;
+    let mut client = OpenBaoClient::with_local_trust(
+        &args.openbao.openbao_url,
+        &args.secrets_dir.secrets_dir,
+    )
+    .with_context(|| messages.error_openbao_client_create_failed())?;
     client
         .health_check()
         .await

--- a/src/commands/init/steps/responder_setup.rs
+++ b/src/commands/init/steps/responder_setup.rs
@@ -165,6 +165,13 @@ pub(super) fn apply_responder_compose_override(
 ) -> Result<()> {
     let compose_str = compose_file.to_string_lossy();
     let override_str = override_path.to_string_lossy();
+    // `--no-deps` mirrors `apply_openbao_agent_compose_override`: the
+    // responder override does not include the `openbao-exposed`
+    // compose file, so without it `compose up` would recreate openbao
+    // to the (override-less) merged config and drop the non-loopback
+    // host-port publish.  Subsequent KV calls against the bind URL
+    // would then fail with `Connection refused`.  See the comment on
+    // that helper for the reinit-recovery scenario that exercises this.
     let args = [
         "compose",
         "-f",
@@ -173,6 +180,7 @@ pub(super) fn apply_responder_compose_override(
         &*override_str,
         "up",
         "-d",
+        "--no-deps",
         RESPONDER_SERVICE_NAME,
     ];
     run_docker(&args, "docker compose responder override", messages)?;

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -178,7 +178,7 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
         openbao_url: args.openbao.openbao_url.clone(),
         openbao_unseal_from_file: None,
     };
-    run_infra_up(&infra_args, messages)?;
+    run_infra_up(&infra_args, messages).await?;
 
     // 12. Re-run init in reinit mode.  Reinit-mode behavior is enforced
     //     inside the init flow: overwrite prompts for preserved files

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -163,7 +163,7 @@ pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result
     }
 
     let runtime_auth = resolve_runtime_auth(&args.runtime_auth, true, messages)?;
-    let mut client = OpenBaoClient::new(&ctx.openbao_url)
+    let mut client = OpenBaoClient::with_local_trust(&ctx.openbao_url, ctx.paths.secrets_dir())
         .with_context(|| messages.error_openbao_client_create_failed())?;
     authenticate_openbao_client(&mut client, &runtime_auth, messages).await?;
     client

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -186,8 +186,11 @@ async fn run_service_add_preview(
         return;
     };
     {
-        let mut client = match OpenBaoClient::new(&state.openbao_url)
-            .with_context(|| messages.error_openbao_client_create_failed())
+        let mut client = match OpenBaoClient::with_local_trust(
+            &state.openbao_url,
+            state.secrets_dir(),
+        )
+        .with_context(|| messages.error_openbao_client_create_failed())
         {
             Ok(client) => client,
             Err(err) => {
@@ -261,7 +264,7 @@ async fn run_service_add_apply(
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("OpenBao auth is required"))?;
 
-    let mut client = OpenBaoClient::new(&state.openbao_url)
+    let mut client = OpenBaoClient::with_local_trust(&state.openbao_url, state.secrets_dir())
         .with_context(|| messages.error_openbao_client_create_failed())?;
     authenticate_openbao_client(&mut client, auth, messages).await?;
 
@@ -471,7 +474,7 @@ async fn run_service_add_remote_idempotent(
     messages: &Messages,
 ) -> Result<()> {
     let secrets_dir = state.secrets_dir();
-    let mut client = OpenBaoClient::new(&state.openbao_url)
+    let mut client = OpenBaoClient::with_local_trust(&state.openbao_url, secrets_dir)
         .with_context(|| messages.error_openbao_client_create_failed())?;
     let auth = resolved
         .runtime_auth

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -186,33 +186,32 @@ async fn run_service_add_preview(
         return;
     };
     {
-        let mut client = match OpenBaoClient::with_local_trust(
-            &state.openbao_url,
-            state.secrets_dir(),
-        )
-        .with_context(|| messages.error_openbao_client_create_failed())
-        {
-            Ok(client) => client,
-            Err(err) => {
-                note.push('\n');
-                note.push_str(
-                    &messages.service_summary_preview_trust_lookup_failed(err.to_string().as_str()),
-                );
-                print_service_add_summary(
-                    &preview_entry,
-                    &preview_secret_id_path,
-                    ServiceAddSummaryOptions {
-                        applied: None,
-                        remote: None,
-                        trusted_ca_sha256: None,
-                        show_snippets: true,
-                        note: Some(note),
-                    },
-                    messages,
-                );
-                return;
-            }
-        };
+        let mut client =
+            match OpenBaoClient::with_local_trust(&state.openbao_url, state.secrets_dir())
+                .with_context(|| messages.error_openbao_client_create_failed())
+            {
+                Ok(client) => client,
+                Err(err) => {
+                    note.push('\n');
+                    note.push_str(
+                        &messages
+                            .service_summary_preview_trust_lookup_failed(err.to_string().as_str()),
+                    );
+                    print_service_add_summary(
+                        &preview_entry,
+                        &preview_secret_id_path,
+                        ServiceAddSummaryOptions {
+                            applied: None,
+                            remote: None,
+                            trusted_ca_sha256: None,
+                            show_snippets: true,
+                            note: Some(note),
+                        },
+                        messages,
+                    );
+                    return;
+                }
+            };
         match authenticate_openbao_client(&mut client, auth, messages).await {
             Ok(()) => {
                 match secrets::read_ca_trust_material(&client, &state.kv_mount, messages).await {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -16,8 +16,20 @@ pub(crate) async fn run_status(args: &StatusArgs, messages: &Messages) -> Result
     let readiness = collect_readiness(&args.compose.compose_file, None, &services, messages)?;
     let infra_failures = collect_container_failures(&readiness);
 
-    let mut client = OpenBaoClient::new(&args.openbao.openbao_url)
-        .with_context(|| messages.error_openbao_client_create_failed())?;
+    let state_path = StateFile::default_path();
+    let state = if state_path.exists() {
+        Some(StateFile::load(&state_path).with_context(|| messages.error_parse_state_failed())?)
+    } else {
+        None
+    };
+    let mut client = match state.as_ref().map(StateFile::secrets_dir) {
+        Some(secrets_dir) => {
+            OpenBaoClient::with_local_trust(&args.openbao.openbao_url, secrets_dir)
+                .with_context(|| messages.error_openbao_client_create_failed())?
+        }
+        None => OpenBaoClient::new(&args.openbao.openbao_url)
+            .with_context(|| messages.error_openbao_client_create_failed())?,
+    };
     let openbao_health = client
         .health_check()
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,10 @@ where
 fn run(cli: Cli, messages: &Messages) -> Result<()> {
     match cli.command {
         CliCommand::Infra(InfraCommand::Up(args)) => {
-            commands::infra::run_infra_up(&args, messages)
-                .with_context(|| messages.error_infra_failed())?;
+            with_runtime("infra up", messages, |rt| {
+                rt.block_on(commands::infra::run_infra_up(&args, messages))
+            })?
+            .with_context(|| messages.error_infra_failed())?;
         }
         CliCommand::Infra(InfraCommand::Install(args)) => {
             commands::infra::run_infra_install(&args, messages)

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -227,6 +227,43 @@ impl OpenBaoClient {
         })
     }
 
+    /// Creates a client that auto-anchors TLS verification to the step-ca
+    /// root bundle at `<secrets_dir>/certs/root_ca.crt` when `base_url` is
+    /// HTTPS and the bundle exists.
+    ///
+    /// Used by CLI commands that load the URL from `state.json`: after
+    /// `init` switches `OpenBao` to TLS the URL becomes `https://...` but
+    /// the server cert is signed by step-ca's private root, which is not
+    /// in the webpki-roots store the default `Client` ships with.  Without
+    /// this anchor every post-init operator command (service add, status,
+    /// rotate, the second `init` pass during reinit) would fail the TLS
+    /// handshake with `UnknownIssuer`.
+    ///
+    /// Falls back to [`Self::new`] when `base_url` is HTTP or when the
+    /// bundle file does not exist — keeping the legacy plaintext-loopback
+    /// path and any externally-managed (publicly-trusted) HTTPS endpoint
+    /// working unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bundle exists but cannot be read or parsed,
+    /// or if the HTTP client fails to build.
+    pub fn with_local_trust(base_url: &str, secrets_dir: &std::path::Path) -> Result<Self> {
+        if base_url.starts_with("https://") {
+            let ca_path = secrets_dir.join("certs").join("root_ca.crt");
+            if ca_path.exists() {
+                let ca_pem = std::fs::read_to_string(&ca_path).with_context(|| {
+                    format!(
+                        "Failed to read OpenBao trust bundle at {}",
+                        ca_path.display()
+                    )
+                })?;
+                return Self::with_pem_trust(base_url, &ca_pem, &[]);
+            }
+        }
+        Self::new(base_url)
+    }
+
     /// Creates a new `OpenBao` client with a pre-configured
     /// [`reqwest::Client`].
     #[must_use]
@@ -1595,5 +1632,54 @@ mod tls_integration_tests {
             .health_check()
             .await
             .expect_err("health check should fail with wrong CA");
+    }
+
+    /// Proves `with_local_trust` reads the step-ca root bundle from
+    /// `<secrets_dir>/certs/root_ca.crt` so HTTPS verification succeeds
+    /// against a server cert signed by that same CA — the path post-init
+    /// `service add` and reinit's second `init` pass take when `openbao_url`
+    /// is `https://...`.
+    #[tokio::test]
+    async fn with_local_trust_loads_step_ca_bundle_for_https() {
+        let ca = TestCa::generate();
+        let server_cert = ca.sign_server_cert();
+        let port = start_tls_server(server_cert).await;
+
+        let secrets_dir = tempfile::tempdir().expect("tempdir");
+        let certs_dir = secrets_dir.path().join("certs");
+        std::fs::create_dir_all(&certs_dir).expect("create certs dir");
+        std::fs::write(certs_dir.join("root_ca.crt"), ca.pem()).expect("write root_ca.crt");
+
+        let client = OpenBaoClient::with_local_trust(
+            &format!("https://localhost:{port}"),
+            secrets_dir.path(),
+        )
+        .expect("client with local trust");
+
+        client
+            .health_check()
+            .await
+            .expect("health check should pass with step-ca root from secrets_dir");
+    }
+
+    /// Proves the helper degrades gracefully when no bundle exists: the
+    /// HTTP path (loopback before TLS is enabled) and the externally-
+    /// trusted HTTPS path keep using the default client.
+    #[tokio::test]
+    async fn with_local_trust_falls_back_to_default_when_bundle_missing() {
+        let secrets_dir = tempfile::tempdir().expect("tempdir");
+
+        // HTTP URL: always uses the default client.
+        let plain = OpenBaoClient::with_local_trust("http://127.0.0.1:1", secrets_dir.path())
+            .expect("http client");
+        assert_eq!(plain.base_url, "http://127.0.0.1:1");
+
+        // HTTPS URL with no bundle: still constructs (system roots), so
+        // an externally-trusted endpoint keeps working.  We don't drive a
+        // request here — just prove construction succeeds.
+        let external =
+            OpenBaoClient::with_local_trust("https://example.invalid", secrets_dir.path())
+                .expect("https client with no bundle still constructs");
+        assert_eq!(external.base_url, "https://example.invalid");
     }
 }

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -227,9 +227,10 @@ impl OpenBaoClient {
         })
     }
 
-    /// Creates a client that auto-anchors TLS verification to the step-ca
-    /// trust bundle at `<secrets_dir>/certs/{root_ca.crt,intermediate_ca.crt}`
-    /// when `base_url` is HTTPS and the root bundle exists.
+    /// Creates a client that augments the default Mozilla webpki trust
+    /// roots with the step-ca trust bundle at
+    /// `<secrets_dir>/certs/{root_ca.crt,intermediate_ca.crt}` when
+    /// `base_url` is HTTPS and the root bundle exists.
     ///
     /// Used by CLI commands that load the URL from `state.json`: after
     /// `init` switches `OpenBao` to TLS the URL becomes `https://...` but
@@ -238,6 +239,14 @@ impl OpenBaoClient {
     /// this anchor every post-init operator command (service add, status,
     /// rotate, the second `init` pass during reinit) would fail the TLS
     /// handshake with `UnknownIssuer`.
+    ///
+    /// The local PEM is *appended* to the webpki root store rather than
+    /// replacing it, so an externally-managed (publicly-trusted) HTTPS
+    /// `OpenBao` URL keeps verifying against the public CA even after
+    /// `init` has populated `<secrets_dir>/certs/`.  An earlier revision
+    /// of this constructor swapped the trust store to PEM-only and
+    /// regressed that path into `UnknownIssuer` once `root_ca.crt`
+    /// existed.
     ///
     /// The `OpenBao` TLS server cert is issued by `step certificate create`
     /// against the step-ca intermediate and written as a single leaf cert
@@ -282,7 +291,12 @@ impl OpenBaoClient {
                     }
                     ca_pem.push_str(&intermediate_pem);
                 }
-                return Self::with_pem_trust(base_url, &ca_pem, &[]);
+                let client = crate::tls::build_http_client_with_local_and_webpki_roots(&ca_pem)?;
+                return Ok(Self {
+                    base_url: base_url.trim_end_matches('/').to_string(),
+                    client,
+                    token: None,
+                });
             }
         }
         Self::new(base_url)

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -228,8 +228,8 @@ impl OpenBaoClient {
     }
 
     /// Creates a client that auto-anchors TLS verification to the step-ca
-    /// root bundle at `<secrets_dir>/certs/root_ca.crt` when `base_url` is
-    /// HTTPS and the bundle exists.
+    /// trust bundle at `<secrets_dir>/certs/{root_ca.crt,intermediate_ca.crt}`
+    /// when `base_url` is HTTPS and the root bundle exists.
     ///
     /// Used by CLI commands that load the URL from `state.json`: after
     /// `init` switches `OpenBao` to TLS the URL becomes `https://...` but
@@ -239,25 +239,49 @@ impl OpenBaoClient {
     /// rotate, the second `init` pass during reinit) would fail the TLS
     /// handshake with `UnknownIssuer`.
     ///
+    /// The `OpenBao` TLS server cert is issued by `step certificate create`
+    /// against the step-ca intermediate and written as a single leaf cert
+    /// (no chain).  The server therefore presents only the leaf during
+    /// the handshake, so the client trust store must accept the
+    /// intermediate as a trust anchor directly — anchoring on the root
+    /// alone would leave rustls unable to bridge leaf → intermediate →
+    /// root.  Include the intermediate when it exists so the same client
+    /// works against both leaf-only and full-chain server certs.
+    ///
     /// Falls back to [`Self::new`] when `base_url` is HTTP or when the
-    /// bundle file does not exist — keeping the legacy plaintext-loopback
+    /// root bundle does not exist — keeping the legacy plaintext-loopback
     /// path and any externally-managed (publicly-trusted) HTTPS endpoint
     /// working unchanged.
     ///
     /// # Errors
     ///
-    /// Returns an error if the bundle exists but cannot be read or parsed,
-    /// or if the HTTP client fails to build.
+    /// Returns an error if a bundle file exists but cannot be read or
+    /// parsed, or if the HTTP client fails to build.
     pub fn with_local_trust(base_url: &str, secrets_dir: &std::path::Path) -> Result<Self> {
         if base_url.starts_with("https://") {
-            let ca_path = secrets_dir.join("certs").join("root_ca.crt");
-            if ca_path.exists() {
-                let ca_pem = std::fs::read_to_string(&ca_path).with_context(|| {
+            let certs_dir = secrets_dir.join("certs");
+            let root_path = certs_dir.join("root_ca.crt");
+            if root_path.exists() {
+                let mut ca_pem = std::fs::read_to_string(&root_path).with_context(|| {
                     format!(
                         "Failed to read OpenBao trust bundle at {}",
-                        ca_path.display()
+                        root_path.display()
                     )
                 })?;
+                let intermediate_path = certs_dir.join("intermediate_ca.crt");
+                if intermediate_path.exists() {
+                    let intermediate_pem = std::fs::read_to_string(&intermediate_path)
+                        .with_context(|| {
+                            format!(
+                                "Failed to read OpenBao trust bundle at {}",
+                                intermediate_path.display()
+                            )
+                        })?;
+                    if !ca_pem.ends_with('\n') {
+                        ca_pem.push('\n');
+                    }
+                    ca_pem.push_str(&intermediate_pem);
+                }
                 return Self::with_pem_trust(base_url, &ca_pem, &[]);
             }
         }
@@ -1551,6 +1575,51 @@ mod tls_integration_tests {
                 key_der: key.serialize_der(),
             }
         }
+
+        fn sign_intermediate(&self, common_name: &str) -> TestIntermediate {
+            let key = KeyPair::generate().expect("generate intermediate key");
+            let mut params = CertificateParams::new(Vec::new()).expect("cert params");
+            params
+                .distinguished_name
+                .push(DnType::CommonName, common_name);
+            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+            let cert = params
+                .signed_by(&key, &self.issuer)
+                .expect("signed intermediate cert");
+            let issuer = Issuer::new(params, key);
+            TestIntermediate { cert, issuer }
+        }
+    }
+
+    /// CA-issued intermediate used to simulate the step-ca topology:
+    /// the `OpenBao` server cert is signed by this intermediate, not
+    /// directly by the root.
+    struct TestIntermediate {
+        cert: rcgen::Certificate,
+        issuer: Issuer<'static, KeyPair>,
+    }
+
+    impl TestIntermediate {
+        fn pem(&self) -> String {
+            self.cert.pem()
+        }
+
+        fn sign_server_cert(&self) -> ServerCert {
+            let key = KeyPair::generate().expect("generate server key");
+            let mut params =
+                CertificateParams::new(vec!["localhost".to_string()]).expect("cert params");
+            params
+                .distinguished_name
+                .push(DnType::CommonName, "localhost");
+            params.is_ca = IsCa::NoCa;
+            let cert = params
+                .signed_by(&key, &self.issuer)
+                .expect("signed server cert");
+            ServerCert {
+                cert_der: cert.der().to_vec(),
+                key_der: key.serialize_der(),
+            }
+        }
     }
 
     struct ServerCert {
@@ -1660,6 +1729,38 @@ mod tls_integration_tests {
             .health_check()
             .await
             .expect("health check should pass with step-ca root from secrets_dir");
+    }
+
+    /// Proves `with_local_trust` also picks up `intermediate_ca.crt` so
+    /// a leaf-only server cert (the form `step certificate create` writes
+    /// for `OpenBao`'s TLS) verifies against a trust store that anchors on
+    /// the step-ca intermediate.  Anchoring on the root alone would leave
+    /// rustls unable to bridge leaf → intermediate when the server does
+    /// not present a chain.
+    #[tokio::test]
+    async fn with_local_trust_accepts_leaf_signed_by_intermediate_with_leaf_only_server() {
+        let root = TestCa::generate();
+        let intermediate = root.sign_intermediate("Test Intermediate");
+        let server_cert = intermediate.sign_server_cert();
+        let port = start_tls_server(server_cert).await;
+
+        let secrets_dir = tempfile::tempdir().expect("tempdir");
+        let certs_dir = secrets_dir.path().join("certs");
+        std::fs::create_dir_all(&certs_dir).expect("create certs dir");
+        std::fs::write(certs_dir.join("root_ca.crt"), root.pem()).expect("write root_ca.crt");
+        std::fs::write(certs_dir.join("intermediate_ca.crt"), intermediate.pem())
+            .expect("write intermediate_ca.crt");
+
+        let client = OpenBaoClient::with_local_trust(
+            &format!("https://localhost:{port}"),
+            secrets_dir.path(),
+        )
+        .expect("client with local trust");
+
+        client
+            .health_check()
+            .await
+            .expect("health check should pass when intermediate is in the trust store");
     }
 
     /// Proves the helper degrades gracefully when no bundle exists: the

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -131,11 +131,68 @@ pub fn build_client_config_from_pem(pem_content: &str, pins: &[String]) -> Resul
     }
 }
 
+/// Builds a [`reqwest::Client`] whose trust store is the union of the
+/// Mozilla webpki root certificates (the same set the default `Client`
+/// ships with) and the given PEM-encoded CA bundle.
+///
+/// This is the trust path the CLI uses for state-backed `OpenBao`
+/// connections after `init` has written a step-ca bundle to
+/// `<secrets_dir>/certs/`: the local step-ca-signed `OpenBao` cert
+/// verifies via the appended PEM, while an externally-managed
+/// (publicly-trusted) HTTPS endpoint reachable from the same code path
+/// keeps verifying via the webpki roots.  Replacing the default trust
+/// store with the local PEM alone — as the original `with_pem_trust`
+/// path did — would regress any public-CA HTTPS `OpenBao` URL into an
+/// `UnknownIssuer` failure once `root_ca.crt` exists on disk.
+///
+/// # Errors
+///
+/// Returns an error if the PEM content cannot be parsed or the HTTP
+/// client fails to build.
+pub fn build_http_client_with_local_and_webpki_roots(pem_content: &str) -> Result<Client> {
+    install_crypto_provider();
+    let root_store = build_local_plus_webpki_root_store(pem_content)?;
+    let config = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    Client::builder()
+        .use_preconfigured_tls(config)
+        .build()
+        .context("Failed to build HTTP client with local+webpki roots")
+}
+
 fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-fn parse_pem_to_root_store(pem_bytes: &[u8]) -> Result<rustls::RootCertStore> {
+/// Builds a [`rustls::RootCertStore`] containing every Mozilla webpki
+/// root plus every certificate parsed from `pem_content`.
+///
+/// Factored out so the union semantics can be asserted in unit tests
+/// without driving a real public-CA TLS handshake.
+///
+/// # Errors
+///
+/// Returns an error if the PEM content cannot be parsed.
+pub(crate) fn build_local_plus_webpki_root_store(
+    pem_content: &str,
+) -> Result<rustls::RootCertStore> {
+    let mut root_store = rustls::RootCertStore::empty();
+    let (loaded, _) =
+        root_store.add_parsable_certificates(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned());
+    if loaded == 0 {
+        anyhow::bail!("webpki root certificate bundle was empty");
+    }
+    let local_certs = parse_pem_to_cert_list(pem_content.as_bytes())?;
+    for cert in local_certs {
+        root_store
+            .add(cert)
+            .context("Failed to add local CA certificate")?;
+    }
+    Ok(root_store)
+}
+
+fn parse_pem_to_cert_list(pem_bytes: &[u8]) -> Result<Vec<CertificateDer<'static>>> {
     let mut remaining = pem_bytes;
     let mut certs = Vec::new();
     while !remaining.is_empty() {
@@ -145,17 +202,22 @@ fn parse_pem_to_root_store(pem_bytes: &[u8]) -> Result<rustls::RootCertStore> {
         let (rest, pem) =
             parse_x509_pem(remaining).map_err(|_| anyhow::anyhow!("Failed to parse CA bundle"))?;
         if pem.label == "CERTIFICATE" {
-            certs.push(pem.contents);
+            certs.push(CertificateDer::from(pem.contents));
         }
         remaining = rest;
     }
     if certs.is_empty() {
         anyhow::bail!("CA bundle contained no certificates");
     }
+    Ok(certs)
+}
+
+fn parse_pem_to_root_store(pem_bytes: &[u8]) -> Result<rustls::RootCertStore> {
+    let certs = parse_pem_to_cert_list(pem_bytes)?;
     let mut root_store = rustls::RootCertStore::empty();
     for cert in certs {
         root_store
-            .add(CertificateDer::from(cert))
+            .add(cert)
             .context("Failed to add CA certificate")?;
     }
     Ok(root_store)
@@ -594,5 +656,41 @@ mod tests {
         let pin = "aa".repeat(32);
         let client = build_http_client_from_pem(&pem, &[pin]);
         assert!(client.is_ok());
+    }
+
+    /// Proves the local-plus-webpki root store keeps every Mozilla
+    /// webpki trust anchor in place and adds the supplied local PEM on
+    /// top.  The regression we are guarding against: the original
+    /// `with_local_trust` path called into `with_pem_trust`, which
+    /// replaced the trust store with the local PEM alone — so any
+    /// externally-managed (publicly-trusted) HTTPS `OpenBao` URL
+    /// started failing with `UnknownIssuer` once `root_ca.crt` existed
+    /// on disk.
+    #[test]
+    fn build_local_plus_webpki_root_store_unions_webpki_and_local_pem() {
+        let pem = generate_ca_pem();
+        let store = build_local_plus_webpki_root_store(&pem).expect("union store");
+        let webpki_count = webpki_root_certs::TLS_SERVER_ROOT_CERTS.len();
+        assert_eq!(
+            store.len(),
+            webpki_count + 1,
+            "expected webpki ({webpki_count}) + 1 local CA, got {}",
+            store.len()
+        );
+    }
+
+    #[test]
+    fn build_local_plus_webpki_root_store_rejects_empty_pem() {
+        let err = build_local_plus_webpki_root_store("").expect_err("empty PEM");
+        assert!(
+            err.to_string().contains("no certificates"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn build_http_client_with_local_and_webpki_roots_succeeds_with_valid_pem() {
+        let pem = generate_ca_pem();
+        assert!(build_http_client_with_local_and_webpki_roots(&pem).is_ok());
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -178,8 +178,8 @@ pub(crate) fn build_local_plus_webpki_root_store(
     pem_content: &str,
 ) -> Result<rustls::RootCertStore> {
     let mut root_store = rustls::RootCertStore::empty();
-    let (loaded, _) =
-        root_store.add_parsable_certificates(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned());
+    let (loaded, _) = root_store
+        .add_parsable_certificates(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned());
     if loaded == 0 {
         anyhow::bail!("webpki root certificate bundle was empty");
     }

--- a/tests/docker_e2e_reinit_recovery.rs
+++ b/tests/docker_e2e_reinit_recovery.rs
@@ -1,0 +1,82 @@
+#[cfg(unix)]
+mod support;
+
+#[cfg(unix)]
+mod unix_integration {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use anyhow::{Context, Result};
+
+    /// Docker-backed E2E coverage for `bootroot reinit` recovery,
+    /// per the §"Acceptance criteria" of issue #600.  Drives the
+    /// harness through all three #598-derived failure modes and
+    /// asserts the recovery contracts (fingerprint preservation,
+    /// `password.txt` preservation, non-loopback bind survival,
+    /// empty service registry) after each scenario.  Marked
+    /// `#[ignore]` so `cargo test` stays fast; CI invokes the
+    /// script directly via `scripts/preflight/ci/e2e-matrix.sh`
+    /// (and the corresponding workflow job).
+    #[test]
+    #[ignore = "Requires local Docker for reinit recovery validation"]
+    fn docker_reinit_recovery_matrix() -> Result<()> {
+        let scenario_id = super::support::docker_harness::unique_scenario_id("reinit-recovery");
+        let artifact_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tmp")
+            .join("e2e")
+            .join(format!("docker-reinit-recovery-{scenario_id}"));
+
+        let output = Command::new("bash")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .arg(super::support::docker_harness::reinit_recovery_script_path())
+            .env("ARTIFACT_DIR", &artifact_dir)
+            .env(
+                "COMPOSE_PROJECT_NAME",
+                format!("bootroot-e2e-reinit-{scenario_id}"),
+            )
+            .env("BOOTROOT_BIN", env!("CARGO_BIN_EXE_bootroot"))
+            .output()
+            .with_context(|| "Failed to run reinit recovery script")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("reinit recovery script failed: {stderr}");
+        }
+
+        let phase_log = artifact_dir.join("phases.log");
+        assert!(phase_log.exists(), "phases.log should exist");
+        let phases = std::fs::read_to_string(&phase_log)
+            .with_context(|| "Failed to read reinit recovery phases log")?;
+
+        for required in [
+            "\"phase\":\"bootstrap-install\"",
+            "\"phase\":\"bootstrap-init\"",
+            "\"phase\":\"scenario-a-clean-openbao-only\"",
+            "\"phase\":\"reinit-scenario-a\"",
+            "\"phase\":\"scenario-b-no-root-token\"",
+            "\"phase\":\"reinit-scenario-b\"",
+            "\"phase\":\"scenario-c-rsync-clone\"",
+            "\"phase\":\"reinit-scenario-c\"",
+            "\"phase\":\"done\"",
+        ] {
+            assert!(
+                phases.contains(required),
+                "phases.log missing expected entry: {required}"
+            );
+        }
+
+        let snapshots = artifact_dir.join("snapshots");
+        for label in ["scenario-a", "scenario-b", "scenario-c"] {
+            assert!(snapshots.join(label).join("password.txt").exists());
+            assert!(snapshots.join(label).join("root_ca.fingerprint").exists());
+            assert!(
+                snapshots
+                    .join(label)
+                    .join("intermediate_ca.fingerprint")
+                    .exists()
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/tests/support/docker_harness.rs
+++ b/tests/support/docker_harness.rs
@@ -44,6 +44,13 @@ pub(crate) fn ca_key_rotation_recovery_script_path() -> PathBuf {
         .join("run-ca-key-rotation-recovery.sh")
 }
 
+pub(crate) fn reinit_recovery_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts")
+        .join("impl")
+        .join("run-reinit-recovery.sh")
+}
+
 pub(crate) fn baseline_scenario_path(file_name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")


### PR DESCRIPTION
## Summary

Follow-up to #598 / PR #599. PR #599 shipped the `bootroot reinit` command and its unit coverage; this PR adds the Docker-backed E2E recovery harness called out in #600's acceptance criteria.

The new `scripts/impl/run-reinit-recovery.sh` drives a real OpenBao + step-ca stack on Docker through all three #598-derived failure modes and asserts the recovery contracts. It is invoked from the Rust test wrapper (`tests/docker_e2e_reinit_recovery.rs`, `#[ignore]`d so `cargo test` stays fast) and wired into both the CI matrix and the extended suite.

### Scenarios exercised

- Scenario A — stuck state after `bootroot clean --openbao-only`.
- Scenario B — initialized-OpenBao-without-root-token (scenario 1 from #598).
- Scenario C — stale-local-state-only rsync-clone (scenario 2 from #598).

### Recovery contracts asserted after each scenario

- step-ca root and intermediate fingerprints unchanged before vs. after `reinit`.
- `secrets/password.txt` not overwritten by an auto-generated password.
- Non-loopback OpenBao bind survives: override file present, snapshotted intent persists in the rewritten `state.json`, post-`reinit` OpenBao listens on the same non-loopback address, and the second `init` pass reaches it via the rewritten client URL.
- Rewritten `state.json` ships with an intentionally empty service registry.
- `bootroot status --openbao-url https://<bind>` succeeds — proves the state-backed operator surface (status, rotate) now anchors rustls verification on the local step-ca bundle and stops failing the post-reinit TLS handshake with `UnknownIssuer`.

### CI wiring

- `.github/workflows/ci.yml` — added a `reinit-recovery` arm to the `test-docker-e2e-matrix` job that runs the new script with artifact capture on failure.
- `scripts/impl/run-extended-suite.sh` — registered a `case_reinit_recovery` case so `e2e-extended.yml` exercises the same path.
- `scripts/preflight/ci/e2e-matrix.sh` — local preflight now drives the recovery path alongside the existing rotation recovery run.
- `tests/support/docker_harness.rs` — added `reinit_recovery_script_path()` helper for the Rust test wrapper.

### Production bugs uncovered by the harness

1. `write_openbao_hcl_with_tls` and `write_openbao_hcl_plaintext` rewrote `openbao/openbao.hcl` without an `audit` stanza, dropping the file audit backend baked into the canonical config shipped in the repo. Any `init` run following an `infra install --openbao-bind` therefore failed at `verify_audit_file` with "no file audit backend found; add an audit stanza to openbao.hcl and restart the server". Both writers now emit the same audit stanza as `openbao/openbao.hcl`, and the unit tests for both functions assert it survives.

2. `issue_openbao_tls_cert` set the freshly issued server cert and key to mode `0600`. The OpenBao image's standard entrypoint cannot fix ownership because `docker-compose.yml` mounts `./openbao` as `:ro` — chown silently fails and the openbao user (a different UID, not in the runner's group) cannot read the files, so the recreated container died with `Error initializing listener of type tcp: error loading TLS cert: ... permission denied`. The cert is public anyway; loosen both files to `0644` since no shared group exists between the runner and openbao users (the security commentary in `set_openbao_readable_permissions` documents the deployment model that makes this acceptable).

3. `write_openbao_exposed_override` and `write_http01_exposed_override` emitted the new `ports:` list under a `!reset` YAML tag. Compose's `!reset` semantics discard the attribute entirely — the supplied list is dropped on the floor — so the recreated OpenBao container had no host-side publish at all and `service add` failed with `tcp connect error: Connection refused` against `https://172.17.0.1:8200`. The correct tag for replacing a value is `!override`; both writers now emit it. Verified against Compose v2 (`docker compose config` confirms the new port mapping survives the merge).

4. `OpenBaoClient::new()` built the CLI's HTTP client with only the webpki-roots Mozilla bundle, so once `init` flipped OpenBao to TLS the next operator call (`service add`, `status`, `rotate`, and reinit's second `init` pass via the orchestrator) failed the handshake with `invalid peer certificate: UnknownIssuer` against the step-ca-signed server cert. Added `OpenBaoClient::with_local_trust(url, secrets_dir)`, which augments the default Mozilla webpki trust store with `<secrets_dir>/certs/root_ca.crt` (and `<secrets_dir>/certs/intermediate_ca.crt` when present) when the URL is `https://...` and the bundle exists, and falls back to the default client for the HTTP loopback path and for HTTPS endpoints with no local bundle. The local PEM is *appended* to the webpki root store rather than replacing it, so an externally-managed (publicly-trusted) HTTPS `OpenBao` URL reachable through the same state-backed code path keeps verifying against the public CA even after `init` has populated `<secrets_dir>/certs/` — a regression the first cut of this constructor introduced by swapping the trust store to PEM-only. The intermediate is needed because `step certificate create` emits a single leaf signed by the intermediate and the server presents only the leaf, so rustls cannot bridge `leaf → intermediate → root` from the root alone. Wired into `service add`'s apply, preview, and remote-idempotent paths; into the init orchestrator; and into the state-backed `bootroot status` and `bootroot rotate` (every non-`infra-cert` subcommand) entrypoints. Covered by rustls-server-backed integration tests in `src/openbao.rs` that prove the root, leaf-only-server, and fallback branches; a unit test in `src/tls.rs` that asserts the assembled root store equals the webpki count + the local PEM count (guarding the public-CA-fallback regression); plus the reinit-recovery E2E that asserts `bootroot status` succeeds against `https://<bind>` after every scenario.

5. `issue_openbao_tls_cert` and `issue_http01_admin_tls_cert` joined the SAN list with commas and passed it under a single `--san` flag. `step certificate create --san` takes one value per flag and must be repeated, so the comma-joined string became a single literal DNS SAN whose name was the whole joined string. The reinit-recovery `service add` then failed against `https://172.17.0.1:8200` with `invalid peer certificate: certificate not valid for name "172.17.0.1"; certificate is only valid for DnsName("openbao.internal,localhost,bootroot-openbao,172.17.0.1")`. Both call sites now emit `--san <value>` per entry; step infers DNS vs IP from the value shape, so IP literals like `172.17.0.1` become IP SANs.

These bugs were latent because no prior E2E exercised `--openbao-bind` + `--openbao-tls-required` end-to-end on real Docker; the reinit-recovery harness is the first one that does.

### Extended-suite test isolation

The `bootroot init --openbao-bind --openbao-tls-required` flow rewrites the repo-level `openbao/openbao.hcl` (mounted `:ro` into the OpenBao container) to a TLS-enabled listener and drops the issued server cert/key under `openbao/tls/server.{crt,key}` (with the key chmodded `0644` by `set_openbao_readable_permissions`). The HCL rewrite and the auxiliary `openbao/config/` tree also persist after the script exits, so when `scripts/impl/run-extended-suite.sh` invokes `case_infra_lifecycle` after `case_reinit_recovery`, the lifecycle case inherits a TLS-bound config while its own `init` talks plaintext to OpenBao and trips an `OpenBao health check failed with status: 400 Bad Request`. Neither `openbao/tls` nor `openbao/config` is gitignored, so without cleanup the harness would also leave an untracked world-readable private key in the workspace. `run-reinit-recovery.sh` now snapshots `openbao/openbao.hcl` (and `openbao/{config,tls}` if they pre-existed) before mutations and, on cleanup, restores the snapshot from the artifact dir and otherwise scrubs both `openbao/config/` and `openbao/tls/` so the checkout is left exactly as the case found it. The matrix didn't hit this because reinit-recovery runs last there.

### Harness-side workaround

`bootroot init`'s `--openbao-bind` path issues the OpenBao TLS cert at the end and then runs `docker compose up -d openbao` to apply it. That recreate brings the container back sealed, and `init` returns without auto-unsealing — so the harness's first `service add` raced into an AppRole login against a sealed Vault and failed with `503 Service Unavailable: Vault is sealed`. The harness now replays the bootstrap summary's unseal keys via `docker exec ... bao operator unseal` (threshold=2, fixed by `bootroot init`'s Shamir parameters) between `init` and the first `service add`. The `docker exec` path was chosen over hitting the host-published `https://172.17.0.1:8200` endpoint because CI runs occasionally timed out on the host-side seal-status poll right after `init`'s TLS recreate, and talking to OpenBao from inside the container sidesteps that host-networking flake entirely. Host accessibility is still verified after the unseal (the next `bootroot service add` connects via the host URL anyway). The workaround stays inside the test harness rather than touching `init` itself because the operator-facing path is to follow `init` with `bootroot infra up`, which already auto-unseals from `secrets/openbao/unseal-keys.txt`.

Closes #600
Part of #598

## Test plan

- [x] `cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent`
- [ ] `scripts/preflight/ci/e2e-matrix.sh` succeeds locally (includes the new reinit-recovery run)
- [ ] `scripts/preflight/ci/e2e-extended.sh` succeeds locally (includes `case_reinit_recovery`)
- [x] CI `test-docker-e2e-matrix` matrix passes, including the new `reinit-recovery` arm
- [x] CI `run-extended` (`e2e-extended.yml`) reports the `reinit-recovery` case green
- [x] Confirm in CI artifacts that `phases.log` reaches `"phase":"done"` and that each scenario's `snapshots/<label>/{password.txt,root_ca.fingerprint,intermediate_ca.fingerprint}` exist

