### PR TITLE
Bump quinn-proto to 0.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Resolves [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) — a high-severity (7.5) remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly. `quinn-proto` is a transitive dependency, and the fix (`0.11.15`) lands within the existing semver range, so only `Cargo.lock` changes.

`cargo audit` fails on the vulnerable `0.11.14`, which currently blocks the Quality Check job on `main` and on every open PR (including #651).

## Verification

- `cargo update -p quinn-proto --precise 0.11.15` touches only `Cargo.lock` (2 lines).
- `cargo audit` reports no vulnerabilities after the bump.

The `rustls-pemfile is unmaintained` notice (RUSTSEC-2025-0134) is an allowed warning that does not fail the build and is out of scope here.

Closes #652