### PR TITLE
Fix remote force-reissue --wait completion write-back (#677)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,26 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed `bootroot rotate force-reissue --wait` timing out against
+  `remote-bootstrap` services even though the certificate was reissued.
+  The remote agent's fast-poll loop applied the reissue correctly but
+  its write-back of the `completed_at` / `completed_version` completion
+  markers to `{kv_mount}/data/bootroot/services/<service>/reissue` was
+  denied, because the service AppRole policy (`build_service_policy`)
+  was read-only over the entire service subtree. The control plane
+  therefore never observed `completed_version` and blocked until
+  `--wait-timeout`, while the agent accumulated `pending_completion_writes`
+  retries forever. The policy now grants `create`/`update` (in addition
+  to `read`) on exactly the reissue path and keeps the rest of the
+  subtree read-only. Because there was previously no code path that
+  re-applied a service policy, already-provisioned services would keep
+  the old read-only policy indefinitely; the idempotent remote
+  `service add` re-run now re-applies `build_service_policy` via
+  `write_policy` so pre-existing services pick up the reissue-path write
+  grant. The remote lifecycle E2E now exercises the genuine KV
+  force-reissue round-trip (a real `rotate force-reissue --wait` against
+  a running agent) instead of faking reissue by deleting cert files, so
+  the missing permission would now be caught in CI.
 - Fixed the pinned http-01 admin TLS client rejecting a valid
   leaf-only responder certificate. `PinnedCertVerifier` matched the
   `trusted_ca_sha256` pins against the certificates the server

--- a/docs/en/concepts.md
+++ b/docs/en/concepts.md
@@ -183,7 +183,9 @@ manual seal, or recovery procedures that transition the node back to sealed.
 
 After bootstrap, the OpenBao Agent authenticates using **AppRole**
 (role_id + secret_id) and receives short-lived tokens. Policies should grant
-only the minimum paths required (read-only for runtime services). AppRole
+only the minimum paths required (read-only over a runtime service's KV
+subtree, except a narrow write on its own `reissue` path so the fast-poll
+loop can acknowledge a `force-reissue` completion). AppRole
 `role_id` and `secret_id` are issued by OpenBao. `role_id` identifies the
 role and is stable, while `secret_id` is a credential that can be rotated.
 Operators deliver the initial values to services (or OpenBao Agent), and

--- a/docs/ko/concepts.md
+++ b/docs/ko/concepts.md
@@ -179,8 +179,10 @@ root token은 초기화 시 **OpenBao가 자동 생성**하며, 운영자가 값
 #### AppRole 자격증명
 
 초기 설정 이후에는 OpenBao Agent가 **AppRole**(role_id + secret_id)로
-로그인해 짧은 TTL 토큰을 받고, 필요한 경로만 읽도록 최소 권한 정책을
-적용합니다. AppRole의 `role_id`/`secret_id`는 OpenBao가 발급합니다.
+로그인해 짧은 TTL 토큰을 받습니다. 최소 권한 정책은 서비스의 KV
+하위 트리를 읽기 전용으로 두되, 자신의 `reissue` 경로에만 좁은 쓰기
+권한을 부여해 fast-poll 루프가 `force-reissue` 완료를 기록할 수 있게
+합니다. AppRole의 `role_id`/`secret_id`는 OpenBao가 발급합니다.
 `role_id`는 역할 식별자이며 고정값이고, `secret_id`는 로그인에 쓰는
 자격증명으로 재발급/회전이 가능합니다. 초기 값은 운영자가
 서비스(OpenBao Agent)에 전달하고, 이후에는 `secret_id`를 주기적으로

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -61,6 +61,14 @@ RUNTIME_SERVICE_ADD_SECRET_ID=""
 RUNTIME_ROTATE_ROLE_ID=""
 RUNTIME_ROTATE_SECRET_ID=""
 CURRENT_PHASE="init"
+# PID of the background bootroot-agent daemon started for the genuine
+# KV force-reissue round-trip. Empty when no daemon is running; the
+# cleanup trap kills it so a failed run never leaks the process.
+REMOTE_AGENT_PID=""
+# Bounds the genuine force-reissue --wait round-trip. The agent's default
+# fast_poll_interval is 30s, so allow generous margin over one poll plus an
+# ACME renewal for slow CI runners.
+FORCE_REISSUE_WAIT_TIMEOUT="${FORCE_REISSUE_WAIT_TIMEOUT:-120s}"
 # Pin POSTGRES_HOST_PORT for the compose stack: docker-compose.yml's
 # default moved from 5432 to 5433 in #588 §4c; the e2e harness
 # expects 5432 (CI runners free that port before the matrix), so
@@ -136,8 +144,16 @@ cleanup_hosts() {
   rm -f "$tmp_file"
 }
 
+stop_remote_agent() {
+  [ -n "$REMOTE_AGENT_PID" ] || return 0
+  kill "$REMOTE_AGENT_PID" >/dev/null 2>&1 || true
+  wait "$REMOTE_AGENT_PID" 2>/dev/null || true
+  REMOTE_AGENT_PID=""
+}
+
 cleanup() {
   log_phase "cleanup"
+  stop_remote_agent
   cleanup_hosts
   capture_artifacts
   compose_down
@@ -494,6 +510,65 @@ force_reissue_remote_service() {
   rm -f "$REMOTE_CERTS_DIR/${service}.crt" "$REMOTE_CERTS_DIR/${service}.key"
 }
 
+# Exercises the genuine KV force-reissue round-trip for a remote-bootstrap
+# service. Unlike force_reissue_remote_service (which fakes reissue by
+# deleting cert files), this runs a real bootroot-agent daemon so its
+# fast-poll loop observes the control-plane's `rotate force-reissue --wait`
+# KV request, renews via ACME, and writes the completion markers back to
+# KV. That write-back requires the service AppRole to hold create/update on
+# its reissue KV path; without it, `--wait` blocks until timeout. This is
+# the coverage that would have caught issue #677.
+run_force_reissue_wait_roundtrip() {
+  local service="$1"
+  local agent_config="$2"
+  local hostname_val="$3"
+  local instance_id="$4"
+  log_phase "force-reissue-wait-${service}"
+
+  # Re-bootstrap so the agent config, credentials and initial cert are
+  # fresh, then snapshot the cert to detect the reissue.
+  run_remote_bootstrap "$service" "$agent_config" "$hostname_val" "$instance_id"
+  snapshot_cert_meta "$service" "before-force-reissue"
+
+  # Start the long-lived agent so its fast-poll loop is the consumer of the
+  # KV force-reissue request. It authenticates via the service AppRole from
+  # the [openbao] section that bootstrap wrote into the agent config.
+  local agent_log="$ARTIFACT_DIR/remote-agent-${service}.log"
+  "$BOOTROOT_AGENT_BIN" --config "$agent_config" >>"$agent_log" 2>&1 &
+  REMOTE_AGENT_PID=$!
+  # Give the daemon a moment to load config and complete its initial login
+  # before the request lands, so the next fast-poll tick observes it.
+  sleep 3
+
+  local reissue_log="$ARTIFACT_DIR/force-reissue-${service}.log"
+  local status=0
+  run_bootroot_control rotate \
+    --compose-file "$COMPOSE_FILE" \
+    --openbao-url "http://${STEPCA_HOST_IP}:8200" \
+    --auth-mode approle \
+    --approle-role-id "$RUNTIME_ROTATE_ROLE_ID" \
+    --approle-secret-id "$RUNTIME_ROTATE_SECRET_ID" \
+    --yes \
+    force-reissue \
+    --service-name "$service" \
+    --wait \
+    --wait-timeout "$FORCE_REISSUE_WAIT_TIMEOUT" >"$reissue_log" 2>&1 || status=$?
+
+  cat "$reissue_log" >>"$RUN_LOG"
+  stop_remote_agent
+
+  # Exit code 124 is the --wait timeout convention; any non-zero here means
+  # the round-trip did not complete, which is exactly the #677 regression.
+  [ "$status" -eq 0 ] \
+    || fail "rotate force-reissue --wait exited ${status} for ${service} (expected completion, not timeout)"
+  grep -q "reported completion" "$reissue_log" \
+    || fail "rotate force-reissue --wait for ${service} did not observe agent completion"
+
+  # The agent must have actually reissued the certificate on disk.
+  snapshot_cert_meta "$service" "after-force-reissue"
+  assert_fingerprint_changed "$service" "before-force-reissue" "after-force-reissue"
+}
+
 run_rotation_secret_id() {
   log_phase "rotate-secret-id"
   run_bootroot_control rotate \
@@ -627,6 +702,9 @@ main() {
   run_verify_pair "after-responder-hmac"
   assert_fingerprint_changed "$SERVICE_NAME" "after-trust-sync" "after-responder-hmac"
   assert_fingerprint_changed "$SERVICE_NAME_2" "after-trust-sync" "after-responder-hmac"
+
+  run_force_reissue_wait_roundtrip \
+    "$SERVICE_NAME" "$REMOTE_AGENT_CONFIG_PATH" "$HOSTNAME" "$INSTANCE_ID"
 
   log_phase "assert-openbao-audit-log"
   assert_openbao_audit_log

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -498,6 +498,9 @@ async fn run_service_add_remote_idempotent(
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("OpenBao auth is required"))?;
     crate::commands::openbao_auth::authenticate_openbao_client(&mut client, auth, messages).await?;
+    // Re-apply the service policy so pre-existing services pick up the reissue
+    // path write grant needed for `rotate force-reissue --wait` completion.
+    approle::reapply_service_policy(&client, state, &entry.service_name, messages).await?;
     let ca_bundle_pem = secrets::read_ca_bundle_pem(&client, &state.kv_mount, messages).await?;
     let wrap_ttl = resolve::effective_wrap_ttl(entry.approle.secret_id_wrap_ttl.as_deref());
     let artifact_wrap_info = if let Some(ttl) = wrap_ttl {

--- a/src/commands/service/approle.rs
+++ b/src/commands/service/approle.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use bootroot::fs_util;
 use bootroot::openbao::{OpenBaoClient, SecretIdOptions};
+use bootroot::trust_bootstrap::SERVICE_REISSUE_KV_SUFFIX;
 use tokio::fs;
 
 use super::{
@@ -61,10 +62,38 @@ pub(super) async fn ensure_service_approle(
     })
 }
 
+/// Re-applies the service `AppRole` policy for an already-provisioned service.
+///
+/// `write_policy` is idempotent, so this is safe to run repeatedly. It exists
+/// so that services provisioned before the reissue-path write grant was added
+/// pick up the updated policy on the idempotent remote `service add` re-run,
+/// instead of keeping the old read-only policy indefinitely.
+pub(super) async fn reapply_service_policy(
+    client: &OpenBaoClient,
+    state: &StateFile,
+    service_name: &str,
+    messages: &Messages,
+) -> Result<()> {
+    let policy_name = service_policy_name(service_name);
+    let policy = build_service_policy(&state.kv_mount, service_name);
+    client
+        .write_policy(&policy_name, &policy)
+        .await
+        .with_context(|| messages.error_openbao_policy_write_failed())?;
+    Ok(())
+}
+
 fn build_service_policy(kv_mount: &str, service_name: &str) -> String {
     let base = format!("{SERVICE_KV_BASE}/{service_name}");
+    // The service subtree is read-only except for its own reissue object: the
+    // fast-poll loop must write `completed_at`/`completed_version` back so the
+    // control plane's `rotate force-reissue --wait` can observe completion.
+    // Narrowly grant create/update on exactly that one path.
     format!(
-        r#"path "{kv_mount}/data/{base}/*" {{
+        r#"path "{kv_mount}/data/{base}/{SERVICE_REISSUE_KV_SUFFIX}" {{
+  capabilities = ["read", "create", "update"]
+}}
+path "{kv_mount}/data/{base}/*" {{
   capabilities = ["read"]
 }}
 path "{kv_mount}/metadata/{base}/*" {{
@@ -112,4 +141,49 @@ pub(super) async fn write_role_id_file(
         .with_context(|| messages.error_write_file_failed(&role_path.display().to_string()))?;
     fs_util::set_key_permissions(&role_path).await?;
     Ok(role_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_policy_grants_write_only_on_reissue_path() {
+        let policy = build_service_policy("secret", "edge-proxy");
+
+        assert!(
+            policy.contains(
+                "path \"secret/data/bootroot/services/edge-proxy/reissue\" {\n  capabilities = [\"read\", \"create\", \"update\"]"
+            ),
+            "reissue path must carry create/update, got:\n{policy}"
+        );
+        assert!(
+            policy.contains(
+                "path \"secret/data/bootroot/services/edge-proxy/*\" {\n  capabilities = [\"read\"]"
+            ),
+            "rest of data subtree must stay read-only, got:\n{policy}"
+        );
+        assert!(
+            policy.contains(
+                "path \"secret/metadata/bootroot/services/edge-proxy/*\" {\n  capabilities = [\"list\"]"
+            ),
+            "metadata subtree must stay list-only, got:\n{policy}"
+        );
+    }
+
+    #[test]
+    fn service_policy_grants_no_broader_write_scope() {
+        let policy = build_service_policy("secret", "edge-proxy");
+
+        // Only the reissue rule may carry create/update; no other rule may.
+        for block in policy.split("path ").filter(|b| !b.is_empty()) {
+            let has_write = block.contains("create") || block.contains("update");
+            let is_reissue =
+                block.starts_with("\"secret/data/bootroot/services/edge-proxy/reissue\"");
+            assert!(
+                !has_write || is_reissue,
+                "unexpected write capability outside the reissue path:\n{block}"
+            );
+        }
+    }
 }

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1347,6 +1347,42 @@ async fn test_app_add_remote_bootstrap_rerun_is_idempotent() {
         fs::read_to_string(temp_dir.path().join("state.json")).expect("read state");
     let state: serde_json::Value = serde_json::from_str(&state_contents).expect("parse state");
     assert!(state["services"]["edge-proxy"].is_object());
+
+    assert_idempotent_rerun_reapplied_policy(&server, "edge-proxy").await;
+}
+
+/// Asserts that the idempotent remote re-run re-POSTed the service policy so a
+/// pre-existing service picks up the reissue-path write grant (issue #677).
+async fn assert_idempotent_rerun_reapplied_policy(server: &MockServer, service_name: &str) {
+    let policy_path = format!("/v1/sys/policies/acl/bootroot-service-{service_name}");
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server records requests");
+    let policy_writes: Vec<_> = requests
+        .iter()
+        .filter(|req| req.method.as_str() == "POST" && req.url.path() == policy_path)
+        .collect();
+    assert!(
+        policy_writes.len() >= 2,
+        "expected policy writes from both the initial add and the idempotent re-run, got {}",
+        policy_writes.len()
+    );
+    let last_policy = policy_writes
+        .last()
+        .expect("at least one policy write recorded");
+    let policy_body: serde_json::Value =
+        serde_json::from_slice(&last_policy.body).expect("parse policy write body");
+    let policy_text = policy_body["policy"]
+        .as_str()
+        .expect("policy field is a string");
+    let expected = format!(
+        "path \"secret/data/bootroot/services/{service_name}/reissue\" {{\n  capabilities = [\"read\", \"create\", \"update\"]"
+    );
+    assert!(
+        policy_text.contains(&expected),
+        "re-applied policy must grant create/update on the reissue path, got:\n{policy_text}"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

On `remote-bootstrap` services, `bootroot rotate force-reissue --wait` never observed completion and blocked until `--wait-timeout`, even though the certificate was actually reissued. The remote agent's fast-poll loop applied the ACME reissue correctly, but its write-back of the `completed_at` / `completed_version` markers to `{kv_mount}/data/bootroot/services/<service>/reissue` was denied: the service AppRole policy (`build_service_policy`) was read-only over the entire service subtree. The control plane therefore never saw `completed_version`, and the agent accumulated `pending_completion_writes` retries forever.

Changes:

- **`build_service_policy` (`src/commands/service/approle.rs`)** now grants `read`/`create`/`update` on exactly the `reissue` path, keeping the rest of the `data/*` subtree `read`-only and `metadata/*` `list`-only. This is the smallest correct fix given that request and completion markers share one KV v2 object; `build_completed_payload` merges the observed payload so a normal completion write does not clobber the request fields.
- **Migration for pre-existing services.** There was previously no code path that re-applied a service policy, so already-provisioned services would keep the old read-only policy indefinitely. The idempotent remote `service add` re-run (`run_service_add_remote_idempotent` in `src/commands/service.rs`) now re-applies the policy via a new `reapply_service_policy` helper calling `write_policy` (idempotent, safe to repeat). The control-plane service-add role already holds write on `sys/policies/acl/bootroot-service-*`, so this needs no new privilege.
- **E2E coverage** (`scripts/impl/run-remote-lifecycle.sh`): a new `run_force_reissue_wait_roundtrip` runs a real `bootroot-agent` daemon and issues a genuine `rotate force-reissue --wait` from the control plane, asserting it returns success (not timeout) and the cert fingerprint changes. It runs alongside the existing `force_reissue_remote_service` (`rm -f`) flow, adding the genuine KV force-reissue round-trip that the `rm -f` shortcut never exercised. This is the coverage that would have caught the bug.
- **Unit coverage**: `build_service_policy` tests assert write capability on the reissue path and no broader write scope; the idempotent-rerun test asserts the service policy is re-POSTed with `create`/`update` on the reissue path.
- Docs (`concepts.md` en/ko) and CHANGELOG updated.

Closes #677

## Test plan

- [x] `build_service_policy` grants `create`/`update` on exactly the reissue path and nothing broader (`service_policy_grants_write_only_on_reissue_path`, `service_policy_grants_no_broader_write_scope`)
- [x] Rest of the service subtree remains read-only (`data/*` read, `metadata/*` list)
- [x] Idempotent remote `service add` re-run re-applies the updated policy for a pre-existing service (`test_app_add_remote_bootstrap_rerun_is_idempotent`)
- [x] A real `rotate force-reissue --wait` against a `remote-bootstrap` service completes within the wait window instead of timing out (`run_force_reissue_wait_roundtrip` in the remote lifecycle E2E)
- [x] The reissued cert/key change on disk during the round-trip
- [x] `cargo clippy --all-targets` is warning-free and `cargo build` succeeds
- [x] Preflight E2E matrix (`scripts/preflight/ci/e2e-matrix.sh`) still passes


