### PR TITLE
Fix reinit with default relative --compose-file (#611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot reinit` failing immediately with
+  `could not derive compose project name from ` (trailing empty string)
+  whenever `--compose-file` was left at its default relative
+  `docker-compose.yml`. `Path::parent` returns `Some("")` — not `None` —
+  for a relative path without a directory component, so the
+  `compose_file.parent().unwrap_or(Path::new("."))` shape used by
+  `reinit`, `clean --openbao-only`, the init orchestrator's `.env`
+  loader and DB-password rotation, and `rotate infra-cert` all fed an
+  empty path into downstream `canonicalize` / `file_name` / `.join`
+  consumers. That broke the curated recovery path documented for
+  partial-init failures and forced operators into the destructive
+  `clean --openbao-only` + `infra install` + `init` escape hatch. The
+  derivation is now funnelled through a single
+  `commands::compose_file::compose_file_dir` helper that normalises the
+  empty-parent case to `"."`. (Closes #611)
 - Fixed `bootroot-agent` writing `ca-bundle.pem` without honoring the
   `--cert-group` policy and without re-asserting a readable mode on
   rotation. The agent now always writes the CA bundle at `0o644` and,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fixed `bootroot reinit` failing immediately with
-  `could not derive compose project name from ` (trailing empty string)
-  whenever `--compose-file` was left at its default relative
+  `could not derive compose project name from` followed by a trailing
+  empty string whenever `--compose-file` was left at its default relative
   `docker-compose.yml`. `Path::parent` returns `Some("")` — not `None` —
   for a relative path without a directory component, so the
   `compose_file.parent().unwrap_or(Path::new("."))` shape used by

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,6 @@
 pub(crate) mod ca;
 pub(crate) mod clean;
+pub(crate) mod compose_file;
 pub(crate) mod constants;
 pub(crate) mod dns_alias;
 pub(crate) mod dotenv;

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -4,6 +4,7 @@ use std::process::Command as ProcessCommand;
 use anyhow::{Context, Result};
 
 use crate::cli::args::CleanArgs;
+use crate::commands::compose_file::compose_file_dir;
 use crate::commands::infra::run_docker;
 use crate::commands::init::{OPENBAO_CONTAINER_NAME, prompt_yes_no};
 use crate::i18n::Messages;
@@ -40,11 +41,8 @@ pub(crate) fn run_clean(args: &CleanArgs, messages: &Messages) -> Result<()> {
 
     // Resolve paths relative to the compose file directory, matching
     // Docker Compose's bind-mount resolution.
-    let compose_dir = args
-        .compose_file
-        .compose_file
-        .parent()
-        .unwrap_or(Path::new("."));
+    let compose_dir = compose_file_dir(&args.compose_file.compose_file);
+    let compose_dir = compose_dir.as_path();
 
     let compose_str = args.compose_file.compose_file.to_string_lossy();
     let mut down_args: Vec<&str> = vec!["compose", "-f", &compose_str];
@@ -100,7 +98,8 @@ pub(crate) fn remove_openbao_container_and_volumes(
     messages: &Messages,
 ) -> Result<()> {
     let compose_str = compose_file.to_string_lossy();
-    let compose_dir = compose_file.parent().unwrap_or(Path::new("."));
+    let compose_dir = compose_file_dir(compose_file);
+    let compose_dir = compose_dir.as_path();
 
     // Discover the compose project name BEFORE removing the container,
     // while the label is still readable. Falling back to the compose-dir
@@ -430,5 +429,52 @@ mod tests {
         assert_eq!(normalise_compose_project_name("Foo.Bar"), "foobar");
         assert_eq!(normalise_compose_project_name("foo_bar-baz"), "foo_bar-baz");
         assert_eq!(normalise_compose_project_name("a/b\\c d"), "abcd");
+    }
+
+    /// Regression for #611: when `--compose-file` defaults to the
+    /// relative `docker-compose.yml`, the derived `compose_dir` flowing
+    /// into `resolve_compose_project` must canonicalise cleanly.  The
+    /// previous `compose_file.parent().unwrap_or(Path::new("."))` shape
+    /// returned `Some("")` here, then `canonicalize("")` failed and
+    /// `PathBuf::from("").file_name()` returned `None`, surfacing as
+    /// `could not derive compose project name from `.
+    #[test]
+    fn resolve_compose_project_handles_dot_relative_compose_dir() {
+        let _guard = env_lock();
+        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
+        clear_compose_project_name();
+        let compose_dir = compose_file_dir(Path::new("docker-compose.yml"));
+        assert_eq!(compose_dir, std::path::PathBuf::from("."));
+        let lookup = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
+        let result = resolve_compose_project(&compose_dir, &lookup);
+        if let Some(prior) = prior {
+            // SAFETY: still inside the env_lock guard.
+            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
+        }
+        let project = result.expect("resolve_compose_project must succeed for `.`");
+        assert!(!project.is_empty());
+    }
+
+    /// Companion to the test above: when `COMPOSE_PROJECT_NAME` is set,
+    /// `remove_openbao_container_and_volumes` (which calls
+    /// `resolve_compose_project`) must honour it even when the
+    /// `compose_dir` is the helper-normalised `.`.
+    #[test]
+    fn resolve_compose_project_honours_env_var_for_dot_relative_compose_dir() {
+        let _guard = env_lock();
+        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
+        // SAFETY: env mutation is serialised by `env_lock` above.
+        unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", "explicit-env-project") };
+        let compose_dir = compose_file_dir(Path::new("docker-compose.yml"));
+        let lookup = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
+        let result = resolve_compose_project(&compose_dir, &lookup);
+        if let Some(prior) = prior {
+            // SAFETY: still inside the env_lock guard.
+            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
+        } else {
+            // SAFETY: still inside the env_lock guard.
+            unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
+        }
+        assert_eq!(result.unwrap(), "explicit-env-project");
     }
 }

--- a/src/commands/compose_file.rs
+++ b/src/commands/compose_file.rs
@@ -1,0 +1,54 @@
+use std::path::{Path, PathBuf};
+
+/// Returns the directory containing `compose_file`, normalising the
+/// "no directory component" case to `"."`.
+///
+/// `Path::parent` returns `Some("")` (not `None`) for relative paths
+/// without a directory component like `docker-compose.yml`, so a naive
+/// `compose_file.parent().unwrap_or(Path::new("."))` produces an empty
+/// path that breaks downstream `canonicalize` / `file_name` / `.join`
+/// behaviour.  Funnel every `--compose-file` directory derivation
+/// through this helper to avoid that footgun.
+pub(crate) fn compose_file_dir(compose_file: &Path) -> PathBuf {
+    match compose_file.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_parent_becomes_dot() {
+        assert_eq!(
+            compose_file_dir(Path::new("docker-compose.yml")),
+            PathBuf::from(".")
+        );
+    }
+
+    #[test]
+    fn explicit_relative_directory_preserved() {
+        assert_eq!(
+            compose_file_dir(Path::new("deploy/docker-compose.yml")),
+            PathBuf::from("deploy")
+        );
+    }
+
+    #[test]
+    fn absolute_directory_preserved() {
+        assert_eq!(
+            compose_file_dir(Path::new("/srv/bootroot/docker-compose.yml")),
+            PathBuf::from("/srv/bootroot")
+        );
+    }
+
+    #[test]
+    fn dot_relative_directory_preserved() {
+        assert_eq!(
+            compose_file_dir(Path::new("./docker-compose.yml")),
+            PathBuf::from(".")
+        );
+    }
+}

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -348,7 +348,8 @@ async fn run_init_inner(
     // Load .env into the process environment so that
     // `build_admin_dsn_from_env()` and `build_dsn_from_env()` can discover
     // the temporary POSTGRES_PASSWORD written by `infra install`.
-    let compose_dir = args.compose.compose_file.parent().unwrap_or(Path::new("."));
+    let compose_dir = crate::commands::compose_file::compose_file_dir(&args.compose.compose_file);
+    let compose_dir = compose_dir.as_path();
     crate::commands::dotenv::load_dotenv_into_env(&compose_dir.join(".env"), messages)?;
 
     let (db_dsn, db_dsn_normalization, admin_dsn_for_kv) =
@@ -821,7 +822,7 @@ async fn maybe_rotate_env_db_password(
     use crate::commands::init::{PATH_STEPCA_DB, PATH_STEPCA_DB_ADMIN};
 
     // Docker Compose reads .env from the compose file's directory.
-    let compose_dir = compose_file.parent().unwrap_or(Path::new("."));
+    let compose_dir = crate::commands::compose_file::compose_file_dir(compose_file);
     let env_path = compose_dir.join(".env");
     if !env_path.exists() {
         return Ok(None);
@@ -885,7 +886,7 @@ async fn maybe_rotate_env_db_password(
     // to 5433, hard-coding `parsed.port` makes this admin connection
     // attempt the wrong host port on a default install and silently skip
     // the `.env` password rotation via the warning path below.
-    let host_port = bootroot::db::resolve_postgres_host_port(compose_dir);
+    let host_port = bootroot::db::resolve_postgres_host_port(&compose_dir);
     let admin_dsn = bootroot::db::build_db_dsn(
         "step",
         &temp_password,

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -13,6 +13,7 @@ use crate::commands::clean::{
     COMPOSE_PROJECT_LABEL, COMPOSE_SERVICE_LABEL, container_exists_via_docker,
     inspect_label_via_docker, remove_openbao_container_and_volumes, resolve_compose_project,
 };
+use crate::commands::compose_file::compose_file_dir;
 use crate::commands::guardrails::client_url_from_bind_addr;
 use crate::commands::infra::run_infra_up;
 use crate::commands::init::{OPENBAO_CONTAINER_NAME, compose_has_openbao, prompt_yes_no, run_init};
@@ -59,10 +60,7 @@ const STEP_CA_INIT_ARTIFACTS: &[&str] = &[
 /// re-run of `init` fails.
 pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result<()> {
     let compose_file = &args.compose.compose_file;
-    let compose_dir = compose_file
-        .parent()
-        .unwrap_or(Path::new("."))
-        .to_path_buf();
+    let compose_dir = compose_file_dir(compose_file);
     let state_path = StateFile::default_path();
 
     // 1. Refuse any operator-supplied `--openbao-url` that differs from
@@ -1427,6 +1425,52 @@ mod tests {
             unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
         }
         result.expect("should accept existing container with matching compose labels");
+    }
+
+    /// Regression for #611: when `--compose-file` is the default
+    /// relative `docker-compose.yml`, `run_reinit` derives `compose_dir`
+    /// via [`compose_file_dir`].  The verifier must accept that
+    /// `compose_dir` and complete its scope check without surfacing
+    /// `could not derive compose project name from `.  Exercises the
+    /// container-absent branch (the stuck-after-`clean --openbao-only`
+    /// recovery path) with CWD pointed at a tempdir holding a valid
+    /// compose declaration.
+    #[test]
+    fn verify_compose_managed_openbao_accepts_default_relative_compose_file() {
+        let _guard = env_lock();
+        let prior_env = std::env::var_os("COMPOSE_PROJECT_NAME");
+        // SAFETY: env access is serialised by `env_lock` above.
+        unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
+
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("docker-compose.yml"),
+            "services:\n  openbao:\n    image: openbao\n",
+        )
+        .unwrap();
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let compose_file = PathBuf::from("docker-compose.yml");
+        let compose_dir = compose_file_dir(&compose_file);
+        let messages = test_messages();
+        let container_exists = |_: &str| -> Result<bool> { Ok(false) };
+        let inspect = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
+        let result = verify_compose_managed_openbao(
+            &compose_file,
+            &compose_dir,
+            &container_exists,
+            &inspect,
+            &messages,
+        );
+
+        std::env::set_current_dir(&original_cwd).unwrap();
+        if let Some(prior) = prior_env {
+            // SAFETY: still inside the env_lock guard.
+            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
+        }
+
+        result.expect("default relative --compose-file must not break the scope check");
     }
 
     #[test]

--- a/src/commands/rotate/infra_cert.rs
+++ b/src/commands/rotate/infra_cert.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result, bail};
 
 use super::RotateContext;
 use super::helpers::{confirm_action, try_restart_container};
+use crate::commands::compose_file::compose_file_dir;
 use crate::commands::init::{
     HTTP01_ADMIN_INFRA_CERT_KEY, OPENBAO_INFRA_CERT_KEY, reissue_http01_admin_tls_cert,
     reissue_openbao_tls_cert,
@@ -31,10 +32,7 @@ pub(super) fn rotate_infra_certs(
     confirm_action(messages.prompt_rotate_infra_tls(), auto_confirm, messages)?;
 
     let state_file = ctx.state_file.clone();
-    let compose_dir = ctx.compose_file.parent().map_or_else(
-        || std::path::PathBuf::from("."),
-        std::path::Path::to_path_buf,
-    );
+    let compose_dir = compose_file_dir(&ctx.compose_file);
 
     let entries: Vec<(String, InfraCertEntry)> = ctx
         .state


### PR DESCRIPTION
## Summary

`bootroot reinit` failed immediately with `could not derive compose project name from ` (trailing empty string) whenever it was invoked without an explicit `--compose-file`, i.e. with the default relative `docker-compose.yml`. `Path::parent` returns `Some("")` — not `None` — for a relative path that has no directory component, so the `compose_file.parent().unwrap_or(Path::new("."))` shape used in `reinit`, `clean --openbao-only`, the init orchestrator's `.env` loader and DB-password rotation, and `rotate infra-cert` all fed an empty path into downstream `canonicalize` / `file_name` / `.join` consumers.

This broke the curated recovery path documented for partial-init failures and forced operators into the destructive `clean --openbao-only` + `infra install` + `init` escape hatch, defeating reinit's purpose of preserving step-ca material.

Funnel every `--compose-file` directory derivation through a single `commands::compose_file::compose_file_dir` helper that normalises the empty-parent case to `"."`.

Touched sites:

- `run_reinit` before `verify_compose_managed_openbao` (`src/commands/reinit.rs`)
- `remove_openbao_container_and_volumes` and `run_clean` (`src/commands/clean.rs`)
- Init orchestrator `.env` loader and DB-password rotation (`src/commands/init/steps/orchestrator.rs`)
- `rotate_infra_certs` (`src/commands/rotate/infra_cert.rs`)

Closes #611

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test compose_file::tests` covers the helper for empty, relative, dot-prefixed, and absolute compose-file paths
- [x] `cargo test resolve_compose_project_handles_dot_relative_compose_dir` confirms `resolve_compose_project` canonicalises cleanly when the compose dir is `.`
- [x] `cargo test resolve_compose_project_honours_env_var_for_dot_relative_compose_dir` confirms `COMPOSE_PROJECT_NAME` still wins over basename derivation
- [x] `cargo test verify_compose_managed_openbao_accepts_default_relative_compose_file` exercises the container-absent reinit recovery branch with the default relative `--compose-file`
- [x] Manual repro: from a directory containing a valid `docker-compose.yml`, `bootroot reinit -y --no-eab --enable auto-generate --summary-json secrets/init-summary.json` no longer fails with `could not derive compose project name from `
- [x] `bootroot clean --openbao-only` with the default relative compose file resolves the compose project name and removes the OpenBao container/volumes