### PR TITLE
Gate rustdoc warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,11 @@ jobs:
       - name: Check Rust Lints (Clippy)
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Check Rustdoc
+        run: cargo doc --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: -D warnings
+
       - name: Check Python Formatting
         run: ruff format --check .
 

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -5,6 +5,7 @@ ignores:
   - "secrets/**"
   - ".github/**"
   - ".venv/**"
+  - "target/**"
 config:
   MD013:
     tables: false

--- a/src/acme/responder_client.rs
+++ b/src/acme/responder_client.rs
@@ -64,7 +64,7 @@ pub async fn register_http01_token(
     .await
 }
 
-/// Reads the CA bundle PEM from disk when [`TrustSettings::ca_bundle_path`] is set.
+/// Reads the CA bundle PEM from disk when `TrustSettings::ca_bundle_path` is set.
 fn read_ca_pem_from_trust(trust: &crate::config::TrustSettings) -> Result<Option<String>> {
     let Some(path) = trust.ca_bundle_path.as_ref() else {
         return Ok(None);

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -95,7 +95,7 @@ pub enum CertGroupError {
     /// In the `remote-bootstrap` deployment mode, only numeric gids are
     /// accepted. The control host's NSS may diverge from the remote
     /// agent host's NSS, so a name lookup on the control host can fail
-    /// or return a colliding number — see [issue #593].
+    /// or return a colliding number — see issue #593.
     #[error(
         "--cert-group must be a numeric gid for remote-bootstrap services (got {0:?}); \
          resolve the name on the remote agent host and pass the number"

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,7 +122,7 @@ pub struct DaemonProfileSettings {
     /// Numeric gid that owns the issued cert/key files and their
     /// parent directories under the `--cert-group` policy.
     /// `None` (the default) preserves the host-local default mode
-    /// and operator-only ownership. See [issue #593].
+    /// and operator-only ownership. See issue #593.
     #[serde(default)]
     pub cert_group_gid: Option<u32>,
 }


### PR DESCRIPTION
CI never ran `cargo doc`, so `rustdoc::broken_intra_doc_links` warnings went undetected. Clippy does not cover rustdoc lints, and the existing "Build Docs" step (`mkdocs build --strict`) only builds the MkDocs site. Three intra-doc links were unresolved on `main`.

## Changes

- `src/cert_group.rs` and `src/config.rs`: drop the link brackets so `[issue #593]` becomes plain text `issue #593`.
- `src/acme/responder_client.rs`: demote `` [`TrustSettings::ca_bundle_path`] `` to a plain code span, since rustdoc cannot link to a struct **field** (only to items), so the link could never resolve.
- `.github/workflows/ci.yml`: add a "Check Rustdoc" step to the Quality Check job running `cargo doc --no-deps --document-private-items` with `RUSTDOCFLAGS=-D warnings`. `--document-private-items` is required so private-item links (the `responder_client.rs` case) are gated too.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` completes with no warnings.
- `cargo fmt -- --check` passes; changes are doc-comment text plus one workflow step, so no Rust code semantics change.

## Supersedes #639

[#639](https://github.com/aicers/bootroot/pull/639) fixes only 2 of the 3 warnings and does not add the CI gate. This PR covers all three and enforces them, so #639 will be closed as superseded.

Closes #650