### PR TITLE
Fix DEFAULT_RETRY_BACKOFF_SECS off-by-one in retry loop (#617)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -920,10 +920,14 @@ mod tests {
         let ok = issue_with_retry_inner(issue_fn, sleep_fn, &TEST_DELAYS).await;
 
         assert!(ok.is_err());
-        assert_eq!(*attempts.lock().unwrap(), 3);
+        assert_eq!(*attempts.lock().unwrap(), TEST_DELAYS.len() + 1);
         assert_eq!(
             *sleeps.lock().unwrap(),
-            vec![Duration::from_secs(1), Duration::from_secs(2)]
+            TEST_DELAYS
+                .iter()
+                .copied()
+                .map(Duration::from_secs)
+                .collect::<Vec<_>>()
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,6 +59,11 @@ where
 
 /// Retries an operation using custom sleep logic between attempts.
 ///
+/// `delays` defines the inter-attempt waits, so the total number of
+/// attempts is `delays.len() + 1`: `delays[i]` is slept between
+/// attempt `i + 1` and attempt `i + 2`. With `delays = [5, 10, 30, 60]`
+/// the operation is invoked at cumulative offsets 0/5/15/45/105s.
+///
 /// # Errors
 /// Returns the final error if all attempts fail.
 pub async fn retry_with_backoff_and_sleep<IssueFn, IssueFut, SleepFn, SleepFut, OnError>(
@@ -74,24 +79,15 @@ where
     SleepFut: Future<Output = ()>,
     OnError: FnMut(usize, &anyhow::Error),
 {
-    if delays.is_empty() {
-        return match issue_fn().await {
-            Ok(()) => Ok(()),
-            Err(err) => {
-                on_error(1, &err);
-                Err(err)
-            }
-        };
-    }
-
+    let total_attempts = delays.len() + 1;
     let mut last_err = None;
-    for (attempt, delay) in delays.iter().enumerate() {
+    for attempt in 0..total_attempts {
         match issue_fn().await {
             Ok(()) => return Ok(()),
             Err(err) => {
                 on_error(attempt + 1, &err);
                 last_err = Some(err);
-                if attempt + 1 < delays.len() {
+                if let Some(delay) = delays.get(attempt) {
                     sleep_fn(Duration::from_secs(*delay)).await;
                 }
             }
@@ -125,4 +121,133 @@ pub fn jittered_delay_with_seed(base: Duration, jitter: Duration, now_ns: i128) 
     let adjusted = u64::try_from(adjusted).unwrap_or(u64::MAX);
 
     Duration::from_nanos(adjusted)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    const DEFAULT_BACKOFF: [u64; 4] = [5, 10, 30, 60];
+
+    #[tokio::test]
+    async fn retry_with_backoff_and_sleep_exhausts_all_delays() {
+        // Pins the inter-attempt semantics: `delays.len() + 1` attempts and
+        // every delay is slept, so [5, 10, 30, 60] yields attempts at
+        // cumulative 0/5/15/45/105s (matching the intent recorded in #303
+        // and the fix for #617).
+        let attempts = Arc::new(Mutex::new(0usize));
+        let sleeps = Arc::new(Mutex::new(Vec::new()));
+        let errors = Arc::new(Mutex::new(Vec::new()));
+
+        let attempts_issue = Arc::clone(&attempts);
+        let issue_fn = move || {
+            let attempts_inner = Arc::clone(&attempts_issue);
+            async move {
+                *attempts_inner.lock().expect("attempts mutex") += 1;
+                anyhow::bail!("persistent failure")
+            }
+        };
+
+        let sleeps_log = Arc::clone(&sleeps);
+        let sleep_fn = move |duration: Duration| {
+            let sleeps_inner = Arc::clone(&sleeps_log);
+            async move {
+                sleeps_inner.lock().expect("sleeps mutex").push(duration);
+            }
+        };
+
+        let errors_log = Arc::clone(&errors);
+        let on_error = move |attempt: usize, _err: &anyhow::Error| {
+            errors_log.lock().expect("errors mutex").push(attempt);
+        };
+
+        let result =
+            retry_with_backoff_and_sleep(issue_fn, sleep_fn, on_error, &DEFAULT_BACKOFF).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            *attempts.lock().expect("attempts mutex"),
+            DEFAULT_BACKOFF.len() + 1
+        );
+        assert_eq!(
+            *sleeps.lock().expect("sleeps mutex"),
+            DEFAULT_BACKOFF
+                .iter()
+                .copied()
+                .map(Duration::from_secs)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            *errors.lock().expect("errors mutex"),
+            (1..=DEFAULT_BACKOFF.len() + 1).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_with_backoff_and_sleep_returns_on_success() {
+        let attempts = Arc::new(Mutex::new(0usize));
+        let sleeps = Arc::new(Mutex::new(Vec::new()));
+
+        let attempts_issue = Arc::clone(&attempts);
+        let issue_fn = move || {
+            let attempts_inner = Arc::clone(&attempts_issue);
+            async move {
+                let mut guard = attempts_inner.lock().expect("attempts mutex");
+                *guard += 1;
+                if *guard < 3 {
+                    anyhow::bail!("transient");
+                }
+                Ok(())
+            }
+        };
+
+        let sleeps_log = Arc::clone(&sleeps);
+        let sleep_fn = move |duration: Duration| {
+            let sleeps_inner = Arc::clone(&sleeps_log);
+            async move {
+                sleeps_inner.lock().expect("sleeps mutex").push(duration);
+            }
+        };
+
+        let result =
+            retry_with_backoff_and_sleep(issue_fn, sleep_fn, |_, _| {}, &DEFAULT_BACKOFF).await;
+
+        assert!(result.is_ok());
+        assert_eq!(*attempts.lock().expect("attempts mutex"), 3);
+        assert_eq!(
+            *sleeps.lock().expect("sleeps mutex"),
+            vec![Duration::from_secs(5), Duration::from_secs(10)]
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_with_backoff_and_sleep_runs_once_when_delays_empty() {
+        let attempts = Arc::new(Mutex::new(0usize));
+        let sleeps = Arc::new(Mutex::new(Vec::new()));
+
+        let attempts_issue = Arc::clone(&attempts);
+        let issue_fn = move || {
+            let attempts_inner = Arc::clone(&attempts_issue);
+            async move {
+                *attempts_inner.lock().expect("attempts mutex") += 1;
+                anyhow::bail!("boom")
+            }
+        };
+
+        let sleeps_log = Arc::clone(&sleeps);
+        let sleep_fn = move |duration: Duration| {
+            let sleeps_inner = Arc::clone(&sleeps_log);
+            async move {
+                sleeps_inner.lock().expect("sleeps mutex").push(duration);
+            }
+        };
+
+        let result = retry_with_backoff_and_sleep(issue_fn, sleep_fn, |_, _| {}, &[]).await;
+
+        assert!(result.is_err());
+        assert_eq!(*attempts.lock().expect("attempts mutex"), 1);
+        assert!(sleeps.lock().expect("sleeps mutex").is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

`retry_with_backoff_and_sleep` performed `delays.len()` attempts and only slept between them, so the trailing `60` in `DEFAULT_RETRY_BACKOFF_SECS = [5, 10, 30, 60]` was never slept. The effective inter-attempt window was 5+10+30 = 45s rather than the 105s envisioned in #303, which matches the +45s exhaustion seen in the #613 field log.

This PR treats `delays` as inter-attempt waits — `delays.len() + 1` total attempts with `delays[i]` slept between attempt `i + 1` and `i + 2`. With the default schedule that produces 5 attempts at cumulative `0 / 5 / 15 / 45 / 105 s`, restoring the original intent.

The existing `daemon::tests::test_issue_with_retry_gives_up` was updated to assert the new attempt count and the full sleep sequence, and a new unit test on the public `utils::retry_with_backoff_and_sleep` pins the inter-attempt semantics so this can't regress silently again.

Closes #617

## Test plan

- [x] `cargo test --lib utils::tests::retry_with_backoff_and_sleep_exhausts_all_delays` — confirms 5 attempts and all four delays are slept
- [x] `cargo test --lib utils::tests::retry_with_backoff_and_sleep_returns_on_success` — confirms early return stops further sleeps
- [x] `cargo test --lib utils::tests::retry_with_backoff_and_sleep_runs_once_when_delays_empty` — confirms empty `delays` still invokes the operation exactly once
- [x] `cargo test --lib daemon::tests::test_issue_with_retry_gives_up` — confirms daemon caller sees the new attempt-count semantics
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings