### PR TITLE
Pin http-01 admin TLS to trust anchors, not presented chain (#675)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,25 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed the pinned http-01 admin TLS client rejecting a valid
+  leaf-only responder certificate. `PinnedCertVerifier` matched the
+  `trusted_ca_sha256` pins against the certificates the server
+  presented on the wire, but the pins are the root/intermediate CA
+  fingerprints while the production responder (`step certificate
+  create` without `--bundle`) presents a leaf-only certificate — so
+  nothing in the presented chain matched a pin and the handshake was
+  rejected, surfacing as "error sending request" on the first agent
+  issuance (`POST /admin/http01`). The verifier now restricts its
+  webpki trust anchors to the pinned subset of the CA bundle, so a
+  successful chain build already proves the leaf chains to a pinned CA
+  and the post-verification presented-chain scan is dropped; leaf-only
+  servers are accepted while subset-pinning still narrows trust to the
+  pinned CAs (a leaf chaining to a non-pinned bundle CA is rejected).
+  When no bundle certificate matches a pin the verifier falls back to
+  direct-pin-only mode (accepting a directly presented pinned CA
+  certificate) instead of building a client that rejects every
+  handshake. The same fix covers the ACME (step-ca) and responder-admin
+  clients for both local-file and remote-bootstrap agents.
 - Fixed `bootroot rotate ca-key` Phase 3 publishing an internally
   inconsistent transitional trust payload. The fingerprint list
   correctly carried both CA generations, but the accompanying

--- a/src/acme/responder_client.rs
+++ b/src/acme/responder_client.rs
@@ -349,12 +349,21 @@ mod tests {
         )
     }
 
-    /// Starts a minimal HTTPS responder that returns `200 OK` for any request.
+    /// Starts a minimal HTTPS responder that returns `200 OK` for any request,
+    /// presenting the leaf plus the CA certificate (a full-chain fixture).
     async fn start_tls_responder(
         server_cert_der: Vec<u8>,
         server_key_der: Vec<u8>,
         ca_cert_der: Vec<u8>,
     ) -> u16 {
+        start_tls_responder_chain(vec![server_cert_der, ca_cert_der], server_key_der).await
+    }
+
+    /// Starts a minimal HTTPS responder presenting exactly the given
+    /// certificate chain on the wire.  A single-element chain models the
+    /// production leaf-only `server.crt` that `step certificate create` writes
+    /// without `--bundle`.
+    async fn start_tls_responder_chain(cert_chain: Vec<Vec<u8>>, server_key_der: Vec<u8>) -> u16 {
         use std::sync::Arc;
 
         use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
@@ -363,13 +372,12 @@ mod tests {
         use tokio_rustls::TlsAcceptor;
 
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let server_cert = CertificateDer::from(server_cert_der);
-        let ca_cert = CertificateDer::from(ca_cert_der);
+        let chain = cert_chain.into_iter().map(CertificateDer::from).collect();
         let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(server_key_der));
 
         let config = rustls::ServerConfig::builder()
             .with_no_client_auth()
-            .with_single_cert(vec![server_cert, ca_cert], key)
+            .with_single_cert(chain, key)
             .expect("server TLS config");
 
         let acceptor = TlsAcceptor::from(Arc::new(config));
@@ -442,6 +450,117 @@ mod tests {
         )
         .await
         .expect_err("wrong pin should reject TLS handshake");
+        assert!(
+            err.to_string().contains("Failed to register HTTP-01 token"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Generates a self-signed CA and a `localhost` leaf certificate signed by
+    /// it.  Returns `(ca_pem, ca_fingerprint, leaf_cert_der, leaf_key_der)`.
+    fn generate_ca_with_leaf(ca_common_name: &str) -> (String, String, Vec<u8>, Vec<u8>) {
+        use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair};
+
+        let ca_key = KeyPair::generate().expect("generate CA key");
+        let mut ca_params = CertificateParams::new(Vec::new()).expect("cert params");
+        ca_params
+            .distinguished_name
+            .push(DnType::CommonName, ca_common_name);
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).expect("self-signed CA");
+        let ca_pem = ca_cert.pem();
+        let ca_der = ca_cert.der().to_vec();
+
+        let fingerprint = {
+            let digest = ring::digest::digest(&ring::digest::SHA256, &ca_der);
+            let mut hex = String::with_capacity(64);
+            for byte in digest.as_ref() {
+                use std::fmt::Write;
+                write!(hex, "{byte:02x}").expect("hex write");
+            }
+            hex
+        };
+
+        let issuer = Issuer::new(ca_params, ca_key);
+        let leaf_key = KeyPair::generate().expect("generate leaf key");
+        let mut leaf_params =
+            CertificateParams::new(vec!["localhost".to_string()]).expect("cert params");
+        leaf_params
+            .distinguished_name
+            .push(DnType::CommonName, "localhost");
+        leaf_params.is_ca = IsCa::NoCa;
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_key, &issuer)
+            .expect("signed leaf cert");
+
+        (
+            ca_pem,
+            fingerprint,
+            leaf_cert.der().to_vec(),
+            leaf_key.serialize_der(),
+        )
+    }
+
+    /// Regression for #675: the production responder presents a **leaf-only**
+    /// certificate (no bundled issuer), yet the pinned agent client must accept
+    /// it because its issuer is pinned.  Before the verifier fix the presented
+    /// chain held only the leaf, which matched no CA pin, so the handshake was
+    /// wrongly rejected.
+    #[tokio::test]
+    async fn test_responder_tls_leaf_only_cert_accepted() {
+        let (ca_pem, ca_fingerprint, leaf_cert_der, leaf_key_der) =
+            generate_ca_with_leaf("Test Responder CA");
+        let port = start_tls_responder_chain(vec![leaf_cert_der], leaf_key_der).await;
+
+        let pins = vec![ca_fingerprint];
+        let trust = ResponderTrust {
+            ca_pem: &ca_pem,
+            ca_pins: &pins,
+        };
+        register_http01_token_with(
+            &format!("https://localhost:{port}"),
+            "hmac-secret",
+            5,
+            "tok",
+            "tok.key",
+            60,
+            Some(&trust),
+        )
+        .await
+        .expect("leaf-only responder with a pinned issuer should be accepted");
+    }
+
+    /// Regression for #675: pinning must narrow trust to the pinned subset of a
+    /// larger bundle.  A leaf chaining to a bundle CA that is **not** pinned is
+    /// chain-valid against the full bundle yet must still be rejected.
+    #[tokio::test]
+    async fn test_responder_tls_non_pinned_bundle_ca_rejected() {
+        let (pinned_ca_pem, pinned_ca_fingerprint, _pinned_leaf, _pinned_key) =
+            generate_ca_with_leaf("Pinned CA");
+        let (unpinned_ca_pem, _unpinned_fingerprint, unpinned_leaf_der, unpinned_key_der) =
+            generate_ca_with_leaf("Unpinned CA");
+
+        // The bundle trusts both CAs, but only the first CA is pinned.
+        let bundle = format!("{pinned_ca_pem}{unpinned_ca_pem}");
+        let pins = vec![pinned_ca_fingerprint];
+        // The responder serves a leaf chaining to the non-pinned CA.
+        let port = start_tls_responder_chain(vec![unpinned_leaf_der], unpinned_key_der).await;
+
+        let trust = ResponderTrust {
+            ca_pem: &bundle,
+            ca_pins: &pins,
+        };
+        let err = register_http01_token_with(
+            &format!("https://localhost:{port}"),
+            "hmac-secret",
+            5,
+            "tok",
+            "tok.key",
+            60,
+            Some(&trust),
+        )
+        .await
+        .expect_err("leaf chaining to a non-pinned bundle CA must be rejected");
         assert!(
             err.to_string().contains("Failed to register HTTP-01 token"),
             "unexpected error: {err}"

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -585,6 +585,7 @@ mod tests {
 
     #[test]
     fn build_pinned_root_verifier_returns_none_when_no_pin_matches_bundle() {
+        install_crypto_provider();
         let pem = generate_ca_pem();
         let certs = parse_pem_to_cert_list(pem.as_bytes()).expect("cert list");
         let pins = HashSet::from([String::from("00")]);
@@ -594,6 +595,7 @@ mod tests {
 
     #[test]
     fn build_pinned_root_verifier_returns_some_when_pin_matches_bundle() {
+        install_crypto_provider();
         let pem = generate_ca_pem();
         let certs = parse_pem_to_cert_list(pem.as_bytes()).expect("cert list");
         let cert = certs.first().expect("at least one certificate");

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -6,6 +6,7 @@ use reqwest::Client;
 use rustls::ClientConfig;
 use rustls::client::WebPkiServerVerifier;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use x509_parser::certificate::X509Certificate;
 use x509_parser::pem::parse_x509_pem;
@@ -51,22 +52,16 @@ pub fn build_http_client(trust: &TrustSettings, insecure_mode: bool) -> Result<C
             .context("Failed to build HTTP client");
     };
 
-    let (root_store, pins) = load_ca_bundle(bundle_path, &trust.trusted_ca_sha256)?;
-    let verifier = WebPkiServerVerifier::builder(Arc::new(root_store.clone()))
-        .build()
-        .context("Failed to build TLS verifier")?;
-    let verifier: Arc<dyn ServerCertVerifier> = if pins.is_empty() {
-        verifier
-    } else {
-        Arc::new(PinnedCertVerifier::new(verifier, pins))
-    };
-
+    let (certs, pins) = load_ca_bundle(bundle_path, &trust.trusted_ca_sha256)?;
+    let root_store = certs_to_root_store(&certs)?;
     let mut config = ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
-    if !trust.trusted_ca_sha256.is_empty() {
-        config.dangerous().set_certificate_verifier(verifier);
+    if !pins.is_empty() {
+        config
+            .dangerous()
+            .set_certificate_verifier(build_pinned_verifier(&certs, &pins)?);
     }
 
     Client::builder()
@@ -112,23 +107,17 @@ pub fn build_http_client_from_pem(pem_content: &str, pins: &[String]) -> Result<
 /// Returns an error if the PEM content cannot be parsed.
 pub fn build_client_config_from_pem(pem_content: &str, pins: &[String]) -> Result<ClientConfig> {
     install_crypto_provider();
-    let root_store = parse_pem_to_root_store(pem_content.as_bytes())?;
+    let certs = parse_pem_to_cert_list(pem_content.as_bytes())?;
+    let root_store = certs_to_root_store(&certs)?;
     let pin_set: HashSet<String> = pins.iter().map(|p| p.to_ascii_lowercase()).collect();
-    if pin_set.is_empty() {
-        Ok(ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth())
-    } else {
-        let verifier = WebPkiServerVerifier::builder(Arc::new(root_store.clone()))
-            .build()
-            .context("Failed to build TLS verifier")?;
-        let pinned = Arc::new(PinnedCertVerifier::new(verifier, pin_set));
-        let mut cfg = ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        cfg.dangerous().set_certificate_verifier(pinned);
-        Ok(cfg)
+    let mut cfg = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    if !pin_set.is_empty() {
+        cfg.dangerous()
+            .set_certificate_verifier(build_pinned_verifier(&certs, &pin_set)?);
     }
+    Ok(cfg)
 }
 
 /// Builds a [`reqwest::Client`] whose trust store is the union of the
@@ -212,6 +201,7 @@ fn parse_pem_to_cert_list(pem_bytes: &[u8]) -> Result<Vec<CertificateDer<'static
     Ok(certs)
 }
 
+#[cfg(test)]
 fn parse_pem_to_root_store(pem_bytes: &[u8]) -> Result<rustls::RootCertStore> {
     let certs = parse_pem_to_cert_list(pem_bytes)?;
     let mut root_store = rustls::RootCertStore::empty();
@@ -226,43 +216,86 @@ fn parse_pem_to_root_store(pem_bytes: &[u8]) -> Result<rustls::RootCertStore> {
 fn load_ca_bundle(
     path: &std::path::Path,
     pins: &[String],
-) -> Result<(rustls::RootCertStore, HashSet<String>)> {
+) -> Result<(Vec<CertificateDer<'static>>, HashSet<String>)> {
     let contents = std::fs::read(path)
         .with_context(|| format!("Failed to read CA bundle at {}", path.display()))?;
-    let root_store = parse_pem_to_root_store(&contents)?;
+    let certs = parse_pem_to_cert_list(&contents)?;
     let pins = pins
         .iter()
         .map(|value| value.to_ascii_lowercase())
         .collect::<HashSet<_>>();
-    Ok((root_store, pins))
+    Ok((certs, pins))
+}
+
+/// Builds a [`rustls::RootCertStore`] from an already-parsed certificate list.
+fn certs_to_root_store(certs: &[CertificateDer<'static>]) -> Result<rustls::RootCertStore> {
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in certs {
+        root_store
+            .add(cert.clone())
+            .context("Failed to add CA certificate")?;
+    }
+    Ok(root_store)
+}
+
+/// Builds the pinned server-certificate verifier for a CA bundle and pin set.
+///
+/// The inner webpki verifier trusts only the bundle certificates whose
+/// SHA-256 fingerprint is pinned, so a successful webpki verification already
+/// proves the presented leaf chains to a pinned trust anchor — no
+/// presented-chain scan is required, and a production leaf-only server is
+/// accepted as long as its issuer is pinned. When no bundle certificate
+/// matches a pin the verifier is direct-pin only: it accepts a handshake
+/// solely when the server presents a directly pinned CA certificate.
+fn build_pinned_verifier(
+    certs: &[CertificateDer<'static>],
+    pins: &HashSet<String>,
+) -> Result<Arc<dyn ServerCertVerifier>> {
+    let inner = build_pinned_root_verifier(certs, pins)?;
+    Ok(Arc::new(PinnedCertVerifier::new(inner, pins.clone())))
+}
+
+/// Builds a webpki verifier whose trust anchors are the pinned subset of the
+/// bundle, or `None` when no bundle certificate matches a pin (an empty root
+/// store cannot back a `WebPkiServerVerifier`, so the caller falls back to a
+/// direct-pin-only verifier instead of failing to build the client).
+fn build_pinned_root_verifier(
+    certs: &[CertificateDer<'static>],
+    pins: &HashSet<String>,
+) -> Result<Option<Arc<dyn ServerCertVerifier>>> {
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in certs {
+        if pins.contains(&sha256_hex(cert.as_ref())) {
+            root_store
+                .add(cert.clone())
+                .context("Failed to add pinned CA certificate")?;
+        }
+    }
+    if root_store.is_empty() {
+        return Ok(None);
+    }
+    let verifier: Arc<dyn ServerCertVerifier> = WebPkiServerVerifier::builder(Arc::new(root_store))
+        .build()
+        .context("Failed to build TLS verifier")?;
+    Ok(Some(verifier))
 }
 
 #[derive(Debug)]
 struct PinnedCertVerifier {
-    inner: Arc<dyn ServerCertVerifier>,
+    /// Webpki verifier restricted to the pinned trust anchors, or `None` when
+    /// no bundle certificate matches a pin (direct-pin-only mode).
+    inner: Option<Arc<dyn ServerCertVerifier>>,
     allowed: HashSet<String>,
+    supported_algs: WebPkiSupportedAlgorithms,
 }
 
 impl PinnedCertVerifier {
-    fn new(inner: Arc<dyn ServerCertVerifier>, allowed: HashSet<String>) -> Self {
-        Self { inner, allowed }
-    }
-
-    fn check_pins(
-        &self,
-        end_entity: &CertificateDer<'_>,
-        intermediates: &[CertificateDer<'_>],
-    ) -> Result<(), rustls::Error> {
-        let matches = self.allowed.contains(&sha256_hex(end_entity.as_ref()))
-            || intermediates
-                .iter()
-                .any(|cert| self.allowed.contains(&sha256_hex(cert.as_ref())));
-        if matches {
-            Ok(())
-        } else {
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::ApplicationVerificationFailure,
-            ))
+    fn new(inner: Option<Arc<dyn ServerCertVerifier>>, allowed: HashSet<String>) -> Self {
+        Self {
+            inner,
+            allowed,
+            supported_algs: rustls::crypto::ring::default_provider()
+                .signature_verification_algorithms,
         }
     }
 
@@ -290,15 +323,18 @@ impl ServerCertVerifier for PinnedCertVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        match self.inner.verify_server_cert(
-            end_entity,
-            intermediates,
-            server_name,
-            ocsp_response,
-            now,
-        ) {
-            Ok(_) => self.check_pins(end_entity, intermediates)?,
-            Err(_) => self.check_direct_pin(end_entity, now)?,
+        // When the inner verifier trusts only the pinned CA subset, a
+        // successful chain build already proves the leaf chains to a pinned
+        // trust anchor, so no presented-chain scan is needed. The direct-pin
+        // fallback still covers pins that are not part of the bundle.
+        let chained = match &self.inner {
+            Some(inner) => inner
+                .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
+                .is_ok(),
+            None => false,
+        };
+        if !chained {
+            self.check_direct_pin(end_entity, now)?;
         }
         Ok(ServerCertVerified::assertion())
     }
@@ -309,7 +345,7 @@ impl ServerCertVerifier for PinnedCertVerifier {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        self.inner.verify_tls12_signature(message, cert, dss)
+        verify_tls12_signature(message, cert, dss, &self.supported_algs)
     }
 
     fn verify_tls13_signature(
@@ -318,11 +354,11 @@ impl ServerCertVerifier for PinnedCertVerifier {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        self.inner.verify_tls13_signature(message, cert, dss)
+        verify_tls13_signature(message, cert, dss, &self.supported_algs)
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.inner.supported_verify_schemes()
+        self.supported_algs.supported_schemes()
     }
 }
 
@@ -516,6 +552,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn pinned_verifier_without_inner_accepts_directly_pinned_ca_certificate() {
+        let certificate = generate_ca_certificate();
+        let fingerprint = sha256_hex(certificate.as_ref());
+        let verifier = PinnedCertVerifier::new(None, HashSet::from([fingerprint]));
+        let result = verifier.verify_server_cert(
+            &certificate,
+            &[],
+            &ServerName::try_from("localhost").expect("valid server name"),
+            &[],
+            direct_pin_test_time(),
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn pinned_verifier_without_inner_rejects_unpinned_certificate() {
+        let certificate = generate_ca_certificate();
+        let verifier = PinnedCertVerifier::new(None, HashSet::from([String::from("00")]));
+        let result = verifier.verify_server_cert(
+            &certificate,
+            &[],
+            &ServerName::try_from("localhost").expect("valid server name"),
+            &[],
+            direct_pin_test_time(),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_pinned_root_verifier_returns_none_when_no_pin_matches_bundle() {
+        let pem = generate_ca_pem();
+        let certs = parse_pem_to_cert_list(pem.as_bytes()).expect("cert list");
+        let pins = HashSet::from([String::from("00")]);
+        let verifier = build_pinned_root_verifier(&certs, &pins).expect("build verifier");
+        assert!(verifier.is_none());
+    }
+
+    #[test]
+    fn build_pinned_root_verifier_returns_some_when_pin_matches_bundle() {
+        let pem = generate_ca_pem();
+        let certs = parse_pem_to_cert_list(pem.as_bytes()).expect("cert list");
+        let cert = certs.first().expect("at least one certificate");
+        let pins = HashSet::from([sha256_hex(cert.as_ref())]);
+        let verifier = build_pinned_root_verifier(&certs, &pins).expect("build verifier");
+        assert!(verifier.is_some());
+    }
+
     fn direct_pin_test_time() -> UnixTime {
         UnixTime::since_unix_epoch(Duration::from_secs(DIRECT_PIN_TEST_NOW_SECS))
     }
@@ -525,7 +611,7 @@ mod tests {
         allowed: HashSet<String>,
         now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        let verifier = PinnedCertVerifier::new(Arc::new(RejectingVerifier), allowed);
+        let verifier = PinnedCertVerifier::new(Some(Arc::new(RejectingVerifier)), allowed);
         verifier.verify_server_cert(
             certificate,
             &[],

--- a/tests/e2e_multi_host_tls.rs
+++ b/tests/e2e_multi_host_tls.rs
@@ -83,11 +83,12 @@
 //!   client (trusting `system_ca`) successfully completes a handshake
 //!   for readiness, proving the responder cert is valid under
 //!   "system-trusted" roots.  The RN-side http01 client built via
-//!   `build_client_config_from_pem` then rejects the same chain when
+//!   `build_client_config_from_pem` then rejects the same cert when
 //!   configured with only the artifact anchor, and — in the separate
 //!   pin test — rejects even when the PEM bundle *also* contains
-//!   `system_ca`, because the SHA-256 pin on the artifact CA does not
-//!   match the chain.  The pin test is the strongest in-process proxy
+//!   `system_ca`, because the SHA-256 pin restricts the client's trust
+//!   anchors to the artifact CA, which did not sign the responder cert.
+//!   The pin test is the strongest in-process proxy
 //!   for "the OS store would accept this cert": a PEM bundle that
 //!   explicitly contains both roots short-circuits the question of
 //!   where the root came from.
@@ -183,14 +184,6 @@ struct SignedCert {
     cert_der: Vec<u8>,
     key_der: Vec<u8>,
     issuer_der: Vec<u8>,
-    issuer_pem: String,
-}
-
-/// Concatenates the server's end-entity PEM and its issuer PEM into a single
-/// chain file suitable for handing to a TLS server that will present both to
-/// clients during the handshake.
-fn server_chain_pem(cert: &SignedCert) -> String {
-    format!("{}{}", cert.cert_pem, cert.issuer_pem)
 }
 
 impl TestCa {
@@ -235,7 +228,6 @@ impl TestCa {
             cert_der: cert.der().to_vec(),
             key_der: key.serialize_der(),
             issuer_der: self.der.clone(),
-            issuer_pem: self.pem.clone(),
         }
     }
 }
@@ -978,9 +970,12 @@ async fn test_multi_host_tls_control_plane_happy_path() {
     let responder_cert = step_ca.sign_server_cert("localhost");
     let responder_cert_path = responder_temp.path().join("responder.cert.pem");
     let responder_key_path = responder_temp.path().join("responder.key.pem");
-    // Serve the CA as part of the chain so SHA-256 pin enforcement on the
-    // RN client can match the pinned CA fingerprint against the chain.
-    fs::write(&responder_cert_path, server_chain_pem(&responder_cert))
+    // Serve a leaf-only certificate, exactly as the production responder
+    // does (`step certificate create` writes `server.crt` without
+    // `--bundle`).  Pin enforcement now restricts the RN client's trust
+    // anchors to the pinned CA rather than scanning the presented chain, so
+    // the pinned issuer does not need to appear on the wire.
+    fs::write(&responder_cert_path, responder_cert.cert_pem.as_bytes())
         .expect("write responder cert");
     fs::write(&responder_key_path, &responder_cert.key_pem).expect("write responder key");
 
@@ -1134,9 +1129,12 @@ async fn test_multi_host_tls_rejects_system_trusted_non_artifact_ca() {
     let responder_cert = system_ca.sign_server_cert("localhost");
     let responder_cert_path = responder_temp.path().join("responder.cert.pem");
     let responder_key_path = responder_temp.path().join("responder.key.pem");
-    // Serve the CA as part of the chain so SHA-256 pin enforcement on the
-    // RN client can match the pinned CA fingerprint against the chain.
-    fs::write(&responder_cert_path, server_chain_pem(&responder_cert))
+    // Serve a leaf-only certificate, exactly as the production responder
+    // does (`step certificate create` writes `server.crt` without
+    // `--bundle`).  Pin enforcement now restricts the RN client's trust
+    // anchors to the pinned CA rather than scanning the presented chain, so
+    // the pinned issuer does not need to appear on the wire.
+    fs::write(&responder_cert_path, responder_cert.cert_pem.as_bytes())
         .expect("write responder cert");
     fs::write(&responder_key_path, &responder_cert.key_pem).expect("write responder key");
 
@@ -1252,8 +1250,9 @@ async fn test_multi_host_tls_rejects_system_trusted_non_artifact_ca() {
 /// trusted root in the client's explicit PEM bundle (modelling what would
 /// happen if the client accidentally merged the system trust store into its
 /// roots), and verify that the pin on `step_ca` still rejects the handshake
-/// because the presented certificate's chain does not include the pinned
-/// CA.  Since `build_client_config_from_pem` only ever consults the
+/// because the responder cert chains to a non-pinned CA and the pin
+/// restricts the client's trust anchors to `step_ca` alone.  Since
+/// `build_client_config_from_pem` only ever consults the
 /// supplied PEM (never the OS trust store), passing a PEM that contains
 /// both roots is the strongest in-process proxy for "the server cert would
 /// be system-trusted".
@@ -1270,9 +1269,12 @@ async fn test_multi_host_tls_pin_rejects_chain_valid_but_non_pinned_ca() {
     let responder_cert = system_ca.sign_server_cert("localhost");
     let responder_cert_path = responder_temp.path().join("responder.cert.pem");
     let responder_key_path = responder_temp.path().join("responder.key.pem");
-    // Serve the CA as part of the chain so SHA-256 pin enforcement on the
-    // RN client can match the pinned CA fingerprint against the chain.
-    fs::write(&responder_cert_path, server_chain_pem(&responder_cert))
+    // Serve a leaf-only certificate, exactly as the production responder
+    // does (`step certificate create` writes `server.crt` without
+    // `--bundle`).  Pin enforcement now restricts the RN client's trust
+    // anchors to the pinned CA rather than scanning the presented chain, so
+    // the pinned issuer does not need to appear on the wire.
+    fs::write(&responder_cert_path, responder_cert.cert_pem.as_bytes())
         .expect("write responder cert");
     fs::write(&responder_key_path, &responder_cert.key_pem).expect("write responder key");
 

--- a/tests/e2e_multi_host_tls_real_daemon.rs
+++ b/tests/e2e_multi_host_tls_real_daemon.rs
@@ -849,7 +849,11 @@ async fn test_real_daemon_multi_host_tls_happy_path() {
     let responder_cert = step_ca.sign_server_cert(&["localhost"]);
     let responder_cert_path = responder_temp.path().join("responder.cert.pem");
     let responder_key_path = responder_temp.path().join("responder.key.pem");
-    fs::write(&responder_cert_path, server_chain_pem(&responder_cert))
+    // Present a leaf-only certificate as the production responder does
+    // (`step certificate create` writes `server.crt` without `--bundle`); the
+    // pinned client trusts the issuer via its filtered trust anchors, not the
+    // presented chain.
+    fs::write(&responder_cert_path, responder_cert.cert_pem.as_bytes())
         .expect("write responder cert");
     fs::write(&responder_key_path, &responder_cert.key_pem).expect("write responder key");
 
@@ -1018,7 +1022,11 @@ async fn test_real_daemon_multi_host_tls_rejects_system_trusted_non_artifact_ca(
     let responder_cert = system_ca.sign_server_cert(&["localhost"]);
     let responder_cert_path = responder_temp.path().join("responder.cert.pem");
     let responder_key_path = responder_temp.path().join("responder.key.pem");
-    fs::write(&responder_cert_path, server_chain_pem(&responder_cert))
+    // Present a leaf-only certificate as the production responder does
+    // (`step certificate create` writes `server.crt` without `--bundle`); the
+    // pinned client trusts the issuer via its filtered trust anchors, not the
+    // presented chain.
+    fs::write(&responder_cert_path, responder_cert.cert_pem.as_bytes())
         .expect("write responder cert");
     fs::write(&responder_key_path, &responder_cert.key_pem).expect("write responder key");
 
@@ -1164,7 +1172,11 @@ async fn test_real_daemon_multi_host_tls_pin_rejects_non_pinned_chain() {
     let responder_cert = system_ca.sign_server_cert(&["localhost"]);
     let responder_cert_path = responder_temp.path().join("responder.cert.pem");
     let responder_key_path = responder_temp.path().join("responder.key.pem");
-    fs::write(&responder_cert_path, server_chain_pem(&responder_cert))
+    // Present a leaf-only certificate as the production responder does
+    // (`step certificate create` writes `server.crt` without `--bundle`); the
+    // pinned client trusts the issuer via its filtered trust anchors, not the
+    // presented chain.
+    fs::write(&responder_cert_path, responder_cert.cert_pem.as_bytes())
         .expect("write responder cert");
     fs::write(&responder_key_path, &responder_cert.key_pem).expect("write responder key");
 


### PR DESCRIPTION
## Summary

When a service uses the TLS-bound HTTP-01 admin API (`--http01-admin-bind`), a `bootroot-agent` with a non-empty `trusted_ca_sha256` could not complete issuance: its HTTPS `POST /admin/http01` to the responder failed at the TLS layer even though the responder certificate was valid against the CA bundle.

The root cause was that `PinnedCertVerifier` matched the pins against the certificates the server *presented on the wire*. The pins are the root/intermediate CA fingerprints, but the production responder (`step certificate create` without `--bundle`) presents a **leaf-only** certificate — so nothing in the presented chain matched a pin and the handshake was rejected, surfacing as `error sending request`. step-ca happened to work only because it serves its full chain.

### Changes

- **Verifier fix (`src/tls.rs`):** the pinned client now restricts its rustls webpki trust anchors to the *pinned subset* of the CA bundle. A successful chain build already proves the presented leaf chains to a pinned CA, so the post-verification presented-chain scan is dropped and leaf-only servers are accepted whenever their issuer is pinned. Subset-pinning still narrows trust: a leaf chaining to a non-pinned bundle CA is rejected.
- **Empty-filtered-store edge case:** when no bundle certificate matches any pin, the verifier falls back to **direct-pin-only mode** instead of building a client that rejects every handshake (an empty root store cannot back a `WebPkiServerVerifier`). The `check_direct_pin` fallback is otherwise unchanged.
- **Coverage:** applies to both the ACME (step-ca) client (`build_http_client`) and the responder-admin client (`build_client_config_from_pem`), for local-file and remote-bootstrap agents, since both wrap the same verifier.
- **Tests:** the multi-host TLS E2E fixtures now serve the production-shaped **leaf-only** `server.crt` (dropping the `server_chain_pem` full-chain helper) so the defect is reachable from tests. New unit tests cover leaf-only acceptance, non-pinned subset rejection, and the empty-filtered-root-store / direct-pin-only edge case.

## Not addressed

The issue lists an **optional server-side hardening** (issuing the http01 admin cert — and the OpenBao TLS cert — as a leaf+intermediate bundle via `step certificate create --bundle`) so servers present a full chain per TLS convention. It is explicitly described as *"not a substitute"* for the verifier fix and *"must not be treated as the fix on its own."* Since the verifier fix resolves the whole class of leaf-only-server failures, this cosmetic hardening is left out to keep the change focused; it can be pursued separately if full-chain presentation is desired for convention's sake.

Closes #675

## Test plan

- [x] Leaf-only acceptance: a real responder presenting the production-shaped leaf-only `server.crt` is accepted by the pinned agent client (`test_responder_tls_leaf_only_cert_accepted`)
- [x] Subset-pin rejection: with a bundle containing multiple CAs but pins naming only one, a leaf chaining to a non-pinned bundle CA is rejected (`test_responder_tls_non_pinned_bundle_ca_rejected`)
- [x] Empty-filtered-root-store: pins that match no bundle certificate yield a direct-pin-only verifier (`build_pinned_root_verifier_returns_none_when_no_pin_matches_bundle`, `pinned_verifier_without_inner_*`)
- [x] Direct-pin fallback still works unchanged (existing `pinned_verifier_*` direct-pin tests pass)
- [x] Multi-host TLS E2E suites updated to serve leaf-only certs and still pass (happy-path acceptance + non-pinned/system-CA rejection)
- [x] `cargo fmt --check`, `cargo clippy --all-targets`, and unit tests pass
