### PR TITLE
Apply --cert-group policy to ca-bundle.pem (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot-agent` writing `ca-bundle.pem` without honoring the
+  `--cert-group` policy and without re-asserting a readable mode on
+  rotation. The agent now always writes the CA bundle at `0o644` and,
+  when `--cert-group <gid>` is configured, `chgrp`s the bundle to the
+  policy's gid on every issuance and rotation — the same treatment
+  already applied to `<svc>-cert.pem` and `<svc>-key.pem`. Re-asserting
+  the mode on every write also undoes any stricter mode left behind by
+  an earlier writer, notably `bootroot-remote bootstrap`'s
+  `write_secret_file` path which creates the bundle at `0o600`; without
+  this fix, rotation overwrote the bytes but never widened the mode, so
+  containerized mTLS clients hit `EACCES` on `ca-bundle.pem` at request
+  time even though bring-up reported success. `0o644` is safe because
+  the bundle is public trust material (issuer/CA chain PEM only, never
+  private keys) — the new `CA_BUNDLE_FILE_MODE` constant documents this
+  invariant. (Closes #608)
 - Fixed `bootroot service add` bailing with `Parent directory not found`
   when the parent of `--agent-config`, `--cert-path`, or `--key-path`
   did not already exist. `service add` is the authoritative writer for

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -725,6 +725,14 @@ Cert/key group-access policy:
     bind-mounted cert/key readable to a non-root containerized
     client without recurring operator `chmod` workarounds — the
     policy is reapplied on every renew, so it survives rotation.
+  - The agent also writes `ca-bundle.pem` (when
+    `[trust].ca_bundle_path` is configured) at `0644` on every
+    issuance and rotation, and `chgrp`s it to the configured gid
+    when the policy is active. `0644` is used regardless of policy
+    because the bundle is public trust material (issuer/CA chain
+    PEM only, never private keys); re-asserting the mode also
+    overrides any stricter mode left behind by an earlier writer
+    (e.g. `bootroot-remote bootstrap`'s `0600` secret-file write).
   - Mode-by-mode acceptance:
     - `local-file`: name or numeric gid. Names are resolved against
       the control host's group DB. `service add` and `service

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -705,6 +705,14 @@ bootroot status
     non-root 사용자로 실행되는 컨테이너 클라이언트가 읽을 수
     있게 됩니다. 회전 시에도 정책이 다시 적용되므로
     운영자가 매번 `chmod`를 다시 걸 필요가 없습니다.
+  - `[trust].ca_bundle_path`가 설정된 경우, agent는 발급/회전마다
+    `ca-bundle.pem`도 `0644`로 기록하고, 정책이 활성화되어 있으면
+    설정된 gid로 `chgrp`합니다. 번들은 발급자/CA 체인 PEM만
+    담는 공개 신뢰 자료(private key 미포함)이므로 정책 여부와
+    무관하게 `0644`가 사용됩니다. 매 회전마다 모드를 다시
+    적용하므로 이전 writer(예: `bootroot-remote bootstrap`의
+    `0600` secret-file write)가 남긴 더 좁은 모드도 함께
+    덮어씁니다.
   - 모드별 허용 형식:
     - `local-file`: 이름 또는 숫자 gid. 이름은 control host의
       그룹 DB에서 해석됩니다. `service add`/`service update`는

--- a/src/acme/flow.rs
+++ b/src/acme/flow.rs
@@ -327,7 +327,7 @@ pub async fn issue_certificate(
             } else {
                 verify_chain_fingerprints(&chain, &settings.trust.trusted_ca_sha256)?;
                 let bundle = build_ca_bundle(&chain);
-                fs_util::write_ca_bundle(bundle_path, &bundle).await?;
+                fs_util::write_ca_bundle(bundle_path, &bundle, policy).await?;
                 info!("CA bundle saved to: {:?}", bundle_path);
             }
         }
@@ -451,7 +451,7 @@ mod tests {
         {
             verify_chain_fingerprints(&chain, &settings.trust.trusted_ca_sha256)?;
             let bundle = build_ca_bundle(&chain);
-            fs_util::write_ca_bundle(bundle_path, &bundle).await?;
+            fs_util::write_ca_bundle(bundle_path, &bundle, policy).await?;
         }
         Ok(())
     }

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -32,6 +32,15 @@ pub const KEY_FILE_MODE_DEFAULT: u32 = 0o600;
 /// Mode for the public cert file. Always world-readable; group policy
 /// only changes ownership.
 pub const CERT_FILE_MODE: u32 = 0o644;
+/// Mode for the CA bundle file. Always world-readable, regardless of
+/// `--cert-group` policy, because the CA bundle is **public trust
+/// material — issuer/CA chain PEM only, never private keys**. This
+/// invariant is what makes `0o644` safe; if the file ever grows to
+/// hold secrets, this mode must change. The mode is re-asserted on
+/// every write so a rotation undoes any prior writer (e.g. the
+/// bootstrap path that creates the file at `0o600`) leaving it at a
+/// stricter mode.
+pub const CA_BUNDLE_FILE_MODE: u32 = 0o644;
 /// Mode for the cert parent directory when `--cert-group` is set and
 /// the cert parent is distinct from the key parent.
 pub const CERT_DIR_MODE_GROUP: u32 = 0o755;

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use tokio::fs;
 
-use crate::cert_group::{self, CertGroupPolicy};
+use crate::cert_group::{self, CA_BUNDLE_FILE_MODE, CertGroupPolicy};
 
 const KEY_FILE_MODE: u32 = 0o600;
 const SECRETS_DIR_MODE: u32 = 0o700;
@@ -90,9 +90,23 @@ pub async fn write_cert_and_key(
 
 /// Writes a CA bundle to disk, creating parent directories as needed.
 ///
+/// Always sets the mode to [`CA_BUNDLE_FILE_MODE`] (`0o644`),
+/// regardless of `policy`. CA bundles are public trust material, and
+/// re-asserting the mode on every write means a rotation overrides
+/// any stricter mode left behind by an earlier writer (notably
+/// `bootroot-remote`'s bootstrap path, which creates the file via
+/// `write_secret_file` at `0o600`). When `policy` is active, also
+/// `chown`s the file to the policy's gid so cert-group members can
+/// read the bundle alongside the cert and key.
+///
 /// # Errors
-/// Returns an error if the directory cannot be created or the bundle cannot be written.
-pub async fn write_ca_bundle(bundle_path: &Path, bundle_pem: &str) -> Result<()> {
+/// Returns an error if the directory cannot be created, the bundle
+/// cannot be written, or the mode/owner cannot be applied.
+pub async fn write_ca_bundle(
+    bundle_path: &Path,
+    bundle_pem: &str,
+    policy: CertGroupPolicy,
+) -> Result<()> {
     let bundle_dir = bundle_path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("CA bundle path has no parent directory"))?;
@@ -102,6 +116,27 @@ pub async fn write_ca_bundle(bundle_path: &Path, bundle_pem: &str) -> Result<()>
     fs::write(bundle_path, bundle_pem)
         .await
         .context("Failed to write CA bundle file")?;
+    fs::set_permissions(
+        bundle_path,
+        std::fs::Permissions::from_mode(CA_BUNDLE_FILE_MODE),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "Failed to set mode {CA_BUNDLE_FILE_MODE:o} on CA bundle {}",
+            bundle_path.display()
+        )
+    })?;
+    if let Some(gid) = policy.gid {
+        let owned = bundle_path.to_path_buf();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            std::os::unix::fs::chown(&owned, None, Some(gid)).with_context(|| {
+                format!("Failed to chown CA bundle {} to gid {gid}", owned.display())
+            })
+        })
+        .await
+        .context("CA bundle chown task panicked")??;
+    }
     Ok(())
 }
 
@@ -262,5 +297,80 @@ mod tests {
         let dir_mode = std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777;
         assert_eq!(key_mode, crate::cert_group::KEY_FILE_MODE_GROUP);
         assert_eq!(dir_mode, crate::cert_group::KEY_DIR_MODE_GROUP);
+    }
+
+    /// CA bundles are public trust material, so the mode must be
+    /// `0o644` whether or not a `--cert-group` policy is in effect.
+    #[tokio::test]
+    async fn write_ca_bundle_no_policy_sets_world_readable_mode() {
+        let dir = tempdir().unwrap();
+        let bundle_path = dir.path().join("ca-bundle.pem");
+
+        write_ca_bundle(&bundle_path, "BUNDLE", CertGroupPolicy::none())
+            .await
+            .unwrap();
+
+        let mode = std::fs::metadata(&bundle_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, CA_BUNDLE_FILE_MODE);
+        let contents = fs::read_to_string(&bundle_path).await.unwrap();
+        assert_eq!(contents, "BUNDLE");
+    }
+
+    /// Rotation must re-assert the mode. The issue #608 root cause:
+    /// `bootroot-remote` creates the bundle at `0o600`, then the
+    /// agent's rotation only rewrote the bytes without restoring the
+    /// mode, leaving the container EACCES on the bundle. Seeding the
+    /// file at `0o600` first locks in that the rotation widens it.
+    #[tokio::test]
+    async fn write_ca_bundle_re_asserts_mode_on_rotation_over_0600_seed() {
+        let dir = tempdir().unwrap();
+        let bundle_path = dir.path().join("ca-bundle.pem");
+        // Seed as a 0o600 file (the bootstrap-time `write_secret_file`
+        // state described in the issue).
+        fs::write(&bundle_path, "stale").await.unwrap();
+        fs::set_permissions(&bundle_path, std::fs::Permissions::from_mode(0o600))
+            .await
+            .unwrap();
+
+        write_ca_bundle(&bundle_path, "FRESH", CertGroupPolicy::none())
+            .await
+            .unwrap();
+
+        let mode = std::fs::metadata(&bundle_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, CA_BUNDLE_FILE_MODE);
+        let contents = fs::read_to_string(&bundle_path).await.unwrap();
+        assert_eq!(contents, "FRESH");
+    }
+
+    /// Under an active `--cert-group` policy, the bundle file must be
+    /// chgrped to the policy's gid and remain at `0o644` (cert-group
+    /// members get read access via group membership, everyone else
+    /// retains read access because the bundle is public material).
+    #[tokio::test]
+    async fn write_ca_bundle_with_policy_chowns_to_gid_and_keeps_0644() {
+        use std::os::unix::fs::MetadataExt;
+
+        let Some(gid) = crate::cert_group::one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempdir().unwrap();
+        let bundle_path = dir.path().join("ca-bundle.pem");
+
+        write_ca_bundle(&bundle_path, "BUNDLE", CertGroupPolicy::with_gid(gid))
+            .await
+            .unwrap();
+
+        let meta = std::fs::metadata(&bundle_path).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, CA_BUNDLE_FILE_MODE);
+        assert_eq!(meta.gid(), gid, "CA bundle gid must match policy");
     }
 }

--- a/tests/e2e_cert_group_chown.rs
+++ b/tests/e2e_cert_group_chown.rs
@@ -29,8 +29,8 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
 
 use bootroot::cert_group::{
-    self, CERT_DIR_MODE_GROUP, CERT_FILE_MODE, CertGroupPolicy, KEY_DIR_MODE_GROUP,
-    KEY_FILE_MODE_GROUP,
+    self, CA_BUNDLE_FILE_MODE, CERT_DIR_MODE_GROUP, CERT_FILE_MODE, CertGroupPolicy,
+    KEY_DIR_MODE_GROUP, KEY_FILE_MODE_GROUP,
 };
 use bootroot::fs_util;
 
@@ -200,4 +200,51 @@ async fn cert_group_chown_rotation_re_asserts_gid_ownership() {
     assert_eq!(key_meta.gid(), gid, "rotation must restore key gid");
     assert_eq!(dir_meta.permissions().mode() & 0o777, KEY_DIR_MODE_GROUP);
     assert_eq!(dir_meta.gid(), gid, "rotation must restore parent gid");
+}
+
+/// Issue #608: `ca-bundle.pem` must follow the `--cert-group` policy
+/// alongside cert.pem / key.pem, not the bootstrap-time `0o600`
+/// secret-file mode. Seeding the bundle as `0o600` first locks in
+/// the "rotation re-asserts mode" behavior — the bug reported in
+/// the issue is exactly that rotation overwrites the bytes but
+/// never widens the mode, so the container inside the deployment
+/// continues to EACCES on the bundle.
+///
+/// The chosen mode is `0o644` (world-readable) because the bundle
+/// is **public trust material — issuer/CA chain PEM only, never
+/// private keys**. See [`CA_BUNDLE_FILE_MODE`].
+#[tokio::test]
+async fn ca_bundle_is_world_readable_public_trust_material_after_rotation() {
+    let Some(gid) = resolve_test_gid() else {
+        eprintln!("skipped: no supplementary gid available for chown test");
+        return;
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let bundle_path = dir.path().join("certs").join("ca-bundle.pem");
+    std::fs::create_dir_all(bundle_path.parent().unwrap()).unwrap();
+
+    // Bootstrap-time state: 0o600, primary gid. Reproduces the
+    // residue left behind by `bootroot-remote bootstrap`'s
+    // `write_secret_file` writer that the issue's evaluation
+    // identifies as the source of the observed `0o600` mode.
+    std::fs::write(&bundle_path, "stale-bundle").unwrap();
+    std::fs::set_permissions(&bundle_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    fs_util::write_ca_bundle(&bundle_path, "fresh-bundle", CertGroupPolicy::with_gid(gid))
+        .await
+        .unwrap();
+
+    let meta = std::fs::metadata(&bundle_path).unwrap();
+    assert_eq!(
+        meta.permissions().mode() & 0o777,
+        CA_BUNDLE_FILE_MODE,
+        "rotation must widen ca-bundle.pem to 0o644 even when seeded at 0o600"
+    );
+    assert_eq!(
+        meta.gid(),
+        gid,
+        "ca-bundle.pem gid must match the --cert-group policy"
+    );
+    let contents = std::fs::read_to_string(&bundle_path).unwrap();
+    assert_eq!(contents, "fresh-bundle");
 }


### PR DESCRIPTION
## Summary

- `bootroot-agent` now writes `ca-bundle.pem` at `0o644` on every issuance and rotation, and `chgrp`s it to the configured gid when `--cert-group` is active — the same treatment already applied to `<svc>-cert.pem` and `<svc>-key.pem`.
- Re-asserting the mode on every write undoes any stricter mode left behind by an earlier writer, notably `bootroot-remote bootstrap`'s `write_secret_file` path which creates the bundle at `0o600`. Without this, rotation overwrote the bytes but never widened the mode, so non-root container clients hit `EACCES` on `ca-bundle.pem` at mTLS time even though bring-up reported success.
- `0o644` is safe because the bundle is public trust material (issuer/CA chain PEM only, never private keys). The new `CA_BUNDLE_FILE_MODE` constant in `src/cert_group.rs` documents this invariant alongside the existing `CERT_FILE_MODE`.

Closes #608

## Test plan

- [x] `cargo clippy --all-targets --no-deps` passes with no warnings
- [x] `cargo test --lib fs_util` covers the three new `write_ca_bundle` unit tests (no-policy mode, rotation re-asserts mode over a `0o600` seed, policy chowns to gid and keeps `0o644`)
- [x] `cargo test --test e2e_cert_group_chown` covers `ca_bundle_is_world_readable_public_trust_material_after_rotation` (seeds `0o600`, asserts rotation widens to `0o644` and `chgrp`s to the policy gid)
- [ ] `scripts/preflight/run-all.sh` (or at minimum `scripts/preflight/ci/e2e-matrix.sh` + `scripts/preflight/ci/e2e-extended.sh`) on a host with Docker
- [ ] Manual: bring up a `docker-deploy` service with `--cert-group nogroup`, confirm `ls -la /opt/<svc>-mtls/` shows `ca-bundle.pem` as `-rw-r--r-- … nogroup …` after the first agent issuance and again after a forced rotation