### PR TITLE
Preserve [trust] section on service update re-render (#643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot service update --reload-style`/`--cert-group` dropping
+  the `[trust]` section of a local-file service's `agent.toml`. Because
+  `service add` writes `[trust]` *inside* the `# BEGIN … # END bootroot
+  managed profile` markers, the update path's whole-span re-render
+  silently deleted it, leaving the agent's ACME client with no
+  `trust.ca_bundle_path`. The next renewal then fell back to the system
+  trust store and failed against a private (step-ca) CA with
+  `UnknownIssuer`. `rerender_local_managed_profile` now snapshots the
+  existing `[trust]` table before the block replacement and re-applies it
+  with a keyed upsert afterwards. The carry-over is verbatim — the
+  rerender path is deliberately offline (no KV handle) — and idempotent:
+  a `[trust]` already outside the markers is updated in place rather than
+  duplicated, and a config with no `[trust]` keeps none.
+
 - Fixed `bootroot-agent` not detecting a post-`init` trust-anchor
   rotation. Its renewal predicate (`should_renew`) only checked leaf
   expiry, so after `bootroot clean` + `init` regenerated the step-ca

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -910,6 +910,15 @@ fn rerender_local_managed_profile(entry: &ServiceEntry) -> Result<()> {
         entry.cert_group_gid,
     );
     let block = inject_hooks_into_managed_profile_block(&block, &entry.post_renew_hooks);
+    // `service add` writes `[trust]` inside the managed-block markers, so
+    // the whole-span replacement below would drop it and leave the agent
+    // unable to verify a private CA. Snapshot it from the pre-replacement
+    // file and re-apply it afterwards. This path is deliberately offline
+    // (no KV handle), so we carry the existing table over verbatim rather
+    // than re-deriving fingerprints. A keyed upsert updates the table in
+    // place wherever it sits, so a `[trust]` already outside the markers
+    // is not duplicated; a file with no `[trust]` keeps none.
+    let trust_pairs = bootroot::toml_util::section_pairs(&current, "trust")?;
     let next = bootroot::trust_bootstrap::upsert_managed_profile_block(
         &current,
         MANAGED_PROFILE_BEGIN_PREFIX,
@@ -917,6 +926,13 @@ fn rerender_local_managed_profile(entry: &ServiceEntry) -> Result<()> {
         &entry.service_name,
         &block,
     );
+    let next = if let Some(pairs) = trust_pairs {
+        let updates: Vec<(&str, String)> =
+            pairs.iter().map(|(k, v)| (k.as_str(), v.clone())).collect();
+        bootroot::toml_util::upsert_section_keys(&next, "trust", &updates)?
+    } else {
+        next
+    };
     std::fs::write(agent_config_path, next)
         .with_context(|| format!("Failed to write {}", agent_config_path.display()))?;
     Ok(())

--- a/src/toml_util.rs
+++ b/src/toml_util.rs
@@ -99,6 +99,33 @@ pub fn insert_missing_section_keys(
     Ok(doc.to_string())
 }
 
+/// Extracts a section's value key-value pairs as raw TOML value strings.
+///
+/// Returns `None` when the section is absent so callers can distinguish
+/// "no section" from "empty section" and avoid synthesizing one. Each
+/// returned value string is the TOML rendering of the value (for example
+/// `"certs/ca.pem"` or `["abc", "def"]`), which round-trips back through
+/// [`upsert_section_keys`]. Only value items are returned; nested
+/// subtables are skipped.
+///
+/// # Errors
+///
+/// Returns an error if `contents` is not valid TOML.
+pub fn section_pairs(contents: &str, section: &str) -> Result<Option<Vec<(String, String)>>> {
+    let doc: DocumentMut = contents.parse().context("failed to parse TOML content")?;
+    let Some(table) = doc.get(section).and_then(Item::as_table) else {
+        return Ok(None);
+    };
+    let pairs = table
+        .iter()
+        .filter_map(|(key, item)| {
+            item.as_value()
+                .map(|value| (key.to_string(), value.to_string().trim().to_string()))
+        })
+        .collect();
+    Ok(Some(pairs))
+}
+
 /// Removes one or more TOML sections by name.
 ///
 /// Handles both top-level (`"eab"`) and dotted (`"profiles.eab"`)
@@ -241,6 +268,39 @@ mod tests {
         let once = upsert_top_level_keys(input, &pairs).unwrap();
         let twice = upsert_top_level_keys(&once, &pairs).unwrap();
         assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn section_pairs_absent_section_returns_none() {
+        let input = "email = \"admin@example.com\"\n";
+        assert!(section_pairs(input, "trust").unwrap().is_none());
+    }
+
+    #[test]
+    fn section_pairs_round_trips_through_upsert() {
+        let input = "[trust]\n\
+                     ca_bundle_path = \"certs/ca.pem\"\n\
+                     trusted_ca_sha256 = [\"abc\", \"def\"]\n";
+        let pairs = section_pairs(input, "trust").unwrap().expect("present");
+        let updates: Vec<(&str, String)> =
+            pairs.iter().map(|(k, v)| (k.as_str(), v.clone())).collect();
+        let output = upsert_section_keys("email = \"x\"\n", "trust", &updates).unwrap();
+        assert!(
+            output.contains("ca_bundle_path = \"certs/ca.pem\""),
+            "{output}"
+        );
+        assert!(
+            output.contains("trusted_ca_sha256 = [\"abc\", \"def\"]"),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn section_pairs_skips_subtables() {
+        let input = "[trust]\nca_bundle_path = \"certs/ca.pem\"\n\n[trust.nested]\nx = 1\n";
+        let pairs = section_pairs(input, "trust").unwrap().expect("present");
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "ca_bundle_path");
     }
 
     #[test]

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -2870,6 +2870,180 @@ fn test_service_update_installs_post_renew_hook_via_reload_style() {
     );
 }
 
+/// Issue #643 — `service update --reload-style …` must preserve a
+/// `[trust]` section that `service add` wrote *inside* the managed-block
+/// markers. The whole-span re-render used to drop it, leaving the agent's
+/// ACME client unable to verify a private CA (`UnknownIssuer`).
+#[cfg(unix)]
+#[test]
+fn test_service_update_reload_style_preserves_inline_trust() {
+    let temp_dir = tempdir().expect("create temp dir");
+    write_state_file(temp_dir.path(), "http://unused:8200").expect("write state.json");
+    write_state_with_app(temp_dir.path());
+
+    // Mirror the `service add` layout: `[trust]` lands inside the
+    // BEGIN/END markers as a dangling-comment-preceding table.
+    let agent_toml = temp_dir.path().join("agent.toml");
+    fs::write(
+        &agent_toml,
+        "# BEGIN bootroot managed profile: edge-proxy\n\
+         [[profiles]]\n\
+         name = \"edge-proxy\"\n\
+         \n\
+         [trust]\n\
+         ca_bundle_path = \"/opt/demo-mtls/ca-bundle.pem\"\n\
+         trusted_ca_sha256 = [\"root-sha\", \"intermediate-sha\"]\n\
+         # END bootroot managed profile: edge-proxy\n",
+    )
+    .expect("seed agent.toml");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "update",
+            "--service-name",
+            "edge-proxy",
+            "--reload-style",
+            "sighup",
+            "--reload-target",
+            "review",
+        ])
+        .output()
+        .expect("run service update");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let agent_contents = fs::read_to_string(&agent_toml).expect("read agent.toml");
+    assert!(
+        agent_contents.contains("[[profiles.hooks.post_renew.success]]"),
+        "agent.toml should be re-rendered with the new hook, got: {agent_contents}"
+    );
+    assert!(
+        agent_contents.contains("ca_bundle_path = \"/opt/demo-mtls/ca-bundle.pem\""),
+        "[trust].ca_bundle_path must survive the re-render, got: {agent_contents}"
+    );
+    assert!(
+        agent_contents.contains("trusted_ca_sha256 = [\"root-sha\", \"intermediate-sha\"]"),
+        "[trust].trusted_ca_sha256 must survive the re-render, got: {agent_contents}"
+    );
+    assert_eq!(
+        agent_contents.matches("[trust]").count(),
+        1,
+        "exactly one [trust] section expected, got: {agent_contents}"
+    );
+}
+
+/// Issue #643 — when `[trust]` already lives *outside* the managed-block
+/// markers, the carry-over must update it in place and never produce a
+/// duplicate section.
+#[cfg(unix)]
+#[test]
+fn test_service_update_reload_style_keeps_outside_trust_unique() {
+    let temp_dir = tempdir().expect("create temp dir");
+    write_state_file(temp_dir.path(), "http://unused:8200").expect("write state.json");
+    write_state_with_app(temp_dir.path());
+
+    let agent_toml = temp_dir.path().join("agent.toml");
+    fs::write(
+        &agent_toml,
+        "[trust]\n\
+         ca_bundle_path = \"/opt/demo-mtls/ca-bundle.pem\"\n\
+         \n\
+         # BEGIN bootroot managed profile: edge-proxy\n\
+         [[profiles]]\n\
+         name = \"edge-proxy\"\n\
+         # END bootroot managed profile: edge-proxy\n",
+    )
+    .expect("seed agent.toml");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "update",
+            "--service-name",
+            "edge-proxy",
+            "--reload-style",
+            "sighup",
+            "--reload-target",
+            "review",
+        ])
+        .output()
+        .expect("run service update");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let agent_contents = fs::read_to_string(&agent_toml).expect("read agent.toml");
+    assert_eq!(
+        agent_contents.matches("[trust]").count(),
+        1,
+        "an out-of-block [trust] must not be duplicated, got: {agent_contents}"
+    );
+    assert!(
+        agent_contents.contains("ca_bundle_path = \"/opt/demo-mtls/ca-bundle.pem\""),
+        "[trust].ca_bundle_path must survive, got: {agent_contents}"
+    );
+}
+
+/// Issue #643 — a config with no `[trust]` section must not gain a
+/// synthesized empty one during a re-render.
+#[cfg(unix)]
+#[test]
+fn test_service_update_reload_style_no_trust_stays_absent() {
+    let temp_dir = tempdir().expect("create temp dir");
+    write_state_file(temp_dir.path(), "http://unused:8200").expect("write state.json");
+    write_state_with_app(temp_dir.path());
+
+    let agent_toml = temp_dir.path().join("agent.toml");
+    fs::write(
+        &agent_toml,
+        "# BEGIN bootroot managed profile: edge-proxy\n\
+         [[profiles]]\n\
+         name = \"edge-proxy\"\n\
+         # END bootroot managed profile: edge-proxy\n",
+    )
+    .expect("seed agent.toml");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "service",
+            "update",
+            "--service-name",
+            "edge-proxy",
+            "--reload-style",
+            "sighup",
+            "--reload-target",
+            "review",
+        ])
+        .output()
+        .expect("run service update");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let agent_contents = fs::read_to_string(&agent_toml).expect("read agent.toml");
+    assert!(
+        !agent_contents.contains("[trust]"),
+        "no [trust] section should be synthesized, got: {agent_contents}"
+    );
+}
+
 /// Issue #614 — `service update --reload-style none` clears a
 /// previously configured hook without re-onboarding.
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

`bootroot service update --reload-style`/`--cert-group` re-renders the managed-profile block of a local-file service's `agent.toml` via a whole-span replacement of the `# BEGIN … # END bootroot managed profile` region. Because `service add` writes the `[trust]` section *inside* those markers, the re-render silently deleted it, leaving the agent's ACME client with no `trust.ca_bundle_path`. The next renewal then fell back to the system trust store and failed against a private (step-ca) CA with `UnknownIssuer` — a latent, silent break with no error from `service update` itself.

This applies the issue's recommended carry-over fix: `rerender_local_managed_profile` now snapshots the existing `[trust]` table from the pre-replacement file and re-applies it with a keyed upsert afterwards.

- The carry-over is **verbatim** — the rerender path is deliberately offline (no KV handle to re-derive ca-bundle path or `trusted_ca_sha256`), so the existing table is reproduced as-is.
- The keyed upsert holds both required invariants: a file with **no** `[trust]` keeps none (no empty section synthesized), and a `[trust]` already **outside** the markers is updated in place rather than duplicated.

A new `toml_util::section_pairs` helper extracts a section's value pairs as raw TOML strings that round-trip back through `upsert_section_keys`, returning `None` when the section is absent so callers can distinguish "no section" from "empty section".

Closes #643

## Test plan

- [x] `service update --reload-style …` on a config whose `[trust]` lives inside the managed-block markers preserves `trust.ca_bundle_path` and `trust.trusted_ca_sha256` (`test_service_update_reload_style_preserves_inline_trust`)
- [x] `service update` on a config whose `[trust]` sits outside the markers does not produce a duplicate `[trust]` section (`test_service_update_reload_style_keeps_outside_trust_unique`)
- [x] `service update` on a config with no `[trust]` leaves it absent — no empty section synthesized (`test_service_update_reload_style_no_trust_stays_absent`)
- [x] `section_pairs` returns `None` for an absent section, round-trips value pairs through `upsert_section_keys`, and skips nested subtables (`toml_util` unit tests)
