### PR TITLE
Tie phase-5 consumer-reload hint to the actually-reissued set (#619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot rotate ca-key` phase 5 listing every `local-file`
+  service in its "Consumer reload/restart required" hint regardless of
+  whether the rotation actually wiped and signaled the service. On a
+  resumed or retried rotation, or after a partial manual migration,
+  services whose cert was already issued by the new intermediate take
+  the skip-migrated branch and are never re-signaled — but they still
+  appeared in the printed hint, so an operator following it would
+  restart consumers that did not need restarting, churning live
+  traffic and eroding trust in the hint. The hint is now built from
+  the services actually processed in the reissue loop, so the
+  skip-migrated branch no longer contributes. (Closes #619)
 - Fixed `bootroot-agent` burning its renewal retry budget against a
   transient `agent.toml` race. The retry loop introduced by #303
   re-reads `agent.toml` on every ACME attempt; if a concurrent

--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -266,6 +266,13 @@ the affected services and their post-renew hook status. Services
 without a hook are flagged explicitly and accompanied by the
 `service update --reload-style ...` remediation pointer.
 
+For `rotate ca-key` specifically, the hint only lists services whose
+cert was actually wiped and re-signaled by this invocation. Services
+already issued by the new intermediate (the skip-migrated branch on
+resumed or retried rotations) are not included, since this rotation
+did not change their on-disk leaf and their consumers do not need to
+reload.
+
 `bootroot reinit` wipes the service registry rather than the cert
 files — its completion hint reminds the operator to re-register each
 consumer with `bootroot service add ... --reload-style ...` so the

--- a/docs/ko/operations.md
+++ b/docs/ko/operations.md
@@ -255,6 +255,12 @@ reload/restart required" 안내를 출력합니다. 훅이 없는 서비스는
 명시적으로 플래그되며 `service update --reload-style ...` 복구
 안내가 함께 표시됩니다.
 
+특히 `rotate ca-key`의 경우 안내에는 이번 호출에서 실제로 인증서를
+삭제하고 재서명한 서비스만 포함됩니다. 이미 새 intermediate로 발급된
+서비스(재개 또는 재시도 회전의 skip-migrated 분기)는 이번 회전이 디스크
+상 leaf를 바꾸지 않았고 컨슈머도 다시 로드할 필요가 없으므로 안내에
+나타나지 않습니다.
+
 `bootroot reinit`은 인증서 파일이 아니라 서비스 레지스트리를 지웁니다.
 완료 안내는 컨슈머의 다음 갱신 주기 전에 갱신 후 훅이 미리 구성되도록
 `bootroot service add ... --reload-style ...`로 각 컨슈머를 재등록할

--- a/src/commands/rotate/ca.rs
+++ b/src/commands/rotate/ca.rs
@@ -224,39 +224,32 @@ pub(super) async fn rotate_ca_key(
         println!("{}", messages.rotate_ca_key_phase_reissue());
 
         let new_inter_cert_path = ctx.paths.intermediate_cert();
+        let mut reissued_local: Vec<&ServiceEntry> = Vec::new();
         for entry in ctx.state.services.values() {
-            let cert_path = &entry.cert_path;
-            if cert_path.exists()
-                && cert_issued_by_new_intermediate(cert_path, &new_inter_cert_path, messages)
-                    .unwrap_or(false)
-            {
-                println!(
-                    "{}",
-                    messages.rotate_ca_key_skip_migrated(&entry.service_name)
-                );
-                continue;
-            }
-
-            if matches!(entry.delivery_mode, DeliveryMode::LocalFile) {
-                let _ = fs::remove_file(cert_path);
-                let _ = fs::remove_file(&entry.key_path);
-                signal_bootroot_agent(entry, messages)?;
-            } else {
-                println!(
-                    "{}",
-                    messages.rotate_ca_key_reissue_remote_hint(&entry.service_name)
-                );
+            match classify_phase5_action(entry, &new_inter_cert_path, messages) {
+                Phase5Action::SkipMigrated => {
+                    println!(
+                        "{}",
+                        messages.rotate_ca_key_skip_migrated(&entry.service_name)
+                    );
+                }
+                Phase5Action::LocalReissue => {
+                    let _ = fs::remove_file(&entry.cert_path);
+                    let _ = fs::remove_file(&entry.key_path);
+                    signal_bootroot_agent(entry, messages)?;
+                    reissued_local.push(entry);
+                }
+                Phase5Action::RemoteHint => {
+                    println!(
+                        "{}",
+                        messages.rotate_ca_key_reissue_remote_hint(&entry.service_name)
+                    );
+                }
             }
         }
 
-        let affected_local: Vec<&ServiceEntry> = ctx
-            .state
-            .services
-            .values()
-            .filter(|entry| matches!(entry.delivery_mode, DeliveryMode::LocalFile))
-            .collect();
         crate::commands::service::print_consumer_reload_hint(
-            affected_local.iter().copied(),
+            reissued_local.iter().copied(),
             messages,
         );
 
@@ -441,6 +434,42 @@ fn restart_openbao_agent_sidecars(ctx: &RotateContext, _messages: &Messages) {
     }
     let _ = try_restart_container(OPENBAO_AGENT_STEPCA_CONTAINER);
     let _ = try_restart_container(OPENBAO_AGENT_RESPONDER_CONTAINER);
+}
+
+/// Outcome for one service entry during phase-5 reissue. Decoupled from
+/// the side-effecting loop so the consumer-reload hint can be exercised
+/// from tests without invoking real signal/filesystem operations.
+#[derive(Debug, PartialEq, Eq)]
+enum Phase5Action {
+    /// Service already presents a cert issued by the new intermediate
+    /// (e.g., resumed rotation, partial manual migration). Nothing to
+    /// reissue and the service should NOT appear in the consumer-reload
+    /// hint.
+    SkipMigrated,
+    /// Local-file delivery service whose cert needs to be wiped and
+    /// re-signaled. Goes into the consumer-reload hint.
+    LocalReissue,
+    /// Remote-bootstrap delivery service. Operator gets a remote hint
+    /// but the consumer-reload hint targets local-file consumers only.
+    RemoteHint,
+}
+
+fn classify_phase5_action(
+    entry: &ServiceEntry,
+    new_inter_cert_path: &Path,
+    messages: &Messages,
+) -> Phase5Action {
+    if entry.cert_path.exists()
+        && cert_issued_by_new_intermediate(&entry.cert_path, new_inter_cert_path, messages)
+            .unwrap_or(false)
+    {
+        return Phase5Action::SkipMigrated;
+    }
+    if matches!(entry.delivery_mode, DeliveryMode::LocalFile) {
+        Phase5Action::LocalReissue
+    } else {
+        Phase5Action::RemoteHint
+    }
 }
 
 /// Checks whether a leaf certificate was issued by the new intermediate CA
@@ -1179,5 +1208,123 @@ mod tests {
         .await;
         let signal = result.expect("mtime tiebreaker should succeed");
         assert_eq!(signal.serial.as_deref(), Some(serial.as_str()));
+    }
+
+    fn make_local_file_entry(name: &str, cert_path: std::path::PathBuf) -> ServiceEntry {
+        use std::path::PathBuf;
+
+        use crate::state::{DeployType, ServiceRoleEntry};
+
+        ServiceEntry {
+            service_name: name.to_string(),
+            deploy_type: DeployType::Daemon,
+            delivery_mode: DeliveryMode::LocalFile,
+            hostname: "h".to_string(),
+            domain: "d.example".to_string(),
+            agent_config_path: PathBuf::from("agent.toml"),
+            cert_path,
+            key_path: PathBuf::from("key.pem"),
+            instance_id: None,
+            container_name: None,
+            notes: None,
+            post_renew_hooks: vec![],
+            approle: ServiceRoleEntry {
+                role_name: "r".to_string(),
+                role_id: "id".to_string(),
+                secret_id_path: PathBuf::from("s"),
+                policy_name: "p".to_string(),
+                secret_id_ttl: None,
+                secret_id_wrap_ttl: None,
+                token_bound_cidrs: None,
+            },
+            agent_email: None,
+            agent_server: None,
+            agent_responder_url: None,
+            cert_group_gid: None,
+        }
+    }
+
+    fn build_issuer(cn: &str) -> (rcgen::Issuer<'static, rcgen::KeyPair>, String) {
+        use rcgen::{CertificateParams, DnType, Issuer, KeyPair};
+
+        let key = KeyPair::generate().expect("ca key");
+        let mut params = CertificateParams::new(vec![cn.to_string()]).expect("ca params");
+        params.distinguished_name.push(DnType::CommonName, cn);
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let cert = params.clone().self_signed(&key).expect("self-signed CA");
+        (Issuer::new(params, key), cert.pem())
+    }
+
+    fn sign_leaf_with(cn: &str, issuer: &rcgen::Issuer<'static, rcgen::KeyPair>) -> String {
+        use rcgen::{CertificateParams, DnType, KeyPair};
+
+        let key = KeyPair::generate().expect("leaf key");
+        let mut params = CertificateParams::new(vec![cn.to_string()]).expect("leaf params");
+        params.distinguished_name.push(DnType::CommonName, cn);
+        params.signed_by(&key, issuer).expect("sign leaf").pem()
+    }
+
+    /// Regression for issue #619: in a mixed registry where one service
+    /// still presents a cert from the old intermediate and another has
+    /// already been migrated, only the unmigrated service should be
+    /// classified for local reissue (and therefore make it into the
+    /// consumer-reload hint).
+    #[test]
+    fn phase5_classifies_only_unmigrated_local_services_for_reissue() {
+        let dir = tempdir().expect("tempdir");
+        let messages = test_messages();
+
+        // Build two intermediates: "old" and "new". A leaf signed by
+        // the new one should be SkipMigrated; a leaf signed by the old
+        // one should be LocalReissue.
+        let (old_issuer, _old_inter_pem) = build_issuer("Old Intermediate");
+        let (new_issuer, new_inter_pem) = build_issuer("New Intermediate");
+
+        let new_inter_path = dir.path().join("new_intermediate.crt");
+        fs::write(&new_inter_path, &new_inter_pem).expect("write new intermediate");
+
+        let unmigrated_cert = dir.path().join("svc_old.crt");
+        fs::write(
+            &unmigrated_cert,
+            sign_leaf_with("svc-old.example", &old_issuer),
+        )
+        .expect("write old leaf");
+        let migrated_cert = dir.path().join("svc_new.crt");
+        fs::write(
+            &migrated_cert,
+            sign_leaf_with("svc-new.example", &new_issuer),
+        )
+        .expect("write new leaf");
+
+        let unmigrated = make_local_file_entry("svc-old", unmigrated_cert);
+        let migrated = make_local_file_entry("svc-new", migrated_cert);
+
+        assert_eq!(
+            classify_phase5_action(&unmigrated, &new_inter_path, &messages),
+            Phase5Action::LocalReissue,
+            "service still on the old intermediate must be reissued"
+        );
+        assert_eq!(
+            classify_phase5_action(&migrated, &new_inter_path, &messages),
+            Phase5Action::SkipMigrated,
+            "service already on the new intermediate must be skipped"
+        );
+
+        // Simulate the phase-5 loop's hint-collection step and verify
+        // only the unmigrated entry would be passed to the
+        // consumer-reload hint.
+        let registry = [&unmigrated, &migrated];
+        let reissued: Vec<&ServiceEntry> = registry
+            .iter()
+            .copied()
+            .filter(|entry| {
+                matches!(
+                    classify_phase5_action(entry, &new_inter_path, &messages),
+                    Phase5Action::LocalReissue
+                )
+            })
+            .collect();
+        assert_eq!(reissued.len(), 1);
+        assert_eq!(reissued[0].service_name, "svc-old");
     }
 }

--- a/tests/bootroot_rotate.rs
+++ b/tests/bootroot_rotate.rs
@@ -2954,12 +2954,20 @@ async fn test_rotate_ca_key_happy_path_phase_0_through_7() {
         stdout.contains("complete") || stdout.contains("Complete"),
         "stdout should mention completion: {stdout}"
     );
-    // Issue #614: phase 5 must surface the consumer-reload hint so
-    // operators see the in-FD pitfall after rotate ca-key wipes the
-    // service cert/key pair.
+    // Issue #619: phase 5 must only build the consumer-reload hint
+    // from services it actually wiped/signaled. Here the only
+    // registered service is already issued by the new intermediate
+    // (skip-migrated branch), so the hint must NOT appear — listing it
+    // would push operators to restart a consumer this rotation did not
+    // touch. The skip-migrated line should still appear to confirm
+    // phase 5 saw the service.
     assert!(
-        stdout.contains("Consumer reload/restart required"),
-        "rotate ca-key should print the consumer-reload hint: {stdout}"
+        stdout.contains("already issued by new intermediate"),
+        "phase 5 should report the service as already migrated: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Consumer reload/restart required"),
+        "rotate ca-key must not print the consumer-reload hint when no service was reissued: {stdout}"
     );
     // rotation-state.json should be cleaned up
     assert!(


### PR DESCRIPTION
## Summary

Phase 5 of `bootroot rotate ca-key` printed the "Consumer reload/restart required" hint from every `local-file` service in `ctx.state.services`, not from the subset the loop actually wiped and signaled. Services whose cert was already issued by the new intermediate take the skip-migrated branch (`src/commands/rotate/ca.rs:233-237`) and are never re-signaled, but they still appeared in the hint. On a resumed or retried rotation, or after a partial manual migration, an operator following the hint would restart consumers this rotation did not touch — churning live traffic and eroding trust in the hint over time.

This PR collects the entries actually reissued inside the loop and passes that set to `print_consumer_reload_hint`, so the skip-migrated branch no longer contributes. The per-entry decision is factored into a small `classify_phase5_action` helper so the classification can be unit-tested without exercising filesystem and signal side effects.

- `src/commands/rotate/ca.rs` — build `reissued_local` inside the loop; route through `classify_phase5_action`; add unit test for a mixed registry (one unmigrated, one already migrated) asserting only the unmigrated entry is classified for reissue.
- `tests/bootroot_rotate.rs` — flip the happy-path E2E assertion so it confirms the hint is *suppressed* when the registry's only service is already on the new intermediate (the previous version asserted the opposite, which was the bug this issue closes).
- `docs/en/operations.md`, `docs/ko/operations.md` — note that the `rotate ca-key` hint only lists services this invocation actually re-signaled.
- `CHANGELOG.md` — Fixed entry.

Closes #619

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin bootroot commands::rotate::ca::tests::phase5_classifies_only_unmigrated_local_services_for_reissue`
- [x] `cargo test --test bootroot_rotate test_rotate_ca_key_happy_path_phase_0_through_7` — confirms phase 5 no longer prints the consumer-reload hint when the only registered service is already issued by the new intermediate, and still prints the "already issued by new intermediate" skip-migrated line.
- [x] Mixed-registry behaviour (one unmigrated `local-file`, one already-migrated) is covered programmatically by `phase5_classifies_only_unmigrated_local_services_for_reissue`, which builds a registry with two leaves signed by two different intermediates and asserts only the unmigrated entry is classified `LocalReissue` (and so feeds the consumer-reload hint).
- [x] Idempotent resume (every service already on the new intermediate → hint suppressed) is covered by `test_rotate_ca_key_happy_path_phase_0_through_7`, which asserts the "Consumer reload/restart required" block is absent while the "already issued by new intermediate" skip-migrated line still appears.
