### PR TITLE
Fill missing --help descriptions across bootroot CLI (#625)

### DIFF
--- a/src/agent_args.rs
+++ b/src/agent_args.rs
@@ -3,7 +3,12 @@ use std::path::PathBuf;
 use clap::{ArgAction, Parser};
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author,
+    version,
+    about = "Daemon that renews service TLS certificates via ACME and reloads their consumers",
+    long_about = None,
+)]
 pub struct Args {
     /// Path to configuration file (default: agent.toml)
     #[arg(long, short)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -498,15 +498,21 @@ pub(crate) enum RotateCommand {
     ///
     /// Alters the role's password in `PostgreSQL`, rewrites the runtime
     /// DSN in `ca.json` and `OpenBao` KV, and restarts step-ca so the
-    /// new DSN takes effect. Requires a `--db-admin-dsn` capable of
-    /// altering the step-ca role.
+    /// new DSN takes effect. Requires an admin DSN capable of altering
+    /// the step-ca role; resolved from `--db-admin-dsn` first and
+    /// otherwise from `bootroot/stepca/db_admin` in `OpenBao` KV.
+    /// Supply the flag to override the KV value, or when running with
+    /// an `AppRole` token whose policy excludes `db_admin`.
     Db(RotateDbArgs),
     /// Rotates the HTTP-01 responder HMAC secret.
     ///
     /// Replaces the shared HMAC used by the HTTP-01 admin API on both
     /// the responder and on every client (`OpenBao` KV templates and
-    /// rendered config). Triggers a responder restart so the new HMAC
-    /// takes effect.
+    /// rendered config). Restarts the `OpenBao` Agent renderer so the
+    /// new HMAC is written to disk, then signals the responder with
+    /// SIGHUP via `docker compose kill -s HUP` when the compose file
+    /// includes the responder service so it reloads the new value
+    /// without dropping in-flight challenges.
     ResponderHmac(RotateResponderHmacArgs),
     /// Rotates `OpenBao` recovery credentials manually.
     ///

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -89,8 +89,14 @@ pub(crate) enum CliCommand {
     /// Cross-checks the rendered `agent.toml`, the corresponding
     /// `state.json` entry, and the bootroot-agent binary itself. With
     /// `--db-check`, also confirms that the runtime DSN in `ca.json`
-    /// authenticates against `PostgreSQL`. Read-only; safe to run at any
-    /// time.
+    /// authenticates against `PostgreSQL`.
+    ///
+    /// Not read-only: under the hood this invokes `bootroot-agent
+    /// --oneshot`, which performs a full ACME issuance/renewal pass for
+    /// every configured profile (writing the leaf cert and key back to
+    /// disk and running any configured post-renew hooks) before the
+    /// rendered-file and bundle checks run. Treat each invocation as a
+    /// real issuance against step-ca.
     Verify(VerifyArgs),
     /// Rotates infrastructure secrets, keys, and certificates managed by
     /// bootroot.
@@ -281,10 +287,16 @@ pub(crate) enum ServiceCommand {
 pub(crate) enum ServiceOpenbaoSidecarCommand {
     /// Starts the per-service `OpenBao` Agent sidecar container.
     ///
-    /// The sidecar templates the service's KV material into rendered
-    /// files on a tmpfs volume and signals the service on change. The
-    /// Docker network is auto-discovered from `bootroot-openbao`'s
-    /// compose project label unless `--openbao-network` is supplied.
+    /// The sidecar runs `openbao agent` against a generated HCL config
+    /// whose `template` blocks render the managed `agent.toml` and trust
+    /// material from `OpenBao` KV into files under the host secrets
+    /// directory, which is bind-mounted into the container (not a tmpfs
+    /// volume). The template blocks specify only `source`, `destination`,
+    /// and `perms` — the sidecar itself does not signal the consumer on
+    /// re-render; consumer reload is the bootroot-agent's responsibility
+    /// via its post-renew hooks. The Docker network is auto-discovered
+    /// from `bootroot-openbao`'s compose project label unless
+    /// `--openbao-network` is supplied.
     Start(ServiceOpenbaoSidecarStartArgs),
     /// Restarts the per-service `OpenBao` Agent sidecar so it re-reads
     /// KV templates after operator-side KV maintenance.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -242,11 +242,13 @@ pub(crate) enum ServiceCommand {
     /// Registers a new bootroot-agent-managed service.
     ///
     /// Generates the service's `OpenBao` `AppRole` and `secret_id`,
-    /// renders the agent's `agent.toml` baseline, records the
-    /// deployment intent in `state.json`, and (for daemon and docker
-    /// deployments) validates the supplied bootroot-agent identity. Use
-    /// `--dry-run` to preview the diff or `--print-only` to emit the
-    /// manual snippets without writing files.
+    /// renders the agent's `agent.toml` baseline, and records the
+    /// deployment intent in `state.json`. For Docker deployments with a
+    /// `--container-name`, also classifies the supplied bootroot-agent
+    /// container against the expected identity (skip with
+    /// `--no-validate-agent`); daemon deployments have no container to
+    /// validate. Use `--dry-run` to preview the diff or `--print-only`
+    /// to emit the manual snippets without writing files.
     Add(Box<ServiceAddArgs>),
     /// Prints the registered configuration and `OpenBao` `AppRole`
     /// metadata for a service.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -99,11 +99,10 @@ pub(crate) enum CliCommand {
     /// `PostgreSQL` password, HTTP-01 responder HMAC, `AppRole`
     /// `secret_id`, `OpenBao` recovery credentials, CA key,
     /// infrastructure TLS certs, EAB credentials, trust-bundle sync).
-    /// Side effects vary per subcommand: most update both `OpenBao` KV
-    /// and `state.json` so the next bootroot-agent cycle picks the new
-    /// material up automatically, while a few (notably `openbao-recovery`
-    /// and `trust-sync`) operate outside the regular rotate context.
-    /// See each subcommand's `--help` for its exact contract.
+    /// Side effects vary per subcommand — most write to `OpenBao` KV
+    /// and/or rendered config and restart the relevant container, while
+    /// only `infra-cert` persists changes back to `state.json`. See each
+    /// subcommand's `--help` for its exact contract.
     Rotate(RotateArgs),
     /// Tears down the bootroot stack and wipes its filesystem state
     /// (`secrets/`, `state.json`, `.env`, and — with confirmation or
@@ -218,10 +217,10 @@ pub(crate) enum MonitoringCommand {
     /// Starts the Prometheus/Grafana monitoring stack with the chosen
     /// exposure profile.
     ///
-    /// `lan` binds to loopback; `public` binds to the host's default
-    /// interface. The Grafana admin password defaults to `admin` on
-    /// first start and is rotated when `--grafana-admin-password` is
-    /// supplied.
+    /// `lan` binds to `GRAFANA_LAN_BIND_ADDR` (default `127.0.0.1`);
+    /// `public` binds to all interfaces (`0.0.0.0:3000`). The Grafana
+    /// admin password defaults to `admin` on first start and is rotated
+    /// when `--grafana-admin-password` is supplied.
     Up(MonitoringUpArgs),
     /// Reports the running state of the monitoring stack containers.
     Status(MonitoringStatusArgs),
@@ -485,9 +484,10 @@ pub(crate) enum RotateCommand {
     /// Rotates step-ca's encryption-key password and re-renders
     /// `password.txt`.
     ///
-    /// The new password is written to `secrets/config/password.txt`
-    /// (mode `0600`), recorded in `OpenBao` KV, and the step-ca
-    /// container is restarted so the new password takes effect.
+    /// The new password is staged as `<secrets_dir>/password.txt.new`,
+    /// recorded in `OpenBao` KV, and the `OpenBao` Agent re-renders the
+    /// final `<secrets_dir>/password.txt` (mode `0600`) before step-ca
+    /// is restarted so the new password takes effect.
     StepcaPassword(RotateStepcaPasswordArgs),
     /// Rotates the `PostgreSQL` password used by step-ca and rewrites
     /// the runtime DSN.
@@ -519,30 +519,38 @@ pub(crate) enum RotateCommand {
     /// Rotates the `OpenBao` `AppRole` `secret_id` for one registered
     /// service.
     ///
-    /// Generates a fresh `secret_id` on the configured `AppRole`,
-    /// writes it to the matching remote-bootstrap or local KV path, and
-    /// revokes the previous `secret_id`. The next bootroot-agent cycle
-    /// picks up the new credential automatically.
+    /// Generates a fresh `secret_id` on the configured `AppRole`. For
+    /// local-file services, writes it atomically to the on-disk
+    /// `secret_id` file and reloads the local `OpenBao` Agent so the new
+    /// credential takes effect. For remote-bootstrap services, publishes
+    /// it to the service's KV bootstrap path so the next bootroot-agent
+    /// cycle picks it up. The previous `secret_id` is not explicitly
+    /// revoked; it remains valid until it expires under the `AppRole`'s
+    /// configured TTL.
     #[command(name = "approle-secret-id")]
     AppRoleSecretId(RotateAppRoleSecretIdArgs),
-    /// Synchronizes step-ca's trust bundle with the recorded chain in
-    /// `state.json`.
+    /// Republishes the current step-ca trust material to every
+    /// registered service via `OpenBao` KV.
     ///
-    /// Reconciles the step-ca container's mounted root and intermediate
-    /// certificates against the deployment-intent record and restarts
-    /// step-ca when drift is detected. Read-mostly; only writes when
-    /// drift is found.
+    /// Reads the mounted root/intermediate certificates from disk,
+    /// computes their fingerprints and the combined CA bundle, and
+    /// writes them unconditionally to each registered service's
+    /// `OpenBao` KV trust path. Does not restart step-ca, does not
+    /// compare against `state.json`, and does not detect drift — every
+    /// run rewrites the KV entries.
     #[command(name = "trust-sync")]
     TrustSync(RotateTrustSyncArgs),
     /// Forces a registered service to re-issue its certificate on the
     /// next bootroot-agent cycle.
     ///
-    /// Marks the service for immediate reissuance in `OpenBao` KV (or
-    /// in the local-file path for `local-file` deployments). With
-    /// `--wait`, blocks until the agent has applied the reissue
-    /// (bounded by `--wait-timeout`). Use when a certificate must be
-    /// re-keyed out of band — for example after a private-key
-    /// compromise scare.
+    /// For local-file services, removes the existing cert and key files
+    /// on disk and signals the local bootroot-agent so it issues a fresh
+    /// pair on its next cycle. For remote-bootstrap services, writes a
+    /// versioned reissue request to the service's `OpenBao` KV path so
+    /// the remote agent picks it up. With `--wait`, blocks until the
+    /// agent has applied the reissue (bounded by `--wait-timeout`). Use
+    /// when a certificate must be re-keyed out of band — for example
+    /// after a private-key compromise scare.
     #[command(name = "force-reissue")]
     ForceReissue(RotateForceReissueArgs),
     /// Rotates step-ca's intermediate signing key (and, with `--full`,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -33,7 +33,12 @@ other compose service, `secrets/`, `state.json`, and `.env` stay
 intact.";
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author,
+    version,
+    about = "Operator CLI for the bootroot certificate and secret control plane",
+    long_about = None,
+)]
 pub(crate) struct Cli {
     /// Language for CLI output (en or ko)
     #[arg(long, env = "BOOTROOT_LANG", default_value = "en", global = true)]
@@ -49,26 +54,75 @@ pub(crate) enum CliCommand {
     /// step-ca, HTTP-01 responder).
     #[command(subcommand, after_help = INFRA_AFTER_HELP)]
     Infra(InfraCommand),
+    /// Manages the optional Prometheus/Grafana monitoring stack.
     #[command(subcommand)]
     Monitoring(MonitoringCommand),
+    /// Initializes a fresh bootroot stack: provisions `OpenBao`, step-ca,
+    /// `PostgreSQL`, and the HTTP-01 responder.
+    ///
+    /// Runs end-to-end on an empty host: starts the compose stack,
+    /// initializes and unseals `OpenBao`, provisions the step-ca PKI,
+    /// renders operator-facing secrets and config under `secrets/`, and
+    /// records the resulting deployment intent in `state.json`. When only
+    /// `OpenBao`-owned state needs to be re-initialized, use `bootroot
+    /// reinit` instead.
     Init(Box<InitArgs>),
     /// Recovers from a partial-init `OpenBao` state by wiping
     /// `OpenBao`-owned state and re-running init while preserving step-ca
     /// material, the operator's compose overrides, and recorded
     /// deployment intent (non-loopback binds).
     Reinit(Box<ReinitArgs>),
+    /// Reports the runtime health of the bootroot infrastructure stack
+    /// and its registered services.
+    ///
+    /// Inspects compose-stack container state, `OpenBao` seal/unseal
+    /// status, step-ca reachability, and the registered service inventory
+    /// in `state.json`. Read-only; safe to run at any time.
     Status(Box<StatusArgs>),
+    /// Registers and manages bootroot-agent-driven service consumers and
+    /// their per-service `OpenBao` Agent sidecars.
     #[command(subcommand)]
     Service(ServiceCommand),
+    /// Verifies that a registered service's bootroot-agent configuration
+    /// is internally consistent and reaches the control plane.
+    ///
+    /// Cross-checks the rendered `agent.toml`, the corresponding
+    /// `state.json` entry, and the bootroot-agent binary itself. With
+    /// `--db-check`, also confirms that the runtime DSN in `ca.json`
+    /// authenticates against `PostgreSQL`. Read-only; safe to run at any
+    /// time.
     Verify(VerifyArgs),
+    /// Rotates infrastructure secrets, keys, and certificates managed by
+    /// bootroot.
+    ///
+    /// Subcommands cover distinct rotation surfaces (step-ca password,
+    /// `PostgreSQL` password, HTTP-01 responder HMAC, `AppRole`
+    /// `secret_id`, `OpenBao` recovery credentials, CA key,
+    /// infrastructure TLS certs, EAB credentials). Each subcommand
+    /// updates `OpenBao` KV and `state.json` together so the next
+    /// bootroot-agent cycle picks up the new material without operator
+    /// intervention.
     Rotate(RotateArgs),
     /// Tears down the bootroot stack and wipes its filesystem state
     /// (`secrets/`, `state.json`, `.env`, and — with confirmation or
     /// `--yes` — `certs/`).
     #[command(long_about = CLEAN_LONG_ABOUT)]
     Clean(CleanArgs),
+    /// Manages `OpenBao` operator material outside the regular init and
+    /// rotate flows.
+    ///
+    /// Currently covers persisting and deleting the on-disk
+    /// `unseal-keys.txt` file under `secrets/openbao/`. Intended for
+    /// post-init operator workflows; routine bootstrap is handled by
+    /// `bootroot init`'s `--save-unseal-keys` / `--no-save-unseal-keys`
+    /// flags.
     #[command(subcommand)]
     Openbao(OpenbaoCommand),
+    /// Manages step-ca configuration that bootroot controls.
+    ///
+    /// Currently scoped to the ACME provisioner's
+    /// `defaultTLSCertDuration` and to restarting the step-ca container
+    /// so a configuration change takes effect.
     #[command(subcommand)]
     Ca(CaCommand),
 }
@@ -116,27 +170,92 @@ pub(crate) struct CaRestartArgs {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum InfraCommand {
+    /// Starts the bootroot compose stack from the existing `secrets/`
+    /// and `state.json`.
+    ///
+    /// Use this on a host that has already been initialized (`bootroot
+    /// init` has been run and `secrets/`, `state.json`, and `.env` are
+    /// present). For first-time setup use `bootroot init`; for recovering
+    /// from a partial init use `bootroot reinit`.
     Up(InfraUpArgs),
+    /// Installs the bootroot compose stack: writes restart-policy
+    /// overrides, optionally re-binds `OpenBao` and the HTTP-01 admin
+    /// API to non-loopback addresses, and brings the stack up.
+    ///
+    /// `--openbao-bind` and `--http01-admin-bind` require explicit TLS
+    /// acknowledgement (`--openbao-tls-required`,
+    /// `--http01-admin-tls-required`) and, for wildcard binds, separate
+    /// `--*-bind-wildcard` and `--*-advertise-addr` flags. These are
+    /// deliberate guardrails — see issue #588 for the rationale.
     Install(InfraInstallArgs),
 }
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum OpenbaoCommand {
+    /// Persists the currently held `OpenBao` unseal keys to
+    /// `<secrets_dir>/openbao/unseal-keys.txt` (mode `0600`).
+    ///
+    /// Useful when an operator initially declined to save the keys at
+    /// init time and later decides to keep them on disk. Requires that
+    /// the keys are still available to bootroot (e.g. via the
+    /// `--summary-json` file from the previous init).
     SaveUnsealKeys(OpenbaoSaveUnsealKeysArgs),
+    /// Deletes the on-disk `OpenBao` unseal-keys file under
+    /// `<secrets_dir>/openbao/`.
+    ///
+    /// Intended for operators who initially saved the keys for
+    /// convenience and now want to remove them from the host. Does not
+    /// rotate the keys themselves; combine with `bootroot rotate
+    /// openbao-recovery --rotate-unseal-keys` for that.
     DeleteUnsealKeys(OpenbaoDeleteUnsealKeysArgs),
 }
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum MonitoringCommand {
+    /// Starts the Prometheus/Grafana monitoring stack with the chosen
+    /// exposure profile.
+    ///
+    /// `lan` binds to loopback; `public` binds to the host's default
+    /// interface. The Grafana admin password defaults to `admin` on
+    /// first start and is rotated when `--grafana-admin-password` is
+    /// supplied.
     Up(MonitoringUpArgs),
+    /// Reports the running state of the monitoring stack containers.
     Status(MonitoringStatusArgs),
+    /// Stops the monitoring stack.
+    ///
+    /// `--reset-grafana-admin-password` clears the persisted Grafana
+    /// admin password so that the next `monitoring up` reseeds it from
+    /// the default or from a freshly supplied
+    /// `--grafana-admin-password`.
     Down(MonitoringDownArgs),
 }
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum ServiceCommand {
+    /// Registers a new bootroot-agent-managed service.
+    ///
+    /// Generates the service's `OpenBao` `AppRole` and `secret_id`,
+    /// renders the agent's `agent.toml` baseline, records the
+    /// deployment intent in `state.json`, and (for daemon and docker
+    /// deployments) validates the supplied bootroot-agent identity. Use
+    /// `--dry-run` to preview the diff or `--print-only` to emit the
+    /// manual snippets without writing files.
     Add(Box<ServiceAddArgs>),
+    /// Prints the registered configuration and `OpenBao` `AppRole`
+    /// material for a service.
+    ///
+    /// Read-only; safe to run at any time. The `AppRole` `secret_id` is
+    /// masked unless the operator explicitly opts into plaintext output
+    /// via the parent flow's `--show-secrets`.
     Info(ServiceInfoArgs),
+    /// Edits a registered service's `secret_id` policy, post-renew hook,
+    /// or cert ownership in place.
+    ///
+    /// Lets the operator adjust `secret_id` TTL, wrap TTL, or CIDR
+    /// binding; swap the reload-style preset; or change `--cert-group`
+    /// without having to remove and re-add the service. See issue #614
+    /// for the in-FD reload pitfall this guards against.
     Update(ServiceUpdateArgs),
     /// Manages the per-service `OpenBao` Agent sidecar container.
     #[command(subcommand, name = "openbao-sidecar")]
@@ -149,6 +268,12 @@ pub(crate) enum ServiceCommand {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum ServiceOpenbaoSidecarCommand {
+    /// Starts the per-service `OpenBao` Agent sidecar container.
+    ///
+    /// The sidecar templates the service's KV material into rendered
+    /// files on a tmpfs volume and signals the service on change. The
+    /// Docker network is auto-discovered from `bootroot-openbao`'s
+    /// compose project label unless `--openbao-network` is supplied.
     Start(ServiceOpenbaoSidecarStartArgs),
     /// Restarts the per-service `OpenBao` Agent sidecar so it re-reads
     /// KV templates after operator-side KV maintenance.
@@ -351,8 +476,27 @@ pub(crate) struct RotateArgs {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum RotateCommand {
+    /// Rotates step-ca's encryption-key password and re-renders
+    /// `password.txt`.
+    ///
+    /// The new password is written to `secrets/config/password.txt`
+    /// (mode `0600`), recorded in `OpenBao` KV, and the step-ca
+    /// container is restarted so the new password takes effect.
     StepcaPassword(RotateStepcaPasswordArgs),
+    /// Rotates the `PostgreSQL` password used by step-ca and rewrites
+    /// the runtime DSN.
+    ///
+    /// Alters the role's password in `PostgreSQL`, rewrites the runtime
+    /// DSN in `ca.json` and `OpenBao` KV, and restarts step-ca so the
+    /// new DSN takes effect. Requires a `--db-admin-dsn` capable of
+    /// altering the step-ca role.
     Db(RotateDbArgs),
+    /// Rotates the HTTP-01 responder HMAC secret.
+    ///
+    /// Replaces the shared HMAC used by the HTTP-01 admin API on both
+    /// the responder and on every client (`OpenBao` KV templates and
+    /// rendered config). Triggers a responder restart so the new HMAC
+    /// takes effect.
     ResponderHmac(RotateResponderHmacArgs),
     /// Rotates `OpenBao` recovery credentials manually.
     ///
@@ -366,12 +510,44 @@ pub(crate) enum RotateCommand {
     /// `--rotate-root-token` can run without unseal key input.
     #[command(name = "openbao-recovery")]
     OpenBaoRecovery(RotateOpenBaoRecoveryArgs),
+    /// Rotates the `OpenBao` `AppRole` `secret_id` for one registered
+    /// service.
+    ///
+    /// Generates a fresh `secret_id` on the configured `AppRole`,
+    /// writes it to the matching remote-bootstrap or local KV path, and
+    /// revokes the previous `secret_id`. The next bootroot-agent cycle
+    /// picks up the new credential automatically.
     #[command(name = "approle-secret-id")]
     AppRoleSecretId(RotateAppRoleSecretIdArgs),
+    /// Synchronizes step-ca's trust bundle with the recorded chain in
+    /// `state.json`.
+    ///
+    /// Reconciles the step-ca container's mounted root and intermediate
+    /// certificates against the deployment-intent record and restarts
+    /// step-ca when drift is detected. Read-mostly; only writes when
+    /// drift is found.
     #[command(name = "trust-sync")]
     TrustSync(RotateTrustSyncArgs),
+    /// Forces a registered service to re-issue its certificate on the
+    /// next bootroot-agent cycle.
+    ///
+    /// Marks the service for immediate reissuance in `OpenBao` KV (or
+    /// in the local-file path for `local-file` deployments). With
+    /// `--wait`, blocks until the agent has applied the reissue
+    /// (bounded by `--wait-timeout`). Use when a certificate must be
+    /// re-keyed out of band — for example after a private-key
+    /// compromise scare.
     #[command(name = "force-reissue")]
     ForceReissue(RotateForceReissueArgs),
+    /// Rotates step-ca's intermediate signing key (and, with `--full`,
+    /// the root signing key).
+    ///
+    /// Issues a new intermediate (and optionally root) key, drives
+    /// every registered service through reissuance, and finalizes trust
+    /// once every agent has migrated. Skipped phases (`--skip
+    /// reissue,finalize`) leave the rotation paused for operator
+    /// follow-up. Use `--cleanup` to delete backup files after a
+    /// successful full rotation.
     #[command(name = "ca-key")]
     CaKey(RotateCaKeyArgs),
     /// Renews infrastructure TLS certificates (e.g. `OpenBao` server cert)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -219,8 +219,12 @@ pub(crate) enum MonitoringCommand {
     ///
     /// `lan` binds to `GRAFANA_LAN_BIND_ADDR` (default `127.0.0.1`);
     /// `public` binds to all interfaces (`0.0.0.0:3000`). The Grafana
-    /// admin password defaults to `admin` on first start and is rotated
-    /// when `--grafana-admin-password` is supplied.
+    /// admin password defaults to `admin` on first boot and is only
+    /// applied then; pass `--grafana-admin-password` before the first
+    /// `monitoring up`, or run `monitoring down
+    /// --reset-grafana-admin-password` to clear the Grafana volume
+    /// before reseeding it. If monitoring is already running, this
+    /// command is a no-op (no password change is applied).
     Up(MonitoringUpArgs),
     /// Reports the running state of the monitoring stack containers.
     Status(MonitoringStatusArgs),
@@ -556,12 +560,18 @@ pub(crate) enum RotateCommand {
     /// Rotates step-ca's intermediate signing key (and, with `--full`,
     /// the root signing key).
     ///
-    /// Issues a new intermediate (and optionally root) key, drives
-    /// every registered service through reissuance, and finalizes trust
-    /// once every agent has migrated. Skipped phases (`--skip
-    /// reissue,finalize`) leave the rotation paused for operator
-    /// follow-up. Use `--cleanup` to delete backup files after a
-    /// successful full rotation.
+    /// Issues a new intermediate (and optionally root) key, then drives
+    /// reissuance for **local-file** services directly: the control
+    /// plane removes their existing cert and key files and signals the
+    /// local bootroot-agent to reissue on its next cycle. For
+    /// **remote-bootstrap** services the control plane only prints an
+    /// instruction to run `bootroot-remote bootstrap` on the service
+    /// host; their reissuance is the operator's responsibility and is
+    /// not verified by the finalize phase (remote-bootstrap services
+    /// are skipped when checking for unmigrated certs). Skipped phases
+    /// (`--skip reissue,finalize`) leave the rotation paused for
+    /// operator follow-up. Use `--cleanup` to delete backup files
+    /// after a successful full rotation.
     #[command(name = "ca-key")]
     CaKey(RotateCaKeyArgs),
     /// Renews infrastructure TLS certificates (e.g. `OpenBao` server cert)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -98,10 +98,12 @@ pub(crate) enum CliCommand {
     /// Subcommands cover distinct rotation surfaces (step-ca password,
     /// `PostgreSQL` password, HTTP-01 responder HMAC, `AppRole`
     /// `secret_id`, `OpenBao` recovery credentials, CA key,
-    /// infrastructure TLS certs, EAB credentials). Each subcommand
-    /// updates `OpenBao` KV and `state.json` together so the next
-    /// bootroot-agent cycle picks up the new material without operator
-    /// intervention.
+    /// infrastructure TLS certs, EAB credentials, trust-bundle sync).
+    /// Side effects vary per subcommand: most update both `OpenBao` KV
+    /// and `state.json` so the next bootroot-agent cycle picks the new
+    /// material up automatically, while a few (notably `openbao-recovery`
+    /// and `trust-sync`) operate outside the regular rotate context.
+    /// See each subcommand's `--help` for its exact contract.
     Rotate(RotateArgs),
     /// Tears down the bootroot stack and wipes its filesystem state
     /// (`secrets/`, `state.json`, `.env`, and — with confirmation or
@@ -192,13 +194,14 @@ pub(crate) enum InfraCommand {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum OpenbaoCommand {
-    /// Persists the currently held `OpenBao` unseal keys to
+    /// Persists `OpenBao` unseal keys to
     /// `<secrets_dir>/openbao/unseal-keys.txt` (mode `0600`).
     ///
     /// Useful when an operator initially declined to save the keys at
-    /// init time and later decides to keep them on disk. Requires that
-    /// the keys are still available to bootroot (e.g. via the
-    /// `--summary-json` file from the previous init).
+    /// init time and later decides to keep them on disk. The command
+    /// interactively prompts for the unseal key threshold and the
+    /// matching number of key shares — the operator must paste each
+    /// share at the prompt — then writes the file atomically.
     SaveUnsealKeys(OpenbaoSaveUnsealKeysArgs),
     /// Deletes the on-disk `OpenBao` unseal-keys file under
     /// `<secrets_dir>/openbao/`.
@@ -243,11 +246,14 @@ pub(crate) enum ServiceCommand {
     /// manual snippets without writing files.
     Add(Box<ServiceAddArgs>),
     /// Prints the registered configuration and `OpenBao` `AppRole`
-    /// material for a service.
+    /// metadata for a service.
     ///
-    /// Read-only; safe to run at any time. The `AppRole` `secret_id` is
-    /// masked unless the operator explicitly opts into plaintext output
-    /// via the parent flow's `--show-secrets`.
+    /// Read-only; safe to run at any time. The output covers deploy type,
+    /// hostname, domain, delivery mode, post-renew hooks, the `AppRole`
+    /// role name and `role_id`, `secret_id` TTL / wrap TTL / token-bound
+    /// CIDRs, the rendered agent config / cert / key / `secret_id` paths,
+    /// the service's `OpenBao` KV path, and the next-step sidecar
+    /// snippet. The `AppRole` `secret_id` itself is never printed.
     Info(ServiceInfoArgs),
     /// Edits a registered service's `secret_id` policy, post-renew hook,
     /// or cert ownership in place.


### PR DESCRIPTION
## Summary

Fills the gaps surfaced by #625 in the `bootroot` CLI help output. All changes are documentation-only — no behavior change.

- Replace the keyword-only `#[command(... about, ...)]` on `bootroot` (`src/cli/args.rs`) and `bootroot-agent` (`src/agent_args.rs`) with explicit `about = "..."` strings so the top-level `--help` no longer shows a blank summary.
- Add `///` variant docs to the 8 previously blank top-level `CliCommand` variants (`Monitoring`, `Init`, `Status`, `Service`, `Verify`, `Rotate`, `Openbao`, `Ca`).
- Add `///` variant docs to every missing second-level variant: `InfraCommand::{Up, Install}`, `OpenbaoCommand::{SaveUnsealKeys, DeleteUnsealKeys}`, `MonitoringCommand::{Up, Status, Down}`, `ServiceCommand::{Add, Info, Update}`, `ServiceOpenbaoSidecarCommand::Start`, and the seven previously blank `RotateCommand` variants (`StepcaPassword`, `Db`, `ResponderHmac`, `AppRoleSecretId`, `TrustSync`, `ForceReissue`, `CaKey`).
- Where it adds operator value, extend the variant doc into a multi-paragraph block (clap's first-paragraph rule keeps the short `about` terse while the long help carries preconditions, side-effects, and pointers). Tone mirrors the existing `CliCommand::Reinit` and `CLEAN_LONG_ABOUT` references called out in the issue.

Style follows the project's third-person-singular Rustdoc convention and backtick-quotes external product names (`OpenBao`, step-ca, `AppRole`, `PostgreSQL`).

Closes #625

## Not addressed

- Long help on `CaCommand::Update` and `CaCommand::Restart`. These already had non-empty variant `///` from the existing codebase, and the issue marked extending them as optional ("where it adds operator value"). The current one-liners read as operator-actionable already, so no follow-up paragraph was added.
- Adding a snapshot test that asserts every variant has non-empty help. The issue explicitly defers this to a follow-up.
- Documenting or un-hiding the deprecated `ServiceCommand::Agent` alias — explicitly out of scope per the issue.
- Removing the dead struct-level `///` on `ReinitArgs`. The issue calls this "harmless, leave the cleanup decision to the implementer"; left as-is to keep the diff doc-only on the variant axis.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `bootroot --help` shows a non-empty top-line summary and a description next to each subcommand (`infra`, `monitoring`, `init`, `reinit`, `status`, `service`, `verify`, `rotate`, `clean`, `openbao`, `ca`)
- [x] `bootroot-agent --help` shows a non-empty top-line summary
- [x] `bootroot infra --help`, `bootroot monitoring --help`, `bootroot openbao --help`, `bootroot service --help`, `bootroot service openbao-sidecar --help`, and `bootroot rotate --help` all show a description next to every visible variant
- [x] `bootroot init --help`, `bootroot status --help`, `bootroot verify --help`, and `bootroot rotate --help` (parent) render the multi-paragraph long help
- [x] `bootroot rotate stepca-password --help`, `... db --help`, `... responder-hmac --help`, `... approle-secret-id --help`, `... trust-sync --help`, `... force-reissue --help`, `... ca-key --help` all render their new multi-paragraph long help
- [x] `bootroot service add --help`, `... info --help`, `... update --help`, and `bootroot service openbao-sidecar start --help` render the new long help
- [x] Hidden `bootroot service agent` alias remains hidden from `bootroot service --help`