### PR TITLE
Exit 124 from rotate --wait on timeout (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-### Changed
-
-- `bootroot rotate force-reissue --wait` now exits with status `124`
-  (the GNU `timeout(1)` convention) when the wait window elapses
-  without the agent reporting completion. The previous behaviour was
-  to print the timeout message and exit `0`, which made a deferred
-  reissue indistinguishable from a successful one for scripted
-  callers. The timeout message itself is unchanged. Callers that
-  prefer the old "ignore timeout" semantics can re-establish them
-  with `|| true`. (Closes #629)
-
 ### Security
 
 - Bumped `rustls-webpki` from 0.103.10 to 0.103.12 to address
@@ -1012,6 +1001,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- `bootroot rotate force-reissue --wait` now exits with status `124`
+  (the GNU `timeout(1)` convention) when the wait window elapses
+  without the agent reporting completion. The previous behaviour was
+  to print the timeout message and exit `0`, which made a deferred
+  reissue indistinguishable from a successful one for scripted
+  callers. The timeout message itself is unchanged. Callers that
+  prefer the old "ignore timeout" semantics can re-establish them
+  with `|| true`. (Closes #629)
 - The published `PostgreSQL` host port now defaults to **5433**
   (`POSTGRES_HOST_PORT=5433`) so bootroot does not claim the
   conventional 5432 out of the box. The conventional port stays free

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- `bootroot rotate force-reissue --wait` now exits with status `124`
+  (the GNU `timeout(1)` convention) when the wait window elapses
+  without the agent reporting completion. The previous behaviour was
+  to print the timeout message and exit `0`, which made a deferred
+  reissue indistinguishable from a successful one for scripted
+  callers. The timeout message itself is unchanged. Callers that
+  prefer the old "ignore timeout" semantics can re-establish them
+  with `|| true`. (Closes #629)
+
 ### Security
 
 - Bumped `rustls-webpki` from 0.103.10 to 0.103.12 to address

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -33,6 +33,16 @@ pub(super) const OPENBAO_RECOVERY_SCOPE_ROOT_TOKEN: &str = "root-token";
 pub(super) const OPENBAO_ROOT_ROTATION_INCOMPLETE_ERROR: &str =
     "OpenBao root-key rotation did not complete; verify unseal keys and retry";
 
+/// Typed outcome of a `bootroot rotate` subcommand so the process
+/// exit code can distinguish a completed rotation from a timed-out
+/// `--wait` window. Routed up through `run_rotate` to `main`, where
+/// `WaitTimedOut` maps to the GNU `timeout(1)` convention of 124.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RotateOutcome {
+    Completed,
+    WaitTimedOut,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct StatePaths {
     secrets_dir: PathBuf,
@@ -116,7 +126,7 @@ pub(super) struct RotateContext {
 }
 
 #[allow(clippy::too_many_lines)]
-pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result<()> {
+pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result<RotateOutcome> {
     let state_path = args
         .state_file
         .clone()
@@ -159,7 +169,8 @@ pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result
     // InfraCert operates on local files and Docker only — it must not
     // require an OpenBao connection so it can fix a broken/expired cert.
     if let RotateCommand::InfraCert(_) = &args.command {
-        return infra_cert::rotate_infra_certs(&mut ctx, args.yes, messages);
+        infra_cert::rotate_infra_certs(&mut ctx, args.yes, messages)?;
+        return Ok(RotateOutcome::Completed);
     }
 
     let runtime_auth = resolve_runtime_auth(&args.runtime_auth, true, messages)?;
@@ -203,7 +214,9 @@ pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result
             ca::rotate_trust_sync(&mut ctx, &client, args.yes, messages).await?;
         }
         RotateCommand::ForceReissue(step_args) => {
-            ca::rotate_force_reissue(&mut ctx, &client, step_args, args.yes, messages).await?;
+            let outcome =
+                ca::rotate_force_reissue(&mut ctx, &client, step_args, args.yes, messages).await?;
+            return Ok(outcome);
         }
         RotateCommand::CaKey(step_args) => {
             ca::rotate_ca_key(&mut ctx, &client, step_args, args.yes, messages).await?;
@@ -216,7 +229,7 @@ pub(crate) async fn run_rotate(args: &RotateArgs, messages: &Messages) -> Result
         }
     }
 
-    Ok(())
+    Ok(RotateOutcome::Completed)
 }
 
 #[cfg(test)]

--- a/src/commands/rotate/ca.rs
+++ b/src/commands/rotate/ca.rs
@@ -10,7 +10,7 @@ use super::helpers::{
 };
 use super::{
     INTERMEDIATE_CA_COMMON_NAME, OPENBAO_AGENT_RESPONDER_CONTAINER, OPENBAO_AGENT_STEPCA_CONTAINER,
-    ROOT_CA_COMMON_NAME, RotateContext,
+    ROOT_CA_COMMON_NAME, RotateContext, RotateOutcome,
 };
 use crate::cli::args::{RotateCaKeyArgs, RotateForceReissueArgs, RotateSkipPhase};
 use crate::commands::infra::run_docker;
@@ -563,7 +563,7 @@ pub(super) async fn rotate_force_reissue(
     args: &RotateForceReissueArgs,
     auto_confirm: bool,
     messages: &Messages,
-) -> Result<()> {
+) -> Result<RotateOutcome> {
     let entry = ctx
         .state
         .services
@@ -589,7 +589,7 @@ async fn rotate_force_reissue_local(
     args: &RotateForceReissueArgs,
     entry: &ServiceEntry,
     messages: &Messages,
-) -> Result<()> {
+) -> Result<RotateOutcome> {
     let cert_path = &entry.cert_path;
     let key_path = &entry.key_path;
 
@@ -618,7 +618,7 @@ async fn rotate_force_reissue_local(
     crate::commands::service::print_consumer_reload_hint(std::iter::once(entry), messages);
 
     if !args.wait {
-        return Ok(());
+        return Ok(RotateOutcome::Completed);
     }
 
     let wait_timeout = humantime::parse_duration(&args.wait_timeout)
@@ -642,7 +642,7 @@ async fn rotate_force_reissue_local(
                     &elapsed,
                 )
             );
-            Ok(())
+            Ok(RotateOutcome::Completed)
         }
         Err(WaitError::Timeout) => {
             println!(
@@ -652,7 +652,7 @@ async fn rotate_force_reissue_local(
                     &args.wait_timeout,
                 )
             );
-            Ok(())
+            Ok(RotateOutcome::WaitTimedOut)
         }
         Err(WaitError::Other(err)) => Err(err),
     }
@@ -663,7 +663,7 @@ async fn rotate_force_reissue_remote(
     client: &OpenBaoClient,
     args: &RotateForceReissueArgs,
     messages: &Messages,
-) -> Result<()> {
+) -> Result<RotateOutcome> {
     use bootroot::trust_bootstrap::{
         REISSUE_REQUESTED_AT_KEY, REISSUE_REQUESTER_KEY, SERVICE_KV_BASE, SERVICE_REISSUE_KV_SUFFIX,
     };
@@ -718,7 +718,7 @@ async fn rotate_force_reissue_remote(
     );
 
     if !args.wait {
-        return Ok(());
+        return Ok(RotateOutcome::Completed);
     }
 
     match wait_for_remote_completion(
@@ -747,7 +747,7 @@ async fn rotate_force_reissue_remote(
                     &elapsed,
                 )
             );
-            Ok(())
+            Ok(RotateOutcome::Completed)
         }
         Err(WaitError::Timeout) => {
             println!(
@@ -757,7 +757,7 @@ async fn rotate_force_reissue_remote(
                     &args.wait_timeout,
                 )
             );
-            Ok(())
+            Ok(RotateOutcome::WaitTimedOut)
         }
         Err(WaitError::Other(err)) => Err(err),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 use anyhow::{Context, Result};
 
 mod cli;
@@ -11,27 +13,37 @@ use crate::cli::args::{
     CaCommand, Cli, CliCommand, InfraCommand, MonitoringCommand, OpenbaoCommand, ServiceCommand,
     ServiceOpenbaoSidecarCommand,
 };
+use crate::commands::rotate::RotateOutcome;
 use crate::i18n::Messages;
 
-fn main() {
+/// GNU `timeout(1)` convention: 124 signals the wait window elapsed
+/// before the operation finished. Returned from `bootroot rotate
+/// force-reissue --wait` so scripted callers can distinguish a
+/// successful reissue from one that was merely queued for the agent.
+const EXIT_CODE_WAIT_TIMEOUT: u8 = 124;
+
+fn main() -> ExitCode {
     let cli = Cli::parse();
     let messages = match Messages::new(&cli.lang) {
         Ok(messages) => messages,
         Err(err) => {
             eprintln!("{err}");
-            std::process::exit(1);
+            return ExitCode::from(1);
         }
     };
-    if let Err(err) = run(cli, &messages) {
-        let message = err
-            .chain()
-            .next()
-            .map_or_else(|| "bootroot error".to_string(), ToString::to_string);
-        eprintln!("{message}");
-        for cause in err.chain().skip(1) {
-            eprintln!("{}", messages.error_details(&cause.to_string()));
+    match run(cli, &messages) {
+        Ok(code) => code,
+        Err(err) => {
+            let message = err
+                .chain()
+                .next()
+                .map_or_else(|| "bootroot error".to_string(), ToString::to_string);
+            eprintln!("{message}");
+            for cause in err.chain().skip(1) {
+                eprintln!("{}", messages.error_details(&cause.to_string()));
+            }
+            ExitCode::from(1)
         }
-        std::process::exit(1);
     }
 }
 
@@ -50,7 +62,7 @@ where
 }
 
 #[allow(clippy::too_many_lines)] // Top-level CLI dispatcher.
-fn run(cli: Cli, messages: &Messages) -> Result<()> {
+fn run(cli: Cli, messages: &Messages) -> Result<ExitCode> {
     match cli.command {
         CliCommand::Infra(InfraCommand::Up(args)) => {
             with_runtime("infra up", messages, |rt| {
@@ -139,10 +151,13 @@ fn run(cli: Cli, messages: &Messages) -> Result<()> {
         CliCommand::Verify(args) => commands::verify::run_verify(&args, messages)
             .with_context(|| messages.error_verify_failed())?,
         CliCommand::Rotate(args) => {
-            with_runtime("rotate", messages, |rt| {
+            let outcome = with_runtime("rotate", messages, |rt| {
                 rt.block_on(commands::rotate::run_rotate(&args, messages))
             })?
             .with_context(|| messages.error_rotate_failed())?;
+            if matches!(outcome, RotateOutcome::WaitTimedOut) {
+                return Ok(ExitCode::from(EXIT_CODE_WAIT_TIMEOUT));
+            }
         }
         CliCommand::Clean(args) => {
             commands::clean::run_clean(&args, messages)
@@ -165,7 +180,7 @@ fn run(cli: Cli, messages: &Messages) -> Result<()> {
                 .with_context(|| "ca restart failed".to_string())?;
         }
     }
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 #[cfg(test)]

--- a/tests/bootroot_rotate.rs
+++ b/tests/bootroot_rotate.rs
@@ -1848,6 +1848,89 @@ async fn test_rotate_force_reissue_remote_wait_reports_completion() {
     );
 }
 
+/// Issue #629: when `--wait` runs out without the agent reporting a
+/// completed reissue, the CLI must exit with code 124 (GNU
+/// `timeout(1)` convention) so scripted callers can distinguish a
+/// finished rotation from one that was merely queued.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_rotate_force_reissue_remote_wait_times_out_with_exit_124() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let openbao = MockServer::start().await;
+    let _secret_path = prepare_app_state(
+        temp_dir.path(),
+        &openbao.uri(),
+        "daemon",
+        "remote-bootstrap",
+    )
+    .expect("prepare state");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/sys/health"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&openbao)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/v1/secret/data/bootroot/services/{SERVICE_NAME}/reissue"
+        )))
+        .and(header("X-Vault-Token", support::ROOT_TOKEN))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "version": 3 }
+        })))
+        .mount(&openbao)
+        .await;
+
+    // GET returns the request payload but NEVER advertises a
+    // `completed_version`, so the wait polls until `--wait-timeout`
+    // elapses without ever observing completion.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/secret/data/bootroot/services/{SERVICE_NAME}/reissue"
+        )))
+        .and(header("X-Vault-Token", support::ROOT_TOKEN))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "data": { "requested_at": "2026-04-19T12:34:56Z", "requester": "ci" },
+                "metadata": { "version": 3 }
+            }
+        })))
+        .mount(&openbao)
+        .await;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "rotate",
+            "--openbao-url",
+            &openbao.uri(),
+            "--root-token",
+            support::ROOT_TOKEN,
+            "--yes",
+            "force-reissue",
+            "--service-name",
+            SERVICE_NAME,
+            "--wait",
+            "--wait-timeout",
+            "1s",
+        ])
+        .output()
+        .expect("run rotate force-reissue --wait");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(124),
+        "expected GNU timeout(1) exit code 124 on --wait timeout;\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("--wait timed out"),
+        "expected timeout message in stdout:\n{stdout}"
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn test_rotate_force_reissue_missing_service_fails() {


### PR DESCRIPTION
## Summary

`bootroot rotate force-reissue --wait` previously printed its timeout message and exited `0`, which made a deferred reissue look identical to a successful one for any caller checking `$?`. The gauntlet#106 incident hid behind exactly this: a 2-minute wait window returned 0 while the actual leaf write would not have happened for another ~57 minutes because the native agent's `check_interval=3600s` had not elapsed.

This change threads a typed `RotateOutcome` from the two timeout branches in `src/commands/rotate/ca.rs` (local-file and remote-bootstrap delivery) up through `run_rotate` to `main`, which now returns `ExitCode` and maps `RotateOutcome::WaitTimedOut` to `ExitCode::from(124)` — the GNU `timeout(1)` convention. The timeout message itself is unchanged.

This keeps the exit-code policy in one place (`main`), makes the timeout path assertable from an integration test without forking a process inside the rotate code, and leaves room for additional exit codes on other CLI surfaces without sprinkling `process::exit` calls through the command tree.

## Compatibility

Behavior break for any caller that currently treats `rotate --wait`'s exit code as authoritative — but those scripts should have been failing all along. Documented in `CHANGELOG.md` under `Unreleased`. Callers that prefer the old "ignore timeout" semantics can restore them with `|| true`.

Closes #629

## Test plan

- [x] `cargo test --test bootroot_rotate test_rotate_force_reissue_remote_wait_times_out_with_exit_124` passes (new test asserting exit code 124 and the unchanged stdout message)
- [x] `cargo test --test bootroot_rotate test_rotate_force_reissue_remote_wait_reports_completion` still passes (success path stays exit 0)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --all -- --check` is clean
- [x] Manual: `bootroot rotate force-reissue --service-name <svc> --yes --wait --wait-timeout 1s` against an agent that will not pick up the request exits 124 and prints the existing `--wait timed out after 1s; bootroot-agent may still pick up the request on its next poll` message — covered by `test_rotate_force_reissue_remote_wait_times_out_with_exit_124`, which forks the real `bootroot` binary against a wiremock OpenBao that never advertises `completed_version` and asserts `status.code() == Some(124)` and the timeout-message substring
- [x] Manual: a `--wait` invocation that *does* observe completion still exits 0 — covered by `test_rotate_force_reissue_remote_wait_reports_completion`, which forks the real binary against a wiremock that advertises `completed_version` and asserts exit 0; additionally, the full Docker E2E matrix (`rotation`, `local-no-hosts-host-daemon`, etc.) exercises `force-reissue --wait` against a live agent and all pass in CI on this branch
- [x] Audit internal callers (gauntlet runbook, any in-tree e2e scripts) for places that need a `|| true` to retain the old swallow-timeout behavior — only in-tree `--wait` callers are `scripts/impl/run-local-lifecycle.sh:930` and `scripts/impl/run-ca-key-rotation-recovery.sh:388`; both run under `set -euo pipefail` and intentionally expect the rotation to complete within the default wait window, so a 124 there *should* fail the script (the desired new behavior) — no `|| true` needed. Gauntlet runbook lives out-of-tree and is called out separately