### PR TITLE
Mention clean teardown in infra --help (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1009,6 +1009,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   callers. The timeout message itself is unchanged. Callers that
   prefer the old "ignore timeout" semantics can re-establish them
   with `|| true`. (Closes #629)
+- Added a teardown footer to `bootroot infra --help` pointing operators
+  at `bootroot clean` (top-level), plus a `long_about` on `bootroot
+  clean --help` describing the full teardown path (compose down with
+  auto-discovered openbao-agent/openbao-exposed overrides, removal of
+  `secrets/`, `state.json`, `.env`, and prompted `certs/`) so the next
+  help page after the footer is no longer a flag-only dead end.
+  Bring-up lives under `infra` (`up`, `install`) while teardown is the
+  top-level `clean`, so an operator who learned `bootroot infra up`
+  would not naturally discover the teardown command by exploring
+  `bootroot infra --help`. The footer closes the discoverability gap
+  without aliasing `infra down` to `clean` — `docker compose down`
+  semantics only touch containers, networks, and volumes, while
+  `bootroot clean` additionally wipes `secrets/`, `state.json`, `.env`,
+  and (optionally) `certs/`, so an alias would silently turn "stop and
+  bring back up later" into "lose every root token, CA material, and
+  service cert". (Closes #632)
 - The published `PostgreSQL` host port now defaults to **5433**
   (`POSTGRES_HOST_PORT=5433`) so bootroot does not claim the
   conventional 5432 out of the box. The conventional port stays free

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -9,6 +9,29 @@ use crate::commands::init::{
 };
 use crate::state::{DeliveryMode, DeployType, HookFailurePolicyEntry};
 
+const INFRA_AFTER_HELP: &str = "\
+Teardown:
+  This command brings the stack up or installs it; it does not tear it
+  down. Use `bootroot clean` (top-level) to stop the compose stack and
+  wipe `secrets/`, `state.json`, `.env`, and (optionally) `certs/`.
+  Run `bootroot clean --help` for details.";
+
+const CLEAN_LONG_ABOUT: &str = "\
+Tears down the bootroot stack and wipes its filesystem state.
+
+Without flags, `bootroot clean`:
+  - runs `docker compose down -v --remove-orphans` against the main
+    compose file plus any auto-discovered openbao-agent sidecar and
+    `openbao-exposed` overrides under `secrets/openbao/`;
+  - removes `secrets/`, `state.json`, and `.env`;
+  - prompts before removing `certs/` (or removes it without prompting
+    when `--yes` is given).
+
+Pass `--openbao-only` to wipe just the `bootroot-openbao` container and
+its named volumes (recovery from a partial-init OpenBao state); every
+other compose service, `secrets/`, `state.json`, and `.env` stay
+intact.";
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub(crate) struct Cli {
@@ -22,7 +45,9 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum CliCommand {
-    #[command(subcommand)]
+    /// Manages the infrastructure compose stack (`OpenBao`, `PostgreSQL`,
+    /// step-ca, HTTP-01 responder).
+    #[command(subcommand, after_help = INFRA_AFTER_HELP)]
     Infra(InfraCommand),
     #[command(subcommand)]
     Monitoring(MonitoringCommand),
@@ -37,6 +62,10 @@ pub(crate) enum CliCommand {
     Service(ServiceCommand),
     Verify(VerifyArgs),
     Rotate(RotateArgs),
+    /// Tears down the bootroot stack and wipes its filesystem state
+    /// (`secrets/`, `state.json`, `.env`, and — with confirmation or
+    /// `--yes` — `certs/`).
+    #[command(long_about = CLEAN_LONG_ABOUT)]
     Clean(CleanArgs),
     #[command(subcommand)]
     Openbao(OpenbaoCommand),


### PR DESCRIPTION
## Summary

`bootroot infra` only carries the bring-up subcommands (`up`, `install`); teardown is the top-level `bootroot clean`. The functionality is complete and documented, but the help surface is asymmetric — operators who learn `bootroot infra up` do not naturally discover `bootroot clean` by exploring `bootroot infra --help`.

This PR

- adds an `after_help` footer on `bootroot infra` pointing at `bootroot clean`;
- adds a doc comment on the `Infra` variant so the top-level `bootroot --help` summary describes it;
- adds a doc comment + `long_about` on the `Clean` variant so the page the footer points at actually describes the full teardown semantics (compose down with auto-discovered openbao-agent / openbao-exposed overrides; removal of `secrets/`, `state.json`, `.env`; prompted `certs/`; `--openbao-only` recovery path) rather than just listing flags.

No new subcommand or alias is introduced.

### Why no `infra down` alias

`docker compose down [-v]` semantics — which an operator typing `bootroot infra down` would import by analogy — only touch containers, networks, and volumes. `bootroot clean` additionally wipes `secrets/`, `state.json`, `.env`, and (optionally) `certs/`. Aliasing `infra down` → `clean` would silently turn "stop and bring back up later" into "lose every root token, CA material, and service cert". The issue (v3/v4 scope) explicitly excludes this path.

A non-destructive `infra down` that just stops the compose stack while preserving filesystem state is a new feature, out of scope here.

Closes #632

## Test plan

- [x] `cargo clippy --all-targets --no-deps -- -D warnings` passes
- [x] `cargo run --bin bootroot -- infra --help` shows the `Teardown:` footer pointing at `bootroot clean`
- [x] `cargo run --bin bootroot -- --help` shows the new `Infra` and `Clean` doc-comment summaries
- [x] `cargo run --bin bootroot -- clean --help` now shows the full teardown semantics (compose down, override discovery, paths removed, `--openbao-only`) instead of a flag-only page
- [x] `cargo run --bin bootroot -- clean -h` short form still shows a one-line summary
- [x] `cargo run --bin bootroot -- infra up --help` and `... infra install --help` are unaffected (no spurious footer on the leaf subcommands)