### PR TITLE
Render OpenBao CA bundle at 0644 for non-root consumers (#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   presupposes `bootroot-openbao` exists (it `docker inspect`s it for the
   compose project label), so skipping dependency startup is safe.
   `refresh` is unchanged. (Closes #657)
+- Fixed the `OpenBao` agent rendering `ca-bundle.pem` at `0600`, which
+  broke non-root containerized consumers reading the bind-mounted CA
+  bundle (e.g. Node with `NODE_EXTRA_CA_CERTS`) with `EACCES`. The
+  bundle is public trust material and is now rendered `0644`, while
+  secret-bearing templates (`agent.toml` and its responder HMAC, role/
+  secret IDs, tokens) stay `0600`. `build_agent_config` now carries the
+  mode per template via a `TemplateSpec { source, destination, perms }`
+  struct instead of a hard-coded `perms = "0600"` on every block. The
+  same fix applies to the copies `service add` pre-seeds before the
+  first template render: both the operator-facing `ca-bundle.pem` next
+  to the cert and the Docker sidecar copy now land at `0644` and pick up
+  the `--cert-group` gid when a policy is set, by routing through
+  `fs_util::write_ca_bundle` instead of the `0600` key-permission
+  helper.
 - Fixed `bootroot service update --reload-style`/`--cert-group` dropping
   the `[trust]` section of a local-file service's `agent.toml`. Because
   `service add` writes `[trust]` *inside* the `# BEGIN … # END bootroot

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -3,7 +3,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use bootroot::fs_util;
-use bootroot::openbao::{AgentConfigParams, STATIC_SECRET_RENDER_INTERVAL, build_agent_config};
+use bootroot::openbao::{
+    AgentConfigParams, STATIC_SECRET_RENDER_INTERVAL, TEMPLATE_PERMS_PUBLIC, TEMPLATE_PERMS_SECRET,
+    TemplateSpec, build_agent_config,
+};
 use bootroot::trust_bootstrap::{
     AgentConfigBaselineParams, apply_agent_config_baseline_defaults, build_ca_bundle_ctmpl,
     build_managed_agent_ctmpl, build_trust_updates as build_shared_trust_updates,
@@ -503,8 +506,16 @@ async fn write_openbao_agent_artifacts(
         &args.secret_id_path,
         &token_path,
         &[
-            (&template_path, &args.agent_config_path),
-            (&bundle_template_path, &args.ca_bundle_path),
+            (
+                &template_path,
+                &args.agent_config_path,
+                TEMPLATE_PERMS_SECRET,
+            ),
+            (
+                &bundle_template_path,
+                &args.ca_bundle_path,
+                TEMPLATE_PERMS_PUBLIC,
+            ),
         ],
     );
     fs::write(&config_path, config).await?;
@@ -517,23 +528,28 @@ fn render_openbao_agent_config(
     role_id_path: &Path,
     secret_id_path: &Path,
     token_path: &Path,
-    template_specs: &[(&Path, &Path)],
+    template_specs: &[(&Path, &Path, &str)],
 ) -> String {
     let role_id = role_id_path.display().to_string();
     let secret_id = secret_id_path.display().to_string();
     let token = token_path.display().to_string();
     let template_strings = template_specs
         .iter()
-        .map(|(source, destination)| {
+        .map(|(source, destination, perms)| {
             (
                 source.display().to_string(),
                 destination.display().to_string(),
+                *perms,
             )
         })
         .collect::<Vec<_>>();
     let templates = template_strings
         .iter()
-        .map(|(source, destination)| (source.as_str(), destination.as_str()))
+        .map(|(source, destination, perms)| TemplateSpec {
+            source: source.as_str(),
+            destination: destination.as_str(),
+            perms,
+        })
         .collect::<Vec<_>>();
     build_agent_config(&AgentConfigParams {
         openbao_addr: openbao_url,
@@ -863,14 +879,24 @@ mod tests {
             &secret_id_path,
             &token_path,
             &[
-                (&agent_template, &agent_dest),
-                (&bundle_template, &bundle_dest),
+                (&agent_template, &agent_dest, TEMPLATE_PERMS_SECRET),
+                (&bundle_template, &bundle_dest, TEMPLATE_PERMS_PUBLIC),
             ],
         );
 
         assert!(
             hcl.contains("remove_secret_id_file_after_reading = false"),
             "remote HCL must keep secret_id file across agent restarts"
+        );
+        assert!(
+            hcl.contains(
+                "  destination = \"/etc/bootroot-agent/ca-bundle.pem\"\n  perms = \"0644\""
+            ),
+            "remote HCL must render the public CA bundle at 0644"
+        );
+        assert!(
+            hcl.contains("  destination = \"/etc/bootroot-agent/agent.toml\"\n  perms = \"0600\""),
+            "remote HCL must keep the secret agent config at 0600"
         );
         assert_eq!(
             hcl.matches("template {").count(),
@@ -914,8 +940,8 @@ mod tests {
             &secret_id_path,
             &token_path,
             &[
-                (&agent_template, &agent_dest),
-                (&bundle_template, &bundle_dest),
+                (&agent_template, &agent_dest, TEMPLATE_PERMS_SECRET),
+                (&bundle_template, &bundle_dest, TEMPLATE_PERMS_PUBLIC),
             ],
         );
 
@@ -927,8 +953,16 @@ mod tests {
         let secret_id_path_str = secret_id_path.display().to_string();
         let token_str = token_path.display().to_string();
         let templates = [
-            (agent_template_str.as_str(), agent_dest_str.as_str()),
-            (bundle_template_str.as_str(), bundle_dest_str.as_str()),
+            TemplateSpec {
+                source: agent_template_str.as_str(),
+                destination: agent_dest_str.as_str(),
+                perms: TEMPLATE_PERMS_SECRET,
+            },
+            TemplateSpec {
+                source: bundle_template_str.as_str(),
+                destination: bundle_dest_str.as_str(),
+                perms: TEMPLATE_PERMS_PUBLIC,
+            },
         ];
         let canonical = build_agent_config(&AgentConfigParams {
             openbao_addr: "http://localhost:8200",

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -676,9 +676,15 @@ fn build_openbao_agent_config(
     secret_id_path: &str,
     templates: &[(String, String)],
 ) -> String {
-    let tpl_refs: Vec<(&str, &str)> = templates
+    // Every template here renders secret material (password, CA signing
+    // key JSON, responder config), so all stay at 0600.
+    let tpl_specs: Vec<bootroot::openbao::TemplateSpec<'_>> = templates
         .iter()
-        .map(|(s, d)| (s.as_str(), d.as_str()))
+        .map(|(s, d)| bootroot::openbao::TemplateSpec {
+            source: s.as_str(),
+            destination: d.as_str(),
+            perms: bootroot::openbao::TEMPLATE_PERMS_SECRET,
+        })
         .collect();
     bootroot::openbao::build_agent_config(&bootroot::openbao::AgentConfigParams {
         openbao_addr,
@@ -687,7 +693,7 @@ fn build_openbao_agent_config(
         token_path: INIT_AGENT_TOKEN_PATH,
         mount_path: None,
         render_interval: bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
-        templates: &tpl_refs,
+        templates: &tpl_specs,
         ca_cert: None,
     })
 }

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -2,7 +2,9 @@ use std::fmt::Write as _;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use bootroot::cert_group::CertGroupPolicy;
 use bootroot::fs_util;
+use bootroot::openbao::{TEMPLATE_PERMS_PUBLIC, TEMPLATE_PERMS_SECRET, TemplateSpec};
 use bootroot::toml_util::toml_encode_string;
 use bootroot::trust_bootstrap::{
     AgentConfigBaselineParams, apply_agent_config_baseline_defaults, build_ca_bundle_ctmpl,
@@ -106,7 +108,19 @@ pub(super) async fn apply_local_service_configs(
     next = bootroot::toml_util::upsert_top_level_keys(&next, &domain_updates)?;
     let acme_updates = vec![("http_responder_hmac", sync_material.responder_hmac.clone())];
     next = bootroot::toml_util::upsert_section_keys(&next, "acme", &acme_updates)?;
-    write_local_ca_bundle(&ca_bundle_path, &sync_material.ca_bundle_pem, messages).await?;
+    // The CA bundle is public trust material: write it 0644 and pick up
+    // the `--cert-group` gid when a policy is set, so cert-group members
+    // and non-root consumers in separate containers can read it.
+    let cert_group_policy = CertGroupPolicy {
+        gid: resolved.cert_group_gid,
+    };
+    write_local_ca_bundle(
+        &ca_bundle_path,
+        &sync_material.ca_bundle_pem,
+        cert_group_policy,
+        messages,
+    )
+    .await?;
     let svc_cred_dir = secret_id_path.parent().unwrap_or(secrets_dir);
     // Pre-seed the same ca-bundle.pem path that the agent template
     // renders to, so the sidecar can verify TLS on first boot and
@@ -115,6 +129,7 @@ pub(super) async fn apply_local_service_configs(
     write_local_ca_bundle(
         &docker_ca_bundle_path,
         &sync_material.ca_bundle_pem,
+        cert_group_policy,
         messages,
     )
     .await?;
@@ -166,16 +181,14 @@ pub(super) async fn apply_local_service_configs(
             messages.error_write_file_failed(&bundle_template_path.display().to_string())
         })?;
     fs_util::set_key_permissions(&bundle_template_path).await?;
-    let template_specs = [
-        (
-            template_path.display().to_string(),
-            resolved.agent_config.display().to_string(),
-        ),
-        (
-            bundle_template_path.display().to_string(),
-            ca_bundle_path.display().to_string(),
-        ),
-    ];
+    // The agent config carries secret material (responder HMAC) and
+    // stays 0600; the CA bundle is public trust material and must be
+    // world-readable (0644) so non-root consumers in separate containers
+    // can read the bind-mounted file.
+    let agent_template_source = template_path.display().to_string();
+    let agent_config_dest = resolved.agent_config.display().to_string();
+    let bundle_template_source = bundle_template_path.display().to_string();
+    let ca_bundle_dest = ca_bundle_path.display().to_string();
 
     let role_id_path = secret_id_path
         .parent()
@@ -189,10 +202,18 @@ pub(super) async fn apply_local_service_configs(
     }
     fs_util::set_key_permissions(&token_path).await?;
     let agent_config_path = openbao_service_dir.join(OPENBAO_AGENT_CONFIG_FILENAME);
-    let templates = template_specs
-        .iter()
-        .map(|(source, destination)| (source.as_str(), destination.as_str()))
-        .collect::<Vec<_>>();
+    let templates = [
+        TemplateSpec {
+            source: &agent_template_source,
+            destination: &agent_config_dest,
+            perms: TEMPLATE_PERMS_SECRET,
+        },
+        TemplateSpec {
+            source: &bundle_template_source,
+            destination: &ca_bundle_dest,
+            perms: TEMPLATE_PERMS_PUBLIC,
+        },
+    ];
     let agent_hcl = render_openbao_agent_config(
         openbao_url,
         &role_id_path,
@@ -235,19 +256,33 @@ pub(super) async fn apply_local_service_configs(
     })
 }
 
-async fn write_local_ca_bundle(path: &Path, bundle_pem: &str, messages: &Messages) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs_util::ensure_secrets_dir(parent).await?;
-    }
+/// Pre-seeds a public CA bundle on disk so the sidecar can verify TLS on
+/// first boot, before the agent template renders.
+///
+/// The bundle is public trust material, so it is written at
+/// [`fs_util::write_ca_bundle`]'s `0644` mode (not the operator-only
+/// `0600` used for secrets) and, when a `--cert-group` policy is active,
+/// `chown`ed to the policy gid. This keeps the pre-seeded copy consistent
+/// with what the agent renders on every subsequent run and lets a
+/// non-root consumer in a separate container read the bind-mounted file.
+///
+/// The PEM is normalized to end in a trailing newline before writing to
+/// preserve the historical on-disk shape (`write_ca_bundle` itself writes
+/// bytes verbatim).
+async fn write_local_ca_bundle(
+    path: &Path,
+    bundle_pem: &str,
+    policy: CertGroupPolicy,
+    messages: &Messages,
+) -> Result<()> {
     let contents = if bundle_pem.ends_with('\n') {
         bundle_pem.to_string()
     } else {
         format!("{bundle_pem}\n")
     };
-    fs::write(path, contents)
+    fs_util::write_ca_bundle(path, &contents, policy)
         .await
         .with_context(|| messages.error_write_file_failed(&path.display().to_string()))?;
-    fs_util::set_key_permissions(path).await?;
     Ok(())
 }
 
@@ -317,7 +352,7 @@ fn render_openbao_agent_config(
     role_id_path: &Path,
     secret_id_path: &Path,
     token_path: &Path,
-    templates: &[(&str, &str)],
+    templates: &[TemplateSpec<'_>],
 ) -> String {
     let role_id = role_id_path.display().to_string();
     let secret_id = secret_id_path.display().to_string();
@@ -438,11 +473,22 @@ fn render_docker_agent_config(inputs: &DockerAgentConfigInputs<'_>) -> Result<St
         None
     };
 
-    let templates = [(tpl_source, tpl_dest), (ca_tpl_source, ca_tpl_dest)];
-    let tpl_refs: Vec<(&str, &str)> = templates
-        .iter()
-        .map(|(s, d)| (s.as_str(), d.as_str()))
-        .collect();
+    // The agent config renders secret material (responder HMAC) and
+    // stays 0600; the CA bundle is public trust material rendered at
+    // 0644 so a non-root consumer in a separate container can read the
+    // bind-mounted file without a manual chmod.
+    let tpl_specs = [
+        TemplateSpec {
+            source: &tpl_source,
+            destination: &tpl_dest,
+            perms: TEMPLATE_PERMS_SECRET,
+        },
+        TemplateSpec {
+            source: &ca_tpl_source,
+            destination: &ca_tpl_dest,
+            perms: TEMPLATE_PERMS_PUBLIC,
+        },
+    ];
 
     Ok(bootroot::openbao::build_agent_config(
         &bootroot::openbao::AgentConfigParams {
@@ -452,7 +498,7 @@ fn render_docker_agent_config(inputs: &DockerAgentConfigInputs<'_>) -> Result<St
             token_path: &token,
             mount_path: Some("auth/approle"),
             render_interval: bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
-            templates: &tpl_refs,
+            templates: &tpl_specs,
             ca_cert: ca_cert.as_deref(),
         },
     ))
@@ -1169,6 +1215,18 @@ mod tests {
             "ca bundle dest must be container path"
         );
         assert!(
+            hcl.contains(
+                "  destination = \"/openbao/secrets/services/edge/ca-bundle.pem\"\n  perms = \"0644\""
+            ),
+            "public CA bundle must render at 0644"
+        );
+        assert!(
+            hcl.contains(
+                "  destination = \"/openbao/secrets/services/edge/agent.toml\"\n  perms = \"0600\""
+            ),
+            "secret agent config must stay at 0600"
+        );
+        assert!(
             !hcl.contains("ca_cert"),
             "http address must not include ca_cert"
         );
@@ -1329,7 +1387,11 @@ mod tests {
             Path::new("/secrets/services/edge/role_id"),
             Path::new("/secrets/services/edge/secret_id"),
             Path::new("/secrets/openbao/services/edge/token"),
-            &[("/tpl.ctmpl", "/out.toml")],
+            &[TemplateSpec {
+                source: "/tpl.ctmpl",
+                destination: "/out.toml",
+                perms: TEMPLATE_PERMS_SECRET,
+            }],
         );
 
         assert!(
@@ -1344,5 +1406,66 @@ mod tests {
             !hcl.contains("ca_cert"),
             "host config must not include ca_cert"
         );
+    }
+
+    #[tokio::test]
+    async fn write_local_ca_bundle_is_world_readable() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ca-bundle.pem");
+        write_local_ca_bundle(
+            &path,
+            "PEM",
+            CertGroupPolicy::none(),
+            &crate::i18n::test_messages(),
+        )
+        .await
+        .expect("write pre-seeded CA bundle");
+
+        let mode = std::fs::metadata(&path)
+            .expect("bundle metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o644,
+            "pre-seeded CA bundle must be world-readable (0644)"
+        );
+        let contents = std::fs::read_to_string(&path).expect("read bundle");
+        assert_eq!(
+            contents, "PEM\n",
+            "bundle must be normalized to end in a trailing newline"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_local_ca_bundle_honors_cert_group_gid() {
+        use std::os::unix::fs::MetadataExt as _;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // Chown against a gid the caller already has membership in, so
+        // the test exercises the policy path without needing root.
+        let Some(gid) = bootroot::cert_group::one_supplementary_test_gid() else {
+            return;
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ca-bundle.pem");
+        write_local_ca_bundle(
+            &path,
+            "PEM\n",
+            CertGroupPolicy::with_gid(gid),
+            &crate::i18n::test_messages(),
+        )
+        .await
+        .expect("write pre-seeded CA bundle with policy");
+
+        let meta = std::fs::metadata(&path).expect("bundle metadata");
+        assert_eq!(
+            meta.permissions().mode() & 0o777,
+            0o644,
+            "cert-group pre-seeded CA bundle must still be 0644"
+        );
+        assert_eq!(meta.gid(), gid, "bundle must be chowned to the policy gid");
     }
 }

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -1215,6 +1215,31 @@ impl OpenBaoClient {
 /// Interval at which the `OpenBao` agent re-renders static secrets.
 pub const STATIC_SECRET_RENDER_INTERVAL: &str = "30s";
 
+/// HCL `perms` for secret-bearing rendered files (agent config,
+/// responder HMAC, role/secret IDs, tokens, etc.).
+pub const TEMPLATE_PERMS_SECRET: &str = "0600";
+/// HCL `perms` for public trust material (the CA bundle).
+pub const TEMPLATE_PERMS_PUBLIC: &str = "0644";
+
+/// Source, destination, and rendered `perms` for one `template` block in
+/// the generated `OpenBao` agent HCL.
+///
+/// Carrying `perms` per template lets a single agent config mix
+/// secret-bearing files (kept at [`TEMPLATE_PERMS_SECRET`]) with public
+/// trust material such as the CA bundle (widened to
+/// [`TEMPLATE_PERMS_PUBLIC`]). The named fields make the intent explicit
+/// at every call site and prevent a positional mistake that would
+/// silently widen a secret file's mode.
+pub struct TemplateSpec<'a> {
+    /// Path to the consul-template source (`.ctmpl`).
+    pub source: &'a str,
+    /// Path the agent renders the template to.
+    pub destination: &'a str,
+    /// Octal `perms` string for the rendered file (e.g.
+    /// [`TEMPLATE_PERMS_SECRET`] or [`TEMPLATE_PERMS_PUBLIC`]).
+    pub perms: &'a str,
+}
+
 /// Parameters for [`build_agent_config`].
 pub struct AgentConfigParams<'a> {
     /// Vault/`OpenBao` server address.
@@ -1229,8 +1254,8 @@ pub struct AgentConfigParams<'a> {
     pub mount_path: Option<&'a str>,
     /// Value for `static_secret_render_interval`.
     pub render_interval: &'a str,
-    /// `(source, destination)` pairs for template blocks.
-    pub templates: &'a [(&'a str, &'a str)],
+    /// Template blocks to render, each with its own `perms`.
+    pub templates: &'a [TemplateSpec<'a>],
     /// Optional path to a CA certificate bundle for TLS verification of
     /// the `OpenBao` server.
     pub ca_cert: Option<&'a str>,
@@ -1277,14 +1302,17 @@ template_config {{
 }}
 "#
     );
-    for (source_path, destination_path) in params.templates {
+    for spec in params.templates {
+        let source_path = spec.source;
+        let destination_path = spec.destination;
+        let perms = spec.perms;
         write!(
             &mut config,
             r#"
 template {{
   source = "{source_path}"
   destination = "{destination_path}"
-  perms = "0600"
+  perms = "{perms}"
 }}
 "#
         )
@@ -1463,7 +1491,11 @@ mod agent_config_tests {
             token_path: "/token",
             mount_path: None,
             render_interval: "30s",
-            templates: &[("/tpl.ctmpl", "/out.toml")],
+            templates: &[TemplateSpec {
+                source: "/tpl.ctmpl",
+                destination: "/out.toml",
+                perms: TEMPLATE_PERMS_SECRET,
+            }],
             ca_cert: None,
         });
         assert!(hcl.contains(r#"address = "http://openbao:8200""#));
@@ -1472,6 +1504,7 @@ mod agent_config_tests {
         assert!(!hcl.contains("ca_cert"));
         assert!(hcl.contains(r#"static_secret_render_interval = "30s""#));
         assert!(hcl.contains(r#"source = "/tpl.ctmpl""#));
+        assert!(hcl.contains(r#"perms = "0600""#));
     }
 
     #[test]
@@ -1483,7 +1516,11 @@ mod agent_config_tests {
             token_path: "/token",
             mount_path: Some("auth/approle"),
             render_interval: "30s",
-            templates: &[("/tpl.ctmpl", "/out.toml")],
+            templates: &[TemplateSpec {
+                source: "/tpl.ctmpl",
+                destination: "/out.toml",
+                perms: TEMPLATE_PERMS_SECRET,
+            }],
             ca_cert: None,
         });
         assert!(hcl.contains(r#"mount_path = "auth/approle""#));
@@ -1498,11 +1535,52 @@ mod agent_config_tests {
             token_path: "/token",
             mount_path: None,
             render_interval: "30s",
-            templates: &[("/a.ctmpl", "/a.out"), ("/b.ctmpl", "/b.out")],
+            templates: &[
+                TemplateSpec {
+                    source: "/a.ctmpl",
+                    destination: "/a.out",
+                    perms: TEMPLATE_PERMS_SECRET,
+                },
+                TemplateSpec {
+                    source: "/b.ctmpl",
+                    destination: "/b.out",
+                    perms: TEMPLATE_PERMS_PUBLIC,
+                },
+            ],
             ca_cert: None,
         });
         assert!(hcl.contains(r#"source = "/a.ctmpl""#));
         assert!(hcl.contains(r#"source = "/b.ctmpl""#));
+    }
+
+    #[test]
+    fn per_template_perms_vary_by_spec() {
+        let hcl = build_agent_config(&AgentConfigParams {
+            openbao_addr: "http://openbao:8200",
+            role_id_path: "/role_id",
+            secret_id_path: "/secret_id",
+            token_path: "/token",
+            mount_path: None,
+            render_interval: "30s",
+            templates: &[
+                TemplateSpec {
+                    source: "/agent.ctmpl",
+                    destination: "/agent.toml",
+                    perms: TEMPLATE_PERMS_SECRET,
+                },
+                TemplateSpec {
+                    source: "/ca-bundle.ctmpl",
+                    destination: "/ca-bundle.pem",
+                    perms: TEMPLATE_PERMS_PUBLIC,
+                },
+            ],
+            ca_cert: None,
+        });
+        // The secret-bearing agent config stays 0600.
+        assert!(hcl.contains("  destination = \"/agent.toml\"\n  perms = \"0600\""));
+        // The public CA bundle is widened to 0644 so non-root consumers
+        // in separate containers can read the bind-mounted file.
+        assert!(hcl.contains("  destination = \"/ca-bundle.pem\"\n  perms = \"0644\""));
     }
 
     #[test]
@@ -1514,7 +1592,11 @@ mod agent_config_tests {
             token_path: "/token",
             mount_path: Some("auth/approle"),
             render_interval: "30s",
-            templates: &[("/tpl.ctmpl", "/out.toml")],
+            templates: &[TemplateSpec {
+                source: "/tpl.ctmpl",
+                destination: "/out.toml",
+                perms: TEMPLATE_PERMS_SECRET,
+            }],
             ca_cert: Some("/certs/ca-bundle.pem"),
         });
         assert!(hcl.contains(r#"address = "https://openbao:8200""#));
@@ -1530,7 +1612,11 @@ mod agent_config_tests {
             token_path: "/token",
             mount_path: None,
             render_interval: "30s",
-            templates: &[("/tpl.ctmpl", "/out.toml")],
+            templates: &[TemplateSpec {
+                source: "/tpl.ctmpl",
+                destination: "/out.toml",
+                perms: TEMPLATE_PERMS_SECRET,
+            }],
             ca_cert: None,
         });
         assert!(!hcl.contains("ca_cert"));

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1628,7 +1628,10 @@ async fn test_app_add_includes_trust_snippet_when_present() {
         .permissions()
         .mode()
         & 0o777;
-    assert_eq!(mode, 0o600);
+    assert_eq!(
+        mode, 0o644,
+        "operator-facing CA bundle is public trust material and must be 0644"
+    );
 }
 
 #[cfg(unix)]
@@ -1941,7 +1944,11 @@ fn assert_openbao_service_agent_files(root: &std::path::Path, service_name: &str
         .permissions()
         .mode()
         & 0o777;
-    assert_eq!(docker_ca_mode, 0o600, "Docker CA bundle must be 0600");
+    assert_eq!(
+        docker_ca_mode, 0o644,
+        "Docker CA bundle must be 0644 (public trust material readable by \
+         non-root containerized consumers)"
+    );
 }
 
 fn path_relative_to_root_or_self<'a>(

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -76,7 +76,10 @@ async fn test_same_host_local_file_happy_path() {
         bundle_contents.contains(expected_ca_pem.trim()),
         "ca-bundle must carry the synced trust material",
     );
-    assert_mode(&files.ca_bundle_path, 0o600);
+    // Public trust material: the CA bundle must be world-readable so a
+    // non-root consumer in a separate container can read the bind-mounted
+    // file. The `.ctmpl` template below stays secret-only (0o600).
+    assert_mode(&files.ca_bundle_path, 0o644);
 
     assert!(
         temp.path()


### PR DESCRIPTION
## Summary

The generated `OpenBao` agent HCL rendered every `template` block with a hard-coded `perms = "0600"`, including the public `ca-bundle.pem`, and the `service add` pre-seed path wrote the same bundle at `0600` via `fs_util::set_key_permissions`. A containerized consumer running as a different, non-root uid (e.g. Node with `NODE_EXTRA_CA_CERTS`) then hit `EACCES` reading the bind-mounted CA bundle and failed TLS. The CA bundle is public trust material and should be world-readable (`0644`).

This PR fixes both places while keeping every secret-bearing file at `0600`:

- **Per-template `perms`.** `build_agent_config` now takes a named `TemplateSpec { source, destination, perms }` per template instead of a bare `(source, destination)` tuple with a hard-coded `perms = "0600"`. The struct makes the intent explicit at each call site and prevents a positional mistake from silently widening a secret file's mode. Two named constants, `TEMPLATE_PERMS_SECRET` (`0600`) and `TEMPLATE_PERMS_PUBLIC` (`0644`), replace the inline literals. All three call sites are updated: local-file (`agent.toml` → secret, `ca-bundle.pem` → public), Docker (same), remote-bootstrap (agent config → secret, CA bundle → public), and init (`password.txt`/`ca.json`/`responder.toml` all secret, unchanged behavior).
- **Pre-seeded bundle.** `write_local_ca_bundle` in `service/local_config.rs` now routes through `fs_util::write_ca_bundle`, which writes `0644` and `chown`s to the `--cert-group` gid when a policy is set, instead of `set_key_permissions` (`0600`). This covers both the operator-facing copy and the Docker sidecar copy, and also fixes the prior silent bug where the pre-seed ignored cert-group ownership. The PEM is normalized to a trailing newline before writing so the on-disk contents are unchanged.

Secret material (`agent.toml`, responder HMAC, role/secret IDs, tokens) stays at `0600`.

### Not addressed by design

The issue's "Related (verify, likely out of scope)" note about `src/bin/bootroot-remote/bootstrap.rs` pre-seeding `ca_bundle_path` via `write_secret_file` (`0600`) is intentionally left out. That is a separate deployment flow from the observed report, the bundle is later widened to `0644` on the first rotation through `write_ca_bundle`, and `write_secret_file` returns an idempotency `ApplyStatus` that `write_ca_bundle` does not — a straight swap would regress that reporting. None of the issue's acceptance criteria depend on it.

Closes #655

## Test plan

- [x] `ca-bundle.pem` is rendered by the `OpenBao` agent with `perms = "0644"` (unit test `per_template_perms_vary_by_spec` and the local/remote HCL assertions)
- [x] `agent.toml` and all secret-bearing templates stay at `perms = "0600"`
- [x] The pre-seeded `ca-bundle.pem` written during `service add` (operator-facing and Docker sidecar copies) is `0644` on disk (`write_local_ca_bundle_is_world_readable`, `assert_openbao_service_agent_files`, `test_app_add_includes_trust_snippet_when_present`, `e2e_same_host_local_file`)
- [x] The pre-seeded bundle picks up the `--cert-group` gid when a policy is set (`write_local_ca_bundle_honors_cert_group_gid`)
- [x] No secret material is widened beyond `0600`
- [x] Perms literals are named constants (`TEMPLATE_PERMS_SECRET`, `TEMPLATE_PERMS_PUBLIC`), not inline strings
- [x] `cargo build --tests`, `cargo clippy --all-targets`, and the affected unit/integration tests pass
- [x] A non-root process in a separate container can read the bind-mounted `ca-bundle.pem` without `chmod` (verified with Docker: a Linux named volume held `ca-bundle.pem` owned by uid 1000; a separate container running as uid 65534 read it successfully at `0644` and got `EACCES` at `0600`, reproducing the original bug)

