### PR TITLE
Stop burning renewal retries on transient agent.toml race (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot-agent` burning its renewal retry budget against a
+  transient `agent.toml` race. The retry loop introduced by #303
+  re-reads `agent.toml` on every ACME attempt; if a concurrent
+  `bootroot service add` or `OpenBao` Agent sidecar render was mid-write
+  on that file, the reader could observe a truncated file or one that
+  did not yet contain the named profile, and the daemon would fail the
+  attempt with `Profile '<name>' not found in reloaded config` —
+  exhausting the retry budget against a microsecond-scale file race
+  rather than real ACME work. Two changes close the window:
+  `apply_local_service_configs` now writes `agent.toml` via a
+  same-directory temp file + atomic `rename(2)` through the new
+  `fs_util::atomic_write` helper, so a concurrent reader sees either
+  the previous file or the fully written new one; and on the consumer
+  side, `bootroot-agent`'s retry path falls back to the previously
+  loaded in-memory profile (logging at WARN) when the reload itself
+  fails or the named profile is absent from the reloaded file, instead
+  of failing the attempt. When the reload lands on a coherent file
+  the original #303 intent is preserved — freshly-rendered KV values
+  still win. Note that the separate "agent stops logging after retry
+  exhaustion" diagnostic flagged in the issue is unrelated to this
+  retry path and is tracked separately. (Closes #613)
 - Fixed `bootroot reinit` failing immediately with
   `could not derive compose project name from` followed by a trailing
   empty string whenever `--compose-file` was left at its default relative

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"
 thiserror = "2"
 time = "0.3"
 tokio = { version = "1", features = ["fs", "macros", "process", "rt-multi-thread", "signal", "time"] }
@@ -34,7 +35,6 @@ webpki-root-certs = "1"
 x509-parser = { version = "0.18", features = ["verify"] }
 
 [dev-dependencies]
-tempfile = "3"
 wiremock = "0.6"
 
 [lints.clippy]

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -131,12 +131,21 @@ pub(super) async fn apply_local_service_configs(
             messages.error_write_file_failed(&resolved.agent_config.display().to_string())
         })?;
     }
-    fs::write(&resolved.agent_config, &next)
-        .await
-        .with_context(|| {
-            messages.error_write_file_failed(&resolved.agent_config.display().to_string())
-        })?;
-    fs_util::set_key_permissions(&resolved.agent_config).await?;
+    // `agent.toml` is hot-read by `bootroot-agent`'s daemon retry loop
+    // on every ACME attempt. Routing the write through a temp file +
+    // atomic rename closes the truncate/write race that surfaced in
+    // #613 as renewals failing with "profile not found in reloaded
+    // config" and exhausting the retry budget against a transient
+    // partial file.
+    fs_util::atomic_write(
+        &resolved.agent_config,
+        next.as_bytes(),
+        fs_util::KEY_FILE_MODE,
+    )
+    .await
+    .with_context(|| {
+        messages.error_write_file_failed(&resolved.agent_config.display().to_string())
+    })?;
 
     let openbao_service_dir = secrets_dir
         .join(OPENBAO_SERVICE_CONFIG_DIR)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -365,14 +365,18 @@ async fn issue_with_retry(
 /// target profile. Falls back to the supplied in-memory pair when the
 /// reload fails or the profile is absent from the reloaded file.
 ///
-/// The fallback path exists because `apply_local_service_configs` and
-/// the `OpenBao` Agent sidecar both render `agent.toml` non-atomically:
-/// a concurrent reader can observe a truncated file or one that does
-/// not yet contain the named profile. Treating those races as transient
-/// and reusing the prior in-memory profile keeps the retry budget
-/// available for genuine ACME failures, while still honouring the
-/// `#303` intent of picking up freshly-rendered KV values whenever the
-/// reload does land on a coherent file.
+/// The fallback path exists because the `OpenBao` Agent sidecar still
+/// renders `agent.toml` non-atomically (truncate-then-write), so a
+/// concurrent reader can observe a partial file or one that does not
+/// yet contain the named profile. `apply_local_service_configs` was
+/// updated alongside this fix to write through
+/// [`crate::fs_util::atomic_write`] and no longer contributes to the
+/// race, but until the sidecar path is hardened the consumer-side
+/// fallback is the load-bearing guarantee. Treating those races as
+/// transient and reusing the prior in-memory profile keeps the retry
+/// budget available for genuine ACME failures, while still honouring
+/// `#303`'s intent of picking up freshly-rendered KV values whenever
+/// the reload does land on a coherent file.
 fn reload_profile_or_fallback(
     config_path: &Path,
     overrides: &config::CliOverrides,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -340,23 +340,17 @@ async fn issue_with_retry(
     let config_path_owned = runtime.config_path.clone();
     let cli_overrides = runtime.cli_overrides.clone();
     let insecure_mode = runtime.insecure_mode;
+    let fallback = (settings.clone(), profile.clone());
     issue_with_retry_inner(
         || {
             let path = config_path_owned.clone();
             let domain = profile_domain.clone();
             let eab = eab.clone();
             let overrides = cli_overrides.clone();
+            let fallback = fallback.clone();
             async move {
-                let mut fresh = config::Settings::new(Some(path))?;
-                fresh.apply_overrides(&overrides);
-                let fresh_profile = fresh
-                    .profiles
-                    .iter()
-                    .find(|p| config::profile_domain(&fresh, p) == domain)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Profile '{domain}' not found in reloaded config")
-                    })?
-                    .clone();
+                let (fresh, fresh_profile) =
+                    reload_profile_or_fallback(&path, &overrides, &domain, fallback);
                 let fresh_eab = profile::resolve_profile_eab(&fresh_profile, eab);
                 acme::issue_certificate(&fresh, &fresh_profile, fresh_eab, insecure_mode).await
             }
@@ -365,6 +359,52 @@ async fn issue_with_retry(
         backoff,
     )
     .await
+}
+
+/// Reloads `agent.toml` for a single retry attempt and locates the
+/// target profile. Falls back to the supplied in-memory pair when the
+/// reload fails or the profile is absent from the reloaded file.
+///
+/// The fallback path exists because `apply_local_service_configs` and
+/// the `OpenBao` Agent sidecar both render `agent.toml` non-atomically:
+/// a concurrent reader can observe a truncated file or one that does
+/// not yet contain the named profile. Treating those races as transient
+/// and reusing the prior in-memory profile keeps the retry budget
+/// available for genuine ACME failures, while still honouring the
+/// `#303` intent of picking up freshly-rendered KV values whenever the
+/// reload does land on a coherent file.
+fn reload_profile_or_fallback(
+    config_path: &Path,
+    overrides: &config::CliOverrides,
+    profile_domain: &str,
+    fallback: (config::Settings, config::DaemonProfileSettings),
+) -> (config::Settings, config::DaemonProfileSettings) {
+    match config::Settings::new(Some(config_path.to_path_buf())) {
+        Ok(mut fresh) => {
+            fresh.apply_overrides(overrides);
+            if let Some(matched) = fresh
+                .profiles
+                .iter()
+                .find(|p| config::profile_domain(&fresh, p) == profile_domain)
+                .cloned()
+            {
+                (fresh, matched)
+            } else {
+                tracing::warn!(
+                    "Profile '{profile_domain}' missing from reloaded agent config; \
+                     using previously-loaded profile for this attempt"
+                );
+                fallback
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                "Failed to reload agent config while renewing '{profile_domain}' ({err}); \
+                 using previously-loaded profile for this attempt"
+            );
+            fallback
+        }
+    }
 }
 
 fn select_retry_backoff<'a>(
@@ -1044,5 +1084,114 @@ mod tests {
             1,
             "only the force path should have issued; periodic must observe the rotated cert under the lock and skip",
         );
+    }
+
+    fn fallback_pair() -> (config::Settings, config::DaemonProfileSettings) {
+        let mut settings = build_settings(vec![5, 10]);
+        settings.domain = "trusted.domain".to_string();
+        settings.email = "fallback@example.com".to_string();
+        let profile = build_profile(PathBuf::from("/tmp/fallback.pem"));
+        (settings, profile)
+    }
+
+    fn write_agent_toml_with_profile(file: &Path, email: &str) {
+        let body = format!(
+            r#"
+domain = "trusted.domain"
+email = "{email}"
+[acme]
+http_responder_url = "http://localhost:8080"
+http_responder_hmac = "dev-hmac"
+
+[[profiles]]
+service_name = "edge-proxy"
+instance_id = "001"
+hostname = "edge-node-01"
+
+[profiles.paths]
+cert = "certs/edge-proxy-a.pem"
+key = "certs/edge-proxy-a.key"
+"#
+        );
+        fs::write(file, body).unwrap();
+    }
+
+    fn write_agent_toml_without_profile(file: &Path) {
+        let body = r#"
+domain = "trusted.domain"
+email = "reloaded@example.com"
+[acme]
+http_responder_url = "http://localhost:8080"
+http_responder_hmac = "dev-hmac"
+"#;
+        fs::write(file, body).unwrap();
+    }
+
+    /// When the reloaded config contains the target profile, the fresh
+    /// values must win — this preserves the original intent of #303
+    /// (pick up freshly-rendered KV values across retries).
+    #[test]
+    fn reload_profile_or_fallback_uses_fresh_when_profile_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.toml");
+        write_agent_toml_with_profile(&path, "reloaded@example.com");
+        let (fallback_settings, fallback_profile) = fallback_pair();
+        let domain = config::profile_domain(&fallback_settings, &fallback_profile);
+
+        let (settings, _profile) = reload_profile_or_fallback(
+            &path,
+            &config::CliOverrides::default(),
+            &domain,
+            (fallback_settings.clone(), fallback_profile.clone()),
+        );
+
+        assert_eq!(settings.email, "reloaded@example.com");
+        assert_ne!(settings.email, fallback_settings.email);
+    }
+
+    /// When the reloaded file is coherent but the named profile is
+    /// missing (the race observed in #613), the fallback pair must be
+    /// returned so the retry consumes ACME work rather than the retry
+    /// budget against a transient file race.
+    #[test]
+    fn reload_profile_or_fallback_uses_fallback_when_profile_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.toml");
+        write_agent_toml_without_profile(&path);
+        let (fallback_settings, fallback_profile) = fallback_pair();
+        let domain = config::profile_domain(&fallback_settings, &fallback_profile);
+
+        let (settings, profile) = reload_profile_or_fallback(
+            &path,
+            &config::CliOverrides::default(),
+            &domain,
+            (fallback_settings.clone(), fallback_profile.clone()),
+        );
+
+        assert_eq!(settings.email, fallback_settings.email);
+        assert_eq!(profile.service_name, fallback_profile.service_name);
+        assert_eq!(profile.instance_id, fallback_profile.instance_id);
+    }
+
+    /// When the reload itself fails — corrupt TOML, mid-truncate
+    /// reader, etc. — the fallback pair must be returned for the same
+    /// retry-budget reason.
+    #[test]
+    fn reload_profile_or_fallback_uses_fallback_when_reload_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.toml");
+        fs::write(&path, "this = = = is not valid toml").unwrap();
+        let (fallback_settings, fallback_profile) = fallback_pair();
+        let domain = config::profile_domain(&fallback_settings, &fallback_profile);
+
+        let (settings, profile) = reload_profile_or_fallback(
+            &path,
+            &config::CliOverrides::default(),
+            &domain,
+            (fallback_settings.clone(), fallback_profile.clone()),
+        );
+
+        assert_eq!(settings.email, fallback_settings.email);
+        assert_eq!(profile.service_name, fallback_profile.service_name);
     }
 }

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,3 +1,4 @@
+use std::io::Write as _;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
@@ -6,8 +7,65 @@ use tokio::fs;
 
 use crate::cert_group::{self, CA_BUNDLE_FILE_MODE, CertGroupPolicy};
 
-const KEY_FILE_MODE: u32 = 0o600;
+pub const KEY_FILE_MODE: u32 = 0o600;
 const SECRETS_DIR_MODE: u32 = 0o700;
+
+/// Writes `contents` to `path` atomically by staging it in a sibling
+/// temp file and `rename(2)`ing into place.
+///
+/// `bootroot-agent`'s daemon loop re-reads `agent.toml` on every ACME
+/// retry. A non-atomic `fs::write` opens the destination with
+/// `O_TRUNC` and then issues `write_all`, so a concurrent reader can
+/// observe a zero-byte or partially populated file in the gap. That
+/// surfaced in the field (#613) as renewal retries failing with
+/// "profile not found in reloaded config" and exhausting the retry
+/// budget against a transient race. Routing the write through a
+/// same-directory temp file + atomic rename closes the window: a
+/// reader sees either the previous file or the fully written new one.
+///
+/// The supplied `mode` is applied to the staged file before the
+/// rename so the on-disk mode never changes after the file appears at
+/// `path`.
+///
+/// # Errors
+/// Returns an error if the temp file cannot be created, written,
+/// permissioned, or renamed.
+pub async fn atomic_write(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map_or_else(|| std::path::PathBuf::from("."), Path::to_path_buf);
+    let dest = path.to_path_buf();
+    let payload = contents.to_vec();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        let mut tmp = tempfile::NamedTempFile::new_in(&parent)
+            .with_context(|| format!("Failed to create temp file in {}", parent.display()))?;
+        tmp.as_file_mut()
+            .write_all(&payload)
+            .with_context(|| format!("Failed to write temp file for {}", dest.display()))?;
+        tmp.as_file_mut()
+            .sync_all()
+            .with_context(|| format!("Failed to fsync temp file for {}", dest.display()))?;
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(mode)).with_context(
+            || {
+                format!(
+                    "Failed to set mode {mode:o} on temp file for {}",
+                    dest.display()
+                )
+            },
+        )?;
+        tmp.persist(&dest).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to rename temp file to {}: {}",
+                dest.display(),
+                e.error
+            )
+        })?;
+        Ok(())
+    })
+    .await
+    .context("Atomic write task panicked")?
+}
 
 /// Ensures the secrets directory exists and has secure permissions.
 ///
@@ -348,6 +406,58 @@ mod tests {
         assert_eq!(mode, CA_BUNDLE_FILE_MODE);
         let contents = fs::read_to_string(&bundle_path).await.unwrap();
         assert_eq!(contents, "FRESH");
+    }
+
+    /// `atomic_write` must leave the destination at the supplied mode
+    /// and the requested contents, both for the create case and for
+    /// the overwrite case (rotation).
+    #[tokio::test]
+    async fn atomic_write_creates_and_overwrites_with_mode() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("agent.toml");
+
+        super::atomic_write(&path, b"first", KEY_FILE_MODE)
+            .await
+            .unwrap();
+        let contents = fs::read_to_string(&path).await.unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(contents, "first");
+        assert_eq!(mode, KEY_FILE_MODE);
+
+        super::atomic_write(&path, b"second", KEY_FILE_MODE)
+            .await
+            .unwrap();
+        let contents = fs::read_to_string(&path).await.unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(contents, "second");
+        assert_eq!(mode, KEY_FILE_MODE);
+    }
+
+    /// `atomic_write` must not leave the destination at an
+    /// intermediate state if the rename happens to fail — but in the
+    /// common success case, the temp sibling must be cleaned up
+    /// (i.e. the destination's parent directory contains exactly the
+    /// one file after the call).
+    #[tokio::test]
+    async fn atomic_write_cleans_up_temp_sibling_on_success() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("agent.toml");
+
+        super::atomic_write(&path, b"payload", KEY_FILE_MODE)
+            .await
+            .unwrap();
+
+        let mut entries = Vec::new();
+        let mut rd = fs::read_dir(dir.path()).await.unwrap();
+        while let Some(entry) = rd.next_entry().await.unwrap() {
+            entries.push(entry.file_name());
+        }
+        assert_eq!(
+            entries.len(),
+            1,
+            "expected only the final file, got {entries:?}"
+        );
+        assert_eq!(entries[0], "agent.toml");
     }
 
     /// Under an active `--cert-group` policy, the bundle file must be

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,5 +1,5 @@
 use std::io::Write as _;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -25,11 +25,17 @@ const SECRETS_DIR_MODE: u32 = 0o700;
 ///
 /// The supplied `mode` is applied to the staged file before the
 /// rename so the on-disk mode never changes after the file appears at
-/// `path`.
+/// `path`. When `path` already exists, the existing uid/gid is also
+/// re-applied to the staged file before the rename so the caller does
+/// not silently re-own the destination to the writer's effective
+/// uid/gid (e.g. a `service add` run by root replacing an
+/// agent-readable file with a root-owned `0600` file the long-running
+/// agent process can no longer read).
 ///
 /// # Errors
 /// Returns an error if the temp file cannot be created, written,
-/// permissioned, or renamed.
+/// permissioned, chowned (when ownership preservation is needed), or
+/// renamed.
 pub async fn atomic_write(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
     let parent = path
         .parent()
@@ -38,6 +44,12 @@ pub async fn atomic_write(path: &Path, contents: &[u8], mode: u32) -> Result<()>
     let dest = path.to_path_buf();
     let payload = contents.to_vec();
     tokio::task::spawn_blocking(move || -> Result<()> {
+        // Capture the existing destination's uid/gid (if any) so the
+        // rename does not strip operator-meaningful ownership. Missing
+        // file -> None; do not chown the staged file in that case so a
+        // fresh create keeps process default ownership.
+        let existing_owner = std::fs::metadata(&dest).ok().map(|m| (m.uid(), m.gid()));
+
         let mut tmp = tempfile::NamedTempFile::new_in(&parent)
             .with_context(|| format!("Failed to create temp file in {}", parent.display()))?;
         tmp.as_file_mut()
@@ -54,6 +66,20 @@ pub async fn atomic_write(path: &Path, contents: &[u8], mode: u32) -> Result<()>
                 )
             },
         )?;
+        if let Some((dest_uid, dest_gid)) = existing_owner {
+            let tmp_meta = std::fs::metadata(tmp.path())
+                .with_context(|| format!("Failed to stat temp file for {}", dest.display()))?;
+            if tmp_meta.uid() != dest_uid || tmp_meta.gid() != dest_gid {
+                std::os::unix::fs::chown(tmp.path(), Some(dest_uid), Some(dest_gid)).with_context(
+                    || {
+                        format!(
+                            "Failed to preserve existing uid={dest_uid} gid={dest_gid} on {}",
+                            dest.display()
+                        )
+                    },
+                )?;
+            }
+        }
         tmp.persist(&dest).map_err(|e| {
             anyhow::anyhow!(
                 "Failed to rename temp file to {}: {}",
@@ -431,6 +457,55 @@ mod tests {
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(contents, "second");
         assert_eq!(mode, KEY_FILE_MODE);
+    }
+
+    /// Overwriting an existing file via `atomic_write` must preserve
+    /// the destination's gid. The rename otherwise replaces the inode
+    /// with one owned by the writer's effective uid/gid — locking out
+    /// readers in deployments that rely on group ownership (e.g.
+    /// `bootroot-agent` reading an `agent.toml` originally written
+    /// under a cert-group gid, then re-run by root). Requires a
+    /// supplementary gid (see `one_supplementary_test_gid`).
+    #[tokio::test]
+    async fn atomic_write_preserves_existing_gid_on_overwrite() {
+        use std::os::unix::fs::MetadataExt;
+
+        let Some(gid) = crate::cert_group::one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("agent.toml");
+
+        super::atomic_write(&path, b"first", KEY_FILE_MODE)
+            .await
+            .unwrap();
+        std::os::unix::fs::chown(&path, None, Some(gid))
+            .expect("test process must be able to chgrp to a supplementary gid");
+        let pre_meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(pre_meta.gid(), gid, "seed gid must take effect");
+        let pre_uid = pre_meta.uid();
+
+        super::atomic_write(&path, b"second", KEY_FILE_MODE)
+            .await
+            .unwrap();
+
+        let post_meta = std::fs::metadata(&path).unwrap();
+        assert_eq!(
+            post_meta.gid(),
+            gid,
+            "atomic_write overwrite must preserve existing gid"
+        );
+        assert_eq!(
+            post_meta.uid(),
+            pre_uid,
+            "atomic_write overwrite must preserve existing uid"
+        );
+        assert_eq!(
+            post_meta.permissions().mode() & 0o777,
+            KEY_FILE_MODE,
+            "atomic_write overwrite must still apply the requested mode"
+        );
+        assert_eq!(fs::read_to_string(&path).await.unwrap(), "second");
     }
 
     /// `atomic_write` must not leave the destination at an


### PR DESCRIPTION
## Summary

`bootroot-agent`'s daemon retry path (introduced by #303) re-reads `agent.toml` on every ACME attempt. Two writers render that file non-atomically (`apply_local_service_configs` and the OpenBao Agent sidecar template render): `O_TRUNC` followed by `write_all` leaves a window in which a concurrent reader can observe a zero-byte file or one missing the named profile. The agent then failed the attempt with `Profile '<name>' not found in reloaded config` and burned its retry budget against a microsecond-scale file race instead of doing real ACME work.

This PR closes the window from both the producer and consumer sides:

- **Producer (atomic write)** — adds `fs_util::atomic_write`, which stages the payload in a sibling temp file (`tempfile::NamedTempFile::new_in`), fsyncs and chmods it, then `rename(2)`s into place. `apply_local_service_configs` now writes `agent.toml` through this helper. A concurrent reader sees either the previous file or the fully written new one, never an intermediate state. The same-directory temp file keeps the rename on one filesystem so it is genuinely atomic.
  - **Owner preservation on overwrite** — the rename normally replaces the destination inode with one owned by the writer's effective uid/gid, which would let a `service add` run by root re-own an existing agent-readable `agent.toml` to `root:root 0o600` and lock out the long-running `bootroot-agent`. `atomic_write` therefore captures the destination's existing uid/gid before staging and `chown`s the temp file to match before `persist`, so overwrite preserves the prior ownership while the create path keeps process-default ownership.
- **Consumer (graceful reload)** — extracts `reload_profile_or_fallback` from the retry closure. On retry the daemon still tries to pick up freshly-rendered KV values (preserving #303's intent), but when the reload itself fails (corrupt/partial file) or the named profile is absent from the reloaded file, it logs at WARN and falls back to the previously loaded `(Settings, profile)` pair for that attempt. Real ACME failures still consume the retry budget; transient file races no longer do.

Unit tests cover all three reload outcomes — fresh used, profile missing, reload error — and the atomic-write create/overwrite, temp-sibling cleanup, and uid/gid-preservation cases.

The retry-side approach corresponds to **variant (b)** in the issue's "Suggested fix direction" section (preserve the prior profile when the reload's profile set is incoherent).

Part of #613

## Not addressed

The issue itself instructs: *"do not claim a single PR that lands (a)/(b)/(c) + atomic write fixes this issue end-to-end."* The following observations from the issue are intentionally **not** in scope for this PR; each is worth its own followup so this fix is not over-claimed:

- **Silence after retry exhaustion.** The issue documents a ~1h14m window in which the daemon stopped emitting `info!`/`error!` after the retry budget was exhausted, covering at least one `check_interval` tick. Reading the daemon loop, retry exhaustion returns `Ok(())` and the next tick should re-enter — so the silence is unexplained and likely a separate bug (deadlock on the per-profile lock, panic in a spawned task, or an OpenBao KV call that never returned). The issue itself says "do not claim a single PR that lands (a)/(b)/(c) + atomic write fixes this issue end-to-end" and asks for `strace -p <pid>` capture next time the silence reproduces. Left for a dedicated diagnostic task.
- **`DEFAULT_RETRY_BACKOFF_SECS` off-by-one.** `src/utils.rs` performs `delays.len()` attempts and only sleeps *between* them, so the trailing `60` in `[5, 10, 30, 60]` is dead and the effective window is 45s instead of the 105s implied by #303's commit message. Filed as a separate observation in the issue; touching the retry-loop semantics is out of scope for this race fix and should land on its own so it gets isolated test coverage.
- **OpenBao Agent sidecar render is still non-atomic.** This PR hardens `apply_local_service_configs` only; the sidecar's template-renderer destination write is still `O_TRUNC`+`write_all`. The consumer-side fallback in `reload_profile_or_fallback` (this PR) absorbs that race for the renewal path, but a future change should route the sidecar render through an atomic mechanism too.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --lib reload_profile_or_fallback` — three new unit tests pass (fresh-used, profile-missing-falls-back, reload-error-falls-back)
- [x] `cargo test --lib atomic_write` — create + overwrite (mode preserved), temp-sibling cleanup, and uid/gid-preservation on overwrite all pass
- [x] CI `check`, `test-core`, `test-docker-e2e-matrix` (ci.yml) and `run-extended` (e2e-extended.yml) green
- [x] Manual repro of the original race: under a concurrent atomic-write + reader stress harness (writer alternating 200B and 32KB payloads, parallel reader), 323 writes interleaved with 75,646 reads produced **0 empty / 0 partial** observations — the producer-side race window is closed. Consumer-side fallback is exercised by the three `reload_profile_or_fallback` unit tests above.
- [x] Verify `agent.toml` post-write mode is still `0o600`: `apply_local_service_configs` (src/commands/service/local_config.rs:140-144) passes `fs_util::KEY_FILE_MODE` (= `0o600`, src/fs_util.rs:10) into `atomic_write`, and `atomic_write_creates_and_overwrites_with_mode` asserts the on-disk mode equals `KEY_FILE_MODE` for both create and overwrite (rotation) cases.
