### PR TITLE
Pass --no-deps on openbao-sidecar start up (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot service openbao-sidecar start` recreating the
+  `bootroot-openbao` container as a side effect of starting a sidecar.
+  The generated per-service override's `depends_on: openbao` made
+  `docker compose ... up -d openbao-agent-<svc>` reconcile the `openbao`
+  dependency, and because the command resolves only the base
+  `docker-compose.yml`, a stack that published OpenBao through an
+  additional operator override (extra ports, networks, etc.) drifted
+  from the running container and got recreated — re-sealing a
+  shamir-sealed OpenBao and dropping the override-only port bindings.
+  `build_compose_up_args` now passes `--no-deps` on the sidecar `up`, so
+  only the sidecar starts and the `openbao` container is left untouched
+  regardless of which operator overrides published it. `start` already
+  presupposes `bootroot-openbao` exists (it `docker inspect`s it for the
+  compose project label), so skipping dependency startup is safe.
+  `refresh` is unchanged. (Closes #657)
 - Fixed `bootroot service update --reload-style`/`--cert-group` dropping
   the `[trust]` section of a local-file service's `agent.toml`. Because
   `service add` writes `[trust]` *inside* the `# BEGIN … # END bootroot

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -1000,6 +1000,16 @@ result, the command now works from any working directory and any
 `COMPOSE_PROJECT_NAME` value without requiring a workaround such as
 `COMPOSE_PROJECT_NAME=bootroot bootroot service openbao-sidecar start ...`.
 
+The sidecar `up` is issued with `--no-deps`, so it brings up only the
+sidecar and never reconciles or recreates the `bootroot-openbao`
+container. Because the command resolves only the base
+`docker-compose.yml`, a stack that publishes OpenBao through an
+additional operator override (extra ports, networks, etc.) would
+otherwise drift from the running container and get recreated —
+re-sealing a shamir-sealed OpenBao and dropping the override-only
+bindings. `--no-deps` avoids that regardless of which operator
+override files published OpenBao.
+
 ### Outputs
 
 - The created sidecar container is named

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -966,6 +966,15 @@ bootroot service update --service-name edge-proxy --reload-style none
 `COMPOSE_PROJECT_NAME` 값에서도 추가 우회(`COMPOSE_PROJECT_NAME=bootroot
 bootroot service openbao-sidecar start ...`) 없이 동작합니다.
 
+사이드카 `up`은 `--no-deps`와 함께 실행되므로 사이드카만 기동하고
+`bootroot-openbao` 컨테이너를 재조정하거나 재생성하지 않습니다. 이
+명령은 기본 `docker-compose.yml`만 해석하기 때문에, OpenBao를 추가
+운영자 override(추가 포트·네트워크 등)로 게시한 스택에서는 그렇지
+않으면 실행 중인 컨테이너와 구성이 어긋나 재생성이 일어나 — shamir로
+봉인된 OpenBao가 다시 봉인되고 override 전용 바인딩이 사라집니다.
+`--no-deps`는 어떤 운영자 override 파일이 OpenBao를 게시했든 이 문제를
+방지합니다.
+
 ### 출력
 
 - 생성되는 사이드카 컨테이너 이름은

--- a/src/commands/service/openbao_sidecar_start.rs
+++ b/src/commands/service/openbao_sidecar_start.rs
@@ -393,6 +393,12 @@ fn build_compose_up_args(
         "-f".to_string(),
         override_path.to_string(),
         "up".to_string(),
+        // Bring up only the sidecar and never reconcile/recreate the
+        // `openbao` dependency. `start` already presupposes the
+        // `bootroot-openbao` container exists, so recreating it on
+        // config drift would needlessly re-seal a shamir-sealed OpenBao
+        // and drop any override-only port bindings (issue #657).
+        "--no-deps".to_string(),
         "-d".to_string(),
         service_name.to_string(),
     ]);
@@ -1015,6 +1021,7 @@ mod tests {
                 "-f",
                 "/path/to/override.yml",
                 "up",
+                "--no-deps",
                 "-d",
                 "openbao-agent-myapp",
             ]
@@ -1032,6 +1039,10 @@ mod tests {
         assert!(
             !args.iter().any(|a| a == "-p"),
             "must not include -p flag when project is None: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--no-deps"),
+            "must include --no-deps so the openbao dependency is not recreated: {args:?}"
         );
         assert_eq!(args.first().map(String::as_str), Some("compose"));
         assert_eq!(args.last().map(String::as_str), Some("openbao-agent-myapp"));


### PR DESCRIPTION
## Summary

`service openbao-sidecar start` shells out to `docker compose -f docker-compose.yml -f <per-service-override> up -d openbao-agent-<svc>`, resolving only the base compose file. The generated per-service override declares `depends_on: openbao`, so `up` reconciles the `openbao` dependency. When a deployment publishes `bootroot-openbao` through an additional operator override (extra ports, networks, etc.), the base-only resolve drifts from the running container and compose **recreates `bootroot-openbao`** as a side effect of starting a sidecar — re-sealing a shamir-sealed OpenBao (outage until re-unseal) and dropping the override-only port bindings.

This PR adds `--no-deps` (positioned as an option to `up`, before `-d`) to the argument list built by `build_compose_up_args`, for both the project-supplied and no-project branches. `up` then brings up only the sidecar and never reconciles/recreates the `openbao` container. This is safe because `start` already presupposes the `bootroot-openbao` container exists (it `docker inspect`s it to discover the compose project label), and the fix is robust regardless of which operator override files published OpenBao.

`refresh` is unchanged (still `docker restart`); no `--compose-file`/override plumbing was added to it.

The existing unit tests `build_compose_up_args_includes_project_when_supplied` and `build_compose_up_args_omits_project_when_not_supplied` were updated to assert `--no-deps` is present. CHANGELOG and the EN/KO CLI docs were updated.

Closes #657

## Test plan

- [x] `build_compose_up_args` includes `--no-deps` before `-d` in the emitted argument list, in both the project-supplied and no-project branches.
- [x] `build_compose_up_args_includes_project_when_supplied` and `build_compose_up_args_omits_project_when_not_supplied` pass and assert `--no-deps` is present (`cargo test --bin bootroot build_compose_up_args`).
- [x] Running `service openbao-sidecar start` against a stack whose `bootroot-openbao` was published via an additional operator override no longer recreates `bootroot-openbao` (a `docker compose --dry-run` equivalent shows no `bootroot-openbao Recreate`).
- [x] `refresh` behavior is unchanged (still `docker restart`, no override plumbing added).
- [x] `cargo clippy` passes with no warnings and `rustfmt` is clean.

