### PR TITLE
Fail fast on EOF in interactive prompts instead of looping forever

### DIFF
--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -31,9 +31,13 @@ impl<'a> Prompt<'a> {
         self.output
             .flush()
             .with_context(|| self.messages.error_prompt_flush_failed())?;
-        self.input
+        let bytes_read = self
+            .input
             .read_line(&mut line)
             .with_context(|| self.messages.error_prompt_read_failed())?;
+        if bytes_read == 0 {
+            anyhow::bail!(self.messages.error_prompt_read_failed());
+        }
         let trimmed = line.trim();
         if trimmed.is_empty()
             && let Some(value) = default
@@ -96,5 +100,33 @@ mod tests {
         let mut prompt = Prompt::new(&mut input, &mut output, &messages);
         let value = prompt.prompt_text("Label", Some("default")).unwrap();
         assert_eq!(value, "value");
+    }
+
+    // A closed/non-TTY stdin (EOF) must error, not read as an empty value.
+    #[test]
+    fn prompt_text_errors_on_eof() {
+        let mut input = Cursor::new("");
+        let mut output = Vec::new();
+        let messages = Messages::new("en").unwrap();
+        let mut prompt = Prompt::new(&mut input, &mut output, &messages);
+        let result = prompt.prompt_text("Label", None);
+        assert!(result.is_err());
+    }
+
+    // EOF must surface as an error instead of re-prompting forever.
+    #[test]
+    fn prompt_with_validation_errors_on_eof_instead_of_looping() {
+        let mut input = Cursor::new("");
+        let mut output = Vec::new();
+        let messages = Messages::new("en").unwrap();
+        let mut prompt = Prompt::new(&mut input, &mut output, &messages);
+        let result = prompt.prompt_with_validation("Label", None, |value| {
+            if value.trim().is_empty() {
+                anyhow::bail!("Value is required")
+            } else {
+                Ok(value.to_string())
+            }
+        });
+        assert!(result.is_err());
     }
 }

--- a/src/commands/openbao_unseal.rs
+++ b/src/commands/openbao_unseal.rs
@@ -52,17 +52,37 @@ pub(crate) fn prompt_unseal_keys_interactive(
 ) -> Result<Vec<String>> {
     use std::io::{self, Write};
 
+    io::stdout()
+        .flush()
+        .with_context(|| messages.error_prompt_flush_failed())?;
+    let stdin = io::stdin();
+    let mut lock = stdin.lock();
+    prompt_unseal_keys_from_reader(threshold, messages, &mut lock)
+}
+
+/// Reads unseal keys from the given reader, prompting via stdout.
+/// Fails fast on EOF instead of treating an empty line as valid input.
+fn prompt_unseal_keys_from_reader<R: std::io::BufRead>(
+    threshold: Option<u32>,
+    messages: &Messages,
+    reader: &mut R,
+) -> Result<Vec<String>> {
+    use std::io::Write;
+
     let count = match threshold {
         Some(value) if value > 0 => value,
         _ => {
             print!("Unseal key threshold (t): ");
-            io::stdout()
+            std::io::stdout()
                 .flush()
                 .with_context(|| messages.error_prompt_flush_failed())?;
             let mut input = String::new();
-            io::stdin()
+            let bytes_read = reader
                 .read_line(&mut input)
                 .with_context(|| messages.error_prompt_read_failed())?;
+            if bytes_read == 0 {
+                anyhow::bail!(messages.error_prompt_read_failed());
+            }
             input
                 .trim()
                 .parse::<u32>()
@@ -72,13 +92,16 @@ pub(crate) fn prompt_unseal_keys_interactive(
     let mut keys = Vec::with_capacity(count as usize);
     for index in 1..=count {
         print!("Unseal key {index}/{count}: ");
-        io::stdout()
+        std::io::stdout()
             .flush()
             .with_context(|| messages.error_prompt_flush_failed())?;
         let mut input = String::new();
-        io::stdin()
+        let bytes_read = reader
             .read_line(&mut input)
             .with_context(|| messages.error_prompt_read_failed())?;
+        if bytes_read == 0 {
+            anyhow::bail!(messages.error_prompt_read_failed());
+        }
         keys.push(input.trim().to_string());
     }
     Ok(keys)
@@ -140,5 +163,21 @@ mod tests {
 
         let err = read_unseal_keys_from_file(&file_path, &test_messages()).unwrap_err();
         assert!(err.to_string().contains("Unseal key file is empty"));
+    }
+
+    // EOF while reading the threshold must error, not read as empty input.
+    #[test]
+    fn test_prompt_unseal_keys_errors_on_eof_reading_threshold() {
+        let mut reader = std::io::Cursor::new(b"".as_slice());
+        let result = prompt_unseal_keys_from_reader(None, &test_messages(), &mut reader);
+        assert!(result.is_err());
+    }
+
+    // EOF while collecting keys must error, not push an empty-string key.
+    #[test]
+    fn test_prompt_unseal_keys_errors_on_eof_reading_keys() {
+        let mut reader = std::io::Cursor::new(b"key-1\n".as_slice());
+        let result = prompt_unseal_keys_from_reader(Some(2), &test_messages(), &mut reader);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Fixes #685.

The interactive prompts called `read_line` and only checked for an I/O error, not the byte count. On a closed or non-TTY stdin `read_line` returns `Ok(0)`, which was treated as a successful empty read. In the validation loop that re-prompts on empty input, that meant an endless loop printing "Value is required" with no way out but killing the process.

This treats a zero-byte read as EOF and returns an error instead, so the prompt fails fast. The unseal-key prompt had the same pattern, so it's fixed too (refactored slightly to make it testable). Added regression tests for both.
