### PR TITLE
Auto-create parent dirs for service add output paths (#607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot service add` bailing with `Parent directory not found`
+  when the parent of `--agent-config`, `--cert-path`, or `--key-path`
+  did not already exist. `service add` is the authoritative writer for
+  those files, so requiring an out-of-band `mkdir -p` chain in sync
+  with the flag values was gratuitous and was the typical first-time
+  failure mode on a cold rebuild. The resolve-side gate now only
+  applies to read-only inputs (`must_exist=true`); the agent-config
+  parent is created at the write boundary in `local_config.rs` via
+  `create_dir_all`, while cert/key parents continue to be created by
+  `fs_util::write_cert_and_key` under the existing `cert_group`
+  permission policy (so a `--cert-group` 0750 key parent is not
+  flattened to 0755). `create_dir_all` leaves pre-existing components
+  untouched, so an operator-tightened directory mode is preserved.
+  `--dry-run` / `--print-only` remain side-effect-free because
+  resolution does not touch the filesystem. (Closes #607)
 - Fixed `bootroot init`'s second pass (the one `reinit` runs after wiping
   OpenBao) recreating the OpenBao container without its
   `openbao-exposed` compose override and dropping the non-loopback

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -118,6 +118,19 @@ pub(super) async fn apply_local_service_configs(
         messages,
     )
     .await?;
+    // `service add` is the authoritative writer for the operator's
+    // `agent.toml`; create its parent chain if missing so callers do not
+    // have to keep a separate `mkdir -p` in sync with `--agent-config`.
+    // `create_dir_all` leaves pre-existing components untouched (mode
+    // and ownership), so an operator-tightened directory is not widened.
+    // Newly created components use process umask (0755 by default).
+    if let Some(parent) = resolved.agent_config.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).await.with_context(|| {
+            messages.error_write_file_failed(&resolved.agent_config.display().to_string())
+        })?;
+    }
     fs::write(&resolved.agent_config, &next)
         .await
         .with_context(|| {

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -480,7 +480,15 @@ fn validate_path(path: &Path, must_exist: bool, messages: &Messages) -> Result<(
     let parent = path.parent().ok_or_else(|| {
         anyhow::anyhow!(messages.error_parent_not_found(&path.display().to_string()))
     })?;
-    if !parent.as_os_str().is_empty() && !parent.exists() {
+    // For input paths (`must_exist=true`) the parent must already exist —
+    // a read on a missing dir would just produce a less helpful error
+    // downstream.  For output paths (`must_exist=false`) `service add` is
+    // the authoritative writer, so the parent is `create_dir_all`-ed at
+    // the write boundary (`local_config.rs` for `agent_config`,
+    // `fs_util::write_cert_and_key` for `cert_path` / `key_path`).
+    // Resolution stays side-effect-free so `--dry-run` / `--print-only`
+    // do not leak directories onto disk.
+    if must_exist && !parent.as_os_str().is_empty() && !parent.exists() {
         anyhow::bail!(messages.error_parent_not_found(&parent.display().to_string()));
     }
     Ok(())
@@ -488,6 +496,8 @@ fn validate_path(path: &Path, must_exist: bool, messages: &Messages) -> Result<(
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::*;
     use crate::cli::args::{AuthMode, RuntimeAuthArgs};
 
@@ -801,6 +811,49 @@ mod tests {
             err.to_string().contains("--post-renew-command"),
             "unexpected error: {err}"
         );
+    }
+
+    /// Issue #607: `service add` output paths must accept a non-existent
+    /// parent so the operator does not have to keep an out-of-band
+    /// `mkdir -p` chain in sync with the flag values. The directory gets
+    /// created at the write boundary (`local_config.rs` and
+    /// `fs_util::write_cert_and_key`) rather than here, so resolution
+    /// stays side-effect-free for `--dry-run` / `--print-only`.
+    #[test]
+    fn validate_path_allows_missing_parent_when_must_exist_is_false() {
+        let messages = Messages::new("en").unwrap();
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("does/not/exist/agent.toml");
+        assert!(!target.parent().unwrap().exists());
+
+        validate_path(&target, false, &messages).expect("missing parent must be accepted");
+        assert!(
+            !target.parent().unwrap().exists(),
+            "validate_path must not create directories on disk"
+        );
+    }
+
+    #[test]
+    fn validate_path_rejects_missing_parent_when_must_exist_is_true() {
+        let messages = Messages::new("en").unwrap();
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("does/not/exist/input.pem");
+
+        let err = validate_path(&target, true, &messages).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found"),
+            "expected a not-found error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_path_accepts_existing_parent_when_must_exist_is_false() {
+        let messages = Messages::new("en").unwrap();
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("agent.toml");
+
+        validate_path(&target, false, &messages).expect("existing parent must be accepted");
     }
 
     #[test]

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -250,6 +250,284 @@ async fn test_app_add_approle_permission_denied_fails() {
     assert!(stderr.contains("OpenBao policy write failed"));
 }
 
+/// Issue #607: `service add` must `mkdir -p` the parent dirs of the
+/// operator-supplied `--agent-config` / `--cert-path` / `--key-path`
+/// values instead of bailing out with `Parent directory not found`,
+/// which used to force every cold rebuild to keep an out-of-band
+/// `mkdir -p` chain in sync with the flag values.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_app_add_creates_missing_parent_dirs_for_output_paths() {
+    use support::ROOT_TOKEN;
+
+    let temp_dir = tempdir().expect("create temp dir");
+    let server = MockServer::start().await;
+
+    // Deep nested paths whose parents do NOT exist on disk.  The cert
+    // and key parents are intentionally different to exercise both
+    // branches of `write_cert_and_key`.
+    let agent_config = temp_dir.path().join("config/edge-proxy/agent.toml");
+    let cert_path = temp_dir.path().join("mtls/certs/edge-proxy.crt");
+    let key_path = temp_dir.path().join("mtls/private/edge-proxy.key");
+    assert!(!agent_config.parent().unwrap().exists());
+    assert!(!cert_path.parent().unwrap().exists());
+    assert!(!key_path.parent().unwrap().exists());
+
+    write_state_file(temp_dir.path(), &server.uri()).expect("write state.json");
+    stub_app_add_openbao(&server, "edge-proxy").await;
+    stub_app_add_trust_missing(&server).await;
+    stub_app_add_service_sync_material(&server, "edge-proxy").await;
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "add",
+            "--service-name",
+            "edge-proxy",
+            "--deploy-type",
+            "daemon",
+            "--hostname",
+            "edge-node-01",
+            "--domain",
+            "trusted.domain",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+            "--cert-path",
+            cert_path.to_string_lossy().as_ref(),
+            "--key-path",
+            key_path.to_string_lossy().as_ref(),
+            "--instance-id",
+            "001",
+            "--root-token",
+            ROOT_TOKEN,
+        ])
+        .output()
+        .expect("run service add");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Parent directory not found"),
+        "service add must no longer reject missing output parents: {stderr}"
+    );
+
+    // The agent-config write boundary in `local_config.rs` created the
+    // chain and wrote the operator's TOML on top of it.
+    assert!(
+        agent_config.parent().unwrap().exists(),
+        "agent_config parent must be created by service add"
+    );
+    let agent_contents = fs::read_to_string(&agent_config).expect("read agent config");
+    assert!(agent_contents.contains("service_name = \"edge-proxy\""));
+
+    // The cert parent is created via the CA-bundle write
+    // (`write_local_ca_bundle` → `ensure_secrets_dir`); the key parent
+    // is created lazily by `write_cert_and_key` at the first rotation,
+    // so we do not assert its existence here.
+    assert!(
+        cert_path.parent().unwrap().exists(),
+        "cert parent must be created by service add (ca-bundle write boundary)"
+    );
+}
+
+/// Issue #607: pre-existing parent dirs with operator-tightened modes
+/// (e.g. `0700`) must NOT be widened by `service add`.  `create_dir_all`
+/// is supposed to leave existing components untouched, but this guards
+/// against future regressions that mistakenly chmod the dir.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_app_add_preserves_existing_parent_dir_mode() {
+    use support::ROOT_TOKEN;
+
+    let temp_dir = tempdir().expect("create temp dir");
+    let server = MockServer::start().await;
+
+    let config_parent = temp_dir.path().join("config");
+    fs::create_dir_all(&config_parent).expect("create config dir");
+    fs::set_permissions(&config_parent, fs::Permissions::from_mode(0o700))
+        .expect("tighten parent mode");
+    let agent_config = config_parent.join("agent.toml");
+    let cert_path = temp_dir.path().join("certs").join("edge-proxy.crt");
+    let key_path = temp_dir.path().join("certs").join("edge-proxy.key");
+    fs::create_dir_all(cert_path.parent().unwrap()).expect("create cert dir");
+
+    write_state_file(temp_dir.path(), &server.uri()).expect("write state.json");
+    stub_app_add_openbao(&server, "edge-proxy").await;
+    stub_app_add_trust_missing(&server).await;
+    stub_app_add_service_sync_material(&server, "edge-proxy").await;
+
+    let before = fs::metadata(&config_parent).unwrap().permissions().mode() & 0o777;
+    assert_eq!(before, 0o700);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "add",
+            "--service-name",
+            "edge-proxy",
+            "--deploy-type",
+            "daemon",
+            "--hostname",
+            "edge-node-01",
+            "--domain",
+            "trusted.domain",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+            "--cert-path",
+            cert_path.to_string_lossy().as_ref(),
+            "--key-path",
+            key_path.to_string_lossy().as_ref(),
+            "--instance-id",
+            "001",
+            "--root-token",
+            ROOT_TOKEN,
+        ])
+        .output()
+        .expect("run service add");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let after = fs::metadata(&config_parent).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        after, 0o700,
+        "pre-existing parent dir mode must not be widened by service add"
+    );
+}
+
+/// Issue #607: when the `--agent-config` parent path collides with an
+/// existing regular file, `create_dir_all` must surface a clear error
+/// (wrapped with the localized `error_write_file_failed` template)
+/// rather than panicking or producing a generic libc message.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_app_add_fails_when_agent_config_parent_is_a_file() {
+    use support::ROOT_TOKEN;
+
+    let temp_dir = tempdir().expect("create temp dir");
+    let server = MockServer::start().await;
+
+    // Stage a regular file where service add will try to mkdir its
+    // parent.  `create_dir_all("blocker/agent.toml-dir")` must fail.
+    let blocker = temp_dir.path().join("blocker");
+    fs::write(&blocker, b"not a directory").expect("stage blocker file");
+    let agent_config = blocker.join("agent.toml");
+    let cert_path = temp_dir.path().join("certs/edge-proxy.crt");
+    let key_path = temp_dir.path().join("certs/edge-proxy.key");
+
+    write_state_file(temp_dir.path(), &server.uri()).expect("write state.json");
+    stub_app_add_openbao(&server, "edge-proxy").await;
+    stub_app_add_trust_missing(&server).await;
+    stub_app_add_service_sync_material(&server, "edge-proxy").await;
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "add",
+            "--service-name",
+            "edge-proxy",
+            "--deploy-type",
+            "daemon",
+            "--hostname",
+            "edge-node-01",
+            "--domain",
+            "trusted.domain",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+            "--cert-path",
+            cert_path.to_string_lossy().as_ref(),
+            "--key-path",
+            key_path.to_string_lossy().as_ref(),
+            "--instance-id",
+            "001",
+            "--root-token",
+            ROOT_TOKEN,
+        ])
+        .output()
+        .expect("run service add");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "service add must fail when agent-config parent collides with a file; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Failed to write")
+            && stderr.contains(agent_config.to_string_lossy().as_ref()),
+        "expected localized write-failure for agent-config path, got:\n{stderr}"
+    );
+}
+
+/// Issue #607: `--dry-run` / `--print-only` must remain side-effect-
+/// free even when output-path parents do not exist.  Resolution lives
+/// in `resolve.rs` (no filesystem writes), and the actual mkdir lives
+/// in `local_config.rs`, so preview-mode never reaches it.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_app_add_print_only_does_not_create_missing_parent_dirs() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let agent_config = temp_dir.path().join("config/edge-proxy/agent.toml");
+    let cert_path = temp_dir.path().join("mtls/edge-proxy.crt");
+    let key_path = temp_dir.path().join("mtls-key/edge-proxy.key");
+
+    write_state_file(temp_dir.path(), "http://localhost:8200").expect("write state.json");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "add",
+            "--print-only",
+            "--service-name",
+            "edge-proxy",
+            "--deploy-type",
+            "daemon",
+            "--hostname",
+            "edge-node-01",
+            "--domain",
+            "trusted.domain",
+            "--agent-config",
+            agent_config.to_string_lossy().as_ref(),
+            "--cert-path",
+            cert_path.to_string_lossy().as_ref(),
+            "--key-path",
+            key_path.to_string_lossy().as_ref(),
+            "--instance-id",
+            "001",
+        ])
+        .output()
+        .expect("run service add");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        !agent_config.parent().unwrap().exists(),
+        "--print-only must not create agent_config parent"
+    );
+    assert!(
+        !cert_path.parent().unwrap().exists(),
+        "--print-only must not create cert parent"
+    );
+    assert!(
+        !key_path.parent().unwrap().exists(),
+        "--print-only must not create key parent"
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn test_app_add_print_only_shows_snippets_without_writes() {
@@ -425,8 +703,13 @@ async fn test_app_add_reprompts_on_invalid_inputs() {
     stub_app_add_openbao(&server, "edge-proxy").await;
     stub_app_add_service_sync_material(&server, "edge-proxy").await;
 
+    // Service add only revalidates a path when the parent is missing
+    // (`must_exist=true`).  Issue #607 dropped that gate for output paths
+    // so `service add` can `create_dir_all` them at the write boundary;
+    // the only remaining reprompt-on-invalid path here is the deploy
+    // type (`invalid` → `daemon`) and the empty instance id.
     let input = format!(
-        "edge-proxy\ninvalid\ndaemon\nedge-node-01\ntrusted.domain\n{}\nmissing/edge-proxy.crt\n{}\n{}\n\n001\n",
+        "edge-proxy\ninvalid\ndaemon\nedge-node-01\ntrusted.domain\n{}\n{}\n{}\n\n001\n",
         agent_config.display(),
         cert_path.display(),
         key_path.display(),


### PR DESCRIPTION
## Summary

`bootroot service add` is the authoritative writer for `--agent-config`, `--cert-path`, and `--key-path`, so the previous `Parent directory not found` rejection just shifted boilerplate to operators (a `mkdir -p` chain that had to be kept in sync with the flag values) and was the typical first-time failure mode on a cold rebuild.

- `src/commands/service/resolve.rs`: `validate_path` now only enforces parent existence for read-only inputs (`must_exist=true`). Output paths flow through unchanged so resolution stays side-effect-free for `--dry-run` / `--print-only`. The remote-bootstrap input gate (`role_id_path` / `secret_id_path` / `eab_file_path`) is unaffected.
- `src/commands/service/local_config.rs`: immediately before writing `agent.toml`, `create_dir_all`s the parent and wraps any failure with the localized `error_write_file_failed` template. `create_dir_all` leaves pre-existing components untouched, so an operator-tightened directory mode is preserved.
- cert/key parents: no change required — `fs_util::write_cert_and_key` already creates them at first ACME issuance under the existing `cert_group` permission policy (0700 / 0750 / 0755 depending on layout), so a `--cert-group` 0750 key parent is not flattened to 0755.
- Tests: unit coverage in `resolve.rs` for the must_exist branch, plus integration coverage in `tests/bootroot_service.rs` for the happy path, mode preservation, parent-is-a-file negative, and `--print-only` side-effect-freeness. Updated the existing reprompt test to reflect that missing output parents no longer trigger a reprompt.
- CHANGELOG entry added under the unreleased Fixed section.

Closes #607

## Test plan

- [x] `cargo test -p bootroot --test bootroot_service test_app_add_creates_missing_parent_dirs_for_output_paths` passes (happy path: deep non-existent parents are created at the write boundary).
- [x] `cargo test -p bootroot --test bootroot_service test_app_add_preserves_existing_parent_dir_mode` passes (0700 operator-tightened dir is not widened).
- [x] `cargo test -p bootroot --test bootroot_service test_app_add_fails_when_agent_config_parent_is_a_file` passes (parent-is-file emits localized `Failed to write` error).
- [x] `cargo test -p bootroot --test bootroot_service test_app_add_print_only_does_not_create_missing_parent_dirs` passes (preview-mode stays side-effect-free).
- [x] `cargo test -p bootroot validate_path_allows_missing_parent_when_must_exist_is_false` passes (unit: resolution accepts missing output parents).
- [x] `cargo test -p bootroot validate_path_rejects_missing_parent_when_must_exist_is_true` passes (unit: input paths still rejected).
- [x] `cargo clippy --all-targets -- -D warnings` is clean.
- [x] Manual reproduce from issue: `service add --agent-config /tmp/x/config/foo.toml --cert-path /tmp/x/mtls/cert.pem --key-path /tmp/x/mtls/key.pem ...` succeeds without an out-of-band `mkdir -p` chain.