### PR TITLE
Harden fast-poll OpenBao channel (#695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - The fast-poll and `bootroot-remote bootstrap` OpenBao TLS clients now
     pin to `trusted_ca_sha256`; the post-trust-apply client rebuild reads
     the freshly applied pins from `agent.toml` so a CA rotation swaps both
-    the anchor and the pins.
+    the anchor and the pins. If those pins cannot be recovered, the rebuild
+    fails and rolls the trust version back rather than silently dropping to
+    unpinned bundle-anchored trust.
+  - OpenBao URL scheme detection (plaintext gate, `https://` CA-bundle
+    requirement, and TLS client selection) is now case-insensitive, so a
+    mixed-case `HTTP://` / `HTTPS://` URL is classified like its lowercase
+    form instead of bypassing the plaintext gate or the pinned TLS path.
   - `OpenBaoClient` HTTP clients now carry a 10s connect and 30s request
     timeout so a stalled endpoint cannot wedge the shared fast-poll loop.
 - Bumped `rustls-webpki` from 0.103.10 to 0.103.12 to address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+- Hardened the `bootroot-agent` fast-poll OpenBao channel (#695):
+  - Config validation now rejects a non-loopback plaintext `http://`
+    `[openbao].url` unless the operator sets the new
+    `[openbao] allow_plaintext_http = true` opt-in; loopback plaintext
+    (`localhost`, `127.0.0.0/8`, `[::1]`) and `https://` validate
+    unchanged. Both `[openbao]` config writers (`bootroot-remote
+    bootstrap` and local `bootroot service add`) upsert the opt-in when
+    they write such a URL, and the fast-poll loop logs a startup warning
+    that AppRole credentials and delivered secrets cross the network
+    unencrypted.
+  - The KV `trust` payload is validated for internal consistency before
+    anything reaches disk: `ca_bundle_pem` must parse into at least one
+    certificate and every `trusted_ca_sha256` fingerprint must match a
+    certificate in the bundle. A malformed payload is rejected without
+    writing the CA bundle file or `agent.toml` and without advancing the
+    seen version, so a corrected control-plane write retries naturally.
+  - The fast-poll and `bootroot-remote bootstrap` OpenBao TLS clients now
+    pin to `trusted_ca_sha256`; the post-trust-apply client rebuild reads
+    the freshly applied pins from `agent.toml` so a CA rotation swaps both
+    the anchor and the pins.
+  - `OpenBaoClient` HTTP clients now carry a 10s connect and 30s request
+    timeout so a stalled endpoint cannot wedge the shared fast-poll loop.
 - Bumped `rustls-webpki` from 0.103.10 to 0.103.12 to address
   RUSTSEC-2026-0098 and RUSTSEC-2026-0099 (incorrect name-constraint
   validation for URI and wildcard names).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ webpki-root-certs = "1"
 x509-parser = { version = "0.18", features = ["verify"] }
 
 [dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }
 wiremock = "0.6"
 
 [lints.clippy]

--- a/agent.toml.example
+++ b/agent.toml.example
@@ -126,6 +126,14 @@ backoff_secs = [5, 10, 30]
 # secret_id_path = "/etc/bootroot/secret_id"
 # # Required when url uses https://
 # ca_bundle_path = "/etc/bootroot/ca-bundle.pem"
+# # Opt-in for a non-loopback plaintext http:// url.  Over plaintext the
+# # AppRole login and every KV poll response carry role_id/secret_id,
+# # responder HMAC, and EAB in cleartext, so validation rejects a
+# # non-loopback http:// url unless this is set.  Loopback plaintext
+# # (localhost, 127.0.0.0/8, [::1]) and https:// never need it.  When set
+# # against a non-loopback plaintext url, the fast-poll loop logs a
+# # startup warning.  Prefer https:// in production.
+# allow_plaintext_http = false
 # # Poll cadence; defaults to 30s
 # fast_poll_interval = "30s"
 # # Persists `last_reissue_seen_version` across restarts.  Must be an

--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -382,6 +382,12 @@ fn build_openbao_updates(
         ("secret_id_path", args.secret_id_path.display().to_string()),
         ("ca_bundle_path", args.ca_bundle_path.display().to_string()),
     ];
+    // A non-loopback plaintext URL fails config validation without the
+    // explicit opt-in, so upsert it whenever we write such a URL. Loopback
+    // plaintext and https:// never need it, so it is not emitted there.
+    if bootroot::config::openbao_url_is_non_loopback_plaintext(&args.openbao_url) {
+        pairs.push(("allow_plaintext_http", "true".to_string()));
+    }
     // Provision an absolute `state_path` when either (a) the key is
     // missing, or (b) the existing value is relative. Case (b) catches
     // legacy configs (written before bootstrap provisioned the key) and
@@ -654,6 +660,7 @@ mod tests {
             profile_key_path: None,
             ca_bundle_path: PathBuf::from("/tmp/ca-bundle.pem"),
             ca_bundle_pem: None,
+            trusted_ca_sha256: Vec::new(),
             post_renew_command: None,
             post_renew_arg: Vec::new(),
             post_renew_timeout_secs: None,
@@ -680,6 +687,43 @@ mod tests {
                 "ca_bundle_path",
                 "state_path",
             ]
+        );
+    }
+
+    #[test]
+    fn build_openbao_updates_emits_opt_in_for_non_loopback_plaintext() {
+        let mut args = test_bootstrap_args();
+        args.openbao_url = "http://10.0.0.5:8200".to_string();
+        let pairs = build_openbao_updates(&args, "");
+        assert!(
+            pairs
+                .iter()
+                .any(|(k, v)| *k == "allow_plaintext_http" && v == "true"),
+            "non-loopback plaintext must upsert the opt-in: {pairs:?}"
+        );
+        let output = bootroot::toml_util::upsert_section_keys("", "openbao", &pairs).unwrap();
+        assert!(output.contains("allow_plaintext_http = true"), "{output}");
+    }
+
+    #[test]
+    fn build_openbao_updates_omits_opt_in_for_loopback_plaintext() {
+        let mut args = test_bootstrap_args();
+        args.openbao_url = "http://127.0.0.1:8200".to_string();
+        let pairs = build_openbao_updates(&args, "");
+        assert!(
+            !pairs.iter().any(|(k, _)| *k == "allow_plaintext_http"),
+            "loopback plaintext must not emit the opt-in: {pairs:?}"
+        );
+    }
+
+    #[test]
+    fn build_openbao_updates_omits_opt_in_for_https() {
+        let mut args = test_bootstrap_args();
+        args.openbao_url = "https://openbao.example:8200".to_string();
+        let pairs = build_openbao_updates(&args, "");
+        assert!(
+            !pairs.iter().any(|(k, _)| *k == "allow_plaintext_http"),
+            "https must not emit the opt-in: {pairs:?}"
         );
     }
 

--- a/src/bin/bootroot-remote/apply_secret_id.rs
+++ b/src/bin/bootroot-remote/apply_secret_id.rs
@@ -21,7 +21,7 @@ async fn resolve_ca_bundle_pem(
     ca_bundle_path: Option<&Path>,
     lang: Locale,
 ) -> Result<Option<String>> {
-    if !openbao_url.starts_with("https://") {
+    if !bootroot::config::openbao_url_is_https(openbao_url) {
         return Ok(None);
     }
     let path = ca_bundle_path.ok_or_else(|| {

--- a/src/bin/bootroot-remote/apply_secret_id.rs
+++ b/src/bin/bootroot-remote/apply_secret_id.rs
@@ -82,7 +82,9 @@ pub(super) async fn run_apply_secret_id(args: ApplySecretIdArgs, lang: Locale) -
 
     let ca_bundle_pem =
         resolve_ca_bundle_pem(&args.openbao_url, args.ca_bundle_path.as_deref(), lang).await?;
-    let mut client = build_openbao_client(&args.openbao_url, ca_bundle_pem.as_deref(), lang)?;
+    // `apply-secret-id` has only a `--ca-bundle-path` PEM and no fingerprint
+    // source, so it passes empty pins and stays bundle-anchored (issue #695).
+    let mut client = build_openbao_client(&args.openbao_url, ca_bundle_pem.as_deref(), &[], lang)?;
     let token = client
         .login_approle(&role_id, &current_secret_id)
         .await
@@ -235,6 +237,7 @@ mod tests {
         let client = build_openbao_client(
             &format!("https://localhost:{port}"),
             Some(&ca_pem),
+            &[],
             Locale::En,
         )
         .expect("https client built from the supplied CA bundle");
@@ -287,7 +290,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_openbao_client_https_without_ca_is_rejected() {
-        let err = build_openbao_client("https://openbao.example:8200", None, Locale::En)
+        let err = build_openbao_client("https://openbao.example:8200", None, &[], Locale::En)
             .expect_err("https client without a CA bundle must be rejected");
         assert!(
             err.to_string().contains("CA bundle"),

--- a/src/bin/bootroot-remote/bootstrap.rs
+++ b/src/bin/bootroot-remote/bootstrap.rs
@@ -68,6 +68,7 @@ pub(super) async fn run_bootstrap(args: ResolvedBootstrapArgs, lang: Locale) -> 
             &args.secret_id_path,
             &args.service_name,
             args.ca_bundle_pem.as_deref(),
+            &args.trusted_ca_sha256,
             lang,
         )
         .await
@@ -108,7 +109,12 @@ pub(super) async fn run_bootstrap(args: ResolvedBootstrapArgs, lang: Locale) -> 
             )
         })?;
 
-    let mut client = build_openbao_client(&args.openbao_url, args.ca_bundle_pem.as_deref(), lang)?;
+    let mut client = build_openbao_client(
+        &args.openbao_url,
+        args.ca_bundle_pem.as_deref(),
+        &args.trusted_ca_sha256,
+        lang,
+    )?;
     let token = client
         .login_approle(&role_id, &current_secret_id)
         .await
@@ -200,6 +206,11 @@ pub(super) async fn run_bootstrap(args: ResolvedBootstrapArgs, lang: Locale) -> 
 /// Unwraps a response-wrapped `secret_id` and writes it to the
 /// expected file path. Classifies failures as expired or
 /// already-unwrapped tokens with appropriate error messages.
+// The parameters mirror the discrete pieces of the bootstrap transport
+// (URL, wrap token + expiry, destination, CA bundle + pins) that each come
+// from a different artifact field; bundling them into a struct would add a
+// one-use type without improving clarity.
+#[allow(clippy::too_many_arguments)]
 async fn unwrap_and_write_secret_id(
     openbao_url: &str,
     wrap_token: &str,
@@ -207,9 +218,10 @@ async fn unwrap_and_write_secret_id(
     secret_id_path: &std::path::Path,
     service_name: &str,
     ca_bundle_pem: Option<&str>,
+    pins: &[String],
     lang: Locale,
 ) -> Result<()> {
-    let client = build_openbao_client(openbao_url, ca_bundle_pem, lang)?;
+    let client = build_openbao_client(openbao_url, ca_bundle_pem, pins, lang)?;
     match client.unwrap_secret_id(wrap_token).await {
         Ok(secret_id) => {
             write_secret_file(secret_id_path, &secret_id)
@@ -529,6 +541,7 @@ mod tests {
             profile_key_path: None,
             ca_bundle_path: PathBuf::new(),
             ca_bundle_pem: None,
+            trusted_ca_sha256: Vec::new(),
             post_renew_command: None,
             post_renew_arg: Vec::new(),
             post_renew_timeout_secs: None,

--- a/src/bin/bootroot-remote/main.rs
+++ b/src/bin/bootroot-remote/main.rs
@@ -202,6 +202,10 @@ struct ResolvedBootstrapArgs {
     profile_key_path: Option<PathBuf>,
     ca_bundle_path: PathBuf,
     ca_bundle_pem: Option<String>,
+    /// SHA-256 fingerprints pinning the bootstrap `OpenBao` TLS connection
+    /// to the CA bundle's trust anchors. Empty for legacy artifacts, in which
+    /// case bootstrap stays bundle-anchored (issue #695).
+    trusted_ca_sha256: Vec<String>,
     post_renew_command: Option<String>,
     post_renew_arg: Vec<String>,
     post_renew_timeout_secs: Option<u64>,
@@ -347,6 +351,12 @@ struct BootstrapArtifact {
     ca_bundle_path: Option<String>,
     #[serde(default)]
     ca_bundle_pem: Option<String>,
+    /// SHA-256 fingerprints of the CA bundle certificates, used to pin the
+    /// bootstrap `OpenBao` TLS connection (issue #695). Absent for artifacts
+    /// produced before the field existed; then bootstrap stays
+    /// bundle-anchored.
+    #[serde(default)]
+    trusted_ca_sha256: Vec<String>,
     #[serde(default)]
     post_renew_hooks: Vec<ArtifactHookEntry>,
     #[serde(default)]
@@ -489,6 +499,10 @@ async fn resolve_bootstrap_args(args: BootstrapArgs) -> Result<ResolvedBootstrap
         .or(args.profile_key_path);
 
     let ca_bundle_pem = artifact.as_ref().and_then(|a| a.ca_bundle_pem.clone());
+    let trusted_ca_sha256 = artifact
+        .as_ref()
+        .map(|a| a.trusted_ca_sha256.clone())
+        .unwrap_or_default();
 
     let wrap_token = artifact.as_ref().and_then(|a| a.wrap_token.clone());
     let wrap_expires_at = artifact.as_ref().and_then(|a| a.wrap_expires_at.clone());
@@ -542,6 +556,7 @@ async fn resolve_bootstrap_args(args: BootstrapArgs) -> Result<ResolvedBootstrap
         profile_key_path,
         ca_bundle_path,
         ca_bundle_pem,
+        trusted_ca_sha256,
         post_renew_command,
         post_renew_arg,
         post_renew_timeout_secs,

--- a/src/bin/bootroot-remote/openbao_client.rs
+++ b/src/bin/bootroot-remote/openbao_client.rs
@@ -10,9 +10,14 @@ use super::{Locale, localized};
 /// that signed the `OpenBao` leaf certificate; without it the TLS handshake
 /// would only trust the Mozilla webpki roots and fail. For an `http://` URL
 /// no CA bundle is needed and one is not required.
+///
+/// `pins` restricts the HTTPS trust anchors to the pinned subset of the
+/// bundle (`trusted_ca_sha256`); an empty slice keeps the bundle-anchored
+/// behavior. `pins` is ignored for a plaintext URL (issue #695).
 pub(super) fn build_openbao_client(
     openbao_url: &str,
     ca_bundle_pem: Option<&str>,
+    pins: &[String],
     lang: Locale,
 ) -> Result<OpenBaoClient> {
     if openbao_url.starts_with("https://") {
@@ -26,7 +31,7 @@ pub(super) fn build_openbao_client(
                 )
             )
         })?;
-        OpenBaoClient::with_pem_trust(openbao_url, pem, &[]).with_context(|| {
+        OpenBaoClient::with_pem_trust(openbao_url, pem, pins).with_context(|| {
             localized(
                 lang,
                 "Failed to build TLS client from CA bundle",

--- a/src/bin/bootroot-remote/openbao_client.rs
+++ b/src/bin/bootroot-remote/openbao_client.rs
@@ -20,7 +20,7 @@ pub(super) fn build_openbao_client(
     pins: &[String],
     lang: Locale,
 ) -> Result<OpenBaoClient> {
-    if openbao_url.starts_with("https://") {
+    if bootroot::config::openbao_url_is_https(openbao_url) {
         let pem = ca_bundle_pem.ok_or_else(|| {
             anyhow::anyhow!(
                 "{}",

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -209,6 +209,14 @@ fn build_local_openbao_updates(
             inputs.ca_bundle_path.display().to_string(),
         ),
     ];
+    // A non-loopback plaintext URL fails config validation without the
+    // explicit opt-in. The local `url` defaults to loopback
+    // `http://localhost:8200`, but an operator can point `bootroot init`
+    // at a non-loopback address, so apply the same rule as the remote
+    // writer. Loopback plaintext and https:// never need it.
+    if bootroot::config::openbao_url_is_non_loopback_plaintext(inputs.openbao_url) {
+        pairs.push(("allow_plaintext_http", "true".to_string()));
+    }
     if needs_absolute_state_path_provisioning(inputs.current_contents) {
         pairs.push((
             "state_path",
@@ -683,6 +691,49 @@ mod tests {
             get("state_path"),
             Some("/etc/bootroot/bootroot-agent-state-edge-proxy.json"),
             "state_path must be absolute and service-keyed"
+        );
+    }
+
+    fn openbao_updates_for_url(url: &str) -> Vec<(&'static str, String)> {
+        build_local_openbao_updates(&LocalOpenBaoUpdateInputs {
+            openbao_url: url,
+            kv_mount: "secret",
+            role_id_path: Path::new("secrets/services/edge-proxy/role_id"),
+            secret_id_path: Path::new("secrets/services/edge-proxy/secret_id"),
+            ca_bundle_path: Path::new("certs/ca-bundle.pem"),
+            agent_config_path: Path::new("/etc/bootroot/agent.toml"),
+            service_name: "edge-proxy",
+            current_contents: "",
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn test_local_openbao_updates_emit_opt_in_for_non_loopback_plaintext() {
+        let updates = openbao_updates_for_url("http://10.0.0.5:8200");
+        assert!(
+            updates
+                .iter()
+                .any(|(k, v)| *k == "allow_plaintext_http" && v == "true"),
+            "non-loopback plaintext must upsert the opt-in: {updates:?}"
+        );
+    }
+
+    #[test]
+    fn test_local_openbao_updates_omit_opt_in_for_loopback_plaintext() {
+        let updates = openbao_updates_for_url("http://localhost:8200");
+        assert!(
+            !updates.iter().any(|(k, _)| *k == "allow_plaintext_http"),
+            "loopback plaintext must not emit the opt-in: {updates:?}"
+        );
+    }
+
+    #[test]
+    fn test_local_openbao_updates_omit_opt_in_for_https() {
+        let updates = openbao_updates_for_url("https://openbao.example:8200");
+        assert!(
+            !updates.iter().any(|(k, _)| *k == "allow_plaintext_http"),
+            "https must not emit the opt-in: {updates:?}"
         );
     }
 

--- a/src/commands/service/remote_bootstrap.rs
+++ b/src/commands/service/remote_bootstrap.rs
@@ -41,6 +41,12 @@ struct RemoteBootstrapArtifact {
     agent_config_path: String,
     ca_bundle_path: String,
     ca_bundle_pem: String,
+    /// SHA-256 fingerprints of the certificates in `ca_bundle_pem`, in the
+    /// `trusted_ca_sha256` form. The remote `bootstrap` pins its `OpenBao`
+    /// TLS connection to these anchors (issue #695). Serialized only when
+    /// non-empty; a remote that pre-dates the field ignores it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    trusted_ca_sha256: Vec<String>,
     /// Operator-supplied override for `email`, carried from
     /// `bootroot service add --agent-email` so that `bootroot-remote
     /// bootstrap` can distinguish "explicit override, clobber remote
@@ -117,6 +123,17 @@ fn artifact_openbao_url(state: &StateFile) -> String {
 
 /// Builds a `RemoteBootstrapArtifact` from common inputs shared by both
 /// the initial service-add and the idempotent re-run paths.
+/// Computes the `trusted_ca_sha256` fingerprints (lowercase hex SHA-256 of
+/// each certificate's DER) for the certificates in a CA bundle PEM. Returns
+/// an empty list when the bundle is empty or unparseable — the remote
+/// bootstrap then falls back to bundle-anchored TLS (no pins).
+fn fingerprints_from_bundle(ca_bundle_pem: &str) -> Vec<String> {
+    if ca_bundle_pem.trim().is_empty() {
+        return Vec::new();
+    }
+    bootroot::tls::ca_bundle_fingerprints(ca_bundle_pem).unwrap_or_default()
+}
+
 #[allow(clippy::too_many_arguments)] // mirrors the many fields of RemoteBootstrapArtifact
 fn build_artifact(
     openbao_url: &str,
@@ -160,6 +177,7 @@ fn build_artifact(
         eab_file_path: eab_path.display().to_string(),
         agent_config_path: agent_config_path.display().to_string(),
         ca_bundle_path: ca_bundle_path.display().to_string(),
+        trusted_ca_sha256: fingerprints_from_bundle(ca_bundle_pem),
         ca_bundle_pem: ca_bundle_pem.to_string(),
         agent_email: agent_email.map(str::to_string),
         agent_server: agent_server.map(str::to_string),
@@ -334,9 +352,33 @@ fn render_remote_run_command_legacy(artifact: &RemoteBootstrapArtifact) -> Strin
 mod tests {
     use std::path::Path;
 
-    use super::build_artifact;
+    use super::{build_artifact, fingerprints_from_bundle};
 
     const TEST_CA_PEM: &str = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n";
+
+    /// The artifact must advertise the bundle's real trust-anchor
+    /// fingerprints so `bootroot-remote bootstrap` can pin its `OpenBao`
+    /// TLS connection (issue #695); an unparseable bundle yields no pins.
+    #[test]
+    fn fingerprints_from_bundle_computes_ca_fingerprints() {
+        use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair};
+
+        let key = KeyPair::generate().expect("generate CA key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Test CA");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key).expect("self-signed CA");
+        let pem = cert.pem();
+
+        let expected = bootroot::tls::ca_bundle_fingerprints(&pem).expect("fingerprints");
+        assert_eq!(fingerprints_from_bundle(&pem), expected);
+        assert_eq!(expected.len(), 1);
+
+        assert!(fingerprints_from_bundle("not a certificate").is_empty());
+        assert!(fingerprints_from_bundle("").is_empty());
+    }
     const TEST_AGENT_EMAIL: &str = "test@example.com";
     const TEST_AGENT_SERVER: &str = "https://step-ca.test:9000/acme/acme/directory";
     const TEST_AGENT_RESPONDER_URL: &str = "http://127.0.0.1:8080";

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,10 @@ use serde::Deserialize;
 mod defaults;
 mod validation;
 
-pub use validation::{parse_cert_duration, validate_cert_duration_vs_default_renew_before};
+pub use validation::{
+    openbao_url_is_non_loopback_plaintext, parse_cert_duration,
+    validate_cert_duration_vs_default_renew_before,
+};
 
 /// CLI-provided overrides that must survive config reloads in daemon mode.
 ///
@@ -64,6 +67,16 @@ pub struct Settings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct OpenBaoSettings {
     pub url: String,
+    /// Opt-in that allows a non-loopback plaintext `http://` `url`.
+    ///
+    /// Over plaintext the `AppRole` login POSTs `role_id` + `secret_id`
+    /// as cleartext and every KV poll response carries `secret_id`,
+    /// responder HMAC, and EAB in cleartext, so a non-loopback plaintext
+    /// URL exposes live credentials on the wire. Validation rejects such
+    /// a URL unless the operator sets this flag; loopback plaintext and
+    /// `https://` never require it. See issue #695.
+    #[serde(default)]
+    pub allow_plaintext_http: bool,
     #[serde(default = "defaults::default_kv_mount")]
     pub kv_mount: String,
     pub role_id_path: PathBuf,
@@ -755,7 +768,7 @@ mod tests {
             key = "certs/edge-proxy-a.key"
 
             [openbao]
-            url = "http://openbao:8200"
+            url = "http://localhost:8200"
             role_id_path = "/etc/bootroot/role_id"
             secret_id_path = "/etc/bootroot/secret_id"
             state_path = "bootroot-agent-state.json"
@@ -798,7 +811,7 @@ mod tests {
             key = "certs/edge-proxy-a.key"
 
             [openbao]
-            url = "http://openbao:8200"
+            url = "http://localhost:8200"
             role_id_path = "/etc/bootroot/role_id"
             secret_id_path = "/etc/bootroot/secret_id"
         "#
@@ -951,7 +964,7 @@ mod tests {
             key = "certs/edge-proxy-a.key"
 
             [openbao]
-            url = "http://openbao:8200"
+            url = "http://localhost:8200"
             role_id_path = "/etc/bootroot/role_id"
             secret_id_path = "/etc/bootroot/secret_id"
             state_path = "/var/lib/bootroot/bootroot-agent-state.json"

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ mod defaults;
 mod validation;
 
 pub use validation::{
-    openbao_url_is_non_loopback_plaintext, parse_cert_duration,
+    openbao_url_is_https, openbao_url_is_non_loopback_plaintext, parse_cert_duration,
     validate_cert_duration_vs_default_renew_before,
 };
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,6 +1,8 @@
+use std::net::IpAddr;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use reqwest::Url;
 
 use super::defaults::default_renew_before;
 use super::{DaemonProfileSettings, HookCommand, OpenBaoSettings, Settings, TrustSettings};
@@ -100,9 +102,57 @@ pub(crate) fn validate_settings(settings: &Settings) -> Result<()> {
     Ok(())
 }
 
+/// Reports whether an `openbao.url` is a non-loopback plaintext
+/// `http://` endpoint — the case that exposes `AppRole` credentials and
+/// delivered secrets on the wire and therefore requires the explicit
+/// `allow_plaintext_http` opt-in.
+///
+/// Loopback plaintext (`localhost`, `127.0.0.0/8`, `[::1]`) and any
+/// `https://` URL return `false`. A URL that does not use the `http://`
+/// scheme, or one whose host cannot be parsed, also returns `false`: the
+/// scheme check confines this to plaintext HTTP, and a host that fails to
+/// parse is left for other validation to reject.
+#[must_use]
+pub fn openbao_url_is_non_loopback_plaintext(url: &str) -> bool {
+    let trimmed = url.trim();
+    if !trimmed.starts_with("http://") {
+        return false;
+    }
+    let Ok(parsed) = Url::parse(trimmed) else {
+        return false;
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    !host_is_loopback(host)
+}
+
+/// Reports whether a URL host string designates the loopback interface.
+fn host_is_loopback(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    // `Url::host_str` keeps the brackets around an IPv6 literal; strip
+    // them before parsing.
+    let candidate = host
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(host);
+    candidate.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
 fn validate_openbao_settings(settings: &OpenBaoSettings) -> Result<()> {
     if settings.url.trim().is_empty() {
         anyhow::bail!("openbao.url must not be empty");
+    }
+    if openbao_url_is_non_loopback_plaintext(&settings.url) && !settings.allow_plaintext_http {
+        anyhow::bail!(
+            "openbao.url ({}) is a non-loopback plaintext http:// endpoint; AppRole \
+             credentials and delivered secrets would cross the network unencrypted. Use \
+             https://, point at a loopback address, or set [openbao] allow_plaintext_http = \
+             true to opt in explicitly",
+            settings.url
+        );
     }
     if settings.kv_mount.trim().is_empty() {
         anyhow::bail!("openbao.kv_mount must not be empty");
@@ -282,5 +332,76 @@ mod tests {
     fn cert_duration_rejects_invalid_value() {
         assert!(validate_cert_duration_vs_default_renew_before("bogus").is_err());
         assert!(validate_cert_duration_vs_default_renew_before("").is_err());
+    }
+
+    fn openbao_settings(url: &str, allow_plaintext_http: bool) -> OpenBaoSettings {
+        OpenBaoSettings {
+            url: url.to_string(),
+            allow_plaintext_http,
+            kv_mount: "secret".to_string(),
+            role_id_path: std::path::PathBuf::from("/etc/bootroot/role_id"),
+            secret_id_path: std::path::PathBuf::from("/etc/bootroot/secret_id"),
+            ca_bundle_path: None,
+            fast_poll_interval: Duration::from_secs(5),
+            state_path: std::path::PathBuf::from("/var/lib/bootroot/state.json"),
+        }
+    }
+
+    #[test]
+    fn openbao_allows_loopback_plaintext_without_opt_in() {
+        for url in [
+            "http://localhost:8200",
+            "http://127.0.0.1:8200",
+            "http://127.5.6.7:8200",
+            "http://[::1]:8200",
+        ] {
+            assert!(
+                validate_openbao_settings(&openbao_settings(url, false)).is_ok(),
+                "loopback plaintext {url} should validate without opt-in"
+            );
+        }
+    }
+
+    #[test]
+    fn openbao_allows_https_without_opt_in() {
+        let mut settings = openbao_settings("https://openbao.example:8200", false);
+        settings.ca_bundle_path = Some(std::path::PathBuf::from("/etc/bootroot/ca-bundle.pem"));
+        assert!(validate_openbao_settings(&settings).is_ok());
+    }
+
+    #[test]
+    fn openbao_rejects_non_loopback_plaintext_without_opt_in() {
+        let err = validate_openbao_settings(&openbao_settings("http://10.0.0.5:8200", false))
+            .expect_err("non-loopback plaintext without opt-in must fail");
+        let message = format!("{err}");
+        assert!(
+            message.contains("allow_plaintext_http"),
+            "error should point at the opt-in: {message}"
+        );
+    }
+
+    #[test]
+    fn openbao_allows_non_loopback_plaintext_with_opt_in() {
+        assert!(validate_openbao_settings(&openbao_settings("http://10.0.0.5:8200", true)).is_ok());
+    }
+
+    #[test]
+    fn non_loopback_plaintext_classifier_matches_expectations() {
+        assert!(openbao_url_is_non_loopback_plaintext(
+            "http://10.0.0.5:8200"
+        ));
+        assert!(openbao_url_is_non_loopback_plaintext(
+            "http://openbao.example:8200"
+        ));
+        assert!(!openbao_url_is_non_loopback_plaintext(
+            "http://localhost:8200"
+        ));
+        assert!(!openbao_url_is_non_loopback_plaintext(
+            "http://127.0.0.1:8200"
+        ));
+        assert!(!openbao_url_is_non_loopback_plaintext("http://[::1]:8200"));
+        assert!(!openbao_url_is_non_loopback_plaintext(
+            "https://openbao.example:8200"
+        ));
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -102,25 +102,38 @@ pub(crate) fn validate_settings(settings: &Settings) -> Result<()> {
     Ok(())
 }
 
+/// Reports whether an `openbao.url` uses the `https://` scheme.
+///
+/// URL schemes are case-insensitive (RFC 3986 §3.1), so `HTTPS://host`
+/// designates the same TLS endpoint as `https://host` and must route
+/// through the CA-bundle-anchored client path identically. Comparing the
+/// parsed scheme case-insensitively — rather than a raw `starts_with` —
+/// keeps a mixed-case scheme from silently falling back to the plaintext
+/// client (issue #695). A URL that fails to parse returns `false`.
+#[must_use]
+pub fn openbao_url_is_https(url: &str) -> bool {
+    Url::parse(url.trim()).is_ok_and(|parsed| parsed.scheme().eq_ignore_ascii_case("https"))
+}
+
 /// Reports whether an `openbao.url` is a non-loopback plaintext
 /// `http://` endpoint — the case that exposes `AppRole` credentials and
 /// delivered secrets on the wire and therefore requires the explicit
 /// `allow_plaintext_http` opt-in.
 ///
 /// Loopback plaintext (`localhost`, `127.0.0.0/8`, `[::1]`) and any
-/// `https://` URL return `false`. A URL that does not use the `http://`
-/// scheme, or one whose host cannot be parsed, also returns `false`: the
-/// scheme check confines this to plaintext HTTP, and a host that fails to
-/// parse is left for other validation to reject.
+/// `https://` URL return `false`. A URL whose scheme is not `http`
+/// (compared case-insensitively, so `HTTP://` counts), or one whose host
+/// cannot be parsed, also returns `false`: the scheme check confines this
+/// to plaintext HTTP, and a host that fails to parse is left for other
+/// validation to reject.
 #[must_use]
 pub fn openbao_url_is_non_loopback_plaintext(url: &str) -> bool {
-    let trimmed = url.trim();
-    if !trimmed.starts_with("http://") {
-        return false;
-    }
-    let Ok(parsed) = Url::parse(trimmed) else {
+    let Ok(parsed) = Url::parse(url.trim()) else {
         return false;
     };
+    if !parsed.scheme().eq_ignore_ascii_case("http") {
+        return false;
+    }
     let Some(host) = parsed.host_str() else {
         return false;
     };
@@ -166,7 +179,7 @@ fn validate_openbao_settings(settings: &OpenBaoSettings) -> Result<()> {
     if settings.fast_poll_interval < Duration::from_secs(1) {
         anyhow::bail!("openbao.fast_poll_interval must be at least 1 second");
     }
-    if settings.url.starts_with("https://") && settings.ca_bundle_path.is_none() {
+    if openbao_url_is_https(&settings.url) && settings.ca_bundle_path.is_none() {
         anyhow::bail!("openbao.ca_bundle_path must be set when openbao.url uses https://");
     }
     if let Some(path) = &settings.ca_bundle_path
@@ -403,5 +416,54 @@ mod tests {
         assert!(!openbao_url_is_non_loopback_plaintext(
             "https://openbao.example:8200"
         ));
+    }
+
+    #[test]
+    fn non_loopback_plaintext_classifier_is_scheme_case_insensitive() {
+        // URL schemes are case-insensitive, so a mixed-case plaintext
+        // scheme must still be gated (issue #695).
+        assert!(openbao_url_is_non_loopback_plaintext(
+            "HTTP://10.0.0.5:8200"
+        ));
+        assert!(openbao_url_is_non_loopback_plaintext(
+            "HtTp://openbao.example:8200"
+        ));
+        assert!(!openbao_url_is_non_loopback_plaintext(
+            "HTTP://127.0.0.1:8200"
+        ));
+        assert!(!openbao_url_is_non_loopback_plaintext(
+            "HTTPS://openbao.example:8200"
+        ));
+    }
+
+    #[test]
+    fn https_classifier_is_scheme_case_insensitive() {
+        assert!(openbao_url_is_https("https://openbao.example:8200"));
+        assert!(openbao_url_is_https("HTTPS://openbao.example:8200"));
+        assert!(openbao_url_is_https("HtTpS://openbao.example:8200"));
+        assert!(!openbao_url_is_https("http://openbao.example:8200"));
+        assert!(!openbao_url_is_https("HTTP://openbao.example:8200"));
+        assert!(!openbao_url_is_https("not a url"));
+    }
+
+    #[test]
+    fn openbao_rejects_mixed_case_non_loopback_plaintext_without_opt_in() {
+        let err = validate_openbao_settings(&openbao_settings("HTTP://10.0.0.5:8200", false))
+            .expect_err("mixed-case non-loopback plaintext without opt-in must fail");
+        assert!(
+            format!("{err}").contains("allow_plaintext_http"),
+            "error should point at the opt-in: {err}"
+        );
+    }
+
+    #[test]
+    fn openbao_requires_ca_bundle_for_mixed_case_https() {
+        let err =
+            validate_openbao_settings(&openbao_settings("HTTPS://openbao.example:8200", false))
+                .expect_err("mixed-case https without a CA bundle must fail");
+        assert!(
+            format!("{err}").contains("ca_bundle_path"),
+            "error should require the CA bundle: {err}"
+        );
     }
 }

--- a/src/fast_poll.rs
+++ b/src/fast_poll.rs
@@ -1407,6 +1407,19 @@ pub(crate) async fn run_fast_poll_loop(
         settings.profiles.len(),
     );
 
+    // Item #695: a non-loopback plaintext OpenBao URL validates only with
+    // the explicit `allow_plaintext_http` opt-in. Surface one prominent
+    // startup warning so operators cannot forget that AppRole credentials
+    // and every delivered secret cross the network unencrypted.
+    if config::openbao_url_is_non_loopback_plaintext(&openbao.url) {
+        warn!(
+            "OpenBao URL {} is a non-loopback plaintext http:// endpoint (allow_plaintext_http \
+             is set): AppRole role_id/secret_id and all delivered secrets (secret_id, responder \
+             HMAC, EAB) cross the network UNENCRYPTED. Use https:// in production.",
+            openbao.url
+        );
+    }
+
     let mut state = match FastPollState::load(&openbao.state_path).await {
         Ok(state) => state,
         Err(err) => {
@@ -1418,12 +1431,18 @@ pub(crate) async fn run_fast_poll_loop(
         }
     };
 
-    // Share the OpenBaoClient across hooks and re-login helpers.
-    let client = build_openbao_client(&openbao)?;
+    // Share the OpenBaoClient across hooks and re-login helpers. At
+    // startup the pins come from the config snapshot; the post-trust-apply
+    // rebuild below re-reads them from the freshly written agent.toml.
+    let client = build_openbao_client(&openbao, &settings.trust.trusted_ca_sha256)?;
     let client = Arc::new(Mutex::new(client));
     if let Err(err) = login(&client, &openbao).await {
         warn!("Initial OpenBao AppRole login failed: {err:#}. Will retry on the next tick.");
     }
+
+    // Retain a copy of the config path for the client rebuild's pin
+    // re-read; the canonical copy is moved into the hooks below.
+    let config_path_for_rebuild = config_path.clone();
 
     // The EAB poll runs only when EAB is sourced from `--eab-file`; a
     // CLI-pinned EAB gets `None` here so fast-poll never overrides the
@@ -1613,7 +1632,13 @@ pub(crate) async fn run_fast_poll_loop(
         // advanced version and just retry the login.
         let mut trust_applied = trust_changed;
         if trust_changed && rebuild_client_on_trust {
-            let rebuilt_ok = match build_openbao_client(&openbao) {
+            // Pin the rebuilt client to the freshly applied anchors, not
+            // the startup snapshot: a rotation that lands a new CA + new
+            // pins in KV has just been written to agent.toml, so re-read
+            // from there. Stale startup pins would strand the client on
+            // the retired CA and defeat zero-touch rotation.
+            let rebuild_pins = read_trust_pins_from_config(&config_path_for_rebuild).await;
+            let rebuilt_ok = match build_openbao_client(&openbao, &rebuild_pins) {
                 Ok(rebuilt) => {
                     *client.lock().await = rebuilt;
                     if let Err(err) = login(&client, &openbao).await {
@@ -1694,7 +1719,22 @@ fn reconcile_trust_rebuild(
     false
 }
 
-fn build_openbao_client(openbao: &config::OpenBaoSettings) -> Result<OpenBaoClient> {
+/// Builds the fast-poll `OpenBaoClient`, anchoring an `https://` endpoint
+/// to the on-disk CA bundle and restricting its trust anchors to `pins`
+/// (`trusted_ca_sha256`) when non-empty. An empty pin set keeps the prior
+/// bundle-anchored behavior. A plaintext endpoint ignores `pins` (there is
+/// no TLS to anchor).
+///
+/// The pins the caller passes matter: at startup they come from the config
+/// snapshot, but on the post-trust-apply rebuild they MUST come from the
+/// freshly applied trust (see `read_trust_pins_from_config`) so a rotation
+/// that swaps the CA also swaps the pins — a stale startup snapshot would
+/// strand the rebuilt client on the retired CA and defeat zero-touch
+/// rotation (issue #695).
+fn build_openbao_client(
+    openbao: &config::OpenBaoSettings,
+    pins: &[String],
+) -> Result<OpenBaoClient> {
     if openbao.url.starts_with("https://") {
         let ca_bundle_path = openbao
             .ca_bundle_path
@@ -1706,11 +1746,35 @@ fn build_openbao_client(openbao: &config::OpenBaoSettings) -> Result<OpenBaoClie
                 ca_bundle_path.display()
             )
         })?;
-        OpenBaoClient::with_pem_trust(&openbao.url, &pem, &[])
+        OpenBaoClient::with_pem_trust(&openbao.url, &pem, pins)
             .context("Failed to build OpenBao client with CA bundle")
     } else {
         OpenBaoClient::new(&openbao.url).context("Failed to build OpenBao client")
     }
+}
+
+/// Reads the current `[trust].trusted_ca_sha256` pins from the on-disk
+/// `agent.toml`. Used to pin the post-trust-apply client rebuild to the
+/// freshly written anchors rather than the startup snapshot. Returns an
+/// empty list (bundle-anchored) if the file is unreadable, unparseable, or
+/// carries no pins — the same fallback as an unpinned config.
+async fn read_trust_pins_from_config(config_path: &Path) -> Vec<String> {
+    let Ok(contents) = fs::read_to_string(config_path).await else {
+        return Vec::new();
+    };
+    let Ok(doc) = contents.parse::<toml_edit::DocumentMut>() else {
+        return Vec::new();
+    };
+    doc.get("trust")
+        .and_then(|trust| trust.get("trusted_ca_sha256"))
+        .and_then(toml_edit::Item::as_array)
+        .map(|array| {
+            array
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 async fn login(
@@ -2615,12 +2679,38 @@ mod tests {
         assert_eq!(pending.requester.as_deref(), Some("alice"));
     }
 
+    /// Generates a self-signed CA certificate, returning its PEM and the
+    /// lowercase hex SHA-256 of its DER (the `trusted_ca_sha256` form).
+    fn generate_ca_cert() -> (String, String) {
+        use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair};
+
+        let key = KeyPair::generate().expect("generate CA key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Bootroot Test CA");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key).expect("self-signed cert");
+        let fingerprint = crate::tls::sha256_hex(cert.der().as_ref());
+        (cert.pem(), fingerprint)
+    }
+
+    /// Builds a structurally valid trust payload: a two-certificate bundle
+    /// whose members' fingerprints are exactly the pinned list, so it
+    /// passes `parse_trust_payload`'s consistency check.
+    fn valid_trust_bundle() -> (Vec<String>, String) {
+        let (pem_a, fp_a) = generate_ca_cert();
+        let (pem_b, fp_b) = generate_ca_cert();
+        (vec![fp_a, fp_b], format!("{pem_a}{pem_b}"))
+    }
+
     fn trust_read(version: u64) -> KvReadWithVersion {
+        let (fingerprints, ca_bundle_pem) = valid_trust_bundle();
         KvReadWithVersion {
             version,
             data: serde_json::json!({
-                "trusted_ca_sha256": ["a".repeat(64), "b".repeat(64)],
-                "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nMII...\n-----END CERTIFICATE-----\n",
+                "trusted_ca_sha256": fingerprints,
+                "ca_bundle_pem": ca_bundle_pem,
             }),
         }
     }
@@ -3361,6 +3451,216 @@ mod tests {
         assert_eq!(config_mode, 0o600);
     }
 
+    /// Trust-poll hook whose `apply_trust` performs the real on-disk write
+    /// (`apply_trust_to_disk`). Used by the no-disk-write regression test so
+    /// that if a malformed payload ever reached the apply stage the seeded
+    /// files would visibly change. Only `read_kv_version` and `apply_trust`
+    /// are exercised by `run_trust_poll_tick`; the rest are unreachable.
+    struct DiskWritingTrustHooks {
+        reads: std::sync::Mutex<std::collections::VecDeque<Result<Option<KvReadWithVersion>>>>,
+        settings: config::Settings,
+        config_path: PathBuf,
+        applied: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FastPollHooks for DiskWritingTrustHooks {
+        fn read_kv_version(
+            &self,
+            _kv_mount: &str,
+            _kv_path: &str,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<Option<KvReadWithVersion>>> + Send + '_>>
+        {
+            let next = self.reads.lock().unwrap().pop_front().unwrap_or(Ok(None));
+            Box::pin(async move { next })
+        }
+
+        fn apply_trust(
+            &self,
+            service: &str,
+            payload: &TrustPayload,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            self.applied
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let settings = self.settings.clone();
+            let config_path = self.config_path.clone();
+            let service = service.to_string();
+            let payload = payload.clone();
+            Box::pin(async move {
+                apply_trust_to_disk(&settings, &config_path, &service, &payload).await
+            })
+        }
+
+        fn write_kv(
+            &self,
+            _: &str,
+            _: &str,
+            _: serde_json::Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            unreachable!("write_kv not used by trust poll")
+        }
+
+        fn trigger_renewal(
+            &self,
+            _: &str,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            unreachable!("trigger_renewal not used by trust poll")
+        }
+
+        fn apply_secret_id(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            unreachable!("apply_secret_id not used by trust poll")
+        }
+
+        fn apply_responder_hmac(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            unreachable!("apply_responder_hmac not used by trust poll")
+        }
+
+        fn apply_eab(
+            &self,
+            _: &str,
+            _: &EabPayload,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            unreachable!("apply_eab not used by trust poll")
+        }
+    }
+
+    /// Regression for issue #695 item 2: a malformed trust KV payload
+    /// (non-PEM garbage, empty-certificate bundle, or a fingerprint absent
+    /// from the bundle) is classified `Malformed` by the pre-apply parse
+    /// gate, so `apply_trust` is never invoked, neither the CA bundle file
+    /// nor `agent.toml` changes on disk, and `last_trust_seen_version` does
+    /// not advance. This gate is scheme-independent: because `trust_changed`
+    /// stays false, the loop's HTTPS rebuild/version-reconcile block is
+    /// never entered, so both the pre-fix HTTPS failure (bundle poisoned,
+    /// then version rolled back) and the pre-fix plaintext failure (bundle
+    /// poisoned, version advanced with no retry) are prevented. A
+    /// subsequent corrected payload applies normally.
+    // Exercises three malformed shapes plus the corrected-payload recovery
+    // in one place so the no-disk-write invariant is asserted together.
+    #[allow(clippy::too_many_lines)]
+    #[tokio::test]
+    async fn malformed_trust_payload_never_reaches_disk() {
+        let (good_fingerprints, good_bundle) = valid_trust_bundle();
+        let valid_fingerprint = good_fingerprints.first().expect("fingerprint").clone();
+
+        let malformed_cases = [
+            // Non-PEM garbage bundle.
+            serde_json::json!({
+                "trusted_ca_sha256": [valid_fingerprint.clone()],
+                "ca_bundle_pem": "not a certificate",
+            }),
+            // Syntactically valid PEM carrying no CERTIFICATE entries.
+            serde_json::json!({
+                "trusted_ca_sha256": [valid_fingerprint.clone()],
+                "ca_bundle_pem": "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n",
+            }),
+            // Well-formed but unrelated fingerprint not present in the bundle.
+            serde_json::json!({
+                "trusted_ca_sha256": ["a".repeat(64)],
+                "ca_bundle_pem": good_bundle.clone(),
+            }),
+        ];
+
+        for malformed in malformed_cases {
+            let dir = tempfile::tempdir().unwrap();
+            let bundle_path = dir.path().join("ca-bundle.pem");
+            let config_path = dir.path().join("agent.toml");
+            let original_bundle =
+                "-----BEGIN CERTIFICATE-----\nORIGINAL\n-----END CERTIFICATE-----\n";
+            let original_config = "email = \"a@b.c\"\n\n[acme]\nurl = \"http://r\"\n";
+            std::fs::write(&bundle_path, original_bundle).unwrap();
+            std::fs::write(&config_path, original_config).unwrap();
+
+            let mut settings = test_settings("edge-proxy");
+            settings.trust.ca_bundle_path = Some(bundle_path.clone());
+
+            let hooks = DiskWritingTrustHooks {
+                reads: std::sync::Mutex::new(std::collections::VecDeque::from(vec![Ok(Some(
+                    KvReadWithVersion {
+                        version: 5,
+                        data: malformed.clone(),
+                    },
+                ))])),
+                settings,
+                config_path: config_path.clone(),
+                applied: std::sync::atomic::AtomicUsize::new(0),
+            };
+            let services = services_single("edge-proxy", "edge-proxy-domain");
+            let mut state = FastPollState::default();
+
+            let (outcomes, changed) =
+                run_trust_poll_tick(&hooks, "secret", &services, &mut state).await;
+
+            assert!(!changed, "malformed payload must not change state");
+            assert!(
+                matches!(outcomes[0], PollApplyOutcome::Malformed { version: 5, .. }),
+                "expected Malformed, got {:?}",
+                outcomes[0]
+            );
+            assert_eq!(
+                hooks.applied.load(std::sync::atomic::Ordering::SeqCst),
+                0,
+                "apply_trust must never run for a malformed payload"
+            );
+            assert!(state.last_trust_seen_version.is_empty());
+            assert_eq!(
+                std::fs::read_to_string(&bundle_path).unwrap(),
+                original_bundle,
+                "CA bundle must be byte-identical"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&config_path).unwrap(),
+                original_config,
+                "agent.toml must be byte-identical"
+            );
+        }
+
+        // A corrected payload applies normally against fresh state.
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("ca-bundle.pem");
+        let config_path = dir.path().join("agent.toml");
+        std::fs::write(&bundle_path, "seed").unwrap();
+        std::fs::write(&config_path, "email = \"a@b.c\"\n").unwrap();
+        let mut settings = test_settings("edge-proxy");
+        settings.trust.ca_bundle_path = Some(bundle_path.clone());
+        let hooks = DiskWritingTrustHooks {
+            reads: std::sync::Mutex::new(std::collections::VecDeque::from(vec![Ok(Some(
+                KvReadWithVersion {
+                    version: 6,
+                    data: serde_json::json!({
+                        "trusted_ca_sha256": good_fingerprints,
+                        "ca_bundle_pem": good_bundle,
+                    }),
+                },
+            ))])),
+            settings,
+            config_path: config_path.clone(),
+            applied: std::sync::atomic::AtomicUsize::new(0),
+        };
+        let services = services_single("edge-proxy", "edge-proxy-domain");
+        let mut state = FastPollState::default();
+        let (outcomes, changed) =
+            run_trust_poll_tick(&hooks, "secret", &services, &mut state).await;
+        assert!(changed);
+        assert!(matches!(
+            outcomes[0],
+            PollApplyOutcome::Applied { version: 6, .. }
+        ));
+        assert_eq!(state.last_trust_seen_version.get("edge-proxy"), Some(&6));
+        assert!(
+            std::fs::read_to_string(&bundle_path)
+                .unwrap()
+                .contains("BEGIN CERTIFICATE")
+        );
+    }
+
     #[tokio::test]
     async fn apply_trust_to_disk_errors_when_no_ca_bundle_path() {
         let dir = tempfile::tempdir().unwrap();
@@ -3416,5 +3716,165 @@ mod tests {
         let path = dir.path().join("agent.toml");
         std::fs::write(&path, toml).unwrap();
         config::Settings::new(Some(path)).expect("build settings")
+    }
+}
+
+#[cfg(test)]
+mod pin_rotation_tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair};
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio_rustls::TlsAcceptor;
+
+    use super::*;
+
+    struct TestCa {
+        pem: String,
+        fingerprint: String,
+        issuer: Issuer<'static, KeyPair>,
+    }
+
+    fn generate_ca(common_name: &str) -> TestCa {
+        let key = KeyPair::generate().expect("generate CA key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, common_name);
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key).expect("self-signed CA");
+        let pem = cert.pem();
+        let fingerprint = crate::tls::sha256_hex(cert.der().as_ref());
+        let issuer = Issuer::new(params, key);
+        TestCa {
+            pem,
+            fingerprint,
+            issuer,
+        }
+    }
+
+    fn sign_server_leaf(ca: &TestCa) -> (Vec<u8>, Vec<u8>) {
+        let key = KeyPair::generate().expect("generate server key");
+        let mut params =
+            CertificateParams::new(vec!["localhost".to_string()]).expect("certificate params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "localhost");
+        params.is_ca = IsCa::NoCa;
+        let cert = params
+            .signed_by(&key, &ca.issuer)
+            .expect("signed server cert");
+        (cert.der().to_vec(), key.serialize_der())
+    }
+
+    async fn start_tls_server(cert_der: Vec<u8>, key_der: Vec<u8>) -> u16 {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let cert = CertificateDer::from(cert_der);
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_der));
+        let config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .expect("server TLS config");
+        let acceptor = TlsAcceptor::from(Arc::new(config));
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("local addr").port();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let acceptor = acceptor.clone();
+                tokio::spawn(async move {
+                    let Ok(mut tls) = acceptor.accept(stream).await else {
+                        return;
+                    };
+                    let mut buf = vec![0u8; 4096];
+                    let _ = tls.read(&mut buf).await;
+                    let _ = tls
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        )
+                        .await;
+                    let _ = tls.shutdown().await;
+                });
+            }
+        });
+        port
+    }
+
+    fn openbao_settings(url: &str, bundle_path: &Path) -> config::OpenBaoSettings {
+        config::OpenBaoSettings {
+            url: url.to_string(),
+            allow_plaintext_http: false,
+            kv_mount: "secret".to_string(),
+            role_id_path: PathBuf::from("/unused/role_id"),
+            secret_id_path: PathBuf::from("/unused/secret_id"),
+            ca_bundle_path: Some(bundle_path.to_path_buf()),
+            fast_poll_interval: Duration::from_secs(5),
+            state_path: PathBuf::from("/unused/state.json"),
+        }
+    }
+
+    /// Item #695: with non-empty pins the fast-poll HTTPS client rejects an
+    /// endpoint whose chain does not terminate at a pinned CA, and the
+    /// post-trust-apply rebuild pins to the FRESHLY applied anchors read
+    /// from `agent.toml` — not the startup snapshot. The endpoint is
+    /// rotated to a new CA; a client built with the stale startup pin fails
+    /// against it (this assertion fails if the rebuild reuses the startup
+    /// snapshot), while a client built with the freshly re-read pin keeps
+    /// polling.
+    #[tokio::test]
+    async fn rebuild_pins_to_freshly_applied_anchors_not_startup_snapshot() {
+        let ca_old = generate_ca("Old Root CA");
+        let ca_new = generate_ca("New Root CA");
+
+        // The rotated endpoint presents a leaf signed by the NEW CA.
+        let (leaf_der, leaf_key) = sign_server_leaf(&ca_new);
+        let port = start_tls_server(leaf_der, leaf_key).await;
+        let url = format!("https://localhost:{port}");
+
+        // The on-disk bundle carries BOTH anchors; the pin set decides
+        // which is a usable trust anchor for this channel.
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("ca-bundle.pem");
+        std::fs::write(&bundle_path, format!("{}{}", ca_old.pem, ca_new.pem)).unwrap();
+        let openbao = openbao_settings(&url, &bundle_path);
+
+        // Stale startup pin (old CA): cannot reach the rotated endpoint.
+        let stale = build_openbao_client(&openbao, std::slice::from_ref(&ca_old.fingerprint))
+            .expect("build stale-pinned client");
+        assert!(
+            stale.health_check().await.is_err(),
+            "a client pinned to the retired CA must reject the rotated endpoint"
+        );
+
+        // Rotation has just rewritten agent.toml with the NEW pin; the
+        // rebuild re-reads it rather than reusing the startup snapshot.
+        let config_path = dir.path().join("agent.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[trust]\ntrusted_ca_sha256 = [\"{}\"]\n",
+                ca_new.fingerprint
+            ),
+        )
+        .unwrap();
+        let fresh_pins = read_trust_pins_from_config(&config_path).await;
+        assert_eq!(fresh_pins, vec![ca_new.fingerprint.clone()]);
+
+        let rebuilt =
+            build_openbao_client(&openbao, &fresh_pins).expect("build fresh-pinned client");
+        assert!(
+            rebuilt.health_check().await.is_ok(),
+            "a client pinned to the freshly applied CA must reach the rotated endpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_trust_pins_from_config_returns_empty_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("agent.toml");
+        std::fs::write(&config_path, "email = \"a@b.c\"\n").unwrap();
+        assert!(read_trust_pins_from_config(&config_path).await.is_empty());
     }
 }

--- a/src/fast_poll.rs
+++ b/src/fast_poll.rs
@@ -1619,11 +1619,13 @@ pub(crate) async fn run_fast_poll_loop(
         // `https://` client anchors trust, so a plaintext endpoint needs no
         // rebuild.
         //
-        // Rebuild BEFORE persisting the advanced trust version. `parse_trust_payload`
-        // only checks that `ca_bundle_pem` is non-empty; the real PEM/root-store
-        // validation happens here in `build_openbao_client`. If the bundle is
-        // malformed, unreadable after the write, or otherwise rejected, the
-        // version must NOT stay marked applied — otherwise the poll reports
+        // Rebuild BEFORE persisting the advanced trust version.
+        // `parse_trust_payload` now validates the bundle's PEM structure and
+        // fingerprint consistency pre-apply, but the root-store construction
+        // that actually anchors this channel's TLS still happens here in
+        // `build_openbao_client`. If the bundle is unreadable after the write,
+        // rejected by rustls, or the freshly applied pins cannot be recovered,
+        // the version must NOT stay marked applied — otherwise the poll reports
         // `UpToDate` forever, never retries the rebuild, and the loop is
         // stranded on stale roots once the old anchor is retired. On a rebuild
         // failure, roll the version back so the next tick re-applies and
@@ -1632,46 +1634,13 @@ pub(crate) async fn run_fast_poll_loop(
         // advanced version and just retry the login.
         let mut trust_applied = trust_changed;
         if trust_changed && rebuild_client_on_trust {
-            // Pin the rebuilt client to the freshly applied anchors, not
-            // the startup snapshot: a rotation that lands a new CA + new
-            // pins in KV has just been written to agent.toml, so re-read
-            // from there. Stale startup pins would strand the client on
-            // the retired CA and defeat zero-touch rotation. Recovering the
-            // pins CAN fail (unreadable/unparseable config, or no pins
-            // written) — treat that as a rebuild failure and roll the
-            // version back rather than silently rebuilding unpinned, which
-            // would downgrade the channel from pinned to bundle-anchored
-            // trust while reporting the rotation as applied.
-            let rebuilt_ok = match read_trust_pins_from_config(&config_path_for_rebuild).await {
-                Ok(rebuild_pins) => match build_openbao_client(&openbao, &rebuild_pins) {
-                    Ok(rebuilt) => {
-                        *client.lock().await = rebuilt;
-                        if let Err(err) = login(&client, &openbao).await {
-                            warn!(
-                                "OpenBao re-login after CA bundle rebuild failed: {err:#}. Will retry on the next tick."
-                            );
-                            needs_relogin = true;
-                        } else {
-                            info!(
-                                "Rebuilt OpenBao client from the refreshed CA bundle after a trust update."
-                            );
-                        }
-                        true
-                    }
-                    Err(err) => {
-                        warn!(
-                            "Failed to rebuild OpenBao client after a trust update: {err:#}. Rolling back the applied trust version so the next tick retries the apply and rebuild."
-                        );
-                        false
-                    }
-                },
-                Err(err) => {
-                    warn!(
-                        "Failed to recover the freshly applied trust pins after a trust update: {err:#}. Rolling back the applied trust version so the next tick retries rather than rebuilding with unpinned bundle-anchored trust."
-                    );
-                    false
-                }
-            };
+            let rebuilt_ok = rebuild_client_after_trust_apply(
+                &client,
+                &openbao,
+                &config_path_for_rebuild,
+                &mut needs_relogin,
+            )
+            .await;
             trust_applied = reconcile_trust_rebuild(&mut state, trust_versions_before, rebuilt_ok);
         }
 
@@ -1729,6 +1698,59 @@ fn reconcile_trust_rebuild(
     }
     state.last_trust_seen_version = versions_before;
     false
+}
+
+/// Rebuilds the fast-poll `OpenBaoClient` after a trust apply, swaps it into
+/// `client`, and re-logs in. Returns whether the rebuild succeeded so the
+/// caller can roll the advanced trust version back on failure.
+///
+/// Pins the rebuilt client to the FRESHLY applied anchors re-read from
+/// `config_path`, never a startup snapshot: a rotation that lands a new CA +
+/// new pins in KV has just written both to `agent.toml`, so the pins are read
+/// back from there. Stale startup pins would strand the client on the retired
+/// CA and defeat zero-touch rotation. Recovering the pins CAN fail (unreadable
+/// / unparseable config, or no pins written) — that is treated as a rebuild
+/// failure so the caller rolls the version back rather than silently rebuilding
+/// unpinned, which would downgrade the channel from pinned to bundle-anchored
+/// trust while reporting the rotation as applied.
+///
+/// A re-login failure after a *successful* rebuild still returns `true` (the
+/// new roots are already swapped in) and sets `needs_relogin` so the caller
+/// retries the login on the next tick.
+async fn rebuild_client_after_trust_apply(
+    client: &Arc<Mutex<OpenBaoClient>>,
+    openbao: &config::OpenBaoSettings,
+    config_path: &Path,
+    needs_relogin: &mut bool,
+) -> bool {
+    let rebuild_pins = match read_trust_pins_from_config(config_path).await {
+        Ok(pins) => pins,
+        Err(err) => {
+            warn!(
+                "Failed to recover the freshly applied trust pins after a trust update: {err:#}. Rolling back the applied trust version so the next tick retries rather than rebuilding with unpinned bundle-anchored trust."
+            );
+            return false;
+        }
+    };
+    let rebuilt = match build_openbao_client(openbao, &rebuild_pins) {
+        Ok(rebuilt) => rebuilt,
+        Err(err) => {
+            warn!(
+                "Failed to rebuild OpenBao client after a trust update: {err:#}. Rolling back the applied trust version so the next tick retries the apply and rebuild."
+            );
+            return false;
+        }
+    };
+    *client.lock().await = rebuilt;
+    if let Err(err) = login(client, openbao).await {
+        warn!(
+            "OpenBao re-login after CA bundle rebuild failed: {err:#}. Will retry on the next tick."
+        );
+        *needs_relogin = true;
+    } else {
+        info!("Rebuilt OpenBao client from the refreshed CA bundle after a trust update.");
+    }
+    true
 }
 
 /// Builds the fast-poll `OpenBaoClient`, anchoring an `https://` endpoint
@@ -3855,12 +3877,14 @@ mod pin_rotation_tests {
 
     /// Item #695: with non-empty pins the fast-poll HTTPS client rejects an
     /// endpoint whose chain does not terminate at a pinned CA, and the
-    /// post-trust-apply rebuild pins to the FRESHLY applied anchors read
-    /// from `agent.toml` — not the startup snapshot. The endpoint is
-    /// rotated to a new CA; a client built with the stale startup pin fails
-    /// against it (this assertion fails if the rebuild reuses the startup
-    /// snapshot), while a client built with the freshly re-read pin keeps
-    /// polling.
+    /// post-trust-apply rebuild pins to the FRESHLY applied anchors read from
+    /// `agent.toml` — not the startup snapshot. This drives the production
+    /// rebuild decision (`rebuild_client_after_trust_apply`, the same helper
+    /// the fast-poll loop calls) rather than re-reading the pins by hand: the
+    /// loop starts holding a client pinned to the retired CA, the endpoint is
+    /// rotated to a new CA, and the helper must swap in a client that reaches
+    /// it. The final assertion fails if the rebuild reuses the stale startup
+    /// snapshot instead of the freshly written pin.
     #[tokio::test]
     async fn rebuild_pins_to_freshly_applied_anchors_not_startup_snapshot() {
         let ca_old = generate_ca("Old Root CA");
@@ -3878,16 +3902,22 @@ mod pin_rotation_tests {
         std::fs::write(&bundle_path, format!("{}{}", ca_old.pem, ca_new.pem)).unwrap();
         let openbao = openbao_settings(&url, &bundle_path);
 
-        // Stale startup pin (old CA): cannot reach the rotated endpoint.
-        let stale = build_openbao_client(&openbao, std::slice::from_ref(&ca_old.fingerprint))
-            .expect("build stale-pinned client");
+        // The loop starts holding a client pinned to the STARTUP snapshot
+        // (old CA); it cannot reach the rotated endpoint.
+        let client = Arc::new(Mutex::new(
+            build_openbao_client(&openbao, std::slice::from_ref(&ca_old.fingerprint))
+                .expect("build startup-pinned client"),
+        ));
         assert!(
-            stale.health_check().await.is_err(),
-            "a client pinned to the retired CA must reject the rotated endpoint"
+            client.lock().await.health_check().await.is_err(),
+            "the startup-pinned client (retired CA) must reject the rotated endpoint"
         );
 
-        // Rotation has just rewritten agent.toml with the NEW pin; the
-        // rebuild re-reads it rather than reusing the startup snapshot.
+        // Rotation has just rewritten agent.toml with the NEW pin. Drive the
+        // production rebuild helper: it MUST re-read the fresh pin from
+        // agent.toml, not reuse the startup snapshot. If it reused the stale
+        // snapshot the swapped-in client would still be pinned to the old CA
+        // and the health check below would fail.
         let config_path = dir.path().join("agent.toml");
         std::fs::write(
             &config_path,
@@ -3897,16 +3927,57 @@ mod pin_rotation_tests {
             ),
         )
         .unwrap();
-        let fresh_pins = read_trust_pins_from_config(&config_path)
-            .await
-            .expect("recover freshly applied pins");
-        assert_eq!(fresh_pins, vec![ca_new.fingerprint.clone()]);
 
-        let rebuilt =
-            build_openbao_client(&openbao, &fresh_pins).expect("build fresh-pinned client");
+        let mut needs_relogin = false;
+        let rebuilt_ok =
+            rebuild_client_after_trust_apply(&client, &openbao, &config_path, &mut needs_relogin)
+                .await;
         assert!(
-            rebuilt.health_check().await.is_ok(),
-            "a client pinned to the freshly applied CA must reach the rotated endpoint"
+            rebuilt_ok,
+            "recovering the freshly applied pins and rebuilding must succeed"
+        );
+        // The stalled/empty test endpoint cannot satisfy an AppRole login, so
+        // the post-rebuild re-login is expected to fail and rearm relogin —
+        // the rebuild itself still succeeded because the roots were swapped in
+        // before the login attempt.
+        assert!(
+            needs_relogin,
+            "a failed post-rebuild re-login must rearm relogin"
+        );
+        assert!(
+            client.lock().await.health_check().await.is_ok(),
+            "after the rebuild the swapped-in client must reach the rotated endpoint using the freshly applied pin (fails if the rebuild reused the startup snapshot)"
+        );
+    }
+
+    /// Item #695 fail-closed guard: when `agent.toml` carries no
+    /// `[trust].trusted_ca_sha256` after a trust apply, the production rebuild
+    /// helper must return `false` so the caller rolls the trust version back,
+    /// rather than silently rebuilding with unpinned bundle-anchored trust.
+    #[tokio::test]
+    async fn rebuild_fails_closed_when_fresh_pins_unrecoverable() {
+        let ca = generate_ca("Root CA");
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = dir.path().join("ca-bundle.pem");
+        std::fs::write(&bundle_path, &ca.pem).unwrap();
+        let openbao = openbao_settings("https://localhost:8200", &bundle_path);
+        let client = Arc::new(Mutex::new(
+            build_openbao_client(&openbao, std::slice::from_ref(&ca.fingerprint))
+                .expect("build client"),
+        ));
+
+        // A config with no [trust].trusted_ca_sha256 is an unrecoverable pin
+        // read after an apply, not an unpinned deployment.
+        let config_path = dir.path().join("agent.toml");
+        std::fs::write(&config_path, "email = \"a@b.c\"\n").unwrap();
+
+        let mut needs_relogin = false;
+        let rebuilt_ok =
+            rebuild_client_after_trust_apply(&client, &openbao, &config_path, &mut needs_relogin)
+                .await;
+        assert!(
+            !rebuilt_ok,
+            "unrecoverable fresh pins must fail the rebuild closed so the version rolls back"
         );
     }
 

--- a/src/fast_poll.rs
+++ b/src/fast_poll.rs
@@ -1590,7 +1590,7 @@ pub(crate) async fn run_fast_poll_loop(
         // failed HTTPS client rebuild below must be able to roll the version
         // back so the next tick retries (see the rebuild block). Only
         // `https://` rebuilds the client, so skip the clone otherwise.
-        let rebuild_client_on_trust = openbao.url.starts_with("https://");
+        let rebuild_client_on_trust = config::openbao_url_is_https(&openbao.url);
         let trust_versions_before = if rebuild_client_on_trust {
             state.last_trust_seen_version.clone()
         } else {
@@ -1636,26 +1636,38 @@ pub(crate) async fn run_fast_poll_loop(
             // the startup snapshot: a rotation that lands a new CA + new
             // pins in KV has just been written to agent.toml, so re-read
             // from there. Stale startup pins would strand the client on
-            // the retired CA and defeat zero-touch rotation.
-            let rebuild_pins = read_trust_pins_from_config(&config_path_for_rebuild).await;
-            let rebuilt_ok = match build_openbao_client(&openbao, &rebuild_pins) {
-                Ok(rebuilt) => {
-                    *client.lock().await = rebuilt;
-                    if let Err(err) = login(&client, &openbao).await {
-                        warn!(
-                            "OpenBao re-login after CA bundle rebuild failed: {err:#}. Will retry on the next tick."
-                        );
-                        needs_relogin = true;
-                    } else {
-                        info!(
-                            "Rebuilt OpenBao client from the refreshed CA bundle after a trust update."
-                        );
+            // the retired CA and defeat zero-touch rotation. Recovering the
+            // pins CAN fail (unreadable/unparseable config, or no pins
+            // written) — treat that as a rebuild failure and roll the
+            // version back rather than silently rebuilding unpinned, which
+            // would downgrade the channel from pinned to bundle-anchored
+            // trust while reporting the rotation as applied.
+            let rebuilt_ok = match read_trust_pins_from_config(&config_path_for_rebuild).await {
+                Ok(rebuild_pins) => match build_openbao_client(&openbao, &rebuild_pins) {
+                    Ok(rebuilt) => {
+                        *client.lock().await = rebuilt;
+                        if let Err(err) = login(&client, &openbao).await {
+                            warn!(
+                                "OpenBao re-login after CA bundle rebuild failed: {err:#}. Will retry on the next tick."
+                            );
+                            needs_relogin = true;
+                        } else {
+                            info!(
+                                "Rebuilt OpenBao client from the refreshed CA bundle after a trust update."
+                            );
+                        }
+                        true
                     }
-                    true
-                }
+                    Err(err) => {
+                        warn!(
+                            "Failed to rebuild OpenBao client after a trust update: {err:#}. Rolling back the applied trust version so the next tick retries the apply and rebuild."
+                        );
+                        false
+                    }
+                },
                 Err(err) => {
                     warn!(
-                        "Failed to rebuild OpenBao client after a trust update: {err:#}. Rolling back the applied trust version so the next tick retries the apply and rebuild."
+                        "Failed to recover the freshly applied trust pins after a trust update: {err:#}. Rolling back the applied trust version so the next tick retries rather than rebuilding with unpinned bundle-anchored trust."
                     );
                     false
                 }
@@ -1735,7 +1747,7 @@ fn build_openbao_client(
     openbao: &config::OpenBaoSettings,
     pins: &[String],
 ) -> Result<OpenBaoClient> {
-    if openbao.url.starts_with("https://") {
+    if config::openbao_url_is_https(&openbao.url) {
         let ca_bundle_path = openbao
             .ca_bundle_path
             .as_ref()
@@ -1754,18 +1766,37 @@ fn build_openbao_client(
 }
 
 /// Reads the current `[trust].trusted_ca_sha256` pins from the on-disk
-/// `agent.toml`. Used to pin the post-trust-apply client rebuild to the
-/// freshly written anchors rather than the startup snapshot. Returns an
-/// empty list (bundle-anchored) if the file is unreadable, unparseable, or
-/// carries no pins — the same fallback as an unpinned config.
-async fn read_trust_pins_from_config(config_path: &Path) -> Vec<String> {
-    let Ok(contents) = fs::read_to_string(config_path).await else {
-        return Vec::new();
-    };
-    let Ok(doc) = contents.parse::<toml_edit::DocumentMut>() else {
-        return Vec::new();
-    };
-    doc.get("trust")
+/// `agent.toml` to pin the post-trust-apply client rebuild to the freshly
+/// written anchors rather than the startup snapshot.
+///
+/// This is only called after a trust apply succeeded, and every trust
+/// payload that applies carries a non-empty `trusted_ca_sha256`
+/// (`parse_trust_payload` rejects an empty pin set), so the just-written
+/// config MUST expose a non-empty pin array. Any failure to recover it —
+/// unreadable file, unparseable TOML, or a missing / non-array / empty
+/// `trusted_ca_sha256` — is therefore an error, NOT a silent fall back to
+/// an empty (bundle-anchored) pin set: swallowing it would let a rotation
+/// downgrade "trust only the pinned anchors" to "trust every CA in the
+/// bundle" while still persisting the version as applied. The caller rolls
+/// the trust version back on `Err` so the next tick retries the apply and
+/// rebuild (issue #695).
+///
+/// # Errors
+///
+/// Returns an error when the config cannot be read or parsed, or when it
+/// carries no usable `[trust].trusted_ca_sha256` pins.
+async fn read_trust_pins_from_config(config_path: &Path) -> Result<Vec<String>> {
+    let contents = fs::read_to_string(config_path).await.with_context(|| {
+        format!(
+            "Failed to read agent config for trust pins at {}",
+            config_path.display()
+        )
+    })?;
+    let doc = contents
+        .parse::<toml_edit::DocumentMut>()
+        .with_context(|| format!("Failed to parse agent config at {}", config_path.display()))?;
+    let pins: Vec<String> = doc
+        .get("trust")
         .and_then(|trust| trust.get("trusted_ca_sha256"))
         .and_then(toml_edit::Item::as_array)
         .map(|array| {
@@ -1774,7 +1805,14 @@ async fn read_trust_pins_from_config(config_path: &Path) -> Vec<String> {
                 .filter_map(|value| value.as_str().map(str::to_string))
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    if pins.is_empty() {
+        anyhow::bail!(
+            "agent config at {} has no [trust].trusted_ca_sha256 pins after a trust apply",
+            config_path.display()
+        );
+    }
+    Ok(pins)
 }
 
 async fn login(
@@ -3859,7 +3897,9 @@ mod pin_rotation_tests {
             ),
         )
         .unwrap();
-        let fresh_pins = read_trust_pins_from_config(&config_path).await;
+        let fresh_pins = read_trust_pins_from_config(&config_path)
+            .await
+            .expect("recover freshly applied pins");
         assert_eq!(fresh_pins, vec![ca_new.fingerprint.clone()]);
 
         let rebuilt =
@@ -3871,10 +3911,24 @@ mod pin_rotation_tests {
     }
 
     #[tokio::test]
-    async fn read_trust_pins_from_config_returns_empty_when_absent() {
+    async fn read_trust_pins_from_config_errs_when_pins_absent() {
+        // A config with no [trust].trusted_ca_sha256 must NOT silently
+        // recover an empty (bundle-anchored) pin set: since every applied
+        // trust payload carries non-empty pins, an empty read here means a
+        // rotation would downgrade pinned trust. The reader errors so the
+        // caller rolls the trust version back instead.
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("agent.toml");
         std::fs::write(&config_path, "email = \"a@b.c\"\n").unwrap();
-        assert!(read_trust_pins_from_config(&config_path).await.is_empty());
+        assert!(read_trust_pins_from_config(&config_path).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_trust_pins_from_config_errs_when_unreadable() {
+        // A missing config file is a recovery failure, not an unpinned
+        // deployment.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("does-not-exist.toml");
+        assert!(read_trust_pins_from_config(&config_path).await.is_err());
     }
 }

--- a/src/kv_payload.rs
+++ b/src/kv_payload.rs
@@ -7,7 +7,9 @@
 //! agree on shape, required fields, and fingerprint formatting. Callers that
 //! need localized error text wrap these errors with their own context.
 
-use anyhow::{Result, bail};
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, bail};
 
 use crate::trust_bootstrap::{
     CA_BUNDLE_PEM_KEY, EAB_HMAC_KEY, EAB_KID_KEY, HMAC_KEY, SECRET_ID_KEY, TRUSTED_CA_KEY,
@@ -26,17 +28,55 @@ pub struct TrustPayload {
 
 /// Parses and validates a service `trust` KV payload.
 ///
+/// Beyond the shape checks, this verifies the payload is internally
+/// consistent before any of it can reach disk: the `ca_bundle_pem` must
+/// parse into at least one certificate, and every `trusted_ca_sha256`
+/// fingerprint must match the SHA-256 of some certificate in that bundle.
+/// The fingerprints and the bundle come from the same payload, so this is
+/// consistency validation rather than independent authentication — but it
+/// rejects non-PEM garbage, empty-certificate bundles, truncated writes,
+/// and operator mistakes before the fast-poll trust-apply hook writes the
+/// bundle to disk (issue #695).
+///
 /// # Errors
 ///
 /// Returns an error when `trusted_ca_sha256` is missing, empty, or contains a
-/// non-string / non-64-hex value, or when `ca_bundle_pem` is missing or empty.
+/// non-string / non-64-hex value, when `ca_bundle_pem` is missing or empty,
+/// when `ca_bundle_pem` does not parse into at least one certificate, or when
+/// a fingerprint does not match any certificate in the bundle.
 pub fn parse_trust_payload(data: &serde_json::Value) -> Result<TrustPayload> {
     let trusted_ca_sha256 = parse_fingerprints(data)?;
     let ca_bundle_pem = parse_required_string(data, &[CA_BUNDLE_PEM_KEY])?;
+    validate_bundle_consistency(&ca_bundle_pem, &trusted_ca_sha256)?;
     Ok(TrustPayload {
         trusted_ca_sha256,
         ca_bundle_pem,
     })
+}
+
+/// Verifies the CA bundle parses into certificates and that every pinned
+/// fingerprint matches one of them.
+///
+/// # Errors
+///
+/// Returns an error when the bundle parses to zero certificates or when a
+/// fingerprint is not present among the bundle certificates' SHA-256 hashes.
+fn validate_bundle_consistency(ca_bundle_pem: &str, fingerprints: &[String]) -> Result<()> {
+    let certs = crate::tls::parse_pem_to_cert_list(ca_bundle_pem.as_bytes())
+        .context("trust payload ca_bundle_pem is not a valid certificate bundle")?;
+    let present: HashSet<String> = certs
+        .iter()
+        .map(|cert| crate::tls::sha256_hex(cert.as_ref()))
+        .collect();
+    for fingerprint in fingerprints {
+        if !present.contains(&fingerprint.to_ascii_lowercase()) {
+            bail!(
+                "trust payload {TRUSTED_CA_KEY} entry {fingerprint} does not match any \
+                 certificate in ca_bundle_pem"
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Parses a service `secret_id` KV payload, returning the credential.
@@ -169,15 +209,76 @@ fn parse_fingerprints(data: &serde_json::Value) -> Result<Vec<String>> {
 mod tests {
     use super::*;
 
+    /// Generates a self-signed CA certificate, returning its PEM and the
+    /// lowercase hex SHA-256 of its DER (the `trusted_ca_sha256` form).
+    fn generate_ca_cert() -> (String, String) {
+        use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair};
+
+        let key = KeyPair::generate().expect("generate CA key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Bootroot Test CA");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let cert = params.self_signed(&key).expect("self-signed cert");
+        let fingerprint = crate::tls::sha256_hex(cert.der().as_ref());
+        (cert.pem(), fingerprint)
+    }
+
     #[test]
     fn parse_trust_payload_accepts_valid_values() {
+        let (pem_a, fp_a) = generate_ca_cert();
+        let (pem_b, fp_b) = generate_ca_cert();
         let data = serde_json::json!({
-            "trusted_ca_sha256": ["a".repeat(64), "b".repeat(64)],
-            "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\n...\n",
+            "trusted_ca_sha256": [fp_a, fp_b],
+            "ca_bundle_pem": format!("{pem_a}{pem_b}"),
         });
         let parsed = parse_trust_payload(&data).expect("parse trust payload");
         assert_eq!(parsed.trusted_ca_sha256.len(), 2);
-        assert!(parsed.ca_bundle_pem.starts_with("-----BEGIN"));
+        assert!(parsed.ca_bundle_pem.contains("-----BEGIN CERTIFICATE-----"));
+    }
+
+    #[test]
+    fn parse_trust_payload_accepts_uppercase_fingerprint() {
+        let (pem, fp) = generate_ca_cert();
+        let data = serde_json::json!({
+            "trusted_ca_sha256": [fp.to_ascii_uppercase()],
+            "ca_bundle_pem": pem,
+        });
+        assert!(parse_trust_payload(&data).is_ok());
+    }
+
+    #[test]
+    fn parse_trust_payload_rejects_non_pem_bundle() {
+        let (_, fp) = generate_ca_cert();
+        let data = serde_json::json!({
+            "trusted_ca_sha256": [fp],
+            "ca_bundle_pem": "this is not a certificate bundle",
+        });
+        assert!(parse_trust_payload(&data).is_err());
+    }
+
+    #[test]
+    fn parse_trust_payload_rejects_bundle_with_no_certificates() {
+        // A syntactically valid PEM that carries no CERTIFICATE entries
+        // parses to zero certs and must be rejected.
+        let (_, fp) = generate_ca_cert();
+        let data = serde_json::json!({
+            "trusted_ca_sha256": [fp],
+            "ca_bundle_pem": "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n",
+        });
+        assert!(parse_trust_payload(&data).is_err());
+    }
+
+    #[test]
+    fn parse_trust_payload_rejects_fingerprint_absent_from_bundle() {
+        let (pem, _) = generate_ca_cert();
+        let data = serde_json::json!({
+            // A well-formed but unrelated fingerprint.
+            "trusted_ca_sha256": ["a".repeat(64)],
+            "ca_bundle_pem": pem,
+        });
+        assert!(parse_trust_payload(&data).is_err());
     }
 
     #[test]

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -198,6 +198,8 @@ impl OpenBaoClient {
     /// Returns an error if the HTTP client cannot be initialized.
     pub fn new(base_url: &str) -> Result<Self> {
         let client = Client::builder()
+            .connect_timeout(crate::tls::OPENBAO_CONNECT_TIMEOUT)
+            .timeout(crate::tls::OPENBAO_REQUEST_TIMEOUT)
             .build()
             .context("Failed to build OpenBao HTTP client")?;
         Ok(Self {
@@ -1882,5 +1884,55 @@ mod tls_integration_tests {
             OpenBaoClient::with_local_trust("https://example.invalid", secrets_dir.path())
                 .expect("https client with no bundle still constructs");
         assert_eq!(external.base_url, "https://example.invalid");
+    }
+}
+
+#[cfg(test)]
+mod timeout_tests {
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    /// A stalling server: accepts the connection and holds every socket
+    /// open forever without ever writing a response, so a client with no
+    /// request timeout would hang indefinitely.
+    async fn spawn_stalling_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stalling listener");
+        let addr = listener.local_addr().expect("stalling listener addr");
+        tokio::spawn(async move {
+            // Retain each accepted stream so the connection stays open (a
+            // dropped stream would send RST and unblock the client early);
+            // the loop ends when accept() errors.
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// Confirms the request timeout constant is wired into the client: a
+    /// read against a server that accepts and stalls fails within the
+    /// bound instead of hanging. Runs under paused time so the virtual
+    /// clock auto-advances to the timeout without a real 30s wait.
+    #[tokio::test(start_paused = true)]
+    async fn read_fails_within_request_timeout_when_server_stalls() {
+        let url = spawn_stalling_server().await;
+        let mut client = OpenBaoClient::new(&url).expect("client init");
+        client.set_token("token".to_string());
+
+        let start = tokio::time::Instant::now();
+        let result = client.try_read_kv("secret", "bootroot/stall").await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "a stalled read must fail rather than hang");
+        assert!(
+            elapsed <= crate::tls::OPENBAO_REQUEST_TIMEOUT + Duration::from_secs(1),
+            "read should time out within the request bound, took {elapsed:?}"
+        );
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use reqwest::Client;
@@ -14,6 +15,21 @@ use x509_parser::prelude::ASN1Time;
 use x509_parser::prelude::FromDer;
 
 use crate::config::TrustSettings;
+
+/// Connect timeout for `OpenBao` HTTP clients.
+///
+/// All `OpenBao` payloads are small JSON, so a TCP connect that has not
+/// completed within this bound is almost certainly a stalled or
+/// black-holed endpoint. Bounding the connect keeps a single hung dial
+/// from wedging the shared fast-poll client (see issue #695).
+pub(crate) const OPENBAO_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Total request timeout for `OpenBao` HTTP clients.
+///
+/// Bounds the whole request (connect + send + receive) so a peer that
+/// accepts the connection and then stalls cannot hang the fast-poll loop
+/// indefinitely, which shares one client across every poll.
+pub(crate) const OPENBAO_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Builds a [`reqwest::Client`] configured according to the given
 /// [`TrustSettings`] and runtime TLS override.
@@ -91,6 +107,8 @@ pub fn build_http_client_from_pem(pem_content: &str, pins: &[String]) -> Result<
     let config = build_client_config_from_pem(pem_content, pins)?;
     Client::builder()
         .use_preconfigured_tls(config)
+        .connect_timeout(OPENBAO_CONNECT_TIMEOUT)
+        .timeout(OPENBAO_REQUEST_TIMEOUT)
         .build()
         .context("Failed to build HTTP client from PEM bundle")
 }
@@ -146,6 +164,8 @@ pub fn build_http_client_with_local_and_webpki_roots(pem_content: &str) -> Resul
         .with_no_client_auth();
     Client::builder()
         .use_preconfigured_tls(config)
+        .connect_timeout(OPENBAO_CONNECT_TIMEOUT)
+        .timeout(OPENBAO_REQUEST_TIMEOUT)
         .build()
         .context("Failed to build HTTP client with local+webpki roots")
 }
@@ -181,7 +201,11 @@ pub(crate) fn build_local_plus_webpki_root_store(
     Ok(root_store)
 }
 
-fn parse_pem_to_cert_list(pem_bytes: &[u8]) -> Result<Vec<CertificateDer<'static>>> {
+/// Parses a PEM-encoded byte buffer into the list of `CERTIFICATE`
+/// entries it contains, rejecting a buffer that parses to zero
+/// certificates. Widened to `pub(crate)` so `kv_payload` can structurally
+/// validate a KV trust bundle before it reaches disk (issue #695).
+pub(crate) fn parse_pem_to_cert_list(pem_bytes: &[u8]) -> Result<Vec<CertificateDer<'static>>> {
     let mut remaining = pem_bytes;
     let mut certs = Vec::new();
     while !remaining.is_empty() {
@@ -362,7 +386,24 @@ impl ServerCertVerifier for PinnedCertVerifier {
     }
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
+/// Computes the `trusted_ca_sha256` fingerprints (lowercase hex SHA-256 of
+/// each certificate's DER) for every certificate in a PEM bundle.
+///
+/// Public so the remote bootstrap binary can advertise a bundle's trust
+/// anchors in its artifact for TLS pinning (issue #695).
+///
+/// # Errors
+///
+/// Returns an error if the PEM parses to zero certificates.
+pub fn ca_bundle_fingerprints(pem_content: &str) -> Result<Vec<String>> {
+    let certs = parse_pem_to_cert_list(pem_content.as_bytes())?;
+    Ok(certs.iter().map(|cert| sha256_hex(cert.as_ref())).collect())
+}
+
+/// Computes the lowercase hex SHA-256 of `bytes`. For a certificate DER
+/// this yields the fingerprint used for `trusted_ca_sha256` pins and the
+/// KV trust-payload consistency check (issue #695).
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     let digest = ring::digest::digest(&ring::digest::SHA256, bytes);
     let mut output = String::with_capacity(digest.as_ref().len() * 2);
     for byte in digest.as_ref() {

--- a/tests/bootroot_remote.rs
+++ b/tests/bootroot_remote.rs
@@ -74,10 +74,8 @@ async fn test_bootroot_remote_applies_service_secrets() {
     assert!(agent_contents.contains("ca_bundle_path = \""));
     assert!(agent_contents.contains("trusted_ca_sha256 = ["));
     let bundle_contents = fs::read_to_string(&ca_bundle_path).expect("read ca bundle");
-    assert_eq!(
-        bundle_contents,
-        "-----BEGIN CERTIFICATE-----\nREMOTE\n-----END CERTIFICATE-----\n"
-    );
+    let (expected_bundle, _) = valid_remote_trust();
+    assert_eq!(bundle_contents, expected_bundle);
 
     assert_mode(&secret_id_path, 0o600);
     assert_mode(&eab_file_path, 0o600);
@@ -655,6 +653,42 @@ async fn test_bootroot_remote_reports_partial_failure_with_json_output() {
     assert!(summary["responder_hmac"]["error"].is_string());
 }
 
+/// Returns a valid trust bundle (a real self-signed CA PEM and the matching
+/// SHA-256 fingerprint), cached so the stub payload and the on-disk-bundle
+/// assertion agree. Post-#695 `parse_trust_payload` rejects a bundle whose
+/// fingerprints do not match its certificates, so the stubs must serve a
+/// consistent, parseable bundle.
+fn valid_remote_trust() -> (String, String) {
+    use std::sync::OnceLock;
+
+    use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair};
+
+    static TRUST: OnceLock<(String, String)> = OnceLock::new();
+    TRUST
+        .get_or_init(|| {
+            let key = KeyPair::generate().expect("generate CA key");
+            let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+            params
+                .distinguished_name
+                .push(DnType::CommonName, "Remote Test CA");
+            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+            let cert = params.self_signed(&key).expect("self-signed CA");
+            let pem = cert.pem();
+            let fingerprint = bootroot::tls::ca_bundle_fingerprints(&pem)
+                .expect("fingerprints")
+                .into_iter()
+                .next()
+                .expect("one fingerprint");
+            (pem, fingerprint)
+        })
+        .clone()
+}
+
+fn valid_trust_payload() -> serde_json::Value {
+    let (pem, fingerprint) = valid_remote_trust();
+    json!({ "trusted_ca_sha256": [fingerprint], "ca_bundle_pem": pem })
+}
+
 async fn stub_openbao_remote_sync(server: &MockServer) {
     Mock::given(method("POST"))
         .and(path("/v1/auth/approle/login"))
@@ -663,11 +697,7 @@ async fn stub_openbao_remote_sync(server: &MockServer) {
         })))
         .mount(server)
         .await;
-    stub_shared_service_payloads(server, json!({
-        "trusted_ca_sha256": ["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"],
-        "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nREMOTE\n-----END CERTIFICATE-----"
-    }))
-    .await;
+    stub_shared_service_payloads(server, valid_trust_payload()).await;
 }
 
 async fn stub_openbao_remote_sync_without_trust_list(server: &MockServer) {
@@ -712,14 +742,7 @@ async fn stub_openbao_remote_sync_without_eab_kv(server: &MockServer) {
         })))
         .mount(server)
         .await;
-    stub_shared_service_payloads_without_eab(
-        server,
-        json!({
-            "trusted_ca_sha256": ["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"],
-            "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nREMOTE\n-----END CERTIFICATE-----"
-        }),
-    )
-    .await;
+    stub_shared_service_payloads_without_eab(server, valid_trust_payload()).await;
     Mock::given(method("GET"))
         .and(path("/v1/secret/data/bootroot/services/edge-proxy/eab"))
         .respond_with(ResponseTemplate::new(404))
@@ -735,14 +758,7 @@ async fn stub_openbao_remote_sync_with_empty_eab_kv(server: &MockServer) {
         })))
         .mount(server)
         .await;
-    stub_shared_service_payloads_without_eab(
-        server,
-        json!({
-            "trusted_ca_sha256": ["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"],
-            "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nREMOTE\n-----END CERTIFICATE-----"
-        }),
-    )
-    .await;
+    stub_shared_service_payloads_without_eab(server, valid_trust_payload()).await;
     Mock::given(method("GET"))
         .and(path("/v1/secret/data/bootroot/services/edge-proxy/eab"))
         .and(header("X-Vault-Token", "remote-token"))
@@ -761,14 +777,7 @@ async fn stub_openbao_remote_sync_with_malformed_eab_kv(server: &MockServer) {
         })))
         .mount(server)
         .await;
-    stub_shared_service_payloads_without_eab(
-        server,
-        json!({
-            "trusted_ca_sha256": ["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"],
-            "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nREMOTE\n-----END CERTIFICATE-----"
-        }),
-    )
-    .await;
+    stub_shared_service_payloads_without_eab(server, valid_trust_payload()).await;
     Mock::given(method("GET"))
         .and(path("/v1/secret/data/bootroot/services/edge-proxy/eab"))
         .and(header("X-Vault-Token", "remote-token"))

--- a/tests/e2e_same_host_local_file.rs
+++ b/tests/e2e_same_host_local_file.rs
@@ -265,7 +265,8 @@ async fn test_same_host_trust_change_propagates_to_agent_config() {
     assert!(agent_contents.contains("# BEGIN BOOTROOT REMOTE PROFILE"));
     let bundle_contents = fs::read_to_string(&files.ca_bundle_path).expect("read ca-bundle");
     assert!(bundle_contents.contains("BEGIN CERTIFICATE"));
-    assert!(bundle_contents.contains("UPDATED-TRUST"));
+    let (expected_pem, _) = support::test_trust_material();
+    assert_eq!(bundle_contents.trim(), expected_pem.trim());
 }
 
 /// Guards the fast-poll model's no-signal contract for local
@@ -898,13 +899,17 @@ async fn stub_remote_pull_openbao(server: &MockServer) {
         .mount(server)
         .await;
 
+    // Post-#695 the fast-poll/bootstrap trust parse rejects a bundle whose
+    // fingerprints do not match its certificates, so serve a real,
+    // internally consistent bundle.
+    let (ca_pem, ca_fp) = support::test_trust_material();
     Mock::given(method("GET"))
         .and(path("/v1/secret/data/bootroot/services/edge-proxy/trust"))
         .and(header("X-Vault-Token", "remote-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "data": { "data": {
-                "trusted_ca_sha256": ["22".repeat(32)],
-                "ca_bundle_pem": "-----BEGIN CERTIFICATE-----\nUPDATED-TRUST\n-----END CERTIFICATE-----"
+                "trusted_ca_sha256": [ca_fp],
+                "ca_bundle_pem": ca_pem
             } }
         })))
         .mount(server)


### PR DESCRIPTION
## Summary

Closes four hardening gaps in the `bootroot-agent` fast-poll OpenBao channel identified by security review. None was exploitable without network position on a plaintext deployment or control-plane write access, but all four are cheap to close and also harden against operator error.

- **Plaintext gate.** `validate_openbao_settings` now rejects a non-loopback `http://` `[openbao].url` unless the operator opts in with the new `[openbao] allow_plaintext_http = true` key. Loopback plaintext (`localhost`, `127.0.0.0/8`, `[::1]`) and `https://` validate unchanged. Both `[openbao]` writers — remote `build_openbao_updates` and local `build_local_openbao_updates` — upsert the opt-in when they emit a non-loopback plaintext URL, and the fast-poll loop logs a prominent startup warning that AppRole credentials and delivered secrets cross the network unencrypted.
- **Trust-payload validation before disk.** `parse_trust_payload` now parses `ca_bundle_pem` into a certificate list (rejecting an empty bundle) and verifies every `trusted_ca_sha256` fingerprint matches a certificate in the bundle, regardless of URL scheme. A malformed payload yields a `Malformed` outcome, leaves the CA bundle file and `agent.toml` byte-identical, and does not advance `last_trust_seen_version`, so a corrected control-plane write retries naturally.
- **Pin wiring.** `build_openbao_client` passes `trusted_ca_sha256` as pins at startup, and the post-trust-apply rebuild reads the freshly applied pins from `agent.toml` (not the stale startup snapshot) so a CA rotation swaps both the anchor and the pins. `bootroot-remote`'s shared client builder gains a pins parameter; `bootstrap` passes the artifact fingerprints and `apply-secret-id` stays bundle-anchored with empty pins.
- **HTTP timeouts.** `OpenBaoClient` constructors now set a 10s connect and 30s request timeout (named constants) so a stalled endpoint cannot wedge the shared fast-poll loop.

## Test plan

- [x] Non-loopback `http://` `[openbao].url` without `allow_plaintext_http = true` fails validation with an actionable error
- [x] Loopback `http://` and `https://` URLs validate unchanged
- [x] The opt-in makes non-loopback plaintext validate and the fast-poll startup logs a warning
- [x] Both `[openbao]` writers upsert `allow_plaintext_http = true` for a non-loopback plaintext `url` and omit it for loopback / `https://`
- [x] A trust payload with non-PEM garbage, an empty-certificate bundle, or a fingerprint absent from the bundle produces `Malformed`, leaves the CA bundle file and `agent.toml` byte-identical, and does not advance `last_trust_seen_version`; a corrected payload then applies normally (both URL schemes)
- [x] With non-empty `trusted_ca_sha256`, the HTTPS client rejects an endpoint whose chain does not terminate at a pinned CA; a KV trust rotation rebuilds the client with the NEW pins and keeps polling
- [x] `OpenBaoClient` HTTP clients enforce the connect/request timeouts (stalling mock server fails within the bound instead of hanging)
- [x] `cargo clippy`, `cargo fmt --check`, and `cargo test` pass
- [x] Docker E2E matrix, extended E2E, and `scripts/preflight/run-all.sh` pass

Closes #695


