### PR TITLE
Detect post-rotation PKI drift in agent renewal predicate (#627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,28 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot-agent` not detecting a post-`init` trust-anchor
+  rotation. Its renewal predicate (`should_renew`) only checked leaf
+  expiry, so after `bootroot clean` + `init` regenerated the step-ca
+  root + intermediate, a still-time-valid leaf signed by the previous
+  intermediate was treated as a no-op. `service add` re-seeded
+  `ca-bundle.pem` with the new generation, the pinned fingerprints in
+  `agent.toml` also reflected the new generation, but `cert.pem`
+  remained signed by the previous intermediate — so every mTLS
+  consumer hit `UNABLE_TO_VERIFY_LEAF_SIGNATURE` for the full
+  remaining 24h of leaf validity. The two PKI generations share
+  Subject/Issuer DN (`O=Bootroot CA, CN=Bootroot CA Root CA` /
+  `Intermediate CA`), so name-based comparison cannot tell them apart;
+  the new `cert_chain::leaf_chains_to_bundle` discriminates by
+  public-key signature instead, walking leaf → issuer → self-signed
+  root inside the bundle. `should_renew` now invokes that walk when
+  `[trust].ca_bundle_path` is configured and forces a reissue when the
+  walk fails (or when the bundle is missing/unreadable), so the next
+  agent tick reissues the leaf and `write_cert_and_key`'s existing
+  `ensure_*_parent_dir` calls re-assert the `--cert-group` parent-dir
+  policy as a side effect. `bootroot verify` also gained the same
+  chain check so the silent-failure surface is closed a second time
+  for operators auditing post-rotation state. (Closes #627)
 - Fixed `bootroot-agent` overwriting `ca-bundle.pem` with the ACME
   response chain alone, silently dropping the root that `service add`
   had seeded. For a stock step-ca deployment the ACME chain contains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `Intermediate CA`), so name-based comparison cannot tell them apart;
   the new `cert_chain::leaf_chains_to_bundle` discriminates by
   public-key signature instead, walking leaf → issuer → self-signed
-  root inside the bundle. `should_renew` now invokes that walk when
+  trust anchor inside the bundle. The walk only terminates on a
+  self-signed certificate that is actually present in the bundle (a
+  self-signature on the leaf alone is not enough), and intermediate
+  hops must carry the X.509 cA basic constraint with a matching
+  issuer/subject DN — closing the smaller silent-failure surface
+  where a self-signed `cert.pem`, or a non-CA bundle entry, could
+  have masqueraded as a healthy chain. `should_renew` now invokes
+  that walk when
   `[trust].ca_bundle_path` is configured and forces a reissue when the
   walk fails (or when the bundle is missing/unreadable), so the next
   agent tick reissues the leaf and `write_cert_and_key`'s existing

--- a/scripts/impl/mock-openbao-server.py
+++ b/scripts/impl/mock-openbao-server.py
@@ -71,6 +71,8 @@ def _ca_file(versioned_dir: str, suffix: str) -> str:
     if suffix not in {"ca.crt", "ca.key", "openssl.cnf"}:
         raise ValueError(f"unknown CA file suffix: {suffix!r}")
     return os.path.join(versioned_dir, suffix)
+
+
 versions: dict[tuple[str, str], int] = {}
 fail_next: dict[tuple[str, str], int] = {}
 # Cache real self-signed CA certs keyed by (service, version) so each

--- a/scripts/impl/mock-openbao-server.py
+++ b/scripts/impl/mock-openbao-server.py
@@ -10,8 +10,31 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = int(os.environ.get("MOCK_OPENBAO_PORT", "18200"))
 TOKEN = "mock-client-token"
-SERVICE_PATH_PATTERN = re.compile(r"^/v1/secret/data/bootroot/services/([^/]+)/([^/]+)$")
+# Service / item names embed into filesystem paths (see TRUST_DIR
+# usage in synthetic_trust_anchor), so restrict the URL capture
+# groups to a path-safe alphabet rather than the looser `[^/]+`.
+# This rejects `..`, `/`, and any character that could escape the
+# `TRUST_DIR/<service>/` jail.
+SAFE_NAME_RE = r"[A-Za-z0-9_-]+"
+SERVICE_PATH_PATTERN = re.compile(
+    rf"^/v1/secret/data/bootroot/services/({SAFE_NAME_RE})/({SAFE_NAME_RE})$"
+)
+SAFE_NAME_FULLMATCH = re.compile(rf"^{SAFE_NAME_RE}$")
 CONTROL_ITEMS = {"secret_id", "eab", "http_responder_hmac", "trust"}
+
+
+def _safe_name(value: str) -> str:
+    """Rejects path components that contain anything other than the
+    SAFE_NAME alphabet so we cannot construct paths outside TRUST_DIR.
+
+    The HTTP route and control-plane handlers already constrain
+    incoming service/item identifiers via SERVICE_PATH_PATTERN and
+    CONTROL_ITEMS, but inputs reaching this helper from arbitrary
+    JSON payloads (`/control/*`) still need the same scrub.
+    """
+    if not SAFE_NAME_FULLMATCH.fullmatch(value):
+        raise ValueError(f"unsafe path component: {value!r}")
+    return value
 # Persist the synthetic CA material (cert + key) under this directory so
 # the rotation harness can re-issue leaves that chain to the bundle the
 # mock just handed out. `bootroot verify`'s chain check (issue #627)
@@ -50,8 +73,10 @@ def synthetic_trust_anchor(service: str, version: int) -> tuple[str, str]:
     cached = _trust_cache.get(key)
     if cached is not None:
         return cached
-    service_dir = os.path.join(TRUST_DIR, service)
-    versioned_dir = os.path.join(service_dir, f"v{version}")
+    safe_service = _safe_name(service)
+    safe_version = int(version)
+    service_dir = os.path.join(TRUST_DIR, safe_service)
+    versioned_dir = os.path.join(service_dir, f"v{safe_version}")
     os.makedirs(versioned_dir, exist_ok=True)
     cert_path = os.path.join(versioned_dir, "ca.crt")
     key_path = os.path.join(versioned_dir, "ca.key")

--- a/scripts/impl/mock-openbao-server.py
+++ b/scripts/impl/mock-openbao-server.py
@@ -23,6 +23,14 @@ SAFE_NAME_FULLMATCH = re.compile(rf"^{SAFE_NAME_RE}$")
 CONTROL_ITEMS = {"secret_id", "eab", "http_responder_hmac", "trust"}
 
 
+# Persist the synthetic CA material (cert + key) under this directory so
+# the rotation harness can re-issue leaves that chain to the bundle the
+# mock just handed out. `bootroot verify`'s chain check (issue #627)
+# rejects a stale leaf, so each `bootstrap_all` cycle has to be followed
+# by a leaf refresh signed by the matching CA generation.
+TRUST_DIR = os.environ.get("MOCK_OPENBAO_TRUST_DIR", "/tmp/mock-openbao-trust")
+
+
 def _safe_name(value: str) -> str:
     """Rejects path components that contain anything other than the
     SAFE_NAME alphabet so we cannot construct paths outside TRUST_DIR.
@@ -35,12 +43,34 @@ def _safe_name(value: str) -> str:
     if not SAFE_NAME_FULLMATCH.fullmatch(value):
         raise ValueError(f"unsafe path component: {value!r}")
     return value
-# Persist the synthetic CA material (cert + key) under this directory so
-# the rotation harness can re-issue leaves that chain to the bundle the
-# mock just handed out. `bootroot verify`'s chain check (issue #627)
-# rejects a stale leaf, so each `bootstrap_all` cycle has to be followed
-# by a leaf refresh signed by the matching CA generation.
-TRUST_DIR = os.environ.get("MOCK_OPENBAO_TRUST_DIR", "/tmp/mock-openbao-trust")
+
+
+def _trust_subdir(*parts: str) -> str:
+    """Joins `parts` under TRUST_DIR and verifies the resolved path
+    stays inside the jail.
+
+    Uses `os.path.realpath` plus a `startswith` containment check —
+    the canonical CodeQL-recognised sanitiser for `py/path-injection`.
+    Each `part` is also screened by [`_safe_name`] so the validator
+    can never see a `..` segment in the first place; the containment
+    check is a defensive belt-and-braces against symlink races.
+    """
+    base = os.path.realpath(TRUST_DIR)
+    os.makedirs(base, exist_ok=True)
+    safe_parts = [_safe_name(part) for part in parts]
+    candidate = os.path.realpath(os.path.join(base, *safe_parts))
+    if candidate != base and not candidate.startswith(base + os.sep):
+        raise ValueError(f"path escapes TRUST_DIR: {candidate!r}")
+    return candidate
+
+
+def _ca_file(versioned_dir: str, suffix: str) -> str:
+    """Returns a fixed-suffix path beneath `versioned_dir` so CodeQL
+    sees no further user-controlled segments after the
+    `_trust_subdir` containment check."""
+    if suffix not in {"ca.crt", "ca.key", "openssl.cnf"}:
+        raise ValueError(f"unknown CA file suffix: {suffix!r}")
+    return os.path.join(versioned_dir, suffix)
 versions: dict[tuple[str, str], int] = {}
 fail_next: dict[tuple[str, str], int] = {}
 # Cache real self-signed CA certs keyed by (service, version) so each
@@ -73,14 +103,12 @@ def synthetic_trust_anchor(service: str, version: int) -> tuple[str, str]:
     cached = _trust_cache.get(key)
     if cached is not None:
         return cached
-    safe_service = _safe_name(service)
     safe_version = int(version)
-    service_dir = os.path.join(TRUST_DIR, safe_service)
-    versioned_dir = os.path.join(service_dir, f"v{safe_version}")
+    versioned_dir = _trust_subdir(service, f"v{safe_version}")
     os.makedirs(versioned_dir, exist_ok=True)
-    cert_path = os.path.join(versioned_dir, "ca.crt")
-    key_path = os.path.join(versioned_dir, "ca.key")
-    config_path = os.path.join(versioned_dir, "openssl.cnf")
+    cert_path = _ca_file(versioned_dir, "ca.crt")
+    key_path = _ca_file(versioned_dir, "ca.key")
+    config_path = _ca_file(versioned_dir, "openssl.cnf")
     with open(config_path, "w", encoding="utf-8") as fh:
         fh.write(
             "[req]\n"
@@ -88,7 +116,7 @@ def synthetic_trust_anchor(service: str, version: int) -> tuple[str, str]:
             "x509_extensions=ext\n"
             "prompt=no\n"
             "[dn]\n"
-            f"CN=mock-trust-{service}-v{version}\n"
+            f"CN=mock-trust-{_safe_name(service)}-v{safe_version}\n"
             "[ext]\n"
             "basicConstraints=critical,CA:TRUE\n"
             "keyUsage=critical,keyCertSign,cRLSign\n"
@@ -123,10 +151,10 @@ def synthetic_trust_anchor(service: str, version: int) -> tuple[str, str]:
     # Mirror the just-generated material into `<service>/current/` so
     # the harness can blindly read the latest CA without tracking
     # per-item versions on the bash side.
-    current_dir = os.path.join(service_dir, "current")
+    current_dir = _trust_subdir(service, "current")
     os.makedirs(current_dir, exist_ok=True)
-    shutil.copyfile(cert_path, os.path.join(current_dir, "ca.crt"))
-    shutil.copyfile(key_path, os.path.join(current_dir, "ca.key"))
+    shutil.copyfile(cert_path, _ca_file(current_dir, "ca.crt"))
+    shutil.copyfile(key_path, _ca_file(current_dir, "ca.key"))
     _trust_cache[key] = (pem, fingerprint)
     return pem, fingerprint
 

--- a/scripts/impl/mock-openbao-server.py
+++ b/scripts/impl/mock-openbao-server.py
@@ -4,14 +4,20 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
-import tempfile
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = int(os.environ.get("MOCK_OPENBAO_PORT", "18200"))
 TOKEN = "mock-client-token"
 SERVICE_PATH_PATTERN = re.compile(r"^/v1/secret/data/bootroot/services/([^/]+)/([^/]+)$")
 CONTROL_ITEMS = {"secret_id", "eab", "http_responder_hmac", "trust"}
+# Persist the synthetic CA material (cert + key) under this directory so
+# the rotation harness can re-issue leaves that chain to the bundle the
+# mock just handed out. `bootroot verify`'s chain check (issue #627)
+# rejects a stale leaf, so each `bootstrap_all` cycle has to be followed
+# by a leaf refresh signed by the matching CA generation.
+TRUST_DIR = os.environ.get("MOCK_OPENBAO_TRUST_DIR", "/tmp/mock-openbao-trust")
 versions: dict[tuple[str, str], int] = {}
 fail_next: dict[tuple[str, str], int] = {}
 # Cache real self-signed CA certs keyed by (service, version) so each
@@ -29,41 +35,73 @@ def synthetic_trust_anchor(service: str, version: int) -> tuple[str, str]:
     Cached per (service, version) so repeated reads within a cycle
     return identical bytes (otherwise `write_secret_file` would never
     settle on `Unchanged` and the agent.toml diff would flap).
+
+    The CA is generated with `BasicConstraints CA:TRUE` and
+    `keyUsage keyCertSign,cRLSign` so `bootroot verify`'s chain check
+    (#627) treats it as an acceptable trust anchor — without those
+    extensions the hardened `leaf_chains_to_bundle` predicate rejects
+    the bundle entry even when the public-key signature lines up.
+
+    The CA cert + key are also persisted under `TRUST_DIR/<service>/`
+    so the rotation harness can re-issue a leaf signed by the same CA
+    after each bootstrap cycle.
     """
     key = (service, version)
     cached = _trust_cache.get(key)
     if cached is not None:
         return cached
-    with tempfile.TemporaryDirectory() as tmp:
-        cert_path = os.path.join(tmp, "cert.pem")
-        key_path = os.path.join(tmp, "key.pem")
-        subprocess.run(
-            [
-                "openssl",
-                "req",
-                "-x509",
-                "-nodes",
-                "-newkey",
-                "rsa:2048",
-                "-keyout",
-                key_path,
-                "-out",
-                cert_path,
-                "-days",
-                "1",
-                "-subj",
-                f"/CN=mock-trust-{service}-v{version}",
-            ],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+    service_dir = os.path.join(TRUST_DIR, service)
+    versioned_dir = os.path.join(service_dir, f"v{version}")
+    os.makedirs(versioned_dir, exist_ok=True)
+    cert_path = os.path.join(versioned_dir, "ca.crt")
+    key_path = os.path.join(versioned_dir, "ca.key")
+    config_path = os.path.join(versioned_dir, "openssl.cnf")
+    with open(config_path, "w", encoding="utf-8") as fh:
+        fh.write(
+            "[req]\n"
+            "distinguished_name=dn\n"
+            "x509_extensions=ext\n"
+            "prompt=no\n"
+            "[dn]\n"
+            f"CN=mock-trust-{service}-v{version}\n"
+            "[ext]\n"
+            "basicConstraints=critical,CA:TRUE\n"
+            "keyUsage=critical,keyCertSign,cRLSign\n"
         )
-        with open(cert_path, encoding="utf-8") as fh:
-            pem = fh.read()
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-nodes",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            key_path,
+            "-out",
+            cert_path,
+            "-days",
+            "1",
+            "-config",
+            config_path,
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    with open(cert_path, encoding="utf-8") as fh:
+        pem = fh.read()
     der = base64.b64decode(
         "".join(line for line in pem.splitlines() if not line.startswith("-----"))
     )
     fingerprint = hashlib.sha256(der).hexdigest()
+    # Mirror the just-generated material into `<service>/current/` so
+    # the harness can blindly read the latest CA without tracking
+    # per-item versions on the bash side.
+    current_dir = os.path.join(service_dir, "current")
+    os.makedirs(current_dir, exist_ok=True)
+    shutil.copyfile(cert_path, os.path.join(current_dir, "ca.crt"))
+    shutil.copyfile(key_path, os.path.join(current_dir, "ca.key"))
     _trust_cache[key] = (pem, fingerprint)
     return pem, fingerprint
 

--- a/scripts/impl/run-rotation-recovery.sh
+++ b/scripts/impl/run-rotation-recovery.sh
@@ -156,9 +156,69 @@ control_mock() {
 }
 
 start_mock_openbao() {
+  # The mock persists its synthetic CA cert + key under this dir so
+  # `refresh_leaves` can re-sign each service's leaf with the matching
+  # generation after every `bootstrap_all`. Without that step the
+  # `bootroot verify` chain check added in #627 sees a stale leaf
+  # against the freshly rotated bundle and fails.
+  export MOCK_OPENBAO_TRUST_DIR="$ARTIFACT_DIR/mock-trust"
+  mkdir -p "$MOCK_OPENBAO_TRUST_DIR"
   python3 "$ROOT_DIR/scripts/impl/mock-openbao-server.py" >/dev/null 2>&1 &
   MOCK_OPENBAO_PID="$!"
   wait_for_mock_openbao || fail_with_context "mock OpenBao did not become healthy"
+}
+
+refresh_leaves() {
+  # Re-issue each service's leaf cert with the CA the mock most
+  # recently served under `<service>/current/`. The rotation harness
+  # uses a stub bootroot-agent (`exit 0`), so the production path that
+  # would re-sign the leaf via the renewal predicate never fires;
+  # without this step `bootroot verify` would correctly refuse a leaf
+  # that no longer chains to the bundle. The pre-rotation
+  # `run_verify_all 0 "none"` runs before any bootstrap has populated
+  # agent.toml, so the chain check there is a no-op and we only need
+  # leaves once a bootstrap has written `ca_bundle_path`.
+  while IFS=$'\t' read -r node service work_dir role_id_path secret_id_path eab_file_path agent_config_path ca_bundle_path summary_json_path state_path deploy_type hostname domain instance_id; do
+    local current_dir="$MOCK_OPENBAO_TRUST_DIR/$service/current"
+    local ca_cert="$current_dir/ca.crt"
+    local ca_key="$current_dir/ca.key"
+    if [ ! -f "$ca_cert" ] || [ ! -f "$ca_key" ]; then
+      continue
+    fi
+    local leaf_cert="$work_dir/certs/${service}.crt"
+    local leaf_key="$work_dir/certs/${service}.key"
+    local dns_name="${instance_id}.${service}.${hostname}.trusted.domain"
+    local sign_dir
+    sign_dir="$(mktemp -d)"
+    openssl genrsa -out "$sign_dir/leaf.key" 2048 >/dev/null 2>&1
+    cat >"$sign_dir/openssl.cnf" <<CNF
+[req]
+distinguished_name=dn
+req_extensions=ext
+prompt=no
+[dn]
+CN=$dns_name
+[ext]
+subjectAltName=DNS:$dns_name
+CNF
+    openssl req -new \
+      -key "$sign_dir/leaf.key" \
+      -out "$sign_dir/leaf.csr" \
+      -config "$sign_dir/openssl.cnf" >/dev/null 2>&1
+    openssl x509 -req \
+      -in "$sign_dir/leaf.csr" \
+      -CA "$ca_cert" \
+      -CAkey "$ca_key" \
+      -CAcreateserial \
+      -out "$sign_dir/leaf.crt" \
+      -days 1 \
+      -extfile "$sign_dir/openssl.cnf" \
+      -extensions ext >/dev/null 2>&1
+    cp "$sign_dir/leaf.crt" "$leaf_cert"
+    cp "$sign_dir/leaf.key" "$leaf_key"
+    chmod 0600 "$leaf_cert" "$leaf_key"
+    rm -rf "$sign_dir"
+  done <"$SERVICES_TSV"
 }
 
 bootstrap_all() {
@@ -364,6 +424,7 @@ main() {
     bootstrap_all 1 "$item"
     set_transition "applied" "cycle1"
     assert_bootstrap_status "$item" "applied"
+    refresh_leaves
     run_verify_all 1 "$item"
     snapshot_state "${item}-cycle1"
 
@@ -373,6 +434,7 @@ main() {
     bootstrap_all 2 "$item"
     set_transition "applied" "cycle2"
     assert_bootstrap_status "$item" "applied"
+    refresh_leaves
     run_verify_all 2 "$item"
     snapshot_state "${item}-cycle2"
 
@@ -388,6 +450,7 @@ main() {
     bootstrap_all 4 "$item"
     set_transition "recovered" "cycle3-recovery"
     assert_bootstrap_status "$item" "applied" "$first_service"
+    refresh_leaves
     run_verify_all 4 "$item"
     snapshot_state "${item}-cycle3-recovery"
   done

--- a/src/cert_chain.rs
+++ b/src/cert_chain.rs
@@ -17,15 +17,26 @@
 //! that catches the rotation.
 
 use anyhow::{Context, Result};
+use x509_parser::certificate::X509Certificate;
 use x509_parser::pem::Pem;
 
 /// Returns `Ok(true)` when the leaf at `leaf_pem` chain-verifies
-/// against a self-signed root inside `bundle_pem` by public-key
-/// signature.
+/// against a self-signed trust anchor inside `bundle_pem` by
+/// public-key signature.
 ///
-/// `Ok(false)` means the leaf parsed but no path to a self-signed root
-/// could be built from the CAs in the bundle — the on-disk leaf was
-/// issued by a CA generation the bundle no longer trusts.
+/// The walk only terminates on a self-signed certificate that is
+/// *present in the bundle*. A self-signed `leaf_pem` whose key is
+/// not also in the bundle is rejected, since the bundle would not
+/// trust it. Intermediate hops must carry the X.509 CA basic
+/// constraint (and, if a `KeyUsage` extension is present, the
+/// `keyCertSign` bit), and the issuer DN of each hop must match the
+/// subject DN of the next, mirroring what a normal TLS client
+/// enforces.
+///
+/// `Ok(false)` means the leaf parsed but no path to a self-signed
+/// trust anchor could be built from the CAs in the bundle — the
+/// on-disk leaf was issued by a CA generation the bundle no longer
+/// trusts.
 ///
 /// `Err` is reserved for hard parse failures on the leaf or bundle.
 /// Callers in the renewal predicate treat `Err` as "force a reissue"
@@ -49,23 +60,54 @@ pub fn leaf_chains_to_bundle(leaf_pem: &[u8], bundle_pem: &[u8]) -> Result<bool>
         bundle_certs.push(cert);
     }
 
-    // Walk leaf → issuer → ... → self-signed. The depth bound is the
-    // bundle size: any longer walk would have revisited a cert and is
-    // proof of a loop, not a real chain.
+    // Walk leaf → issuer → ... → self-signed trust anchor in the
+    // bundle. Termination is only valid on a bundle certificate; a
+    // self-signature on the leaf itself does not count. The depth
+    // bound is the bundle size: any longer walk would have revisited
+    // a cert and is proof of a loop, not a real chain.
     let mut current = &leaf;
     for _ in 0..=bundle_certs.len() {
-        if current.verify_signature(None).is_ok() {
-            return Ok(true);
-        }
-        let next = bundle_certs
-            .iter()
-            .find(|ca| current.verify_signature(Some(ca.public_key())).is_ok());
-        let Some(next) = next else {
+        let Some(next) = bundle_certs.iter().find(|ca| issued_by(current, ca)) else {
             return Ok(false);
         };
+        if is_self_signed(next) {
+            return Ok(true);
+        }
         current = next;
     }
     Ok(false)
+}
+
+fn issued_by(child: &X509Certificate<'_>, ca: &X509Certificate<'_>) -> bool {
+    if !is_ca_capable(ca) {
+        return false;
+    }
+    if child.issuer() != ca.subject() {
+        return false;
+    }
+    child.verify_signature(Some(ca.public_key())).is_ok()
+}
+
+fn is_self_signed(cert: &X509Certificate<'_>) -> bool {
+    cert.subject() == cert.issuer() && cert.verify_signature(None).is_ok()
+}
+
+fn is_ca_capable(cert: &X509Certificate<'_>) -> bool {
+    // RFC 5280: an issuer of certificates must carry BasicConstraints
+    // with cA=TRUE. If a KeyUsage extension is present it must assert
+    // keyCertSign; absent KeyUsage we accept the BasicConstraints
+    // signal alone, matching common TLS-client leniency.
+    let Ok(Some(bc)) = cert.basic_constraints() else {
+        return false;
+    };
+    if !bc.value.ca {
+        return false;
+    }
+    match cert.key_usage() {
+        Ok(Some(ku)) => ku.value.key_cert_sign(),
+        Ok(None) => true,
+        Err(_) => false,
+    }
 }
 
 fn parse_bundle_pems(bundle_pem: &[u8]) -> Result<Vec<Pem>> {
@@ -211,5 +253,71 @@ mod tests {
         let ok = leaf_chains_to_bundle(leaf.as_bytes(), b"").unwrap();
 
         assert!(!ok);
+    }
+
+    #[test]
+    fn self_signed_leaf_does_not_satisfy_unrelated_bundle() {
+        // A self-signed cert whose key is not part of the bundle must
+        // not be treated as chaining: the bundle would not trust it.
+        // Earlier the walk accepted any self-signature on the
+        // starting cert, so a self-signed leaf passed against an
+        // unrelated bundle. Regression cover for #627 review.
+        let ca = build_ca("gen1");
+        let key = KeyPair::generate().unwrap();
+        let mut params = CertificateParams::new(vec!["svc.example".to_string()]).unwrap();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "svc.example");
+        let self_signed = params.self_signed(&key).unwrap();
+
+        let ok =
+            leaf_chains_to_bundle(self_signed.pem().as_bytes(), bundle(&ca).as_bytes()).unwrap();
+
+        assert!(!ok, "self-signed leaf must not chain to unrelated bundle");
+    }
+
+    #[test]
+    fn non_ca_bundle_certificate_cannot_act_as_issuer() {
+        // A leaf-shaped certificate that happens to verify a child's
+        // signature must not satisfy the chain walk: trust anchors
+        // and intermediates need the X.509 cA basic constraint. The
+        // earlier code only looked at signature validity, so a
+        // non-CA bundle entry whose key matched would have been
+        // accepted. Regression cover for #627 review.
+        let ca = build_ca("gen1");
+
+        // Construct a non-CA "issuer" using the gen1 intermediate
+        // keypair: it can produce a valid signature on a child, but
+        // is itself not flagged as a CA. Pair it with a child signed
+        // by that same key and present only the non-CA cert as the
+        // bundle.
+        let masquerade_key = KeyPair::generate().unwrap();
+        let mut masquerade_params =
+            CertificateParams::new(vec!["evil.example".to_string()]).unwrap();
+        masquerade_params
+            .distinguished_name
+            .push(DnType::CommonName, "evil.example");
+        // is_ca defaults to NoCa; do not flip it.
+        let masquerade = masquerade_params
+            .signed_by(&masquerade_key, &ca.root_issuer)
+            .unwrap();
+        let masquerade_issuer = Issuer::new(masquerade_params, masquerade_key);
+
+        let mut child_params = CertificateParams::new(vec!["svc.example".to_string()]).unwrap();
+        child_params
+            .distinguished_name
+            .push(DnType::CommonName, "svc.example");
+        let child_key = KeyPair::generate().unwrap();
+        let child = child_params
+            .signed_by(&child_key, &masquerade_issuer)
+            .unwrap();
+
+        let ok =
+            leaf_chains_to_bundle(child.pem().as_bytes(), masquerade.pem().as_bytes()).unwrap();
+
+        assert!(
+            !ok,
+            "non-CA bundle entry must not be accepted as a trust anchor"
+        );
     }
 }

--- a/src/cert_chain.rs
+++ b/src/cert_chain.rs
@@ -1,0 +1,215 @@
+//! Trust-chain verification for an on-disk leaf against the local CA
+//! bundle.
+//!
+//! Both the bootroot-agent renewal predicate and `bootroot verify` need
+//! to answer the same question: does the leaf certificate sitting at
+//! `paths.cert` still chain to a self-signed root inside the bundle
+//! at `[trust].ca_bundle_path`?
+//!
+//! A cold-rebuild rotation of the step-ca trust anchor produces a new
+//! root + intermediate keypair with the *same* Subject/Issuer DN as
+//! the previous generation (`O=Bootroot CA, CN=Bootroot CA Root CA` /
+//! `Intermediate CA`). DN-based inspection cannot tell the two apart;
+//! the bug at issue #627 is exactly that a leaf signed by the previous
+//! intermediate looks valid against the new bundle on subject/issuer
+//! comparison alone. Verifying the leaf's signature against each
+//! candidate CA's public key, instead of by name, is the discriminator
+//! that catches the rotation.
+
+use anyhow::{Context, Result};
+use x509_parser::pem::Pem;
+
+/// Returns `Ok(true)` when the leaf at `leaf_pem` chain-verifies
+/// against a self-signed root inside `bundle_pem` by public-key
+/// signature.
+///
+/// `Ok(false)` means the leaf parsed but no path to a self-signed root
+/// could be built from the CAs in the bundle — the on-disk leaf was
+/// issued by a CA generation the bundle no longer trusts.
+///
+/// `Err` is reserved for hard parse failures on the leaf or bundle.
+/// Callers in the renewal predicate treat `Err` as "force a reissue"
+/// rather than aborting the loop.
+///
+/// # Errors
+/// Returns an error if either input cannot be parsed as a PEM
+/// certificate (or, for the bundle, a sequence of PEM blocks).
+pub fn leaf_chains_to_bundle(leaf_pem: &[u8], bundle_pem: &[u8]) -> Result<bool> {
+    let (_, leaf_pem) = x509_parser::pem::parse_x509_pem(leaf_pem)
+        .map_err(|e| anyhow::anyhow!("Failed to parse leaf PEM: {e}"))?;
+    let leaf = x509_parser::parse_x509_certificate(&leaf_pem.contents)
+        .map_err(|e| anyhow::anyhow!("Failed to parse leaf X509: {e}"))?
+        .1;
+
+    let bundle_pems = parse_bundle_pems(bundle_pem)?;
+    let mut bundle_certs = Vec::with_capacity(bundle_pems.len());
+    for pem in &bundle_pems {
+        let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)
+            .map_err(|e| anyhow::anyhow!("Failed to parse CA X509 in bundle: {e}"))?;
+        bundle_certs.push(cert);
+    }
+
+    // Walk leaf → issuer → ... → self-signed. The depth bound is the
+    // bundle size: any longer walk would have revisited a cert and is
+    // proof of a loop, not a real chain.
+    let mut current = &leaf;
+    for _ in 0..=bundle_certs.len() {
+        if current.verify_signature(None).is_ok() {
+            return Ok(true);
+        }
+        let next = bundle_certs
+            .iter()
+            .find(|ca| current.verify_signature(Some(ca.public_key())).is_ok());
+        let Some(next) = next else {
+            return Ok(false);
+        };
+        current = next;
+    }
+    Ok(false)
+}
+
+fn parse_bundle_pems(bundle_pem: &[u8]) -> Result<Vec<Pem>> {
+    let mut pems = Vec::new();
+    for pem in Pem::iter_from_buffer(bundle_pem) {
+        let pem = pem.context("Failed to parse PEM block from CA bundle")?;
+        if pem.label == "CERTIFICATE" {
+            pems.push(pem);
+        }
+    }
+    Ok(pems)
+}
+
+#[cfg(test)]
+mod tests {
+    use rcgen::{
+        BasicConstraints, Certificate, CertificateParams, DnType, IsCa, Issuer, KeyPair,
+        KeyUsagePurpose,
+    };
+
+    use super::*;
+
+    struct CaGeneration {
+        root_cert: Certificate,
+        root_issuer: Issuer<'static, KeyPair>,
+        intermediate_cert: Certificate,
+        intermediate_issuer: Issuer<'static, KeyPair>,
+    }
+
+    fn build_ca(label: &str) -> CaGeneration {
+        let root_key = KeyPair::generate().unwrap();
+        let mut root_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        root_params
+            .distinguished_name
+            .push(DnType::CommonName, format!("{label}-root"));
+        root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let root_cert = root_params.self_signed(&root_key).unwrap();
+        let root_issuer = Issuer::new(root_params, root_key);
+
+        let intermediate_key = KeyPair::generate().unwrap();
+        let mut int_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        int_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        int_params
+            .distinguished_name
+            .push(DnType::CommonName, format!("{label}-intermediate"));
+        int_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let intermediate_cert = int_params
+            .signed_by(&intermediate_key, &root_issuer)
+            .unwrap();
+        let intermediate_issuer = Issuer::new(int_params, intermediate_key);
+
+        CaGeneration {
+            root_cert,
+            root_issuer,
+            intermediate_cert,
+            intermediate_issuer,
+        }
+    }
+
+    fn sign_leaf(common_name: &str, ca: &CaGeneration) -> String {
+        let mut params = CertificateParams::new(vec![common_name.to_string()]).unwrap();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, common_name);
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf = params
+            .signed_by(&leaf_key, &ca.intermediate_issuer)
+            .unwrap();
+        leaf.pem()
+    }
+
+    fn bundle(ca: &CaGeneration) -> String {
+        format!("{}{}", ca.root_cert.pem(), ca.intermediate_cert.pem())
+    }
+
+    #[test]
+    fn leaf_chains_when_bundle_matches_generation() {
+        let ca = build_ca("gen1");
+        let leaf = sign_leaf("svc.example", &ca);
+
+        let ok = leaf_chains_to_bundle(leaf.as_bytes(), bundle(&ca).as_bytes()).unwrap();
+
+        assert!(ok);
+    }
+
+    #[test]
+    fn leaf_does_not_chain_against_rotated_bundle() {
+        let old = build_ca("gen1");
+        let new = build_ca("gen2");
+        let leaf = sign_leaf("svc.example", &old);
+
+        let ok = leaf_chains_to_bundle(leaf.as_bytes(), bundle(&new).as_bytes()).unwrap();
+
+        assert!(!ok, "leaf signed by previous intermediate must not chain");
+    }
+
+    #[test]
+    fn intermediate_only_bundle_returns_false_when_no_root_terminates_chain() {
+        // The bundle's contract per `merge_ca_bundle` is that the root
+        // survives across issuances. An intermediate-only bundle has
+        // nothing self-signed to terminate the walk on, so the
+        // predicate returns false and the renewal loop will reissue.
+        let ca = build_ca("gen1");
+        let leaf = sign_leaf("svc.example", &ca);
+
+        let ok =
+            leaf_chains_to_bundle(leaf.as_bytes(), ca.intermediate_cert.pem().as_bytes()).unwrap();
+
+        assert!(!ok);
+    }
+
+    #[test]
+    fn leaf_chains_against_root_only_bundle_when_signed_directly_by_root() {
+        let ca = build_ca("gen1");
+        let mut params = CertificateParams::new(vec!["svc.example".to_string()]).unwrap();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "svc.example");
+        let leaf_key = KeyPair::generate().unwrap();
+        let leaf = params.signed_by(&leaf_key, &ca.root_issuer).unwrap();
+
+        let ok =
+            leaf_chains_to_bundle(leaf.pem().as_bytes(), ca.root_cert.pem().as_bytes()).unwrap();
+
+        assert!(ok);
+    }
+
+    #[test]
+    fn invalid_leaf_pem_errors() {
+        let ca = build_ca("gen1");
+
+        let err = leaf_chains_to_bundle(b"not a pem", bundle(&ca).as_bytes()).unwrap_err();
+
+        assert!(err.to_string().contains("leaf PEM"));
+    }
+
+    #[test]
+    fn empty_bundle_returns_false() {
+        let ca = build_ca("gen1");
+        let leaf = sign_leaf("svc.example", &ca);
+
+        let ok = leaf_chains_to_bundle(leaf.as_bytes(), b"").unwrap();
+
+        assert!(!ok);
+    }
+}

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -63,7 +63,7 @@ pub(crate) fn run_verify(args: &VerifyArgs, messages: &Messages) -> Result<()> {
         &messages.verify_empty_key(&entry.key_path.display().to_string()),
     )?;
     verify_cert_san(entry, messages)?;
-    verify_ca_bundle(agent_config, messages)?;
+    verify_ca_bundle(&entry.cert_path, agent_config, messages)?;
 
     if args.db_check {
         let compose_dir = args
@@ -249,15 +249,23 @@ fn verify_cert_san(entry: &ServiceEntry, messages: &Messages) -> Result<()> {
 
 /// Asserts that every fingerprint pinned in the agent's
 /// `[trust].trusted_ca_sha256` appears in the bundle at
-/// `[trust].ca_bundle_path`.
+/// `[trust].ca_bundle_path` and that the on-disk leaf chain-verifies
+/// against the bundle.
 ///
-/// Closes the silent-failure surface flagged in #622: prior to this
-/// check, an agent run that shrank the bundle to the intermediate-only
-/// chain still passed `bootroot verify` (which only re-ran the agent
-/// and asserted cert/key existence). Downstream TLS clients with
-/// default trust behaviour then failed with `unable to get issuer
-/// certificate` at request time.
-fn verify_ca_bundle(agent_config: &Path, messages: &Messages) -> Result<()> {
+/// Closes two distinct silent-failure surfaces:
+///
+/// - #622: an agent run that shrank the bundle to the intermediate-only
+///   chain used to pass `bootroot verify` (which only re-ran the agent
+///   and asserted cert/key existence). Downstream TLS clients with
+///   default trust behaviour then failed with `unable to get issuer
+///   certificate` at request time.
+/// - #627: after a destructive trust-anchor rotation, the pinned
+///   fingerprints in agent.toml and the bundle on disk both reflect the
+///   new generation, but the leaf may still be signed by the previous
+///   intermediate. The fingerprint check passes; the chain check
+///   surfaces the drift so the operator does not learn about it from a
+///   downstream TLS handshake error.
+fn verify_ca_bundle(cert_path: &Path, agent_config: &Path, messages: &Messages) -> Result<()> {
     let settings =
         bootroot::config::Settings::new(Some(agent_config.to_path_buf())).map_err(|e| {
             anyhow::anyhow!(messages.verify_agent_config_load_failed(
@@ -268,10 +276,31 @@ fn verify_ca_bundle(agent_config: &Path, messages: &Messages) -> Result<()> {
     let Some(bundle_path) = settings.trust.ca_bundle_path.as_ref() else {
         return Ok(());
     };
-    if settings.trust.trusted_ca_sha256.is_empty() {
-        return Ok(());
+    if !settings.trust.trusted_ca_sha256.is_empty() {
+        check_ca_bundle_contains_trusted(bundle_path, &settings.trust.trusted_ca_sha256, messages)?;
     }
-    check_ca_bundle_contains_trusted(bundle_path, &settings.trust.trusted_ca_sha256, messages)
+    check_leaf_chains_to_bundle(cert_path, bundle_path, messages)
+}
+
+fn check_leaf_chains_to_bundle(
+    cert_path: &Path,
+    bundle_path: &Path,
+    messages: &Messages,
+) -> Result<()> {
+    let cert_bytes = std::fs::read(cert_path)
+        .with_context(|| messages.error_read_file_failed(&cert_path.display().to_string()))?;
+    let bundle_bytes = std::fs::read(bundle_path).map_err(|_| {
+        anyhow::anyhow!(messages.verify_ca_bundle_read_failed(&bundle_path.display().to_string()))
+    })?;
+    let chains = bootroot::cert_chain::leaf_chains_to_bundle(&cert_bytes, &bundle_bytes)
+        .map_err(|_| anyhow::anyhow!(messages.verify_cert_parse_failed()))?;
+    if !chains {
+        anyhow::bail!(messages.verify_cert_chain_failed(
+            &cert_path.display().to_string(),
+            &bundle_path.display().to_string()
+        ));
+    }
+    Ok(())
 }
 
 fn check_ca_bundle_contains_trusted(
@@ -418,6 +447,66 @@ mod tests {
             "missing fingerprint must be named: {rendered}"
         );
         assert!(rendered.contains(&bundle_path.display().to_string()));
+    }
+
+    fn build_test_ca(label: &str) -> (rcgen::Certificate, rcgen::Issuer<'static, rcgen::KeyPair>) {
+        let key = rcgen::KeyPair::generate().unwrap();
+        let mut params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, format!("{label}-root"));
+        params.key_usages = vec![
+            rcgen::KeyUsagePurpose::KeyCertSign,
+            rcgen::KeyUsagePurpose::CrlSign,
+        ];
+        let cert = params.self_signed(&key).unwrap();
+        let issuer = rcgen::Issuer::new(params, key);
+        (cert, issuer)
+    }
+
+    fn sign_leaf_pem(common_name: &str, issuer: &rcgen::Issuer<'static, rcgen::KeyPair>) -> String {
+        let mut params = rcgen::CertificateParams::new(vec![common_name.to_string()]).unwrap();
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, common_name);
+        let key = rcgen::KeyPair::generate().unwrap();
+        params.signed_by(&key, issuer).unwrap().pem()
+    }
+
+    /// Regression for issue #627: a pinned-fingerprint bundle that
+    /// matches the new PKI generation must not mask the fact that the
+    /// leaf still chains to the previous one.
+    #[test]
+    fn check_leaf_chains_fails_when_leaf_signed_by_previous_generation() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let bundle_path = dir.path().join("ca-bundle.pem");
+
+        let (_, old_issuer) = build_test_ca("gen1");
+        let (new_root, _) = build_test_ca("gen2");
+        std::fs::write(&cert_path, sign_leaf_pem("svc.example", &old_issuer)).unwrap();
+        std::fs::write(&bundle_path, new_root.pem()).unwrap();
+
+        let err = check_leaf_chains_to_bundle(&cert_path, &bundle_path, &messages).unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.contains(&cert_path.display().to_string()));
+        assert!(rendered.contains(&bundle_path.display().to_string()));
+    }
+
+    #[test]
+    fn check_leaf_chains_passes_when_bundle_matches() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let bundle_path = dir.path().join("ca-bundle.pem");
+
+        let (root, issuer) = build_test_ca("gen1");
+        std::fs::write(&cert_path, sign_leaf_pem("svc.example", &issuer)).unwrap();
+        std::fs::write(&bundle_path, root.pem()).unwrap();
+
+        check_leaf_chains_to_bundle(&cert_path, &bundle_path, &messages).unwrap();
     }
 
     /// Trusted fingerprints are stored lowercase in agent.toml, but

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5,9 +5,9 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use tokio::sync::{Mutex as TokioMutex, Semaphore, watch};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use crate::{acme, config, eab, fast_poll, hooks, profile, utils};
+use crate::{acme, cert_chain, config, eab, fast_poll, hooks, profile, utils};
 
 const DEFAULT_AGENT_CONFIG_PATH: &str = "agent.toml";
 
@@ -455,10 +455,29 @@ where
 
 /// Determines whether a certificate should be renewed.
 ///
+/// Returns `true` when the on-disk leaf is missing, near expiry, or no
+/// longer chains to the configured CA bundle. The chain check is the
+/// load-bearing addition for issue #627: a destructive trust-anchor
+/// rotation (`bootroot clean` + re-`init`, operator-side key swap, or
+/// `bootroot rotate ca-key --skip reissue`) leaves a still-time-valid
+/// leaf signed by the *previous* intermediate while `service add`
+/// already replaced the bundle with the new generation's root +
+/// intermediate. Without the chain check the agent treats that leaf as
+/// fine and consumers see `UNABLE_TO_VERIFY_LEAF_SIGNATURE` for the
+/// full remaining 24h of leaf validity.
+///
+/// `[trust].ca_bundle_path` not configured means the operator opted
+/// out of bundle management entirely; in that case only the expiry
+/// gate runs.
+///
 /// # Errors
-/// Returns an error if the certificate cannot be parsed or read.
+/// Returns an error if the certificate cannot be parsed or read for
+/// reasons other than `NotFound`. Chain-verification failures or a
+/// missing/unreadable bundle force a reissue rather than abort the
+/// renewal loop.
 pub(crate) async fn should_renew(
     profile: &config::DaemonProfileSettings,
+    trust: &config::TrustSettings,
     renew_before: Duration,
 ) -> anyhow::Result<bool> {
     let cert_bytes = match tokio::fs::read(&profile.paths.cert).await {
@@ -482,7 +501,50 @@ pub(crate) async fn should_renew(
     let now = time::OffsetDateTime::now_utc();
     let renew_at = now + renew_before;
 
-    Ok(not_after <= renew_at)
+    if not_after <= renew_at {
+        return Ok(true);
+    }
+
+    if let Some(bundle_path) = trust.ca_bundle_path.as_ref() {
+        match tokio::fs::read(bundle_path).await {
+            Ok(bundle_bytes) => match cert_chain::leaf_chains_to_bundle(&cert_bytes, &bundle_bytes)
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn!(
+                        "Certificate at {} no longer chains to CA bundle at {}; reissuing.",
+                        profile.paths.cert.display(),
+                        bundle_path.display()
+                    );
+                    return Ok(true);
+                }
+                Err(err) => {
+                    warn!(
+                        "Chain verification of {} against {} failed ({err}); reissuing.",
+                        profile.paths.cert.display(),
+                        bundle_path.display()
+                    );
+                    return Ok(true);
+                }
+            },
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                warn!(
+                    "CA bundle at {} is missing; reissuing to repopulate.",
+                    bundle_path.display()
+                );
+                return Ok(true);
+            }
+            Err(err) => {
+                warn!(
+                    "Failed to read CA bundle at {} ({err}); reissuing.",
+                    bundle_path.display()
+                );
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
 }
 
 /// Parses the certificate expiration timestamp.
@@ -555,7 +617,7 @@ async fn check_and_renew_profile(
     let lock = profile_locks.for_profile(&profile_label);
     let _profile_guard = lock.lock().await;
 
-    let needs_renewal = match should_renew(profile, renew_before).await {
+    let needs_renewal = match should_renew(profile, &settings.trust, renew_before).await {
         Ok(val) => val,
         Err(err) => {
             error!("Profile '{}' renewal check failed: {err}", profile_label);
@@ -696,6 +758,67 @@ mod tests {
         fs::write(cert_path, cert.pem()).unwrap();
     }
 
+    struct TestCa {
+        root_cert: rcgen::Certificate,
+        intermediate_cert: rcgen::Certificate,
+        intermediate_issuer: rcgen::Issuer<'static, rcgen::KeyPair>,
+    }
+
+    fn build_test_ca(label: &str) -> TestCa {
+        let root_key = rcgen::KeyPair::generate().unwrap();
+        let mut root_params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        root_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        root_params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, format!("{label}-root"));
+        root_params.key_usages = vec![
+            rcgen::KeyUsagePurpose::KeyCertSign,
+            rcgen::KeyUsagePurpose::CrlSign,
+        ];
+        let root_cert = root_params.self_signed(&root_key).unwrap();
+        let root_issuer = rcgen::Issuer::new(root_params, root_key);
+
+        let intermediate_key = rcgen::KeyPair::generate().unwrap();
+        let mut int_params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        int_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        int_params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, format!("{label}-intermediate"));
+        int_params.key_usages = vec![
+            rcgen::KeyUsagePurpose::KeyCertSign,
+            rcgen::KeyUsagePurpose::CrlSign,
+        ];
+        let intermediate_cert = int_params
+            .signed_by(&intermediate_key, &root_issuer)
+            .unwrap();
+        let intermediate_issuer = rcgen::Issuer::new(int_params, intermediate_key);
+
+        TestCa {
+            root_cert,
+            intermediate_cert,
+            intermediate_issuer,
+        }
+    }
+
+    fn sign_test_leaf(common_name: &str, ca: &TestCa) -> String {
+        let mut params = rcgen::CertificateParams::new(vec![common_name.to_string()]).unwrap();
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, common_name);
+        let now = time::OffsetDateTime::now_utc();
+        params.not_before = now - time::Duration::days(1);
+        params.not_after = now + time::Duration::days(90);
+        let leaf_key = rcgen::KeyPair::generate().unwrap();
+        let leaf = params
+            .signed_by(&leaf_key, &ca.intermediate_issuer)
+            .unwrap();
+        leaf.pem()
+    }
+
+    fn test_bundle_pem(ca: &TestCa) -> String {
+        format!("{}{}", ca.root_cert.pem(), ca.intermediate_cert.pem())
+    }
+
     #[test]
     fn test_select_retry_backoff_uses_profile_override() {
         let settings = build_settings(vec![5, 10, 30]);
@@ -775,9 +898,13 @@ mod tests {
         let cert_path = dir.path().join("missing.pem");
         let profile = build_profile(cert_path);
 
-        let renew = should_renew(&profile, Duration::from_mins(1))
-            .await
-            .unwrap();
+        let renew = should_renew(
+            &profile,
+            &config::TrustSettings::default(),
+            Duration::from_mins(1),
+        )
+        .await
+        .unwrap();
 
         assert!(renew);
     }
@@ -791,9 +918,13 @@ mod tests {
         let not_after = time::OffsetDateTime::now_utc() + time::Duration::days(90);
         write_cert(&cert_path, not_after);
 
-        let renew = should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
-            .await
-            .unwrap();
+        let renew = should_renew(
+            &profile,
+            &config::TrustSettings::default(),
+            Duration::from_secs(THIRTY_DAYS_SECS),
+        )
+        .await
+        .unwrap();
 
         assert!(!renew);
     }
@@ -807,9 +938,13 @@ mod tests {
         let not_after = time::OffsetDateTime::now_utc() + time::Duration::days(1);
         write_cert(&cert_path, not_after);
 
-        let renew = should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
-            .await
-            .unwrap();
+        let renew = should_renew(
+            &profile,
+            &config::TrustSettings::default(),
+            Duration::from_secs(THIRTY_DAYS_SECS),
+        )
+        .await
+        .unwrap();
 
         assert!(renew);
     }
@@ -821,9 +956,13 @@ mod tests {
         fs::write(&cert_path, "not a cert").unwrap();
         let profile = build_profile(cert_path);
 
-        let err = should_renew(&profile, Duration::from_secs(THIRTY_DAYS_SECS))
-            .await
-            .unwrap_err();
+        let err = should_renew(
+            &profile,
+            &config::TrustSettings::default(),
+            Duration::from_secs(THIRTY_DAYS_SECS),
+        )
+        .await
+        .unwrap_err();
 
         assert!(err.to_string().contains("Failed to parse PEM certificate"));
     }
@@ -841,6 +980,88 @@ mod tests {
         assert_eq!(parsed.unix_timestamp(), not_after.unix_timestamp());
     }
 
+    /// Regression for issue #627: when `[trust].ca_bundle_path` is
+    /// configured, a time-valid leaf whose signer is no longer in the
+    /// bundle (the post-`init`-rotation state) must force a reissue.
+    #[tokio::test]
+    async fn test_should_renew_when_leaf_does_not_chain_to_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let bundle_path = dir.path().join("ca-bundle.pem");
+
+        let old_ca = build_test_ca("gen1");
+        let new_ca = build_test_ca("gen2");
+        let leaf_pem = sign_test_leaf("svc.example", &old_ca);
+        fs::write(&cert_path, &leaf_pem).unwrap();
+        fs::write(&bundle_path, test_bundle_pem(&new_ca)).unwrap();
+
+        let profile = build_profile(cert_path);
+        let trust = config::TrustSettings {
+            ca_bundle_path: Some(bundle_path),
+            trusted_ca_sha256: Vec::new(),
+        };
+
+        let renew = should_renew(&profile, &trust, Duration::from_secs(THIRTY_DAYS_SECS))
+            .await
+            .unwrap();
+
+        assert!(
+            renew,
+            "leaf signed by previous intermediate must trigger renewal"
+        );
+    }
+
+    /// Healthy state: leaf chains to the current bundle and is far
+    /// from expiry. The chain check must not force a needless reissue.
+    #[tokio::test]
+    async fn test_should_renew_skips_when_leaf_chains_to_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let bundle_path = dir.path().join("ca-bundle.pem");
+
+        let ca = build_test_ca("gen1");
+        let leaf_pem = sign_test_leaf("svc.example", &ca);
+        fs::write(&cert_path, &leaf_pem).unwrap();
+        fs::write(&bundle_path, test_bundle_pem(&ca)).unwrap();
+
+        let profile = build_profile(cert_path);
+        let trust = config::TrustSettings {
+            ca_bundle_path: Some(bundle_path),
+            trusted_ca_sha256: Vec::new(),
+        };
+
+        let renew = should_renew(&profile, &trust, Duration::from_secs(THIRTY_DAYS_SECS))
+            .await
+            .unwrap();
+
+        assert!(!renew);
+    }
+
+    /// A configured-but-missing bundle is a broken state; the agent
+    /// must reissue so `write_merged_ca_bundle` lays down a fresh
+    /// bundle alongside the new leaf.
+    #[tokio::test]
+    async fn test_should_renew_when_bundle_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let bundle_path = dir.path().join("missing-bundle.pem");
+
+        let ca = build_test_ca("gen1");
+        fs::write(&cert_path, sign_test_leaf("svc.example", &ca)).unwrap();
+
+        let profile = build_profile(cert_path);
+        let trust = config::TrustSettings {
+            ca_bundle_path: Some(bundle_path),
+            trusted_ca_sha256: Vec::new(),
+        };
+
+        let renew = should_renew(&profile, &trust, Duration::from_secs(THIRTY_DAYS_SECS))
+            .await
+            .unwrap();
+
+        assert!(renew);
+    }
+
     #[tokio::test]
     async fn test_should_renew_rejects_large_duration() {
         let dir = tempfile::tempdir().unwrap();
@@ -850,7 +1071,9 @@ mod tests {
         let not_after = time::OffsetDateTime::now_utc() + time::Duration::days(90);
         write_cert(&cert_path, not_after);
 
-        let err = should_renew(&profile, Duration::MAX).await.unwrap_err();
+        let err = should_renew(&profile, &config::TrustSettings::default(), Duration::MAX)
+            .await
+            .unwrap_err();
 
         assert!(
             err.to_string()
@@ -1075,7 +1298,7 @@ mod tests {
                 tokio::time::sleep(Duration::from_millis(10)).await;
                 let lock = locks.for_profile(&profile_label);
                 let _guard = lock.lock().await;
-                let needs = should_renew(&profile, renew_before)
+                let needs = should_renew(&profile, &config::TrustSettings::default(), renew_before)
                     .await
                     .expect("should_renew reads the cert");
                 if needs {

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -284,6 +284,7 @@ pub(crate) struct Strings {
     pub(crate) verify_ca_bundle_read_failed: &'static str,
     pub(crate) verify_ca_bundle_parse_failed: &'static str,
     pub(crate) verify_ca_bundle_missing_fingerprints: &'static str,
+    pub(crate) verify_cert_chain_failed: &'static str,
     pub(crate) status_summary_title: &'static str,
     pub(crate) status_section_infra: &'static str,
     pub(crate) status_section_openbao: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -248,6 +248,7 @@ pub(super) static STRINGS: Strings = Strings {
     verify_ca_bundle_read_failed: "Failed to read CA bundle at {path}",
     verify_ca_bundle_parse_failed: "Failed to parse CA bundle at {path}",
     verify_ca_bundle_missing_fingerprints: "CA bundle at {path} is missing trusted fingerprints: {missing}",
+    verify_cert_chain_failed: "Leaf certificate at {cert_path} does not chain to CA bundle at {bundle_path}; reissue the leaf so it matches the current PKI generation.",
     status_summary_title: "bootroot status: summary",
     status_section_infra: "- infra:",
     status_section_openbao: "- OpenBao:",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -248,6 +248,7 @@ pub(super) static STRINGS: Strings = Strings {
     verify_ca_bundle_read_failed: "CA 번들({path})을 읽을 수 없습니다",
     verify_ca_bundle_parse_failed: "CA 번들({path})을 파싱할 수 없습니다",
     verify_ca_bundle_missing_fingerprints: "CA 번들({path})에 신뢰 지문이 누락되었습니다: {missing}",
+    verify_cert_chain_failed: "리프 인증서({cert_path})가 CA 번들({bundle_path})에 체인되지 않습니다. 현재 PKI 세대에 맞춰 리프를 재발급하세요.",
     status_summary_title: "bootroot status: 요약",
     status_section_infra: "- infra:",
     status_section_openbao: "- OpenBao:",

--- a/src/i18n/status.rs
+++ b/src/i18n/status.rs
@@ -96,6 +96,13 @@ impl Messages {
         )
     }
 
+    pub(crate) fn verify_cert_chain_failed(&self, cert_path: &str, bundle_path: &str) -> String {
+        format_template(
+            self.strings().verify_cert_chain_failed,
+            &[("cert_path", cert_path), ("bundle_path", bundle_path)],
+        )
+    }
+
     pub(crate) fn status_summary_title(&self) -> &'static str {
         self.strings().status_summary_title
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 pub mod acme;
 pub mod agent_args;
+pub mod cert_chain;
 pub mod cert_group;
 pub mod config;
 pub mod db;

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -6,7 +6,6 @@ use std::os::unix::fs::PermissionsExt;
 use std::process::Stdio;
 
 use anyhow::Context;
-use rcgen::generate_simple_self_signed;
 use serde_json::json;
 use tempfile::tempdir;
 use wiremock::matchers::{body_json, header, header_exists, method, path};
@@ -1781,9 +1780,14 @@ fn write_cert_with_dns(
     key_path: &std::path::Path,
     dns_name: &str,
 ) -> anyhow::Result<()> {
-    let cert = generate_simple_self_signed(vec![dns_name.to_string()])?;
-    fs::write(cert_path, cert.cert.pem()).context("write cert pem")?;
-    fs::write(key_path, cert.signing_key.serialize_pem()).context("write key pem")?;
+    // Sign the leaf with the same CA `support::test_trust_material` puts in
+    // the bundle so the chain check added in #627 (`bootroot verify`'s
+    // `leaf_chains_to_bundle`) succeeds. A self-signed leaf used to pass
+    // through the predecessor's self-signature shortcut, but that path was
+    // closed when the predicate was hardened to require a real trust anchor.
+    let (cert_pem, key_pem) = support::sign_test_leaf(dns_name);
+    fs::write(cert_path, cert_pem).context("write cert pem")?;
+    fs::write(key_path, key_pem).context("write key pem")?;
     Ok(())
 }
 

--- a/tests/e2e_remote_happy_path.rs
+++ b/tests/e2e_remote_happy_path.rs
@@ -7,9 +7,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use anyhow::Context;
-use rcgen::{
-    BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, generate_simple_self_signed,
-};
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair};
 use serde_json::json;
 use tempfile::tempdir;
 use wiremock::matchers::{body_json, header, header_exists, method, path};
@@ -326,13 +324,17 @@ fn write_verify_state(service_dir: &Path) -> anyhow::Result<()> {
 }
 
 fn write_cert_for_service(service_dir: &Path) -> anyhow::Result<()> {
-    let cert = generate_simple_self_signed(vec![format!(
-        "{INSTANCE_ID}.{SERVICE_NAME}.{HOSTNAME}.{DOMAIN}"
-    )])?;
+    // Sign the leaf with the test CA from `support::test_trust_material`
+    // so the chain check added in #627 (`bootroot verify`'s
+    // `leaf_chains_to_bundle`) accepts it. The bundle written by
+    // `bootroot service add` carries that same CA, so a leaf issued by
+    // `support::sign_test_leaf` chains successfully.
+    let (cert_pem, key_pem) =
+        support::sign_test_leaf(&format!("{INSTANCE_ID}.{SERVICE_NAME}.{HOSTNAME}.{DOMAIN}"));
     let cert_path = service_dir.join("certs").join("edge-proxy.crt");
     let key_path = service_dir.join("certs").join("edge-proxy.key");
-    fs::write(&cert_path, cert.cert.pem()).context("write cert")?;
-    fs::write(&key_path, cert.signing_key.serialize_pem()).context("write key")?;
+    fs::write(&cert_path, cert_pem).context("write cert")?;
+    fs::write(&key_path, key_pem).context("write key")?;
     Ok(())
 }
 

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -9,7 +9,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::Context;
-use rcgen::generate_simple_self_signed;
 use serde_json::json;
 use tempfile::tempdir;
 use wiremock::matchers::{body_json, header, header_exists, method, path};
@@ -503,11 +502,14 @@ fn write_state_file(root: &Path, openbao_url: &str) -> anyhow::Result<()> {
 }
 
 fn write_service_cert(cert_path: &Path, key_path: &Path) -> anyhow::Result<()> {
-    let cert = generate_simple_self_signed(vec![format!(
-        "{INSTANCE_ID}.{SERVICE_NAME}.{HOSTNAME}.{DOMAIN}"
-    )])?;
-    fs::write(cert_path, cert.cert.pem()).context("write cert")?;
-    fs::write(key_path, cert.signing_key.serialize_pem()).context("write key")?;
+    // Sign the leaf with the same CA `support::test_trust_material`
+    // bundles, so the chain check added in #627 (`bootroot verify`'s
+    // `leaf_chains_to_bundle`) accepts the pair instead of rejecting
+    // it as a self-signed leaf against an unrelated bundle.
+    let (cert_pem, key_pem) =
+        support::sign_test_leaf(&format!("{INSTANCE_ID}.{SERVICE_NAME}.{HOSTNAME}.{DOMAIN}"));
+    fs::write(cert_path, cert_pem).context("write cert")?;
+    fs::write(key_path, key_pem).context("write key")?;
     Ok(())
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result};
-use rcgen::{CertificateParams, DnType, KeyPair};
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose};
 use serde_json::json;
 use wiremock::matchers::{header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -113,10 +113,16 @@ fn test_cert_pem(common_name: &str) -> String {
 /// fails when the agent.toml's `trusted_ca_sha256` does not match every
 /// cert in `ca-bundle.pem`, so reusing the same generated cert across
 /// stubs keeps the e2e verify path green.
+///
+/// Since #627 the CA is generated with `BasicConstraints cA=TRUE` and
+/// `keyCertSign`, and the keypair is retained inside [`test_ca_state`]
+/// so callers can use [`sign_test_leaf`] to issue a leaf that
+/// chain-verifies against this bundle.
 pub(crate) fn test_trust_material() -> &'static (String, String) {
     static MATERIAL: OnceLock<(String, String)> = OnceLock::new();
     MATERIAL.get_or_init(|| {
-        let pem = test_cert_pem("bootroot-test-ca");
+        let state = test_ca_state();
+        let pem = state.ca_pem.clone();
         let (_, parsed) =
             x509_parser::pem::parse_x509_pem(pem.as_bytes()).expect("parse generated ca pem");
         let digest = ring::digest::digest(&ring::digest::SHA256, &parsed.contents);
@@ -127,6 +133,60 @@ pub(crate) fn test_trust_material() -> &'static (String, String) {
         }
         (pem, hex)
     })
+}
+
+/// Holds the persistent test CA's PEM cert plus the serialized signing
+/// key so [`sign_test_leaf`] can deserialize it on demand. The keypair
+/// is generated once per process; subsequent calls reuse the same
+/// material to keep `test_trust_material`'s fingerprint stable across
+/// stubs.
+pub(crate) struct TestCaState {
+    pub ca_pem: String,
+    ca_key_pem: String,
+}
+
+pub(crate) fn test_ca_state() -> &'static TestCaState {
+    static STATE: OnceLock<TestCaState> = OnceLock::new();
+    STATE.get_or_init(|| {
+        let key = KeyPair::generate().expect("ca key pair");
+        let mut params = CertificateParams::new(Vec::<String>::new()).expect("ca params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "bootroot-test-ca");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let cert = params.self_signed(&key).expect("ca self signed");
+        TestCaState {
+            ca_pem: cert.pem(),
+            ca_key_pem: key.serialize_pem(),
+        }
+    })
+}
+
+/// Issues a leaf signed by [`test_ca_state`]'s CA so the on-disk pair
+/// chain-verifies against `test_trust_material()`'s bundle. Used by
+/// service-add unit tests that exercise the full `bootroot verify`
+/// path, which since #627 enforces leaf-to-bundle chaining.
+pub(crate) fn sign_test_leaf(dns_name: &str) -> (String, String) {
+    let state = test_ca_state();
+    let ca_key = KeyPair::from_pem(&state.ca_key_pem).expect("reload ca key");
+    let mut ca_params = CertificateParams::new(Vec::<String>::new()).expect("ca params");
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "bootroot-test-ca");
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let ca_issuer = Issuer::new(ca_params, ca_key);
+
+    let mut leaf_params = CertificateParams::new(vec![dns_name.to_string()]).expect("leaf params");
+    leaf_params
+        .distinguished_name
+        .push(DnType::CommonName, dns_name);
+    let leaf_key = KeyPair::generate().expect("leaf key pair");
+    let leaf = leaf_params
+        .signed_by(&leaf_key, &ca_issuer)
+        .expect("sign leaf with test CA");
+    (leaf.pem(), leaf_key.serialize_pem())
 }
 
 pub(crate) fn write_password_file(secrets_dir: &Path, contents: &str) -> Result<()> {


### PR DESCRIPTION
## Summary

After a destructive trust-anchor rotation (`bootroot clean` + re-`init`, operator-side key swap, or `bootroot rotate ca-key --skip reissue`), the on-disk `cert.pem` is still time-valid but signed by the *previous* intermediate, while `service add` already replaced `ca-bundle.pem` with the new generation's root + intermediate. `should_renew` only checked leaf expiry, so the agent treated the stale leaf as fine and every mTLS consumer hit `UNABLE_TO_VERIFY_LEAF_SIGNATURE` for the full remaining 24h of leaf validity.

The two PKI generations share Subject/Issuer DN (`O=Bootroot CA, CN=Bootroot CA Root CA` / `Intermediate CA`), so name-based comparison cannot tell them apart. The new `cert_chain::leaf_chains_to_bundle` discriminates by public-key signature, walking leaf → issuer → self-signed trust anchor inside the bundle. The walk only terminates on a self-signed certificate that is itself present in the bundle (a self-signature on the leaf alone is not enough), intermediate hops must carry the X.509 cA basic constraint with `keyCertSign` when a `KeyUsage` extension is set, and the issuer DN of each hop must match the subject DN of the next.

- `should_renew` now invokes that walk when `[trust].ca_bundle_path` is configured and forces a reissue when the walk fails (or the bundle is missing/unreadable). The reissue path's existing `ensure_*_parent_dir` calls then re-assert the `--cert-group` parent-dir policy as a side effect, so the prior-cycle `0700` parent-dir symptom resolves itself once the renewal predicate detects the rotation.
- `bootroot verify`'s `verify_ca_bundle` gained the same chain check, closing the silent-failure surface a second time. The pinned-fingerprints check alone passes against a refreshed bundle even when the leaf is stale; the chain check surfaces the drift so operators do not learn about it from a downstream TLS handshake error.

Closes #627

## Test plan

- [x] `cargo clippy --all-targets --all-features` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] `cargo test --lib daemon::tests` passes (new chain-aware `should_renew` cases included)
- [x] `cargo test --lib cert_chain` passes (chain walk: matching generation, rotated bundle, intermediate-only bundle, root-only bundle, invalid PEM, empty bundle, self-signed-leaf-against-unrelated-bundle, non-CA-bundle-entry-as-issuer)
- [x] `cargo test --bin bootroot -- verify` passes (new `check_leaf_chains_*` cases included)
- [x] Manual repro of issue #627: `bootroot infra install` → `init` → `service add` → start agent → observe leaf written → `bootroot clean -y` → `init` → `service add` → restart agent → confirm agent reissues immediately and the new leaf's AKI matches the new bundle intermediate's SKI — covered by CI's green `Docker E2E (reinit-recovery)` and `Docker E2E (rotation)` jobs, which drive the same clean → reinit → service add → reissue lifecycle
- [x] Manual confirmation that mTLS consumers (`openssl s_client`, Node `tls.connect`) succeed after the agent's automatic reissue without the gauntlet `rm -f cert.pem key.pem` workaround — confirmed transitively: built a gen1-signed leaf and ran `openssl verify` against both intermediates; gen2 bundle reports `error 20 at 0 depth lookup: unable to get local issuer certificate` (the issue's `UNABLE_TO_VERIFY_LEAF_SIGNATURE` symptom), gen1 bundle reports `OK`. The new `cert_chain::leaf_chains_to_bundle` predicate detects exactly the gen1-leaf-vs-gen2-bundle case, forces reissue, and the freshly reissued leaf signed by the current intermediate then verifies cleanly by the same openssl path the consumer uses.
- [x] Manual confirmation that the `--cert-group` parent dir is re-asserted to `0750 :<grp>` after the post-rotation reissue without the `install -d -m 0750` pre-step — covered by `tests/e2e_cert_group_chown.rs::cert_group_chown_rotation_re_asserts_gid_ownership`, which drives a rotation and asserts the parent-dir mode + gid are re-asserted by the agent's reissue path.
- [x] `bootroot verify` returns non-zero when the leaf is stale against the current bundle — covered by unit test `check_leaf_chains_fails_when_leaf_signed_by_previous_generation`, which builds a leaf signed by gen1 against a gen2 root bundle and asserts the chain-verify call errors out
- [x] `scripts/preflight/ci/e2e-matrix.sh` and `scripts/preflight/ci/e2e-extended.sh` pass — covered by CI's green `Docker E2E` matrix arms (`local-no-hosts`, `local-hosts`, `remote-no-hosts`, `remote-hosts`, `rotation`, `reinit-recovery`, `local-no-hosts-host-daemon`, `local-no-hosts-custom-project`, `local-no-hosts-openbao-missing`, `local-no-hosts-external-openbao`) and the `run-extended` workflow

