### PR TITLE
Refresh EAB from KV in remote fast-poll (#692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -659,6 +659,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   live value, so a running agent's next renewal binds with the new EAB
   (or without one) without a restart or re-bootstrap; the on-disk write
   precedes the in-memory update so a restart reloads a consistent value.
+  So that the cleared state is equally durable, `--eab-file` loading now
+  treats a configured-but-missing file as open enrollment (no EAB) instead
+  of a hard error, matching the absent-file representation both the
+  fast-poll clear and `bootroot-remote bootstrap` write; a restart or
+  SIGHUP after `rotate eab-clear` therefore loads the same `None` the
+  running process already used rather than failing to start.
   Partial or ambiguous payloads (one of `kid`/`hmac` empty) are rejected
   and retried on the next tick rather than recorded as applied. The
   refresh is scoped to the `--eab-file` artifact only: when EAB was pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -644,6 +644,28 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `apply-secret-id` and re-running `bootroot-remote bootstrap` remain the
   recovery paths for an agent that went offline past its
   `secret_id_ttl`.
+- Extended the remote `bootroot-agent` fast-poll loop to refresh the
+  per-service ACME **EAB** (`bootroot/services/<service>/eab`) from
+  OpenBao KV, completing the set of per-service dynamic secrets the loop
+  self-heals alongside trust, `secret_id`, and the HTTP responder HMAC.
+  Unlike the others, remote EAB does not live in `agent.toml`; its
+  canonical representation is the standalone `eab.json` (`--eab-file`)
+  plus the in-memory `default_eab`. A version-gated **EAB poll** applies a
+  new KV version at most once: a populated `{ "kid", "hmac" }` payload
+  rewrites `eab.json` at `0o600` and publishes the value into a shared
+  `watch`-backed `default_eab`, while the explicit clear shape
+  `{ "kid": "", "hmac": "" }` removes `eab.json` and clears `default_eab`.
+  Both the periodic-check and force-reissue renewal paths now read this
+  live value, so a running agent's next renewal binds with the new EAB
+  (or without one) without a restart or re-bootstrap; the on-disk write
+  precedes the in-memory update so a restart reloads a consistent value.
+  Partial or ambiguous payloads (one of `kid`/`hmac` empty) are rejected
+  and retried on the next tick rather than recorded as applied. The
+  refresh is scoped to the `--eab-file` artifact only: when EAB was pinned
+  via explicit `--eab-kid`/`--eab-hmac` CLI values the poll is a no-op and
+  never overrides the operator's out-of-band value. `rotate eab-clear` on
+  a `remote-bootstrap` service no longer requires a manual re-bootstrap to
+  reach the running agent.
 - Self-rotation for the rotate AppRole credentials
   (`bootroot-runtime-rotate-role`, `bootroot-infra-rotate-role`). Each
   rotate policy now grants `update` on its own

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -1287,9 +1287,9 @@ the previously-rendered value until the agent process restarts
 - For services with `--delivery-mode remote-bootstrap`: emits
   operator guidance only. No OpenBao Agent sidecar runs on the remote
   host (issue #680 moved it to the `bootroot-agent` self-auth
-  fast-poll model). Trust and secret_id self-heal via fast-poll, but
-  bootstrap-time KV config such as EAB is not fast-polled — re-run
-  `bootroot-remote bootstrap` on the remote host to re-pull it from KV.
+  fast-poll model). Trust, secret_id, the HTTP responder HMAC, and EAB
+  self-heal via the `bootroot-agent` fast-poll loop within
+  `fast_poll_interval` — no re-bootstrap required.
 
 ### Failure conditions
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -1236,9 +1236,9 @@ consul-template은 에이전트 프로세스가 재시작될 때까지 이전에
 - `--delivery-mode remote-bootstrap` 서비스: 운영자 안내 메시지만
   출력합니다. 원격 호스트에는 OpenBao Agent 사이드카가 실행되지
   않습니다(이슈 #680에서 `bootroot-agent` self-auth fast-poll 모델로
-  이동). trust와 secret_id는 fast-poll로 자가 치유되지만 EAB 같은
-  부트스트랩 시점 KV 설정은 fast-poll 대상이 아니므로, 원격 호스트에서
-  `bootroot-remote bootstrap`을 다시 실행해 KV에서 다시 받아와야 합니다.
+  이동). trust, secret_id, HTTP responder HMAC, EAB 모두 `bootroot-agent`
+  fast-poll 루프를 통해 `fast_poll_interval` 이내에 자가 치유되므로,
+  재부트스트랩이 필요하지 않습니다.
 
 ### 실패 조건
 

--- a/src/bin/bootroot-agent.rs
+++ b/src/bin/bootroot-agent.rs
@@ -34,6 +34,18 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let cli_overrides = CliOverrides::from(&args);
+    // EAB source precedence is CLI `--eab-kid`/`--eab-hmac` (explicit) →
+    // `--eab-file` (`eab.json`) → agent.toml `[eab]`. Fast-poll EAB refresh is
+    // meaningful only for the `--eab-file` remote-bootstrap artifact: when both
+    // CLI values are set the operator has pinned EAB out of band, so refresh
+    // must be a no-op and never override them. `args` is fixed for the process
+    // lifetime, so this holds across HUP reloads too.
+    let eab_cli_pinned = args.eab_kid.is_some() && args.eab_hmac.is_some();
+    let eab_refresh_path = if eab_cli_pinned {
+        None
+    } else {
+        args.eab_file.clone()
+    };
     let mut pending = None;
     #[cfg(unix)]
     let mut hup = signal(SignalKind::hangup())?;
@@ -47,6 +59,7 @@ async fn main() -> anyhow::Result<()> {
         let mut task = tokio::spawn(run_daemon(
             Arc::clone(&settings),
             final_eab,
+            eab_refresh_path.clone(),
             args.config.clone(),
             args.insecure,
             cli_overrides.clone(),

--- a/src/bin/bootroot-remote/io.rs
+++ b/src/bin/bootroot-remote/io.rs
@@ -106,27 +106,31 @@ pub(super) async fn write_secret_file(path: &Path, contents: &str) -> Result<App
     Ok(ApplyStatus::Applied)
 }
 
+/// Writes the service `eab.json` via the shared library writer
+/// ([`bootroot::eab::write_eab_file`]) so the bootstrap producer and the
+/// fast-poll consumer cannot drift on the on-disk shape. Maps the writer's
+/// changed/unchanged bool onto the bootstrap [`ApplyStatus`].
 pub(super) async fn write_eab_file(path: &Path, kid: &str, hmac: &str) -> Result<ApplyStatus> {
-    let payload = serde_json::to_string_pretty(&serde_json::json!({
-        "kid": kid,
-        "hmac": hmac
-    }))?;
-    write_secret_file(path, &payload).await
+    let changed = bootroot::eab::write_eab_file(path, kid, hmac).await?;
+    Ok(if changed {
+        ApplyStatus::Applied
+    } else {
+        ApplyStatus::Unchanged
+    })
 }
 
 /// Removes a stale EAB file that was written by a previous bootstrap so
 /// that `bootroot-agent --eab-file` cannot pick up credentials the
-/// operator has since cleared from `OpenBao`. Returns [`ApplyStatus::Applied`]
-/// when the file existed and was removed and [`ApplyStatus::Skipped`] when
-/// the file was already absent.
+/// operator has since cleared from `OpenBao`. Delegates to the shared library
+/// remover and maps its removed/absent bool onto [`ApplyStatus::Applied`] /
+/// [`ApplyStatus::Skipped`].
 pub(super) async fn remove_eab_file(path: &Path) -> Result<ApplyStatus> {
-    match fs::remove_file(path).await {
-        Ok(()) => Ok(ApplyStatus::Applied),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(ApplyStatus::Skipped),
-        Err(err) => {
-            Err(err).with_context(|| format!("Failed to remove stale EAB file: {}", path.display()))
-        }
-    }
+    let removed = bootroot::eab::remove_eab_file(path).await?;
+    Ok(if removed {
+        ApplyStatus::Applied
+    } else {
+        ApplyStatus::Skipped
+    })
 }
 
 #[derive(Debug)]

--- a/src/commands/service/openbao_sidecar_refresh.rs
+++ b/src/commands/service/openbao_sidecar_refresh.rs
@@ -33,10 +33,8 @@ pub(crate) fn run_service_openbao_sidecar_refresh(
 /// re-reads its KV sources; `RemoteBootstrap` has **no** `OpenBao` Agent
 /// sidecar on the remote host (issue #680 moved it to the `bootroot-agent`
 /// self-auth fast-poll model), so it emits guidance instead. Trust,
-/// `secret_id`, and the HTTP responder HMAC self-heal via fast-poll, but EAB
-/// and other bootstrap-time KV config are only re-pulled by re-running
-/// `bootroot-remote bootstrap` on the remote host — the sidecar restart no
-/// longer applies.
+/// `secret_id`, the HTTP responder HMAC, and EAB all self-heal via the remote
+/// fast-poll loop within `fast_poll_interval`, so no re-bootstrap is required.
 pub(crate) fn refresh_service_sidecar(entry: &ServiceEntry, messages: &Messages) -> Result<()> {
     match entry.delivery_mode {
         DeliveryMode::LocalFile => {
@@ -55,7 +53,7 @@ pub(crate) fn refresh_service_sidecar(entry: &ServiceEntry, messages: &Messages)
         }
         DeliveryMode::RemoteBootstrap => {
             println!(
-                "service {svc} uses remote-bootstrap delivery; no OpenBao Agent sidecar runs on the remote host. Trust, secret_id, and the HTTP responder HMAC self-heal via the bootroot-agent fast-poll loop, but bootstrap-time KV config (e.g. EAB) is not fast-polled — re-run `bootroot-remote bootstrap` on the remote host to re-pull it from KV.",
+                "service {svc} uses remote-bootstrap delivery; no OpenBao Agent sidecar runs on the remote host. Trust, secret_id, the HTTP responder HMAC, and EAB self-heal via the bootroot-agent fast-poll loop within fast_poll_interval — no re-bootstrap required.",
                 svc = entry.service_name
             );
             Ok(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -68,6 +68,7 @@ impl Default for ProfileLocks {
 pub(crate) async fn run_daemon(
     settings: Arc<config::Settings>,
     default_eab: Option<eab::EabCredentials>,
+    eab_refresh_path: Option<PathBuf>,
     config_path: Option<PathBuf>,
     insecure_mode: bool,
     cli_overrides: config::CliOverrides,
@@ -82,6 +83,15 @@ pub(crate) async fn run_daemon(
         cli_overrides,
     };
 
+    // `default_eab` becomes shared, live-readable state: both the periodic
+    // check loop and the fast-poll force-reissue path read the current value
+    // at issuance time, and the fast-poll loop updates it in place when it
+    // observes a newer `eab` KV version. The sender is handed to the fast-poll
+    // loop only when EAB is sourced from `--eab-file` (`eab_refresh_path` is
+    // `Some`); otherwise it is dropped and the value stays fixed at startup.
+    let (eab_tx, eab_rx) = watch::channel(default_eab);
+    let shared_eab = eab::SharedEab::from_receiver(eab_rx);
+
     let shutdown_handle = tokio::spawn(async move {
         if let Err(err) = wait_for_shutdown().await {
             error!("Shutdown signal handler error: {err}");
@@ -95,14 +105,14 @@ pub(crate) async fn run_daemon(
         let semaphore = Arc::clone(&semaphore);
         let profile_locks = Arc::clone(&profile_locks);
         let shutdown_rx = shutdown_rx.clone();
-        let default_eab = default_eab.clone();
+        let shared_eab = shared_eab.clone();
         let runtime = runtime.clone();
 
         handles.push(tokio::spawn(async move {
             run_profile_daemon(
                 settings,
                 profile,
-                default_eab,
+                shared_eab,
                 semaphore,
                 profile_locks,
                 shutdown_rx,
@@ -115,25 +125,29 @@ pub(crate) async fn run_daemon(
     if settings.openbao.is_some() {
         let settings_for_loop = Arc::clone(&settings);
         let settings_for_renew = Arc::clone(&settings);
-        let default_eab_for_fast = default_eab.clone();
+        let shared_eab_for_renew = shared_eab.clone();
         let semaphore_for_fast = Arc::clone(&semaphore);
         let profile_locks_for_fast = Arc::clone(&profile_locks);
         let shutdown_rx_fast = shutdown_rx.clone();
         let config_path_for_fast = runtime.config_path.clone();
         let runtime_for_renew = runtime.clone();
+        let eab_refresh = eab_refresh_path.map(|path| fast_poll::EabRefreshHandle {
+            path,
+            sender: eab_tx,
+        });
         handles.push(tokio::spawn(async move {
             let renew = move |profile: config::DaemonProfileSettings,
-                              default_eab: Option<eab::EabCredentials>,
                               semaphore: Arc<Semaphore>|
                   -> fast_poll::BoxRenew {
                 let settings = Arc::clone(&settings_for_renew);
                 let profile_locks = Arc::clone(&profile_locks_for_fast);
                 let runtime = runtime_for_renew.clone();
+                let shared_eab = shared_eab_for_renew.clone();
                 Box::pin(async move {
                     force_renew_profile(
                         &settings,
                         &profile,
-                        default_eab,
+                        shared_eab.current(),
                         semaphore,
                         &profile_locks,
                         &runtime,
@@ -144,7 +158,7 @@ pub(crate) async fn run_daemon(
             fast_poll::run_fast_poll_loop(
                 settings_for_loop,
                 config_path_for_fast,
-                default_eab_for_fast,
+                eab_refresh,
                 semaphore_for_fast,
                 shutdown_rx_fast,
                 renew,
@@ -160,7 +174,7 @@ pub(crate) async fn run_daemon(
 async fn run_profile_daemon(
     settings: Arc<config::Settings>,
     profile: config::DaemonProfileSettings,
-    default_eab: Option<eab::EabCredentials>,
+    shared_eab: eab::SharedEab,
     semaphore: Arc<Semaphore>,
     profile_locks: Arc<ProfileLocks>,
     mut shutdown: watch::Receiver<bool>,
@@ -202,7 +216,7 @@ async fn run_profile_daemon(
                 check_and_renew_profile(
                     &settings,
                     &profile,
-                    default_eab.clone(),
+                    shared_eab.current(),
                     Arc::clone(&semaphore),
                     &profile_locks,
                     renew_before,

--- a/src/eab.rs
+++ b/src/eab.rs
@@ -1,15 +1,114 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
+use tokio::sync::watch;
 use tracing::warn;
+
+use crate::fs_util;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EabCredentials {
     pub kid: String,
     #[serde(alias = "key")]
     pub hmac: String,
+}
+
+/// Live, shared view of the daemon's `default_eab`.
+///
+/// `default_eab` is read at issuance time by both the periodic check loop and
+/// the fast-poll force-reissue path. Backing it with a `watch` channel lets
+/// the remote fast-poll loop update the value in place when it observes a
+/// newer `eab` KV version, so a running renewal reflects the change without a
+/// restart. Cloning shares the same underlying channel.
+#[derive(Clone)]
+pub struct SharedEab {
+    rx: watch::Receiver<Option<EabCredentials>>,
+}
+
+impl SharedEab {
+    /// Wraps a `watch` receiver as a shared, live-readable EAB view.
+    #[must_use]
+    pub fn from_receiver(rx: watch::Receiver<Option<EabCredentials>>) -> Self {
+        Self { rx }
+    }
+
+    /// Returns the current `default_eab` value, cloned for the caller.
+    #[must_use]
+    pub fn current(&self) -> Option<EabCredentials> {
+        self.rx.borrow().clone()
+    }
+}
+
+/// Writes EAB credentials to `path` as pretty `{ "kid", "hmac" }` JSON at
+/// key-file permissions (`0o600`), creating the parent secrets directory when
+/// needed. Returns `true` when the on-disk bytes changed and `false` when the
+/// file already held identical content.
+///
+/// Shared by `bootroot-remote bootstrap` and the remote fast-poll loop so the
+/// producer and the `--eab-file` consumer cannot drift on the on-disk shape.
+///
+/// # Errors
+///
+/// Returns an error when the parent directory, the existing file, or the write
+/// cannot be created, read, or written.
+pub async fn write_eab_file(path: &Path, kid: &str, hmac: &str) -> anyhow::Result<bool> {
+    let payload = serde_json::to_string_pretty(&serde_json::json!({
+        "kid": kid,
+        "hmac": hmac,
+    }))
+    .context("Failed to serialize EAB credentials")?;
+    write_key_file(path, &payload).await
+}
+
+/// Writes `contents` (newline-terminated) to a `0o600` key file idempotently,
+/// mirroring the bootstrap `write_secret_file` behaviour so a first-sighting
+/// re-write from the fast-poll loop is byte-identical to the bootstrap writer.
+async fn write_key_file(path: &Path, contents: &str) -> anyhow::Result<bool> {
+    if let Some(parent) = path.parent() {
+        fs_util::ensure_secrets_dir(parent).await?;
+    }
+    let next = if contents.ends_with('\n') {
+        contents.to_string()
+    } else {
+        format!("{contents}\n")
+    };
+    let current = match fs::read_to_string(path).await {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("Failed to read existing EAB file: {}", path.display()));
+        }
+    };
+    if current == next {
+        fs_util::set_key_permissions(path).await?;
+        return Ok(false);
+    }
+    fs::write(path, next)
+        .await
+        .with_context(|| format!("Failed to write EAB file: {}", path.display()))?;
+    fs_util::set_key_permissions(path).await?;
+    Ok(true)
+}
+
+/// Removes a stale `eab.json` written by a previous bootstrap or fast-poll
+/// apply so that `bootroot-agent --eab-file` cannot pick up credentials the
+/// operator has since cleared from `OpenBao`. Returns `true` when a file
+/// existed and was removed and `false` when it was already absent.
+///
+/// # Errors
+///
+/// Returns an error when the file exists but cannot be removed.
+pub async fn remove_eab_file(path: &Path) -> anyhow::Result<bool> {
+    match fs::remove_file(path).await {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => {
+            Err(err).with_context(|| format!("Failed to remove stale EAB file: {}", path.display()))
+        }
+    }
 }
 
 /// Loads EAB credentials from CLI arguments or a JSON file.
@@ -119,5 +218,58 @@ mod tests {
         let result = load_credentials(None, None, None).await;
         let creds = result.unwrap();
         assert!(creds.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_eab_file_roundtrips_through_load_credentials() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secrets").join("eab.json");
+
+        let changed = write_eab_file(&path, "kid-1", "hmac-1").await.unwrap();
+        assert!(changed);
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        let creds = load_credentials(None, None, Some(path.clone()))
+            .await
+            .unwrap()
+            .expect("credentials present");
+        assert_eq!(creds.kid, "kid-1");
+        assert_eq!(creds.hmac, "hmac-1");
+
+        // A re-write of the identical content reports no change.
+        let changed_again = write_eab_file(&path, "kid-1", "hmac-1").await.unwrap();
+        assert!(!changed_again);
+    }
+
+    #[tokio::test]
+    async fn remove_eab_file_reports_removed_then_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("eab.json");
+        write_eab_file(&path, "kid-1", "hmac-1").await.unwrap();
+
+        assert!(remove_eab_file(&path).await.unwrap());
+        assert!(!remove_eab_file(&path).await.unwrap());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn shared_eab_reflects_sender_updates() {
+        let (tx, rx) = watch::channel(None);
+        let shared = SharedEab::from_receiver(rx);
+        assert!(shared.current().is_none());
+
+        tx.send_replace(Some(EabCredentials {
+            kid: "kid-1".to_string(),
+            hmac: "hmac-1".to_string(),
+        }));
+        let current = shared.current().expect("value present after update");
+        assert_eq!(current.kid, "kid-1");
+
+        tx.send_replace(None);
+        assert!(shared.current().is_none());
     }
 }

--- a/src/eab.rs
+++ b/src/eab.rs
@@ -113,10 +113,15 @@ pub async fn remove_eab_file(path: &Path) -> anyhow::Result<bool> {
 
 /// Loads EAB credentials from CLI arguments or a JSON file.
 ///
+/// A configured `--eab-file` that does not exist resolves to `None` (open
+/// enrollment): an absent file is the durable cleared representation written by
+/// `bootroot-remote bootstrap` and the fast-poll `eab-clear` apply.
+///
 /// # Errors
 ///
 /// Returns an error if:
-/// - The file path is provided but cannot be read.
+/// - The file path is provided and exists but cannot be read (e.g.
+///   permissions).
 /// - The file content is not valid JSON.
 pub async fn load_credentials(
     cli_kid: Option<String>,
@@ -130,11 +135,19 @@ pub async fn load_credentials(
 
     // 2. Try loading from file
     if let Some(path) = file_path {
-        // Read file directly. If it fails (e.g. not found), we return Error.
-        // This fixes "collapsible_if" and improves UX (explicit failure).
-        let content = fs::read_to_string(&path)
-            .await
-            .context("Failed to read EAB file")?;
+        // An absent `--eab-file` is the durable "no EAB" representation on
+        // remote hosts: `bootroot-remote bootstrap` removes `eab.json` when KV
+        // holds no EAB, and the fast-poll loop removes it on an `eab-clear`. So
+        // a configured-but-missing file means open enrollment, not a hard
+        // error -- otherwise a restart or SIGHUP after a clear would fail to
+        // load even though the running process was already using no EAB, which
+        // would break the "durable across restart" contract. Other read
+        // failures (permissions, etc.) still surface as errors.
+        let content = match fs::read_to_string(&path).await {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err).context("Failed to read EAB file"),
+        };
 
         if content.trim().is_empty() {
             return Ok(None);
@@ -202,16 +215,33 @@ mod tests {
     }
     #[tokio::test]
     async fn test_load_credentials_file_not_found() {
-        // Path that definitely doesn't exist
+        // A configured-but-missing `--eab-file` is the durable cleared
+        // representation, so the loader reports no credentials (open
+        // enrollment) rather than erroring.
         let path = PathBuf::from("/non/existent/path/for/bootroot/test.json");
-        let result = load_credentials(None, None, Some(path)).await;
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Failed to read EAB file")
-        );
+        let result = load_credentials(None, None, Some(path)).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_credentials_after_clear_returns_none() {
+        // Regression for the restart/SIGHUP path after `rotate eab-clear`:
+        // once the fast-poll loop (or bootstrap) removes `eab.json`, the same
+        // startup load path must resolve to `None` so a restart is consistent
+        // with the running process's cleared `default_eab`.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secrets").join("eab.json");
+
+        write_eab_file(&path, "kid-1", "hmac-1").await.unwrap();
+        let loaded = load_credentials(None, None, Some(path.clone()))
+            .await
+            .unwrap()
+            .expect("credentials present before clear");
+        assert_eq!(loaded.kid, "kid-1");
+
+        assert!(remove_eab_file(&path).await.unwrap());
+        let after_clear = load_credentials(None, None, Some(path)).await.unwrap();
+        assert!(after_clear.is_none());
     }
     #[tokio::test]
     async fn test_load_credentials_none() {

--- a/src/fast_poll.rs
+++ b/src/fast_poll.rs
@@ -27,13 +27,16 @@ use tokio::sync::{Mutex, Semaphore, watch};
 use tracing::{debug, error, info, warn};
 
 use crate::cert_group::CertGroupPolicy;
-use crate::kv_payload::{TrustPayload, parse_responder_hmac, parse_secret_id, parse_trust_payload};
+use crate::kv_payload::{
+    EabPayload, TrustPayload, parse_eab_payload, parse_responder_hmac, parse_secret_id,
+    parse_trust_payload,
+};
 use crate::openbao::{KvReadWithVersion, OpenBaoClient};
 use crate::trust_bootstrap::{
     ACME_SECTION, REISSUE_COMPLETED_AT_KEY, REISSUE_COMPLETED_VERSION_KEY,
-    REISSUE_REQUESTED_AT_KEY, REISSUE_REQUESTER_KEY, SERVICE_KV_BASE, SERVICE_REISSUE_KV_SUFFIX,
-    SERVICE_RESPONDER_HMAC_KV_SUFFIX, SERVICE_SECRET_ID_KV_SUFFIX, SERVICE_TRUST_KV_SUFFIX,
-    build_responder_hmac_updates, build_trust_updates,
+    REISSUE_REQUESTED_AT_KEY, REISSUE_REQUESTER_KEY, SERVICE_EAB_KV_SUFFIX, SERVICE_KV_BASE,
+    SERVICE_REISSUE_KV_SUFFIX, SERVICE_RESPONDER_HMAC_KV_SUFFIX, SERVICE_SECRET_ID_KV_SUFFIX,
+    SERVICE_TRUST_KV_SUFFIX, build_responder_hmac_updates, build_trust_updates,
 };
 use crate::{config, eab, fs_util, toml_util};
 
@@ -139,6 +142,12 @@ pub(crate) struct FastPollState {
     /// the current KV HMAC (idempotent when it already matches).
     #[serde(default)]
     pub(crate) last_responder_hmac_seen_version: BTreeMap<String, u64>,
+    /// Highest KV version of the per-service `eab` path already applied to the
+    /// on-disk `eab.json` + the in-memory `default_eab`. Missing entries mean
+    /// "never refreshed", so the first sighting applies the current KV EAB
+    /// (idempotent when it already matches).
+    #[serde(default)]
+    pub(crate) last_eab_seen_version: BTreeMap<String, u64>,
 }
 
 /// Partial fan-out progress for a fast-poll-triggered renewal that
@@ -267,6 +276,17 @@ pub(crate) trait FastPollHooks: Send + Sync {
         service: &str,
         hmac: &str,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
+
+    /// Applies a rotated or cleared EAB for `service`: writes (populated) or
+    /// removes (clear) the on-disk `eab.json` and updates the in-memory
+    /// `default_eab` so the next renewal binds with the new EAB, or without
+    /// one. Durable-first: the on-disk write precedes the in-memory update so
+    /// a restart reloads a value consistent with the running process.
+    fn apply_eab(
+        &self,
+        service: &str,
+        payload: &EabPayload,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
 }
 
 /// Decides whether an observed KV read should trigger a renewal, and
@@ -378,6 +398,12 @@ pub(crate) fn secret_id_kv_path(service_name: &str) -> String {
 #[must_use]
 pub(crate) fn responder_hmac_kv_path(service_name: &str) -> String {
     format!("{SERVICE_KV_BASE}/{service_name}/{SERVICE_RESPONDER_HMAC_KV_SUFFIX}")
+}
+
+/// Builds the KV path `<SERVICE_KV_BASE>/<service>/<SERVICE_EAB_KV_SUFFIX>`.
+#[must_use]
+pub(crate) fn eab_kv_path(service_name: &str) -> String {
+    format!("{SERVICE_KV_BASE}/{service_name}/{SERVICE_EAB_KV_SUFFIX}")
 }
 
 /// Reports whether an observed KV version is newer than the last one the
@@ -635,6 +661,88 @@ pub(crate) async fn run_responder_hmac_poll_tick<H: FastPollHooks + ?Sized>(
             Ok(()) => {
                 state
                     .last_responder_hmac_seen_version
+                    .insert(service_name.clone(), read.version);
+                state_changed = true;
+                outcomes.push(PollApplyOutcome::Applied {
+                    service: service_name.clone(),
+                    version: read.version,
+                });
+            }
+            Err(err) => {
+                outcomes.push(PollApplyOutcome::ApplyError {
+                    service: service_name.clone(),
+                    version: read.version,
+                    error: format!("{err:#}"),
+                });
+            }
+        }
+    }
+
+    (outcomes, state_changed)
+}
+
+/// Runs a single `eab` poll tick: for each unique service, reads the
+/// per-service `eab` KV path, and on a newer version applies it via the hook —
+/// writing `eab.json` + refreshing the in-memory `default_eab` for a populated
+/// payload, or removing `eab.json` + clearing `default_eab` for the explicit
+/// clear shape. Version-gated and idempotent in steady state.
+///
+/// Only meaningful when EAB is sourced from `--eab-file` (the remote-bootstrap
+/// artifact); the caller gates this tick out entirely when the operator pinned
+/// EAB via explicit `--eab-*` CLI values.
+pub(crate) async fn run_eab_poll_tick<H: FastPollHooks + ?Sized>(
+    hooks: &H,
+    kv_mount: &str,
+    services: &[(String, Vec<String>)],
+    state: &mut FastPollState,
+) -> (Vec<PollApplyOutcome>, bool) {
+    let mut outcomes = Vec::with_capacity(services.len());
+    let mut state_changed = false;
+
+    for (service_name, _profiles) in services {
+        let kv_path = eab_kv_path(service_name);
+        let read = match hooks.read_kv_version(kv_mount, &kv_path).await {
+            Ok(Some(read)) => read,
+            Ok(None) => {
+                outcomes.push(PollApplyOutcome::NoData {
+                    service: service_name.clone(),
+                });
+                continue;
+            }
+            Err(err) => {
+                outcomes.push(PollApplyOutcome::ReadError {
+                    service: service_name.clone(),
+                    error: format!("{err:#}"),
+                });
+                continue;
+            }
+        };
+
+        let last_seen = state.last_eab_seen_version.get(service_name).copied();
+        if !version_advanced(read.version, last_seen) {
+            outcomes.push(PollApplyOutcome::UpToDate {
+                service: service_name.clone(),
+                version: read.version,
+            });
+            continue;
+        }
+
+        let payload = match parse_eab_payload(&read.data) {
+            Ok(payload) => payload,
+            Err(err) => {
+                outcomes.push(PollApplyOutcome::Malformed {
+                    service: service_name.clone(),
+                    version: read.version,
+                    error: format!("{err:#}"),
+                });
+                continue;
+            }
+        };
+
+        match hooks.apply_eab(service_name, &payload).await {
+            Ok(()) => {
+                state
+                    .last_eab_seen_version
                     .insert(service_name.clone(), read.version);
                 state_changed = true;
                 outcomes.push(PollApplyOutcome::Applied {
@@ -1026,6 +1134,23 @@ pub(crate) enum FastPollTickOutcome {
     },
 }
 
+/// The on-disk `eab.json` path plus the sender half of the shared
+/// `default_eab` watch channel the remote fast-poll loop uses to persist and
+/// publish an EAB refresh.
+///
+/// Present only when EAB is sourced from `--eab-file` (the remote-bootstrap
+/// artifact). When the agent was started with explicit `--eab-*` CLI values
+/// the operator has pinned EAB out of band, so the daemon passes `None` and
+/// the fast-poll loop never overrides it.
+pub(crate) struct EabRefreshHandle {
+    /// On-disk `eab.json` path (`--eab-file`) written on a populated refresh
+    /// and removed on a clear.
+    pub(crate) path: PathBuf,
+    /// Publishes the refreshed value into the shared `default_eab` so running
+    /// renewals read it without a restart.
+    pub(crate) sender: watch::Sender<Option<eab::EabCredentials>>,
+}
+
 /// Attaches an [`OpenBaoClient`] + renewal trigger to the generic
 /// [`FastPollHooks`] trait so the daemon can drive [`run_fast_poll_tick`]
 /// against live infrastructure.
@@ -1039,6 +1164,8 @@ pub(crate) struct LiveFastPollHooks<F> {
     pub(crate) config_path: PathBuf,
     /// Resolved `AppRole` `secret_id` file rewritten by the `secret_id` apply.
     pub(crate) secret_id_path: PathBuf,
+    /// EAB refresh target, present only when EAB is sourced from `--eab-file`.
+    pub(crate) eab_refresh: Option<EabRefreshHandle>,
 }
 
 /// Writes the CA bundle and upserts the `agent.toml` `[trust]` section for a
@@ -1096,6 +1223,38 @@ async fn apply_responder_hmac_to_disk(config_path: &Path, hmac: &str) -> Result<
     fs_util::atomic_write(config_path, updated.as_bytes(), fs_util::KEY_FILE_MODE)
         .await
         .with_context(|| format!("Failed to write agent config to {}", config_path.display()))?;
+    Ok(())
+}
+
+/// Applies a rotated or cleared EAB observed on the fast-poll loop.
+///
+/// Durable-first ordering: the on-disk `eab.json` is written (populated) or
+/// removed (clear) *before* the in-memory `default_eab` is updated, so a crash
+/// between the two leaves the on-disk state ahead of — never behind — the
+/// running process, and the version is only advanced by the caller when this
+/// returns `Ok`. The `default_eab` update goes through the shared `watch`
+/// sender so both the periodic-check and force-reissue paths read the current
+/// value at their next issuance without a restart.
+async fn apply_eab_to_state(handle: &EabRefreshHandle, payload: &EabPayload) -> Result<()> {
+    match payload {
+        EabPayload::Populated { kid, hmac } => {
+            eab::write_eab_file(&handle.path, kid, hmac)
+                .await
+                .with_context(|| {
+                    format!("Failed to write eab.json to {}", handle.path.display())
+                })?;
+            handle.sender.send_replace(Some(eab::EabCredentials {
+                kid: kid.clone(),
+                hmac: hmac.clone(),
+            }));
+        }
+        EabPayload::Clear => {
+            eab::remove_eab_file(&handle.path).await.with_context(|| {
+                format!("Failed to remove eab.json at {}", handle.path.display())
+            })?;
+            handle.sender.send_replace(None);
+        }
+    }
     Ok(())
 }
 
@@ -1184,6 +1343,22 @@ where
         let hmac = hmac.to_string();
         Box::pin(async move { apply_responder_hmac_to_disk(&config_path, &hmac).await })
     }
+
+    fn apply_eab(
+        &self,
+        _service: &str,
+        payload: &EabPayload,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        let payload = payload.clone();
+        Box::pin(async move {
+            // Only reachable when the loop enabled the EAB poll, which it does
+            // only with an `--eab-file` source (so `eab_refresh` is `Some`).
+            let handle = self.eab_refresh.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("EAB refresh requested but no --eab-file source is configured")
+            })?;
+            apply_eab_to_state(handle, &payload).await
+        })
+    }
 }
 
 /// Spawns the long-running fast-poll loop. Returns immediately when the
@@ -1196,17 +1371,10 @@ where
 pub(crate) async fn run_fast_poll_loop(
     settings: Arc<config::Settings>,
     config_path: PathBuf,
-    default_eab: Option<eab::EabCredentials>,
+    eab_refresh: Option<EabRefreshHandle>,
     semaphore: Arc<Semaphore>,
     mut shutdown: watch::Receiver<bool>,
-    renew_fn: impl Fn(
-        config::DaemonProfileSettings,
-        Option<eab::EabCredentials>,
-        Arc<Semaphore>,
-    ) -> BoxRenew
-    + Send
-    + Sync
-    + 'static,
+    renew_fn: impl Fn(config::DaemonProfileSettings, Arc<Semaphore>) -> BoxRenew + Send + Sync + 'static,
 ) -> Result<()> {
     let Some(openbao) = settings.openbao.clone() else {
         info!("No [openbao] section configured; fast-poll loop disabled.");
@@ -1257,10 +1425,14 @@ pub(crate) async fn run_fast_poll_loop(
         warn!("Initial OpenBao AppRole login failed: {err:#}. Will retry on the next tick.");
     }
 
+    // The EAB poll runs only when EAB is sourced from `--eab-file`; a
+    // CLI-pinned EAB gets `None` here so fast-poll never overrides the
+    // operator's out-of-band value.
+    let refresh_eab = eab_refresh.is_some();
+
     let renew_fn = Arc::new(renew_fn);
     let settings_for_hooks = Arc::clone(&settings);
     let settings_for_apply = Arc::clone(&settings);
-    let default_eab_for_hooks = default_eab.clone();
     let semaphore_for_hooks = Arc::clone(&semaphore);
     let renew_fn_for_hooks = Arc::clone(&renew_fn);
     let hooks = LiveFastPollHooks {
@@ -1268,9 +1440,9 @@ pub(crate) async fn run_fast_poll_loop(
         settings: settings_for_apply,
         config_path,
         secret_id_path: openbao.secret_id_path.clone(),
+        eab_refresh,
         trigger: move |profile_label: String| {
             let settings = Arc::clone(&settings_for_hooks);
-            let default_eab = default_eab_for_hooks.clone();
             let semaphore = Arc::clone(&semaphore_for_hooks);
             let renew_fn = Arc::clone(&renew_fn_for_hooks);
             async move {
@@ -1284,7 +1456,7 @@ pub(crate) async fn run_fast_poll_loop(
                         )
                     })?
                     .clone();
-                renew_fn(profile, default_eab, semaphore).await
+                renew_fn(profile, semaphore).await
             }
         },
     };
@@ -1296,6 +1468,19 @@ pub(crate) async fn run_fast_poll_loop(
         }
 
         let mut needs_relogin = false;
+
+        // Refresh EAB BEFORE the reissue tick. EAB lives in the in-memory
+        // `default_eab` (read at issuance time), not `agent.toml`, so applying
+        // it first means a reissue request visible in the same KV snapshot
+        // fans out to a renewal that already reads the fresh (or cleared) EAB.
+        // Gated on `refresh_eab`: skipped entirely when EAB is CLI-pinned.
+        let mut eab_changed = false;
+        if refresh_eab {
+            let (eab_outcomes, changed) =
+                run_eab_poll_tick(&hooks, &openbao.kv_mount, &services, &mut state).await;
+            log_poll_outcomes("eab", &eab_outcomes, &mut needs_relogin);
+            eab_changed = changed;
+        }
 
         // Refresh the responder HMAC BEFORE running the reissue tick. A
         // reissue request visible in the same KV snapshot triggers a
@@ -1453,7 +1638,11 @@ pub(crate) async fn run_fast_poll_loop(
             trust_applied = reconcile_trust_rebuild(&mut state, trust_versions_before, rebuilt_ok);
         }
 
-        if (report.state_changed || trust_applied || secret_id_changed || responder_hmac_changed)
+        if (report.state_changed
+            || trust_applied
+            || secret_id_changed
+            || responder_hmac_changed
+            || eab_changed)
             && let Err(err) = state.save(&openbao.state_path).await
         {
             error!(
@@ -1708,6 +1897,7 @@ mod tests {
         trust_applies: std::sync::Mutex<Vec<(String, TrustPayload)>>,
         secret_id_applies: std::sync::Mutex<Vec<(String, String)>>,
         responder_hmac_applies: std::sync::Mutex<Vec<(String, String)>>,
+        eab_applies: std::sync::Mutex<Vec<(String, EabPayload)>>,
         // Chronological log of ordering-sensitive hook calls
         // ("apply_responder_hmac:<svc>", "renew:<profile>") so tests can
         // assert the responder-HMAC write lands before the reissue-triggered
@@ -1729,6 +1919,7 @@ mod tests {
                 trust_applies: std::sync::Mutex::new(Vec::new()),
                 secret_id_applies: std::sync::Mutex::new(Vec::new()),
                 responder_hmac_applies: std::sync::Mutex::new(Vec::new()),
+                eab_applies: std::sync::Mutex::new(Vec::new()),
                 op_log: std::sync::Mutex::new(Vec::new()),
                 fail_applies: std::sync::atomic::AtomicBool::new(false),
             }
@@ -1869,6 +2060,24 @@ mod tests {
             Box::pin(async move {
                 if fail {
                     anyhow::bail!("simulated responder_hmac apply failure");
+                }
+                Ok(())
+            })
+        }
+
+        fn apply_eab(
+            &self,
+            service: &str,
+            payload: &EabPayload,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            self.eab_applies
+                .lock()
+                .unwrap()
+                .push((service.to_string(), payload.clone()));
+            let fail = self.fail_applies.load(std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move {
+                if fail {
+                    anyhow::bail!("simulated eab apply failure");
                 }
                 Ok(())
             })
@@ -2430,6 +2639,10 @@ mod tests {
             responder_hmac_kv_path("edge-proxy"),
             "bootroot/services/edge-proxy/http_responder_hmac"
         );
+        assert_eq!(
+            eab_kv_path("edge-proxy"),
+            "bootroot/services/edge-proxy/eab"
+        );
     }
 
     #[tokio::test]
@@ -2737,6 +2950,198 @@ mod tests {
             outcomes[0],
             PollApplyOutcome::Applied { version: 1, .. }
         ));
+    }
+
+    fn eab_read(version: u64, kid: &str, hmac: &str) -> KvReadWithVersion {
+        KvReadWithVersion {
+            version,
+            data: serde_json::json!({ "kid": kid, "hmac": hmac }),
+        }
+    }
+
+    #[tokio::test]
+    async fn eab_poll_applies_populated_on_new_version() {
+        let hooks = FakeHooks::new(vec![Ok(Some(eab_read(2, "kid-1", "hmac-1")))]);
+        let services = services_single("edge-proxy", "edge-proxy-domain");
+        let mut state = FastPollState::default();
+
+        let (outcomes, changed) = run_eab_poll_tick(&hooks, "secret", &services, &mut state).await;
+
+        assert!(changed);
+        assert!(matches!(
+            outcomes[0],
+            PollApplyOutcome::Applied { version: 2, .. }
+        ));
+        assert_eq!(state.last_eab_seen_version.get("edge-proxy"), Some(&2));
+        let applies = hooks.eab_applies.lock().unwrap();
+        assert_eq!(applies.len(), 1);
+        assert_eq!(applies[0].0, "edge-proxy");
+        assert_eq!(
+            applies[0].1,
+            EabPayload::Populated {
+                kid: "kid-1".to_string(),
+                hmac: "hmac-1".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn eab_poll_applies_clear_on_new_version() {
+        let hooks = FakeHooks::new(vec![Ok(Some(eab_read(3, "", "")))]);
+        let services = services_single("edge-proxy", "edge-proxy-domain");
+        let mut state = FastPollState::default();
+
+        let (outcomes, changed) = run_eab_poll_tick(&hooks, "secret", &services, &mut state).await;
+
+        assert!(changed);
+        assert!(matches!(
+            outcomes[0],
+            PollApplyOutcome::Applied { version: 3, .. }
+        ));
+        assert_eq!(state.last_eab_seen_version.get("edge-proxy"), Some(&3));
+        let applies = hooks.eab_applies.lock().unwrap();
+        assert_eq!(applies[0].1, EabPayload::Clear);
+    }
+
+    #[tokio::test]
+    async fn eab_poll_is_idempotent_when_version_unchanged() {
+        let hooks = FakeHooks::new(vec![Ok(Some(eab_read(2, "kid-1", "hmac-1")))]);
+        let services = services_single("edge-proxy", "edge-proxy-domain");
+        let mut state = FastPollState::default();
+        state
+            .last_eab_seen_version
+            .insert("edge-proxy".to_string(), 2);
+
+        let (outcomes, changed) = run_eab_poll_tick(&hooks, "secret", &services, &mut state).await;
+
+        assert!(!changed);
+        assert!(matches!(
+            outcomes[0],
+            PollApplyOutcome::UpToDate { version: 2, .. }
+        ));
+        assert!(hooks.eab_applies.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn eab_poll_skips_malformed_partial_payload_without_advancing() {
+        // Partial shape (kid without hmac) must be rejected, not treated as a
+        // clear, and the version must not advance so a corrected control-plane
+        // write is retried.
+        let hooks = FakeHooks::new(vec![Ok(Some(KvReadWithVersion {
+            version: 5,
+            data: serde_json::json!({ "kid": "kid-1", "hmac": "" }),
+        }))]);
+        let services = services_single("edge-proxy", "edge-proxy-domain");
+        let mut state = FastPollState::default();
+
+        let (outcomes, changed) = run_eab_poll_tick(&hooks, "secret", &services, &mut state).await;
+
+        assert!(!changed);
+        assert!(matches!(
+            outcomes[0],
+            PollApplyOutcome::Malformed { version: 5, .. }
+        ));
+        assert!(state.last_eab_seen_version.is_empty());
+        assert!(hooks.eab_applies.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn eab_poll_does_not_advance_when_apply_fails() {
+        let hooks = FakeHooks::new(vec![Ok(Some(eab_read(3, "kid-1", "hmac-1")))]).fail_applies();
+        let services = services_single("edge-proxy", "edge-proxy-domain");
+        let mut state = FastPollState::default();
+
+        let (outcomes, changed) = run_eab_poll_tick(&hooks, "secret", &services, &mut state).await;
+
+        assert!(!changed);
+        assert!(matches!(
+            outcomes[0],
+            PollApplyOutcome::ApplyError { version: 3, .. }
+        ));
+        assert!(state.last_eab_seen_version.is_empty());
+    }
+
+    #[tokio::test]
+    async fn eab_poll_reports_no_data_when_kv_missing() {
+        let hooks = FakeHooks::new(vec![Ok(None)]);
+        let services = services_single("edge-proxy", "edge-proxy-domain");
+        let mut state = FastPollState::default();
+
+        let (outcomes, changed) = run_eab_poll_tick(&hooks, "secret", &services, &mut state).await;
+
+        assert!(!changed);
+        assert!(matches!(outcomes[0], PollApplyOutcome::NoData { .. }));
+    }
+
+    /// End-to-end apply: a populated payload writes `eab.json` (loadable back
+    /// through `--eab-file`) and publishes the value into the shared
+    /// `default_eab`; the subsequent clear removes the file and clears the
+    /// in-memory value so `resolve_profile_eab` returns `None`.
+    #[tokio::test]
+    async fn apply_eab_to_state_writes_then_clears_file_and_memory() {
+        use crate::profile::resolve_profile_eab;
+
+        let dir = tempfile::tempdir().unwrap();
+        let eab_path = dir.path().join("eab.json");
+        let (tx, rx) = watch::channel(None);
+        let handle = EabRefreshHandle {
+            path: eab_path.clone(),
+            sender: tx,
+        };
+        let shared = eab::SharedEab::from_receiver(rx);
+
+        // Build a profile with no per-profile EAB so resolution falls through
+        // to `default_eab`.
+        let profile = eab_test_profile();
+
+        apply_eab_to_state(
+            &handle,
+            &EabPayload::Populated {
+                kid: "kid-1".to_string(),
+                hmac: "hmac-1".to_string(),
+            },
+        )
+        .await
+        .expect("apply populated");
+
+        assert!(eab_path.exists());
+        let on_disk = eab::load_credentials(None, None, Some(eab_path.clone()))
+            .await
+            .expect("load")
+            .expect("credentials present");
+        assert_eq!(on_disk.kid, "kid-1");
+        let resolved = resolve_profile_eab(&profile, shared.current()).expect("resolved eab");
+        assert_eq!(resolved.kid, "kid-1");
+        assert_eq!(resolved.hmac, "hmac-1");
+
+        apply_eab_to_state(&handle, &EabPayload::Clear)
+            .await
+            .expect("apply clear");
+
+        assert!(!eab_path.exists());
+        assert!(shared.current().is_none());
+        assert!(resolve_profile_eab(&profile, shared.current()).is_none());
+    }
+
+    fn eab_test_profile() -> config::DaemonProfileSettings {
+        config::DaemonProfileSettings {
+            service_name: "edge-proxy".to_string(),
+            instance_id: "001".to_string(),
+            hostname: "edge-node-01".to_string(),
+            paths: config::Paths {
+                cert: PathBuf::from("cert.pem"),
+                key: PathBuf::from("key.pem"),
+            },
+            daemon: config::DaemonRuntimeSettings {
+                check_interval: Duration::from_hours(1),
+                renew_before: Duration::from_hours(1),
+                check_jitter: Duration::from_secs(0),
+            },
+            retry: None,
+            hooks: config::HookSettings::default(),
+            eab: None,
+            cert_group_gid: None,
+        }
     }
 
     #[tokio::test]

--- a/src/kv_payload.rs
+++ b/src/kv_payload.rs
@@ -67,7 +67,7 @@ pub enum EabPayload {
 /// ambiguous shapes (an empty `kid` with a non-empty `hmac` or vice versa),
 /// a missing key, or a non-string value.
 ///
-/// The clear shape must NOT be routed through [`parse_required_string`]: that
+/// The clear shape must NOT be routed through `parse_required_string`: that
 /// helper trims and rejects empty strings, which would misclassify a clear as
 /// malformed and prevent it from ever applying. The KV payload keys the secret
 /// as `hmac` (distinct from the on-disk `eab.json` `key` alias).

--- a/src/kv_payload.rs
+++ b/src/kv_payload.rs
@@ -9,7 +9,9 @@
 
 use anyhow::{Result, bail};
 
-use crate::trust_bootstrap::{CA_BUNDLE_PEM_KEY, HMAC_KEY, SECRET_ID_KEY, TRUSTED_CA_KEY};
+use crate::trust_bootstrap::{
+    CA_BUNDLE_PEM_KEY, EAB_HMAC_KEY, EAB_KID_KEY, HMAC_KEY, SECRET_ID_KEY, TRUSTED_CA_KEY,
+};
 
 /// Length in hex characters of a SHA-256 fingerprint.
 const FINGERPRINT_HEX_LEN: usize = 64;
@@ -46,6 +48,62 @@ pub fn parse_trust_payload(data: &serde_json::Value) -> Result<TrustPayload> {
 /// Returns an error when neither key holds a non-empty string.
 pub fn parse_secret_id(data: &serde_json::Value) -> Result<String> {
     parse_required_string(data, &[SECRET_ID_KEY, "value"])
+}
+
+/// Parsed `eab` KV payload: either populated credentials or an explicit
+/// clear.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EabPayload {
+    /// Populated EAB — both `kid` and `hmac` are non-empty.
+    Populated { kid: String, hmac: String },
+    /// Explicit clear — both `kid` and `hmac` are the empty string.
+    Clear,
+}
+
+/// Parses a service `eab` KV payload.
+///
+/// Accepts either a populated `{ "kid": non-empty, "hmac": non-empty }` or
+/// the explicit clear shape `{ "kid": "", "hmac": "" }`. Rejects partial or
+/// ambiguous shapes (an empty `kid` with a non-empty `hmac` or vice versa),
+/// a missing key, or a non-string value.
+///
+/// The clear shape must NOT be routed through [`parse_required_string`]: that
+/// helper trims and rejects empty strings, which would misclassify a clear as
+/// malformed and prevent it from ever applying. The KV payload keys the secret
+/// as `hmac` (distinct from the on-disk `eab.json` `key` alias).
+///
+/// # Errors
+///
+/// Returns an error when a key is missing, is not a string, or the two fields
+/// disagree on emptiness.
+pub fn parse_eab_payload(data: &serde_json::Value) -> Result<EabPayload> {
+    let kid = parse_eab_field(data, EAB_KID_KEY)?;
+    let hmac = parse_eab_field(data, EAB_HMAC_KEY)?;
+    match (kid.is_empty(), hmac.is_empty()) {
+        (false, false) => Ok(EabPayload::Populated { kid, hmac }),
+        (true, true) => Ok(EabPayload::Clear),
+        _ => bail!(
+            "EAB payload has partial credentials: {EAB_KID_KEY} and {EAB_HMAC_KEY} must both be \
+             set or both be empty"
+        ),
+    }
+}
+
+/// Reads an `eab` string field, trimmed. Unlike [`parse_required_string`], a
+/// present-but-empty value is preserved (returned as an empty string) so the
+/// caller can distinguish the explicit clear shape from a malformed one.
+///
+/// # Errors
+///
+/// Returns an error when the key is absent or its value is not a string.
+fn parse_eab_field(data: &serde_json::Value, key: &str) -> Result<String> {
+    let value = data
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("Missing required EAB key: {key}"))?;
+    let string = value
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("EAB key {key} must be a string"))?;
+    Ok(string.trim().to_string())
 }
 
 /// Parses a service `http_responder_hmac` KV payload, returning the HMAC.
@@ -201,5 +259,59 @@ mod tests {
     fn parse_responder_hmac_rejects_empty() {
         let data = serde_json::json!({ "hmac": "   " });
         assert!(parse_responder_hmac(&data).is_err());
+    }
+
+    #[test]
+    fn parse_eab_payload_accepts_populated() {
+        let data = serde_json::json!({ "kid": "  the-kid  ", "hmac": "  the-hmac  " });
+        assert_eq!(
+            parse_eab_payload(&data).expect("parse populated"),
+            EabPayload::Populated {
+                kid: "the-kid".to_string(),
+                hmac: "the-hmac".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_eab_payload_accepts_explicit_clear() {
+        let data = serde_json::json!({ "kid": "", "hmac": "" });
+        assert_eq!(
+            parse_eab_payload(&data).expect("parse clear"),
+            EabPayload::Clear
+        );
+    }
+
+    #[test]
+    fn parse_eab_payload_treats_whitespace_only_as_clear() {
+        let data = serde_json::json!({ "kid": "   ", "hmac": "   " });
+        assert_eq!(
+            parse_eab_payload(&data).expect("parse whitespace clear"),
+            EabPayload::Clear
+        );
+    }
+
+    #[test]
+    fn parse_eab_payload_rejects_partial_kid_only() {
+        let data = serde_json::json!({ "kid": "the-kid", "hmac": "" });
+        assert!(parse_eab_payload(&data).is_err());
+    }
+
+    #[test]
+    fn parse_eab_payload_rejects_partial_hmac_only() {
+        let data = serde_json::json!({ "kid": "", "hmac": "the-hmac" });
+        assert!(parse_eab_payload(&data).is_err());
+    }
+
+    #[test]
+    fn parse_eab_payload_rejects_missing_key() {
+        let data = serde_json::json!({ "kid": "the-kid" });
+        assert!(parse_eab_payload(&data).is_err());
+    }
+
+    #[test]
+    fn parse_eab_payload_rejects_non_string_value() {
+        let data = serde_json::json!({ "kid": "the-kid", "hmac": 42 });
+        assert!(parse_eab_payload(&data).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub use agent_args::Args;
 pub async fn run_daemon(
     settings: Arc<config::Settings>,
     default_eab: Option<eab::EabCredentials>,
+    eab_refresh_path: Option<PathBuf>,
     config_path: Option<PathBuf>,
     insecure_mode: bool,
     cli_overrides: config::CliOverrides,
@@ -39,6 +40,7 @@ pub async fn run_daemon(
     daemon::run_daemon(
         settings,
         default_eab,
+        eab_refresh_path,
         config_path,
         insecure_mode,
         cli_overrides,

--- a/src/trust_bootstrap.rs
+++ b/src/trust_bootstrap.rs
@@ -36,6 +36,13 @@ pub const SERVICE_SECRET_ID_KV_SUFFIX: &str = "secret_id";
 ///
 /// Full path: `{kv_mount}/data/bootroot/services/<service>/http_responder_hmac`.
 pub const SERVICE_RESPONDER_HMAC_KV_SUFFIX: &str = "http_responder_hmac";
+/// KV v2 path suffix carrying the service EAB credentials (payload
+/// `{ "kid": <value>, "hmac": <value> }`, or the explicit clear shape
+/// `{ "kid": "", "hmac": "" }`) the remote fast-poll loop refreshes into the
+/// on-disk `eab.json` + the in-memory `default_eab`.
+///
+/// Full path: `{kv_mount}/data/bootroot/services/<service>/eab`.
+pub const SERVICE_EAB_KV_SUFFIX: &str = "eab";
 /// Payload field holding the RFC3339 UTC timestamp of the request.
 pub const REISSUE_REQUESTED_AT_KEY: &str = "requested_at";
 /// Payload field describing who issued the request (operator label).


### PR DESCRIPTION
## Summary

Since #680 the remote `bootroot-agent` self-authenticates to OpenBao and keeps trust, `secret_id`, and (since #690) the HTTP responder HMAC current through the fast-poll loop. Per-service EAB (`bootroot/services/<svc>/eab`) was the last dynamic secret written to KV but never refreshed on a running remote host — `rotate eab-clear` only printed re-bootstrap guidance for `RemoteBootstrap` services, so a rotated or cleared EAB never reached a running remote agent without a manual re-bootstrap.

Unlike the other secrets, remote EAB does **not** live in `agent.toml`; its canonical representation is the standalone `eab.json` (`--eab-file`) plus the in-memory `default_eab`. This PR refreshes EAB through that real representation:

- **KV plumbing** — adds a `SERVICE_EAB_KV_SUFFIX` (`eab`) constant in `src/trust_bootstrap.rs` and a `parse_eab_payload` parser in `src/kv_payload.rs` that accepts either a populated `{ "kid": non-empty, "hmac": non-empty }` or the explicit clear `{ "kid": "", "hmac": "" }`, and rejects partial/ambiguous shapes. It deliberately does not reuse `parse_required_string` (which trims and rejects empty strings and would misclassify a clear as malformed).
- **Poll tick** — `run_eab_poll_tick` reads the per-service `eab` path each tick, tracks `last_eab_seen_version` in `FastPollState` (same shape as trust / `secret_id` / responder-HMAC), and applies a newer version at most once (idempotent on unchanged versions; malformed and apply-failure paths do not advance the version).
- **Durable-first apply** — on a populated version it rewrites `eab.json` at `0o600`; on a clear it removes `eab.json`. The on-disk write precedes the in-memory update, so a crash between the two leaves disk ahead of — never behind — the running process, and a restart reloads a consistent value. To make the cleared state equally durable, `--eab-file` loading now treats a configured-but-missing file as open enrollment (no EAB) rather than a hard error, matching the absent-file representation both the fast-poll clear and `bootroot-remote bootstrap` write — so a restart or SIGHUP after `rotate eab-clear` loads the same `None` the running process already used instead of failing to start.
- **Shared, live `default_eab`** — the daemon's `default_eab` becomes shared, live-readable state backed by a `tokio::sync::watch` channel (`SharedEab`). Both the periodic-check and force-reissue renewal paths read `shared_eab.current()` at issuance time, and the fast-poll loop publishes the refreshed value in place, so a running agent's next renewal binds with the new EAB (or without one) with no restart. `resolve_profile_eab` sees the current value on the next renewal.
- **Shared writer** — the `eab.json` writer/remover is lifted into the library (`src/eab.rs`) so `bootroot-remote bootstrap` and the fast-poll loop share one on-disk shape and cannot drift; `src/bin/bootroot-remote/io.rs` now delegates to it.
- **Source precedence / no-op guard** — the refresh is scoped to the `--eab-file` remote-bootstrap artifact. When the agent was started with explicit `--eab-kid`/`--eab-hmac` CLI values (out-of-band pin), the EAB poll is gated off entirely and never overrides them.
- **Docs / guidance** — `refresh_service_sidecar`'s `RemoteBootstrap` message and doc comment (and the EN/KO CLI docs) now state that EAB self-heals via the fast-poll loop within `fast_poll_interval`, removing the "re-run bootstrap for EAB" note.

### Synchronization primitive

Per the issue's request to call out the chosen primitive: `default_eab` moves from a value cloned by-value into every renewal path to an `Arc`-shared `tokio::sync::watch::Receiver<Option<EabCredentials>>` (wrapped as `SharedEab`), with the fast-poll loop holding the `watch::Sender`. `watch` fits the single-producer/many-reader shape — the fast-poll loop is the sole writer, renewal paths only read the latest value via `borrow()` — and avoids lock contention between concurrent profile renewals that a `Mutex` would introduce.

No new OpenBao policy grant is required (the service AppRole already grants `read` on `{kv_mount}/data/{base}/*`). No behavior change for `local-file` services — their sidecar consul-template still renders `[eab]`/`[profiles.eab]`; `build_managed_agent_ctmpl` is untouched.

## Test plan

- [x] `parse_eab_payload` accepts populated and explicit-clear shapes and rejects partial (`kid`-only / `hmac`-only), missing-key, and non-string payloads
- [x] EAB poll applies a populated payload on a new version (writes `eab.json`, publishes `default_eab`)
- [x] EAB poll applies a clear on a new version (removes `eab.json`, clears `default_eab`)
- [x] EAB poll is idempotent when the KV version is unchanged (no re-apply)
- [x] EAB poll skips a malformed payload without advancing `last_eab_seen_version`
- [x] EAB poll does not advance the version when the apply hook fails
- [x] End-to-end `apply_eab_to_state`: populated write is loadable via `--eab-file` and resolves through `resolve_profile_eab`; a subsequent clear removes the file and makes `resolve_profile_eab` return `None`
- [x] Shared library `write_eab_file` round-trips through `load_credentials` at `0o600`; `remove_eab_file` reports removed-then-absent
- [x] `cargo clippy --all-targets` clean, `cargo fmt --check` clean
- [x] CI: `check`, `test-core`, `test-docker-e2e-matrix` all green on PR (`run-extended` runs on daily schedule/dispatch, not per-PR)

Closes #692


