### PR TITLE
Fix duplicate agent profile on delivery-mode transition (#662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed a delivery-mode transition (`local-file` → `remote-bootstrap`
+  or the reverse) leaving a duplicate `[[profiles]]` block in
+  `agent.toml`. The two code paths wrote their managed profile under
+  different marker strings, so an upsert on one path never matched the
+  block the other path had written and appended a second one for the
+  same service. Each path now strips any block written under the
+  opposite path's markers before upserting its own, via the shared
+  `strip_foreign_managed_profiles` helper in `trust_bootstrap` (both
+  marker pairs now live there as `LOCAL_FILE_PROFILE_MARKERS` /
+  `REMOTE_BOOTSTRAP_PROFILE_MARKERS`), making both transition
+  directions idempotent on already-deployed hosts. `bootroot service
+  remove` also gains a `--strip-config` flag that removes the managed
+  profile block from `agent.toml` without deleting the cert/key or the
+  per-service secret/config directories, giving operators a
+  non-destructive way to clear a stale block during a live transition;
+  its strip recognises either path's markers, and `--delete-artifacts`
+  implies it. (Closes #662)
 - Fixed `bootroot service openbao-sidecar start` recreating the
   `bootroot-openbao` container as a side effect of starting a sidecar.
   The generated per-service override's `depends_on: openbao` made

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   per-service secret/config directories, giving operators a
   non-destructive way to clear a stale block during a live transition;
   its strip recognises either path's markers, and `--delete-artifacts`
-  implies it. (Closes #662)
+  implies it. Because that strip has no follow-up re-sync, it removes
+  only the service's `[[profiles]]` entry and its marker comments and
+  preserves the global `[trust]`/`[openbao]`/`[acme]` tables that
+  `toml_edit` floats inside the marker span, so a still-serving host
+  keeps the trust and OpenBao config its agent depends on. (Closes #662)
 - Fixed `bootroot service openbao-sidecar start` recreating the
   `bootroot-openbao` container as a side effect of starting a sidecar.
   The generated per-service override's `depends_on: openbao` made

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -958,6 +958,15 @@ regenerates the `secret_id` delivery material regardless, the fresh
   flag is given. Even with the flag, `agent.toml` is edited in place —
   only the managed block is removed — so an operator-owned config file is
   never deleted.
+- `--strip-config`: strip bootroot's managed profile block from
+  `agent.toml` **without** deleting the cert/key files or the per-service
+  secret and `OpenBao` config directories. Intended for a live
+  delivery-mode transition, where the service is still serving so the
+  cert/key must be kept, yet the stale managed block must go. Implied by
+  `--delete-artifacts` (combining the two is redundant but harmless). As
+  with `--delete-artifacts`, the strip removes a block written under
+  *either* delivery mode's markers, so a block left by the opposite mode
+  (or by an older binary) is cleared regardless of which path wrote it.
 - Runtime authentication flags (`--root-token`, `--root-token-file`,
   `--approle-role-id`/`--approle-secret-id`, `--auth-mode`, …): same as
   `service add`, used to authenticate to `OpenBao` for the teardown.
@@ -1008,8 +1017,12 @@ bootroot service remove --service-name edge-proxy --dry-run
 # and agent.toml preserved).
 bootroot service remove --service-name edge-proxy --yes
 
-# Change delivery-mode from local-file to remote-bootstrap.
-bootroot service remove --service-name edge-proxy --yes
+# Change delivery-mode from local-file to remote-bootstrap. The re-add and
+# subsequent bootstrap replace the stale managed block in place, so no
+# manual agent.toml edit is needed; add --strip-config to the remove step
+# to clear the block up front (keeping the cert/key) as a belt-and-braces
+# step for a live transition.
+bootroot service remove --service-name edge-proxy --yes --strip-config
 bootroot service add --service-name edge-proxy \
   --delivery-mode remote-bootstrap ...
 

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -962,11 +962,15 @@ regenerates the `secret_id` delivery material regardless, the fresh
   `agent.toml` **without** deleting the cert/key files or the per-service
   secret and `OpenBao` config directories. Intended for a live
   delivery-mode transition, where the service is still serving so the
-  cert/key must be kept, yet the stale managed block must go. Implied by
-  `--delete-artifacts` (combining the two is redundant but harmless). As
-  with `--delete-artifacts`, the strip removes a block written under
-  *either* delivery mode's markers, so a block left by the opposite mode
-  (or by an older binary) is cleared regardless of which path wrote it.
+  cert/key must be kept, yet the stale managed block must go. Only the
+  service's `[[profiles]]` entry and its marker comments are removed; the
+  global `[trust]`, `[openbao]`, and `[acme]` tables the running agent
+  depends on are preserved, even though they physically sit inside the
+  marker comments. Implied by `--delete-artifacts` (combining the two is
+  redundant but harmless). As with `--delete-artifacts`, the strip removes
+  a block written under *either* delivery mode's markers, so a block left
+  by the opposite mode (or by an older binary) is cleared regardless of
+  which path wrote it.
 - Runtime authentication flags (`--root-token`, `--root-token-file`,
   `--approle-role-id`/`--approle-secret-id`, `--auth-mode`, …): same as
   `service add`, used to authenticate to `OpenBao` for the teardown.

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -924,6 +924,14 @@ bootroot service update --service-name edge-proxy --reload-style none
   생성) 이 플래그가 없으면 디스크 자료는 보존됩니다. 이 플래그가 있어도
   `agent.toml`은 관리 블록만 제거하는 방식으로 편집되므로 운영자 소유 설정
   파일은 삭제되지 않습니다.
+- `--strip-config`: 인증서/키 파일이나 서비스별 시크릿 및 `OpenBao` 설정
+  디렉터리는 삭제하지 않고 `agent.toml`에서 bootroot 관리 프로필 블록만
+  제거합니다. 서비스가 여전히 서비스 중이라 인증서/키는 유지해야 하지만
+  낡은 관리 블록은 제거해야 하는 라이브 delivery-mode 전환을 위한
+  플래그입니다. `--delete-artifacts`에 포함되며(둘을 함께 지정하면 중복이나
+  무해) `--delete-artifacts`와 마찬가지로 *어느* delivery-mode의 마커로
+  기록된 블록이든 제거하므로 반대 모드(또는 이전 바이너리)가 남긴 블록도
+  기록한 경로와 무관하게 정리됩니다.
 - 런타임 인증 플래그(`--root-token`, `--root-token-file`,
   `--approle-role-id`/`--approle-secret-id`, `--auth-mode`, …):
   `service add`와 동일하며, 제거를 위해 `OpenBao`에 인증하는 데 사용됩니다.
@@ -970,8 +978,11 @@ bootroot service remove --service-name edge-proxy --dry-run
 # 서비스 등록 해제(OpenBao AppRole/정책/KV 정리; 인증서/키 및 agent.toml 보존).
 bootroot service remove --service-name edge-proxy --yes
 
-# delivery-mode를 local-file에서 remote-bootstrap으로 변경.
-bootroot service remove --service-name edge-proxy --yes
+# delivery-mode를 local-file에서 remote-bootstrap으로 변경. 재등록과 이어지는
+# 부트스트랩이 낡은 관리 블록을 그 자리에서 교체하므로 agent.toml을 수동으로
+# 편집할 필요가 없습니다. 라이브 전환에서는 remove 단계에 --strip-config를
+# 추가해 (인증서/키는 유지하면서) 블록을 미리 정리할 수 있습니다.
+bootroot service remove --service-name edge-proxy --yes --strip-config
 bootroot service add --service-name edge-proxy \
   --delivery-mode remote-bootstrap ...
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -928,7 +928,10 @@ bootroot service update --service-name edge-proxy --reload-style none
   디렉터리는 삭제하지 않고 `agent.toml`에서 bootroot 관리 프로필 블록만
   제거합니다. 서비스가 여전히 서비스 중이라 인증서/키는 유지해야 하지만
   낡은 관리 블록은 제거해야 하는 라이브 delivery-mode 전환을 위한
-  플래그입니다. `--delete-artifacts`에 포함되며(둘을 함께 지정하면 중복이나
+  플래그입니다. 해당 서비스의 `[[profiles]]` 항목과 마커 주석만 제거하며,
+  마커 주석 사이에 물리적으로 위치하더라도 실행 중인 에이전트가 의존하는
+  전역 `[trust]`, `[openbao]`, `[acme]` 테이블은 보존합니다.
+  `--delete-artifacts`에 포함되며(둘을 함께 지정하면 중복이나
   무해) `--delete-artifacts`와 마찬가지로 *어느* delivery-mode의 마커로
   기록된 블록이든 제거하므로 반대 모드(또는 이전 바이너리)가 남긴 블록도
   기록한 경로와 무관하게 정리됩니다.

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -8,9 +8,10 @@ use bootroot::openbao::{
     TemplateSpec, build_agent_config,
 };
 use bootroot::trust_bootstrap::{
-    AgentConfigBaselineParams, apply_agent_config_baseline_defaults, build_ca_bundle_ctmpl,
-    build_managed_agent_ctmpl, build_trust_updates as build_shared_trust_updates,
-    render_managed_profile_block as render_profile,
+    AgentConfigBaselineParams, REMOTE_BOOTSTRAP_PROFILE_MARKERS,
+    apply_agent_config_baseline_defaults, build_ca_bundle_ctmpl, build_managed_agent_ctmpl,
+    build_trust_updates as build_shared_trust_updates,
+    render_managed_profile_block as render_profile, strip_foreign_managed_profiles,
     upsert_managed_profile_block as upsert_shared_managed_profile_block,
 };
 use tokio::fs;
@@ -57,6 +58,18 @@ pub(super) async fn apply_agent_config_updates(
             );
         }
     };
+    // Strip any managed profile block the local-file path left for this
+    // service on a prior delivery mode, before any table is appended. Done
+    // on the raw file so the strip stays contained to the intended
+    // `[[profiles]]` block (the end marker floats past tables added later,
+    // and the `[trust]` collateral it may carry is re-synced below).
+    // Without this, a local→remote transition would append a duplicate
+    // block for the service (#662).
+    let agent_config = strip_foreign_managed_profiles(
+        &agent_config,
+        REMOTE_BOOTSTRAP_PROFILE_MARKERS,
+        &args.service_name,
+    );
     // Backfill any baseline fields missing from a pre-existing agent.toml
     // (and seed a fresh file from the same baseline).  Without this step,
     // an operator who passed `--agent-server` / `--agent-responder-url`
@@ -580,6 +593,52 @@ mod tests {
         )
         .unwrap();
         assert!(output.contains("http_responder_hmac = \"new\""));
+    }
+
+    /// local-file → remote-bootstrap transition: `bootroot-remote
+    /// bootstrap` runs over an `agent.toml` that already carries a
+    /// `bootroot managed profile` block. Stripping foreign blocks before
+    /// upserting the remote block must leave exactly one `[[profiles]]`,
+    /// not a duplicate (#662).
+    #[test]
+    fn remote_bootstrap_strips_pre_existing_local_block() {
+        let local_block = render_profile(
+            bootroot::trust_bootstrap::LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
+            bootroot::trust_bootstrap::LOCAL_FILE_PROFILE_MARKERS.end_prefix,
+            "giganto",
+            "001",
+            "node-01",
+            Path::new("/etc/bootroot-agent/certs/giganto.crt"),
+            Path::new("/etc/bootroot-agent/certs/giganto.key"),
+            None,
+        );
+        let existing = format!("email = \"admin@example.com\"\n\n{local_block}\n");
+
+        let stripped =
+            strip_foreign_managed_profiles(&existing, REMOTE_BOOTSTRAP_PROFILE_MARKERS, "giganto");
+        let remote_block = render_managed_profile_block(
+            "giganto",
+            "001",
+            "node-01",
+            Path::new("/etc/bootroot-agent/certs/giganto.crt"),
+            Path::new("/etc/bootroot-agent/certs/giganto.key"),
+            None,
+        );
+        let updated = upsert_managed_profile_block(&stripped, "giganto", &remote_block);
+
+        assert_eq!(
+            updated.matches("[[profiles]]").count(),
+            1,
+            "exactly one profile block must remain: {updated}"
+        );
+        assert!(
+            !updated.contains(bootroot::trust_bootstrap::LOCAL_FILE_PROFILE_MARKERS.begin_prefix),
+            "the stale local-file block must be stripped: {updated}"
+        );
+        assert!(
+            updated.contains(REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix),
+            "the remote marker must be present: {updated}"
+        );
     }
 
     #[test]

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -15,8 +15,10 @@ use bootroot::trust_bootstrap::{
 };
 use clap::{Parser, ValueEnum};
 
-const MANAGED_PROFILE_BEGIN_PREFIX: &str = "# BEGIN BOOTROOT REMOTE PROFILE";
-const MANAGED_PROFILE_END_PREFIX: &str = "# END BOOTROOT REMOTE PROFILE";
+const MANAGED_PROFILE_BEGIN_PREFIX: &str =
+    bootroot::trust_bootstrap::REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix;
+const MANAGED_PROFILE_END_PREFIX: &str =
+    bootroot::trust_bootstrap::REMOTE_BOOTSTRAP_PROFILE_MARKERS.end_prefix;
 const DEFAULT_AGENT_EMAIL: &str = "admin@example.com";
 const DEFAULT_AGENT_SERVER: &str = "https://localhost:9000/acme/acme/directory";
 const DEFAULT_AGENT_DOMAIN: &str = "trusted.domain";

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1431,6 +1431,10 @@ pub(crate) struct ServiceUpdateArgs {
     pub(crate) post_renew_on_failure: Option<HookFailurePolicyArg>,
 }
 
+// Each boolean flag is a deliberate, independent CLI opt-in (skip
+// confirmation, preview, delete artifacts, strip only the config block);
+// they are not mutually exclusive state and do not model a state machine.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Args, Debug)]
 pub(crate) struct ServiceRemoveArgs {
     /// Service name identifier
@@ -1463,6 +1467,21 @@ pub(crate) struct ServiceRemoveArgs {
     /// deleted.
     #[arg(long)]
     pub(crate) delete_artifacts: bool,
+
+    /// Strips the managed profile block from `agent.toml` without deleting
+    /// the cert/key files or the per-service secret and `OpenBao` config
+    /// directories.
+    ///
+    /// Intended for live delivery-mode transitions: when moving a service
+    /// between `local-file` and `remote-bootstrap` the operator must keep
+    /// the cert/key (the service is still serving) yet wants the stale
+    /// managed block gone so the subsequent bootstrap does not leave a
+    /// duplicate `[[profiles]]`. `--delete-artifacts` already strips the
+    /// block but also deletes the cert/key, so it cannot be used here.
+    /// Implied by `--delete-artifacts`; combining the two is redundant but
+    /// harmless.
+    #[arg(long)]
+    pub(crate) strip_config: bool,
 
     #[command(flatten)]
     pub(crate) runtime_auth: RuntimeAuthArgs,
@@ -2242,6 +2261,7 @@ mod tests {
                 assert!(!args.yes);
                 assert!(!args.dry_run);
                 assert!(!args.delete_artifacts);
+                assert!(!args.strip_config);
             }
             _ => panic!("expected service remove"),
         }
@@ -2264,6 +2284,7 @@ mod tests {
                 assert!(args.yes);
                 assert!(args.dry_run);
                 assert!(args.delete_artifacts);
+                assert!(!args.strip_config);
             }
             _ => panic!("expected service remove"),
         }
@@ -2282,6 +2303,25 @@ mod tests {
         match cli.command {
             CliCommand::Service(ServiceCommand::Remove(args)) => {
                 assert!(args.yes);
+            }
+            _ => panic!("expected service remove"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parses_service_remove_strip_config() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "service",
+            "remove",
+            "--service-name",
+            "edge-proxy",
+            "--strip-config",
+        ]);
+        match cli.command {
+            CliCommand::Service(ServiceCommand::Remove(args)) => {
+                assert!(args.strip_config);
+                assert!(!args.delete_artifacts);
             }
             _ => panic!("expected service remove"),
         }

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -37,8 +37,10 @@ pub(super) const OPENBAO_AGENT_CA_BUNDLE_TEMPLATE_FILENAME: &str = "ca-bundle.pe
 pub(super) const OPENBAO_AGENT_TOKEN_FILENAME: &str = "token";
 pub(super) const REMOTE_BOOTSTRAP_DIR: &str = "remote-bootstrap/services";
 pub(super) const REMOTE_BOOTSTRAP_FILENAME: &str = "bootstrap.json";
-pub(super) const MANAGED_PROFILE_BEGIN_PREFIX: &str = "# BEGIN bootroot managed profile:";
-pub(super) const MANAGED_PROFILE_END_PREFIX: &str = "# END bootroot managed profile:";
+pub(super) const MANAGED_PROFILE_BEGIN_PREFIX: &str =
+    bootroot::trust_bootstrap::LOCAL_FILE_PROFILE_MARKERS.begin_prefix;
+pub(super) const MANAGED_PROFILE_END_PREFIX: &str =
+    bootroot::trust_bootstrap::LOCAL_FILE_PROFILE_MARKERS.end_prefix;
 pub(super) const DEFAULT_AGENT_EMAIL: &str = "admin@example.com";
 pub(super) const DEFAULT_AGENT_SERVER: &str = "https://localhost:9000/acme/acme/directory";
 pub(super) const DEFAULT_AGENT_RESPONDER_URL: &str = "http://127.0.0.1:8080";

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -7,9 +7,10 @@ use bootroot::fs_util;
 use bootroot::openbao::{TEMPLATE_PERMS_PUBLIC, TEMPLATE_PERMS_SECRET, TemplateSpec};
 use bootroot::toml_util::toml_encode_string;
 use bootroot::trust_bootstrap::{
-    AgentConfigBaselineParams, apply_agent_config_baseline_defaults, build_ca_bundle_ctmpl,
-    build_managed_agent_ctmpl, build_trust_updates,
-    render_managed_profile_block as render_managed_profile, upsert_managed_profile_block,
+    AgentConfigBaselineParams, LOCAL_FILE_PROFILE_MARKERS, apply_agent_config_baseline_defaults,
+    build_ca_bundle_ctmpl, build_managed_agent_ctmpl, build_trust_updates,
+    render_managed_profile_block as render_managed_profile, strip_foreign_managed_profiles,
+    upsert_managed_profile_block,
 };
 use tokio::fs;
 
@@ -66,6 +67,17 @@ pub(super) async fn apply_local_service_configs(
     } else {
         String::new()
     };
+    // Strip any managed profile block the remote-bootstrap path left for
+    // this service on a prior delivery mode, before any table is appended.
+    // Done on the raw file so the strip stays contained to the intended
+    // `[[profiles]]` block (the end marker floats past tables added later).
+    // Without this, a remote→local transition would append a duplicate
+    // block for the service (#662).
+    let current = strip_foreign_managed_profiles(
+        &current,
+        LOCAL_FILE_PROFILE_MARKERS,
+        &resolved.service_name,
+    );
     // Backfill any baseline fields missing from the operator-facing
     // `agent.toml` — both for a fresh file and for an existing file that
     // lacks `email` / `server` / `[acme].http_responder_url` or the
@@ -556,6 +568,49 @@ mod tests {
         let once = upsert_managed_profile("", "edge-proxy", &block);
         let twice = upsert_managed_profile(&once, "edge-proxy", &block);
         assert_eq!(once, twice);
+    }
+
+    /// remote-bootstrap → local-file transition: local-file `service add`
+    /// runs over an `agent.toml` that already carries a `BOOTROOT REMOTE
+    /// PROFILE` block. Stripping foreign blocks before upserting the local
+    /// block must leave exactly one `[[profiles]]`, not a duplicate (#662).
+    #[test]
+    fn test_local_add_strips_pre_existing_remote_block() {
+        let args = test_resolved();
+        let remote_block = render_managed_profile(
+            bootroot::trust_bootstrap::REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix,
+            bootroot::trust_bootstrap::REMOTE_BOOTSTRAP_PROFILE_MARKERS.end_prefix,
+            &args.service_name,
+            args.instance_id.as_deref().unwrap_or_default(),
+            &args.hostname,
+            &args.cert_path,
+            &args.key_path,
+            args.cert_group_gid,
+        );
+        let existing = format!("email = \"admin@example.com\"\n\n{remote_block}\n");
+
+        let stripped = strip_foreign_managed_profiles(
+            &existing,
+            LOCAL_FILE_PROFILE_MARKERS,
+            &args.service_name,
+        );
+        let local_block = render_managed_profile_block(&args);
+        let updated = upsert_managed_profile(&stripped, &args.service_name, &local_block);
+
+        assert_eq!(
+            updated.matches("[[profiles]]").count(),
+            1,
+            "exactly one profile block must remain: {updated}"
+        );
+        assert!(
+            !updated
+                .contains(bootroot::trust_bootstrap::REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix),
+            "the stale remote block must be stripped: {updated}"
+        );
+        assert!(
+            updated.contains(LOCAL_FILE_PROFILE_MARKERS.begin_prefix),
+            "the local-file marker must be present: {updated}"
+        );
     }
 
     #[test]

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -3,12 +3,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use bootroot::openbao::OpenBaoClient;
-use bootroot::trust_bootstrap::remove_managed_profile_block;
-
-use super::{
-    MANAGED_PROFILE_BEGIN_PREFIX, MANAGED_PROFILE_END_PREFIX, OPENBAO_SERVICE_CONFIG_DIR,
-    REMOTE_BOOTSTRAP_DIR, SERVICE_SECRET_DIR,
+use bootroot::trust_bootstrap::{
+    LOCAL_FILE_PROFILE_MARKERS, REMOTE_BOOTSTRAP_PROFILE_MARKERS, remove_managed_profile_block,
 };
+
+use super::{OPENBAO_SERVICE_CONFIG_DIR, REMOTE_BOOTSTRAP_DIR, SERVICE_SECRET_DIR};
 use crate::cli::args::ServiceRemoveArgs;
 use crate::cli::prompt::Prompt;
 use crate::commands::constants::SERVICE_KV_BASE;
@@ -80,7 +79,13 @@ pub(crate) async fn run_service_remove(
         None
     };
 
-    print_remove_plan(&entry, &kv_paths, artifacts.as_ref(), messages);
+    print_remove_plan(
+        &entry,
+        &kv_paths,
+        artifacts.as_ref(),
+        args.strip_config,
+        messages,
+    );
 
     if args.dry_run {
         println!("{}", messages.service_remove_dry_run());
@@ -135,9 +140,20 @@ pub(crate) async fn run_service_remove(
             let result = delete_file_if_present(file);
             report.record(&format!("file {}", file.display()), result, messages);
         }
-        let strip_result = strip_managed_profile(&plan.agent_config, &entry.service_name);
+    }
+
+    // Strip the managed profile block whenever the operator asked for it,
+    // either via `--delete-artifacts` (which also deleted the cert/key
+    // above) or `--strip-config` (which leaves them intact for a live
+    // delivery-mode transition). The agent config file itself is never
+    // deleted — only bootroot's managed block is removed.
+    if args.delete_artifacts || args.strip_config {
+        let strip_result = strip_managed_profile(&entry.agent_config_path, &entry.service_name);
         report.record(
-            &format!("managed profile block in {}", plan.agent_config.display()),
+            &format!(
+                "managed profile block in {}",
+                entry.agent_config_path.display()
+            ),
             strip_result,
             messages,
         );
@@ -253,6 +269,7 @@ fn print_remove_plan(
     entry: &ServiceEntry,
     kv_paths: &[String],
     artifacts: Option<&ArtifactPlan>,
+    strip_config: bool,
     messages: &Messages,
 ) {
     println!(
@@ -270,26 +287,33 @@ fn print_remove_plan(
     for path in kv_paths {
         println!("{}", messages.service_remove_plan_kv(path));
     }
-    match artifacts {
-        Some(plan) => {
-            for dir in &plan.dirs {
-                println!(
-                    "{}",
-                    messages.service_remove_plan_artifact(&dir.display().to_string())
-                );
-            }
-            for file in &plan.files {
-                println!(
-                    "{}",
-                    messages.service_remove_plan_artifact(&file.display().to_string())
-                );
-            }
+    if let Some(plan) = artifacts {
+        for dir in &plan.dirs {
             println!(
                 "{}",
-                messages.service_remove_plan_agent_config(&plan.agent_config.display().to_string())
+                messages.service_remove_plan_artifact(&dir.display().to_string())
             );
         }
-        None => println!("{}", messages.service_remove_plan_artifacts_preserved()),
+        for file in &plan.files {
+            println!(
+                "{}",
+                messages.service_remove_plan_artifact(&file.display().to_string())
+            );
+        }
+        println!(
+            "{}",
+            messages.service_remove_plan_agent_config(&plan.agent_config.display().to_string())
+        );
+    } else {
+        println!("{}", messages.service_remove_plan_artifacts_preserved());
+        if strip_config {
+            println!(
+                "{}",
+                messages.service_remove_plan_agent_config(
+                    &entry.agent_config_path.display().to_string()
+                )
+            );
+        }
     }
 }
 
@@ -358,9 +382,13 @@ fn delete_file_if_present(path: &Path) -> Result<bool> {
 
 /// Strips bootroot's managed profile block from `agent.toml` in place.
 ///
-/// Returns `Ok(true)` when a block was present and removed, `Ok(false)`
-/// when the file is absent or carries no managed block (idempotent
-/// re-run). The operator-owned file itself is never deleted.
+/// Removes a block written under *either* code path's markers — the
+/// local-file `service add` pair and the `bootroot-remote bootstrap` pair
+/// — so a stale block left by the opposite delivery mode (or by an older
+/// binary) is cleared regardless of which path wrote it. Returns
+/// `Ok(true)` when a block was present and removed, `Ok(false)` when the
+/// file is absent or carries no managed block (idempotent re-run). The
+/// operator-owned file itself is never deleted.
 fn strip_managed_profile(path: &Path, service_name: &str) -> Result<bool> {
     let current = match std::fs::read_to_string(path) {
         Ok(contents) => contents,
@@ -369,10 +397,16 @@ fn strip_managed_profile(path: &Path, service_name: &str) -> Result<bool> {
             return Err(err).with_context(|| format!("Failed to read {}", path.display()));
         }
     };
-    let next = remove_managed_profile_block(
+    let mut next = remove_managed_profile_block(
         &current,
-        MANAGED_PROFILE_BEGIN_PREFIX,
-        MANAGED_PROFILE_END_PREFIX,
+        LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
+        LOCAL_FILE_PROFILE_MARKERS.end_prefix,
+        service_name,
+    );
+    next = remove_managed_profile_block(
+        &next,
+        REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix,
+        REMOTE_BOOTSTRAP_PROFILE_MARKERS.end_prefix,
         service_name,
     );
     if next == current {
@@ -594,8 +628,8 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let path = dir.path().join("agent.toml");
         let block = bootroot::trust_bootstrap::render_managed_profile_block(
-            MANAGED_PROFILE_BEGIN_PREFIX,
-            MANAGED_PROFILE_END_PREFIX,
+            LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
+            LOCAL_FILE_PROFILE_MARKERS.end_prefix,
             "svc",
             "001",
             "host1",
@@ -605,8 +639,8 @@ mod tests {
         );
         let contents = bootroot::trust_bootstrap::upsert_managed_profile_block(
             "email = \"a@b.c\"\n",
-            MANAGED_PROFILE_BEGIN_PREFIX,
-            MANAGED_PROFILE_END_PREFIX,
+            LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
+            LOCAL_FILE_PROFILE_MARKERS.end_prefix,
             "svc",
             &block,
         );
@@ -620,6 +654,33 @@ mod tests {
         // Idempotent: the file still exists, no block, returns false.
         assert!(!strip_managed_profile(&path, "svc").expect("strip idempotent"));
         assert!(path.exists());
+    }
+
+    /// A stale block may sit under the *opposite* path's markers after a
+    /// delivery-mode transition. `--strip-config` must clear it regardless
+    /// of which path wrote it, so strip recognises the remote markers too.
+    #[test]
+    fn strip_managed_profile_removes_remote_marker_block() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("agent.toml");
+        let block = bootroot::trust_bootstrap::render_managed_profile_block(
+            REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix,
+            REMOTE_BOOTSTRAP_PROFILE_MARKERS.end_prefix,
+            "svc",
+            "001",
+            "host1",
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            None,
+        );
+        let contents = format!("email = \"a@b.c\"\n\n{block}\n");
+        std::fs::write(&path, &contents).expect("write");
+
+        assert!(strip_managed_profile(&path, "svc").expect("strip ok"));
+        let after = std::fs::read_to_string(&path).expect("read");
+        assert!(!after.contains("[[profiles]]"));
+        assert!(!after.contains(REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix));
+        assert!(after.contains("email = \"a@b.c\""));
     }
 
     #[test]

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -3,9 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use bootroot::openbao::OpenBaoClient;
-use bootroot::trust_bootstrap::{
-    LOCAL_FILE_PROFILE_MARKERS, REMOTE_BOOTSTRAP_PROFILE_MARKERS, remove_managed_profile_block,
-};
+use bootroot::trust_bootstrap::remove_managed_service_profile;
 
 use super::{OPENBAO_SERVICE_CONFIG_DIR, REMOTE_BOOTSTRAP_DIR, SERVICE_SECRET_DIR};
 use crate::cli::args::ServiceRemoveArgs;
@@ -382,13 +380,18 @@ fn delete_file_if_present(path: &Path) -> Result<bool> {
 
 /// Strips bootroot's managed profile block from `agent.toml` in place.
 ///
-/// Removes a block written under *either* code path's markers — the
-/// local-file `service add` pair and the `bootroot-remote bootstrap` pair
-/// — so a stale block left by the opposite delivery mode (or by an older
-/// binary) is cleared regardless of which path wrote it. Returns
-/// `Ok(true)` when a block was present and removed, `Ok(false)` when the
-/// file is absent or carries no managed block (idempotent re-run). The
-/// operator-owned file itself is never deleted.
+/// Removes the managed `[[profiles]]` entry for the service — written
+/// under *either* code path's markers (local-file `service add` or
+/// `bootroot-remote bootstrap`) — plus its marker comment lines, so a
+/// stale block left by the opposite delivery mode (or by an older binary)
+/// is cleared regardless of which path wrote it. Crucially it preserves
+/// the global `[trust]`/`[openbao]`/`[acme]` tables, which `toml_edit`
+/// floats *inside* the marker span: `service remove --strip-config` leaves
+/// the cert/key in place for a still-serving host, so it must not drop the
+/// config that host's agent depends on. Returns `Ok(true)` when a block
+/// was present and removed, `Ok(false)` when the file is absent or carries
+/// no managed block (idempotent re-run). The operator-owned file itself is
+/// never deleted.
 fn strip_managed_profile(path: &Path, service_name: &str) -> Result<bool> {
     let current = match std::fs::read_to_string(path) {
         Ok(contents) => contents,
@@ -397,18 +400,8 @@ fn strip_managed_profile(path: &Path, service_name: &str) -> Result<bool> {
             return Err(err).with_context(|| format!("Failed to read {}", path.display()));
         }
     };
-    let mut next = remove_managed_profile_block(
-        &current,
-        LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
-        LOCAL_FILE_PROFILE_MARKERS.end_prefix,
-        service_name,
-    );
-    next = remove_managed_profile_block(
-        &next,
-        REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix,
-        REMOTE_BOOTSTRAP_PROFILE_MARKERS.end_prefix,
-        service_name,
-    );
+    let next = remove_managed_service_profile(&current, service_name)
+        .with_context(|| format!("Failed to update {}", path.display()))?;
     if next == current {
         return Ok(false);
     }
@@ -422,6 +415,8 @@ mod tests {
     use std::path::PathBuf;
 
     use tempfile::tempdir;
+
+    use bootroot::trust_bootstrap::{LOCAL_FILE_PROFILE_MARKERS, REMOTE_BOOTSTRAP_PROFILE_MARKERS};
 
     use super::*;
     use crate::i18n::test_messages;
@@ -681,6 +676,105 @@ mod tests {
         assert!(!after.contains("[[profiles]]"));
         assert!(!after.contains(REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix));
         assert!(after.contains("email = \"a@b.c\""));
+    }
+
+    /// On a real host `agent.toml` the profile is written first, then the
+    /// `[acme]`/`[trust]`/`[openbao]` tables are upserted; `toml_edit`
+    /// floats the end-marker comment past them, so those global tables end
+    /// up *inside* the marker span. `--strip-config` keeps the cert/key for
+    /// a still-serving host and does not re-sync, so it must clear only the
+    /// profile and leave every global table intact.
+    #[test]
+    fn strip_managed_profile_preserves_floated_global_tables() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("agent.toml");
+        let block = bootroot::trust_bootstrap::render_managed_profile_block(
+            LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
+            LOCAL_FILE_PROFILE_MARKERS.end_prefix,
+            "svc",
+            "001",
+            "host1",
+            Path::new("/certs/cert.pem"),
+            Path::new("/certs/key.pem"),
+            None,
+        );
+        // Build the file the way the real pipeline does: profile first,
+        // then the global sections upserted on top so their tables float
+        // inside the marker span.
+        let contents = bootroot::trust_bootstrap::upsert_managed_profile_block(
+            "email = \"a@b.c\"\n",
+            LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
+            LOCAL_FILE_PROFILE_MARKERS.end_prefix,
+            "svc",
+            &block,
+        );
+        let contents = bootroot::toml_util::upsert_section_keys(
+            &contents,
+            "acme",
+            &[("http_responder_hmac", "hmac".into())],
+        )
+        .expect("acme");
+        let contents = bootroot::toml_util::upsert_section_keys(
+            &contents,
+            "trust",
+            &[
+                ("ca_bundle_path", "certs/ca.pem".into()),
+                ("trusted_ca_sha256", "[\"abc\"]".into()),
+            ],
+        )
+        .expect("trust");
+        let contents = bootroot::toml_util::upsert_section_keys(
+            &contents,
+            "openbao",
+            &[("addr", "http://localhost:8200".into())],
+        )
+        .expect("openbao");
+        // Sanity: the end marker floated past the global tables.
+        let end = format!("{} svc", LOCAL_FILE_PROFILE_MARKERS.end_prefix);
+        let end_pos = contents.find(&end).expect("end marker present");
+        assert!(
+            contents[..end_pos].contains("[openbao]"),
+            "test premise: global tables must float inside the span:\n{contents}"
+        );
+        std::fs::write(&path, &contents).expect("write");
+
+        assert!(strip_managed_profile(&path, "svc").expect("strip ok"));
+        let after = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            !after.contains("[[profiles]]"),
+            "profile left behind: {after}"
+        );
+        assert!(
+            !after.contains(LOCAL_FILE_PROFILE_MARKERS.begin_prefix),
+            "begin marker left behind: {after}"
+        );
+        assert!(
+            !after.contains(LOCAL_FILE_PROFILE_MARKERS.end_prefix),
+            "end marker left behind: {after}"
+        );
+        // The global tables the running agent depends on survive.
+        assert!(after.contains("[trust]"), "trust dropped: {after}");
+        assert!(
+            after.contains("ca_bundle_path = \"certs/ca.pem\""),
+            "{after}"
+        );
+        assert!(after.contains("trusted_ca_sha256 = [\"abc\"]"), "{after}");
+        assert!(after.contains("[openbao]"), "openbao dropped: {after}");
+        assert!(
+            after.contains("addr = \"http://localhost:8200\""),
+            "{after}"
+        );
+        assert!(after.contains("[acme]"), "acme dropped: {after}");
+        assert!(after.contains("http_responder_hmac = \"hmac\""), "{after}");
+        assert!(after.contains("email = \"a@b.c\""), "{after}");
+
+        // The stripped file must still parse as valid TOML.
+        after
+            .parse::<toml_edit::DocumentMut>()
+            .expect("valid TOML after strip");
+
+        // Idempotent re-run: no profile remains, returns false.
+        assert!(!strip_managed_profile(&path, "svc").expect("idempotent"));
     }
 
     #[test]

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -776,6 +776,55 @@ mod tests {
         assert!(!strip_managed_profile(&path, "svc").expect("idempotent"));
     }
 
+    /// The exact #662 duplicate — a local-file block and a remote-bootstrap
+    /// block for the same service — is what an already-affected host carries.
+    /// `--strip-config` must clear *both* profile entries and all markers so
+    /// no orphaned, marker-less profile is left behind.
+    #[test]
+    fn strip_managed_profile_clears_both_transition_blocks() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("agent.toml");
+        let render = |markers: bootroot::trust_bootstrap::ManagedProfileMarkers| {
+            bootroot::trust_bootstrap::render_managed_profile_block(
+                markers.begin_prefix,
+                markers.end_prefix,
+                "svc",
+                "001",
+                "host1",
+                Path::new("/certs/cert.pem"),
+                Path::new("/certs/key.pem"),
+                None,
+            )
+        };
+        let local = render(LOCAL_FILE_PROFILE_MARKERS);
+        let remote = render(REMOTE_BOOTSTRAP_PROFILE_MARKERS);
+        let contents = format!(
+            "email = \"a@b.c\"\n\n{local}\n\n{remote}\n\n[trust]\nca_bundle_path = \"c\"\n"
+        );
+        std::fs::write(&path, &contents).expect("write");
+
+        assert!(strip_managed_profile(&path, "svc").expect("strip ok"));
+        let after = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            !after.contains("[[profiles]]"),
+            "profile left behind: {after}"
+        );
+        assert!(
+            !after.contains("service_name = \"svc\""),
+            "orphaned profile left behind: {after}"
+        );
+        assert!(
+            !after.contains(LOCAL_FILE_PROFILE_MARKERS.begin_prefix)
+                && !after.contains(REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix),
+            "markers left behind: {after}"
+        );
+        assert!(after.contains("[trust]"), "trust dropped: {after}");
+        after
+            .parse::<toml_edit::DocumentMut>()
+            .expect("valid TOML after strip");
+        assert!(!strip_managed_profile(&path, "svc").expect("idempotent"));
+    }
+
     #[test]
     fn strip_managed_profile_absent_file_is_noop() {
         let dir = tempdir().expect("tempdir");

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -414,9 +414,8 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
-    use tempfile::tempdir;
-
     use bootroot::trust_bootstrap::{LOCAL_FILE_PROFILE_MARKERS, REMOTE_BOOTSTRAP_PROFILE_MARKERS};
+    use tempfile::tempdir;
 
     use super::*;
     use crate::i18n::test_messages;

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -831,4 +831,28 @@ mod tests {
         let path = dir.path().join("missing.toml");
         assert!(!strip_managed_profile(&path, "svc").expect("absent ok"));
     }
+
+    /// An operator-owned `[[profiles]]` entry sharing the `service_name`
+    /// but carrying no bootroot managed marker must survive `--strip-config`
+    /// untouched. Stripping is scoped to bootroot's managed profile, so with
+    /// no managed marker present the file is left byte-for-byte unchanged and
+    /// the strip reports no change.
+    #[test]
+    fn strip_managed_profile_preserves_unmarked_operator_profile() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("agent.toml");
+        let contents = "email = \"a@b.c\"\n\n\
+[[profiles]]\n\
+service_name = \"svc\"\n\
+instance_id = \"001\"\n\n\
+[trust]\nca_bundle_path = \"c\"\n";
+        std::fs::write(&path, contents).expect("write");
+
+        assert!(!strip_managed_profile(&path, "svc").expect("strip noop"));
+        let after = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(
+            after, contents,
+            "unmarked operator profile must be left intact: {after}"
+        );
+    }
 }

--- a/src/toml_util.rs
+++ b/src/toml_util.rs
@@ -150,6 +150,43 @@ pub fn remove_sections(contents: &str, sections: &[&str]) -> Result<String> {
     Ok(doc.to_string())
 }
 
+/// Removes the first array-of-tables entry under `array` whose `key`
+/// equals `value`, dropping the array itself when it becomes empty.
+///
+/// Returns the re-rendered document paired with `true` when an entry was
+/// removed. When no entry matches, returns the input unchanged with
+/// `false` so the caller can skip an unnecessary rewrite (and avoid the
+/// cosmetic reflow `to_string` would otherwise apply). Only the matched
+/// `[[array]]` element is touched — sibling tables (`[trust]`,
+/// `[openbao]`, …) are left in place, even when `toml_edit` had floated
+/// them physically after the removed element.
+///
+/// # Errors
+///
+/// Returns an error if `contents` is not valid TOML.
+pub fn remove_array_of_tables_entry(
+    contents: &str,
+    array: &str,
+    key: &str,
+    value: &str,
+) -> Result<(String, bool)> {
+    let mut doc: DocumentMut = contents.parse().context("failed to parse TOML content")?;
+    let Some(entries) = doc.get_mut(array).and_then(Item::as_array_of_tables_mut) else {
+        return Ok((contents.to_string(), false));
+    };
+    let Some(index) = entries
+        .iter()
+        .position(|table| table.get(key).and_then(Item::as_str) == Some(value))
+    else {
+        return Ok((contents.to_string(), false));
+    };
+    entries.remove(index);
+    if entries.is_empty() {
+        doc.remove(array);
+    }
+    Ok((doc.to_string(), true))
+}
+
 /// Encodes a string as a TOML basic string with proper escaping.
 ///
 /// Returns the value including surrounding double quotes, with all
@@ -172,6 +209,40 @@ fn parse_value(raw: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remove_array_of_tables_entry_removes_only_the_match() {
+        let input = concat!(
+            "[[profiles]]\nservice_name = \"a\"\n[profiles.paths]\ncert = \"a.pem\"\n\n",
+            "[[profiles]]\nservice_name = \"b\"\n[profiles.paths]\ncert = \"b.pem\"\n\n",
+            "[trust]\nca_bundle_path = \"c\"\n",
+        );
+        let (output, removed) =
+            remove_array_of_tables_entry(input, "profiles", "service_name", "a").unwrap();
+        assert!(removed);
+        assert!(!output.contains("service_name = \"a\""), "{output}");
+        assert!(output.contains("service_name = \"b\""), "{output}");
+        assert!(output.contains("[trust]"), "{output}");
+    }
+
+    #[test]
+    fn remove_array_of_tables_entry_drops_empty_array() {
+        let input = "[[profiles]]\nservice_name = \"a\"\n\n[trust]\nca_bundle_path = \"c\"\n";
+        let (output, removed) =
+            remove_array_of_tables_entry(input, "profiles", "service_name", "a").unwrap();
+        assert!(removed);
+        assert!(!output.contains("[[profiles]]"), "{output}");
+        assert!(output.contains("[trust]"), "{output}");
+    }
+
+    #[test]
+    fn remove_array_of_tables_entry_no_match_is_unchanged() {
+        let input = "[[profiles]]\nservice_name = \"a\"\n";
+        let (output, removed) =
+            remove_array_of_tables_entry(input, "profiles", "service_name", "missing").unwrap();
+        assert!(!removed);
+        assert_eq!(output, input);
+    }
 
     #[test]
     fn upsert_updates_existing_key() {

--- a/src/toml_util.rs
+++ b/src/toml_util.rs
@@ -150,21 +150,26 @@ pub fn remove_sections(contents: &str, sections: &[&str]) -> Result<String> {
     Ok(doc.to_string())
 }
 
-/// Removes the first array-of-tables entry under `array` whose `key`
-/// equals `value`, dropping the array itself when it becomes empty.
+/// Removes every array-of-tables entry under `array` whose `key` equals
+/// `value`, dropping the array itself when it becomes empty.
 ///
-/// Returns the re-rendered document paired with `true` when an entry was
-/// removed. When no entry matches, returns the input unchanged with
-/// `false` so the caller can skip an unnecessary rewrite (and avoid the
-/// cosmetic reflow `to_string` would otherwise apply). Only the matched
-/// `[[array]]` element is touched — sibling tables (`[trust]`,
+/// Returns the re-rendered document paired with `true` when at least one
+/// entry was removed. When no entry matches, returns the input unchanged
+/// with `false` so the caller can skip an unnecessary rewrite (and avoid
+/// the cosmetic reflow `to_string` would otherwise apply). Only the
+/// matched `[[array]]` elements are touched — sibling tables (`[trust]`,
 /// `[openbao]`, …) are left in place, even when `toml_edit` had floated
-/// them physically after the removed element.
+/// them physically after a removed element.
+///
+/// Removing *all* matches (not just the first) matters when a
+/// `service add` ⇄ `bootroot-remote bootstrap` transition has already
+/// left a host with two profile entries for the same service (issue
+/// #662): a single-match strip would delete one and orphan the other.
 ///
 /// # Errors
 ///
 /// Returns an error if `contents` is not valid TOML.
-pub fn remove_array_of_tables_entry(
+pub fn remove_array_of_tables_entries(
     contents: &str,
     array: &str,
     key: &str,
@@ -174,13 +179,18 @@ pub fn remove_array_of_tables_entry(
     let Some(entries) = doc.get_mut(array).and_then(Item::as_array_of_tables_mut) else {
         return Ok((contents.to_string(), false));
     };
-    let Some(index) = entries
-        .iter()
-        .position(|table| table.get(key).and_then(Item::as_str) == Some(value))
-    else {
+    let mut removed = false;
+    loop {
+        let index = entries
+            .iter()
+            .position(|table| table.get(key).and_then(Item::as_str) == Some(value));
+        let Some(index) = index else { break };
+        entries.remove(index);
+        removed = true;
+    }
+    if !removed {
         return Ok((contents.to_string(), false));
-    };
-    entries.remove(index);
+    }
     if entries.is_empty() {
         doc.remove(array);
     }
@@ -211,14 +221,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn remove_array_of_tables_entry_removes_only_the_match() {
+    fn remove_array_of_tables_entries_removes_only_the_match() {
         let input = concat!(
             "[[profiles]]\nservice_name = \"a\"\n[profiles.paths]\ncert = \"a.pem\"\n\n",
             "[[profiles]]\nservice_name = \"b\"\n[profiles.paths]\ncert = \"b.pem\"\n\n",
             "[trust]\nca_bundle_path = \"c\"\n",
         );
         let (output, removed) =
-            remove_array_of_tables_entry(input, "profiles", "service_name", "a").unwrap();
+            remove_array_of_tables_entries(input, "profiles", "service_name", "a").unwrap();
         assert!(removed);
         assert!(!output.contains("service_name = \"a\""), "{output}");
         assert!(output.contains("service_name = \"b\""), "{output}");
@@ -226,20 +236,38 @@ mod tests {
     }
 
     #[test]
-    fn remove_array_of_tables_entry_drops_empty_array() {
+    fn remove_array_of_tables_entries_removes_all_duplicates() {
+        let input = concat!(
+            "[[profiles]]\nservice_name = \"dup\"\n[profiles.paths]\ncert = \"one.pem\"\n\n",
+            "[[profiles]]\nservice_name = \"keep\"\n[profiles.paths]\ncert = \"keep.pem\"\n\n",
+            "[[profiles]]\nservice_name = \"dup\"\n[profiles.paths]\ncert = \"two.pem\"\n\n",
+            "[trust]\nca_bundle_path = \"c\"\n",
+        );
+        let (output, removed) =
+            remove_array_of_tables_entries(input, "profiles", "service_name", "dup").unwrap();
+        assert!(removed);
+        assert!(!output.contains("service_name = \"dup\""), "{output}");
+        assert!(!output.contains("one.pem"), "{output}");
+        assert!(!output.contains("two.pem"), "{output}");
+        assert!(output.contains("service_name = \"keep\""), "{output}");
+        assert!(output.contains("[trust]"), "{output}");
+    }
+
+    #[test]
+    fn remove_array_of_tables_entries_drops_empty_array() {
         let input = "[[profiles]]\nservice_name = \"a\"\n\n[trust]\nca_bundle_path = \"c\"\n";
         let (output, removed) =
-            remove_array_of_tables_entry(input, "profiles", "service_name", "a").unwrap();
+            remove_array_of_tables_entries(input, "profiles", "service_name", "a").unwrap();
         assert!(removed);
         assert!(!output.contains("[[profiles]]"), "{output}");
         assert!(output.contains("[trust]"), "{output}");
     }
 
     #[test]
-    fn remove_array_of_tables_entry_no_match_is_unchanged() {
+    fn remove_array_of_tables_entries_no_match_is_unchanged() {
         let input = "[[profiles]]\nservice_name = \"a\"\n";
         let (output, removed) =
-            remove_array_of_tables_entry(input, "profiles", "service_name", "missing").unwrap();
+            remove_array_of_tables_entries(input, "profiles", "service_name", "missing").unwrap();
         assert!(!removed);
         assert_eq!(output, input);
     }

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -360,10 +360,23 @@ pub fn remove_managed_profile_block(
 /// the marker sweep clears both marker pairs, so the profile removal must
 /// be equally exhaustive or a marker-less profile would be orphaned.
 ///
+/// Removal is gated on the presence of a managed begin marker for the
+/// service (under either code path). When no managed marker is present the
+/// input is returned unchanged, so an operator-owned, unmarked
+/// `[[profiles]]` entry that merely shares the `service_name` is never
+/// touched — only bootroot's own managed profile is cleared.
+///
 /// # Errors
 ///
 /// Returns an error if `contents` is not valid TOML.
 pub fn remove_managed_service_profile(contents: &str, service_name: &str) -> Result<String> {
+    let has_managed_marker = ALL_MANAGED_PROFILE_MARKERS.iter().any(|markers| {
+        let begin_marker = format!("{} {service_name}", markers.begin_prefix);
+        find_marker_line(contents, &begin_marker, 0).is_some()
+    });
+    if !has_managed_marker {
+        return Ok(contents.to_string());
+    }
     let (rendered, removed) = toml_util::remove_array_of_tables_entries(
         contents,
         "profiles",
@@ -765,6 +778,25 @@ mod tests {
         let contents = "email = \"a@b.c\"\n\n[trust]\nca_bundle_path = \"c\"\n";
         let out = remove_managed_service_profile(contents, "giganto").expect("remove ok");
         assert_eq!(out, contents);
+    }
+
+    /// An operator-owned `[[profiles]]` entry that merely shares the
+    /// `service_name` but carries no bootroot managed marker must survive
+    /// `--strip-config` untouched. Removal is scoped to bootroot's managed
+    /// profile, not "any profile for this service", so with no managed
+    /// marker present the file is returned verbatim (no reflow).
+    #[test]
+    fn remove_managed_service_profile_preserves_unmarked_operator_profile() {
+        let contents = "email = \"a@b.c\"\n\n\
+[[profiles]]\n\
+service_name = \"giganto\"\n\
+instance_id = \"001\"\n\n\
+[trust]\nca_bundle_path = \"c\"\n";
+        let out = remove_managed_service_profile(contents, "giganto").expect("remove ok");
+        assert_eq!(
+            out, contents,
+            "an unmarked operator-owned profile must be left intact: {out}"
+        );
     }
 
     /// Service names are DNS labels and can be prefixes of one another

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -120,6 +120,37 @@ pub fn apply_agent_config_baseline_defaults(
     Ok(next)
 }
 
+/// Begin/end marker prefixes delimiting one code path's managed profile
+/// block in `agent.toml`.
+///
+/// The local-file `service add` path and the `bootroot-remote bootstrap`
+/// path each write their block under a distinct marker pair. Keeping both
+/// pairs here — and pairing every upsert with a strip of the *other*
+/// path's markers via [`strip_foreign_managed_profiles`] — is what stops a
+/// delivery-mode transition from leaving two profile blocks for the same
+/// service (issue #662).
+#[derive(Clone, Copy)]
+pub struct ManagedProfileMarkers {
+    pub begin_prefix: &'static str,
+    pub end_prefix: &'static str,
+}
+
+/// Markers written by the local-file `service add` path.
+pub const LOCAL_FILE_PROFILE_MARKERS: ManagedProfileMarkers = ManagedProfileMarkers {
+    begin_prefix: "# BEGIN bootroot managed profile:",
+    end_prefix: "# END bootroot managed profile:",
+};
+
+/// Markers written by the `bootroot-remote bootstrap` path.
+pub const REMOTE_BOOTSTRAP_PROFILE_MARKERS: ManagedProfileMarkers = ManagedProfileMarkers {
+    begin_prefix: "# BEGIN BOOTROOT REMOTE PROFILE",
+    end_prefix: "# END BOOTROOT REMOTE PROFILE",
+};
+
+/// Every managed-profile marker pair a bootroot code path may have written.
+pub const ALL_MANAGED_PROFILE_MARKERS: [ManagedProfileMarkers; 2] =
+    [LOCAL_FILE_PROFILE_MARKERS, REMOTE_BOOTSTRAP_PROFILE_MARKERS];
+
 /// Renders a managed profile block for `agent.toml`.
 ///
 /// When `cert_group_gid` is `Some`, the rendered block contains a
@@ -229,6 +260,47 @@ pub fn upsert_managed_profile_block(
     }
     updated.push_str(replacement);
     updated
+}
+
+/// Strips every managed profile block written under a marker pair *other*
+/// than `own` for `service_name`, leaving the caller's own block (if any)
+/// untouched.
+///
+/// A delivery-mode transition (`service remove` + `service add
+/// --delivery-mode <other>`, then re-bootstrap on the service host) runs
+/// one code path over an `agent.toml` the other path previously wrote.
+/// Because each path's upsert recognises only its own markers, without
+/// this strip the pre-existing block is never matched and
+/// [`upsert_managed_profile_block`] falls through to its append branch,
+/// leaving a second `[[profiles]]` for the same service.
+///
+/// Callers must run this on the **raw** `agent.toml` contents before
+/// applying their own `[trust]`/`[openbao]`/profile sections. The end
+/// marker of a block is a trailing comment that `toml_edit` floats past
+/// any table inserted afterwards, so stripping only stays contained to the
+/// intended `[[profiles]]` block while the file is still as the other path
+/// last wrote it. The stripped `[trust]` collateral a floated marker may
+/// carry is re-emitted authoritatively by the caller's own trust sync.
+/// See issue #662.
+#[must_use]
+pub fn strip_foreign_managed_profiles(
+    contents: &str,
+    own: ManagedProfileMarkers,
+    service_name: &str,
+) -> String {
+    let mut next = contents.to_string();
+    for markers in ALL_MANAGED_PROFILE_MARKERS {
+        if markers.begin_prefix == own.begin_prefix {
+            continue;
+        }
+        next = remove_managed_profile_block(
+            &next,
+            markers.begin_prefix,
+            markers.end_prefix,
+            service_name,
+        );
+    }
+    next
 }
 
 /// Removes a managed profile block from `agent.toml` contents.
@@ -427,6 +499,70 @@ mod tests {
         let twice =
             upsert_managed_profile_block(&once, BEGIN_PREFIX, END_PREFIX, "edge-proxy", &block);
         assert_eq!(once, twice);
+    }
+
+    fn render_profile_for(markers: ManagedProfileMarkers, service: &str) -> String {
+        render_managed_profile_block(
+            markers.begin_prefix,
+            markers.end_prefix,
+            service,
+            "001",
+            "node-01",
+            Path::new(&format!("certs/{service}.crt")),
+            Path::new(&format!("certs/{service}.key")),
+            None,
+        )
+    }
+
+    /// A delivery-mode transition runs one code path over an `agent.toml`
+    /// the other path wrote. Stripping foreign blocks before upserting the
+    /// own block must leave exactly one `[[profiles]]`, not a duplicate.
+    #[test]
+    fn strip_foreign_managed_profiles_removes_opposite_marker() {
+        let legacy_local = render_profile_for(LOCAL_FILE_PROFILE_MARKERS, "giganto");
+        let existing =
+            format!("email = \"a@b.c\"\n\n{legacy_local}\n\n[trust]\nca_bundle_path = \"c\"\n");
+
+        let stripped =
+            strip_foreign_managed_profiles(&existing, REMOTE_BOOTSTRAP_PROFILE_MARKERS, "giganto");
+        assert!(
+            !stripped.contains(LOCAL_FILE_PROFILE_MARKERS.begin_prefix),
+            "the foreign local-file block must be stripped: {stripped}"
+        );
+
+        let remote = render_profile_for(REMOTE_BOOTSTRAP_PROFILE_MARKERS, "giganto");
+        let updated = upsert_managed_profile_block(
+            &stripped,
+            REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix,
+            REMOTE_BOOTSTRAP_PROFILE_MARKERS.end_prefix,
+            "giganto",
+            &remote,
+        );
+
+        assert_eq!(
+            updated.matches("[[profiles]]").count(),
+            1,
+            "exactly one profile block must remain: {updated}"
+        );
+        assert!(
+            updated.contains(REMOTE_BOOTSTRAP_PROFILE_MARKERS.begin_prefix),
+            "the new remote marker must be present: {updated}"
+        );
+        assert!(
+            updated.contains("email = \"a@b.c\""),
+            "operator content must survive: {updated}"
+        );
+    }
+
+    /// Leaves the caller's own block alone — stripping foreign markers is a
+    /// no-op when only the own-path block is present.
+    #[test]
+    fn strip_foreign_managed_profiles_keeps_own_block() {
+        let own = render_profile_for(REMOTE_BOOTSTRAP_PROFILE_MARKERS, "giganto");
+        let existing = format!("email = \"a@b.c\"\n\n{own}\n");
+        let stripped =
+            strip_foreign_managed_profiles(&existing, REMOTE_BOOTSTRAP_PROFILE_MARKERS, "giganto");
+        assert_eq!(stripped, existing);
     }
 
     #[test]

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -335,6 +335,62 @@ pub fn remove_managed_profile_block(
     updated
 }
 
+/// Removes only the managed `[[profiles]]` entry for `service_name` and
+/// its marker comment lines, leaving every other table untouched.
+///
+/// Unlike [`remove_managed_profile_block`], which deletes the whole byte
+/// span between the begin and end markers, this preserves global tables
+/// (`[trust]`, `[openbao]`, `[acme]`, …) that `toml_edit` floats *inside*
+/// that span when they are appended after the profile block (see the
+/// floating note on [`strip_foreign_managed_profiles`]).
+///
+/// The whole-span strip is correct only where the caller re-emits those
+/// tables afterwards — the delivery-mode transition paths do. `service
+/// remove --strip-config` does **not** re-sync: it clears a stale profile
+/// from a still-serving host, so dropping the `[trust]`/`[openbao]` config
+/// the running agent depends on would be a regression. This surgical
+/// variant removes the array element via `toml_edit` (which owns exactly
+/// the profile and its `[profiles.*]` sub-tables) and then sweeps the
+/// begin/end marker comments, which survive as trailing decor. It matches
+/// either code path's markers.
+///
+/// # Errors
+///
+/// Returns an error if `contents` is not valid TOML.
+pub fn remove_managed_service_profile(contents: &str, service_name: &str) -> Result<String> {
+    let (rendered, removed) = toml_util::remove_array_of_tables_entry(
+        contents,
+        "profiles",
+        "service_name",
+        service_name,
+    )?;
+    let base = if removed { &rendered } else { contents };
+    Ok(strip_profile_marker_lines(base, service_name))
+}
+
+/// Drops any line that exactly matches a begin/end marker for
+/// `service_name`, under either code path's marker pair.
+///
+/// Removing the `[[profiles]]` array element leaves its marker comments
+/// behind as document decor, so they must be swept textually. Full-line
+/// equality (mirroring [`find_marker_line`]) keeps a service name that is
+/// a prefix of another from matching the wrong marker.
+fn strip_profile_marker_lines(contents: &str, service_name: &str) -> String {
+    let mut out = String::with_capacity(contents.len());
+    for line in contents.split_inclusive('\n') {
+        let body = line.strip_suffix('\n').unwrap_or(line);
+        let body = body.strip_suffix('\r').unwrap_or(body);
+        let is_marker = ALL_MANAGED_PROFILE_MARKERS.iter().any(|markers| {
+            body == format!("{} {service_name}", markers.begin_prefix)
+                || body == format!("{} {service_name}", markers.end_prefix)
+        });
+        if !is_marker {
+            out.push_str(line);
+        }
+    }
+    out
+}
+
 /// Builds trust section updates for a managed service profile.
 #[must_use]
 pub fn build_trust_updates(
@@ -614,6 +670,61 @@ mod tests {
         assert_eq!(once, contents);
         let twice = remove_managed_profile_block(&once, BEGIN_PREFIX, END_PREFIX, "edge-proxy");
         assert_eq!(twice, contents);
+    }
+
+    /// The surgical variant removes only the `[[profiles]]` entry and its
+    /// marker comments, preserving global tables that floated inside the
+    /// marker span (unlike the whole-span [`remove_managed_profile_block`]).
+    #[test]
+    fn remove_managed_service_profile_preserves_floated_tables() {
+        let block = render_profile_for(LOCAL_FILE_PROFILE_MARKERS, "giganto");
+        let with_block = upsert_managed_profile_block(
+            "email = \"a@b.c\"\n",
+            LOCAL_FILE_PROFILE_MARKERS.begin_prefix,
+            LOCAL_FILE_PROFILE_MARKERS.end_prefix,
+            "giganto",
+            &block,
+        );
+        // Upsert global tables so they float inside the marker span, as the
+        // real pipeline does.
+        let with_block =
+            toml_util::upsert_section_keys(&with_block, "trust", &[("ca_bundle_path", "c".into())])
+                .expect("trust");
+        let with_block =
+            toml_util::upsert_section_keys(&with_block, "openbao", &[("addr", "u".into())])
+                .expect("openbao");
+
+        let removed = remove_managed_service_profile(&with_block, "giganto").expect("remove ok");
+        assert!(
+            !removed.contains("[[profiles]]"),
+            "profile must be gone: {removed}"
+        );
+        assert!(
+            !removed.contains(LOCAL_FILE_PROFILE_MARKERS.begin_prefix)
+                && !removed.contains(LOCAL_FILE_PROFILE_MARKERS.end_prefix),
+            "markers must be gone: {removed}"
+        );
+        assert!(removed.contains("[trust]"), "trust must survive: {removed}");
+        assert!(
+            removed.contains("[openbao]"),
+            "openbao must survive: {removed}"
+        );
+        assert!(
+            removed.contains("email = \"a@b.c\""),
+            "operator content must survive: {removed}"
+        );
+        removed
+            .parse::<toml_edit::DocumentMut>()
+            .expect("valid TOML after strip");
+    }
+
+    /// Returns the input unchanged (no reflow) when the service has no
+    /// managed profile, so an idempotent re-run is a true no-op.
+    #[test]
+    fn remove_managed_service_profile_is_noop_when_absent() {
+        let contents = "email = \"a@b.c\"\n\n[trust]\nca_bundle_path = \"c\"\n";
+        let out = remove_managed_service_profile(contents, "giganto").expect("remove ok");
+        assert_eq!(out, contents);
     }
 
     /// Service names are DNS labels and can be prefixes of one another

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -349,16 +349,22 @@ pub fn remove_managed_profile_block(
 /// remove --strip-config` does **not** re-sync: it clears a stale profile
 /// from a still-serving host, so dropping the `[trust]`/`[openbao]` config
 /// the running agent depends on would be a regression. This surgical
-/// variant removes the array element via `toml_edit` (which owns exactly
+/// variant removes the array elements via `toml_edit` (which owns exactly
 /// the profile and its `[profiles.*]` sub-tables) and then sweeps the
 /// begin/end marker comments, which survive as trailing decor. It matches
 /// either code path's markers.
+///
+/// It removes **every** `[[profiles]]` entry for the service, not just the
+/// first: an already-affected host may carry the exact #662 duplicate (a
+/// local-file block and a remote-bootstrap block for the same service), and
+/// the marker sweep clears both marker pairs, so the profile removal must
+/// be equally exhaustive or a marker-less profile would be orphaned.
 ///
 /// # Errors
 ///
 /// Returns an error if `contents` is not valid TOML.
 pub fn remove_managed_service_profile(contents: &str, service_name: &str) -> Result<String> {
-    let (rendered, removed) = toml_util::remove_array_of_tables_entry(
+    let (rendered, removed) = toml_util::remove_array_of_tables_entries(
         contents,
         "profiles",
         "service_name",
@@ -713,6 +719,40 @@ mod tests {
             removed.contains("email = \"a@b.c\""),
             "operator content must survive: {removed}"
         );
+        removed
+            .parse::<toml_edit::DocumentMut>()
+            .expect("valid TOML after strip");
+    }
+
+    /// An already-affected host carries the exact #662 duplicate: one
+    /// local-file block and one remote-bootstrap block for the same
+    /// service. `--strip-config` sweeps both marker pairs, so it must also
+    /// remove *both* `[[profiles]]` entries — otherwise the second profile
+    /// survives without markers and can never be matched/cleaned again.
+    #[test]
+    fn remove_managed_service_profile_clears_both_transition_blocks() {
+        let local = render_profile_for(LOCAL_FILE_PROFILE_MARKERS, "giganto");
+        let remote = render_profile_for(REMOTE_BOOTSTRAP_PROFILE_MARKERS, "giganto");
+        let with_blocks = format!(
+            "email = \"a@b.c\"\n\n{local}\n\n{remote}\n\n[trust]\nca_bundle_path = \"c\"\n"
+        );
+
+        let removed = remove_managed_service_profile(&with_blocks, "giganto").expect("remove ok");
+        assert!(
+            !removed.contains("[[profiles]]"),
+            "no profile entry may remain: {removed}"
+        );
+        assert!(
+            !removed.contains("service_name = \"giganto\""),
+            "no orphaned profile may remain: {removed}"
+        );
+        for markers in ALL_MANAGED_PROFILE_MARKERS {
+            assert!(
+                !removed.contains(markers.begin_prefix) && !removed.contains(markers.end_prefix),
+                "all markers must be gone: {removed}"
+            );
+        }
+        assert!(removed.contains("[trust]"), "trust must survive: {removed}");
         removed
             .parse::<toml_edit::DocumentMut>()
             .expect("valid TOML after strip");

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -250,6 +250,16 @@ async fn test_same_host_trust_change_propagates_to_agent_config() {
     assert!(agent_contents.contains("trusted_ca_sha256 = ["));
     assert!(agent_contents.contains("ca_bundle_path = \""));
     assert!(!agent_contents.contains("verify_certificates"));
+    // The local→remote transition must not leave a duplicate profile
+    // block: the pre-existing local-file block is stripped and replaced by
+    // exactly one remote block for the service (#662).
+    assert_eq!(
+        agent_contents.matches("[[profiles]]").count(),
+        1,
+        "exactly one profile block must remain: {agent_contents}"
+    );
+    assert!(!agent_contents.contains("# BEGIN bootroot managed profile:"));
+    assert!(agent_contents.contains("# BEGIN BOOTROOT REMOTE PROFILE"));
     let bundle_contents = fs::read_to_string(&files.ca_bundle_path).expect("read ca-bundle");
     assert!(bundle_contents.contains("BEGIN CERTIFICATE"));
     assert!(bundle_contents.contains("UPDATED-TRUST"));


### PR DESCRIPTION
## Summary

Transitioning a service between delivery modes left `agent.toml` with two `[[profiles]]` blocks for the same service. The local-file `service add` path and the `bootroot-remote bootstrap` path wrote their managed profile under **different** begin/end markers, so an upsert on one path never matched the block the other path had written and fell through to the append branch, tacking on a duplicate. The bug is bidirectional (local→remote and remote→local).

This PR:

- Moves both marker pairs into `trust_bootstrap` as `LOCAL_FILE_PROFILE_MARKERS` / `REMOTE_BOOTSTRAP_PROFILE_MARKERS`, so the two wrappers can no longer drift apart. `service.rs` and `bootroot-remote/main.rs` now reference these constants instead of duplicating the literals.
- Adds a shared `strip_foreign_managed_profiles` helper. Each path strips any block written under the *opposite* path's markers before upserting its own, making both transition directions idempotent — including on **already-deployed** hosts that carry a block under the old string.
- Adds a `--strip-config` flag to `bootroot service remove` that removes the managed profile block from `agent.toml` **without** deleting the cert/key or the per-service secret/config directories — a non-destructive way to clear a stale block during a live transition (the operator wants to keep the cert/key while the service is still serving). Its strip recognises either path's markers, and `--delete-artifacts` implies it.

  Unlike the transition paths, `--strip-config` does **not** re-sync afterwards, so it cannot use the whole-span strip: `toml_edit` floats the end-marker comment past the `[trust]`/`[openbao]`/`[acme]` tables that are appended after the profile, placing those global tables *inside* the marker span. `--strip-config` therefore removes the service's `[[profiles]]` entries (via `toml_edit`) and its marker comment lines, preserving the global tables the still-serving host's agent depends on. New `trust_bootstrap::remove_managed_service_profile` (built on a `toml_util::remove_array_of_tables_entries` primitive) implements this. Removal is **gated on the presence of a managed begin marker** for the service (under either path): when no managed marker is present the file is returned unchanged, so an operator-owned, unmarked `[[profiles]]` entry that merely shares the `service_name` is never touched. When a managed marker *is* present it removes **every** matching profile entry, not just the first, so a host already carrying the #662 duplicate (a local-file block *and* a remote-bootstrap block for the same service) is fully cleared rather than leaving a marker-less profile orphaned behind the swept markers. The whole-span `remove_managed_profile_block` is retained for the transition paths that do re-sync.

## Test plan

- [x] `strip_foreign_managed_profiles` replaces a block written under the opposite marker in place (single resulting block, no append) and is a no-op for the own-path block
- [x] `bootroot-remote/agent_config` regression: local→remote transition leaves exactly one `[[profiles]]`
- [x] `local_config` regression: remote→local transition leaves exactly one `[[profiles]]`
- [x] `service remove --strip-config` removes the managed block while leaving cert/key and secret/config directories intact
- [x] `--strip-config` on the realistic config shape (profile + floated `[acme]`/`[trust]`/`[openbao]`) drops only the profile and markers and preserves the global tables; output re-parses as valid TOML
- [x] `remove_managed_service_profile` preserves floated tables and is a true no-op (no reflow) when the service has no profile
- [x] `remove_managed_service_profile` / `--strip-config` leave an operator-owned, unmarked `[[profiles]]` entry that shares the `service_name` byte-for-byte unchanged (removal is scoped to bootroot's managed profile, not "any profile for this service")
- [x] `remove_array_of_tables_entries` removes every matching entry (incl. duplicates), drops an emptied array, and reports no-change when nothing matches
- [x] `remove_managed_service_profile` clears **both** profile entries when a host carries the #662 duplicate (one local-file + one remote-bootstrap block), leaving no orphaned profile — asserted at both the `trust_bootstrap` and `service remove --strip-config` levels
- [x] `--strip-config` CLI flag parses and defaults to false; `--delete-artifacts` still strips the block
- [x] E2E `test_same_host_trust_change_propagates_to_agent_config` asserts a single profile block after transition
- [x] `cargo clippy --all-targets` clean; `cargo test` green

Closes #662
