### PR TITLE
Wire TLS trust into infra OpenBao Agents (#698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,29 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fixed the two infra `OpenBao` Agents
+  (`bootroot-openbao-agent-stepca` / `-responder`) being unable to
+  authenticate to a native-TLS `OpenBao` provisioned via
+  `infra install --openbao-bind <non-loopback>:8200
+  --openbao-tls-required` (#698). The agents were minted before the
+  `OpenBao` TLS transition, so their compose override pinned
+  `VAULT_ADDR=http://bootroot-openbao:8200` (whose env value overrides the
+  agent HCL `vault.address`) and no CA trust was wired — the HCL was built
+  with `ca_cert: None` and the override emitted no `VAULT_CACERT`. The
+  breakage was latent because both agents render once at init and coast on
+  the init-time token; the first forced re-render (`rotate
+  responder-hmac`, `rotate stepca-password`, a host reboot, or an agent
+  restart after the token TTL) failed AppRole login with `400 Client sent
+  an HTTP request to an HTTPS server`, silently stalling certificate
+  reissuance/renewal fleet-wide. `init` now generates the infra agents in
+  their final TLS form — `https://` `VAULT_ADDR`, HCL `vault { ca_cert }`
+  pointing at a provisioned `secrets/certs/ca-bundle.pem` (root +
+  intermediate, `0644` so the separate agent container can read the
+  bind-mounted leaf-chain) — and defers their `docker compose up` to a
+  second phase after the `OpenBao` TLS transition, so the agents never
+  start against a still-plaintext listener. The loopback / no-TLS path is
+  unchanged: `http://`, no `VAULT_CACERT`, HCL `ca_cert` absent, single
+  phase.
 - Fixed `bootroot rotate approle-secret-id` re-owning the service
   `secret_id` file to the rotating CLI user. The rewrite staged a fresh
   `0600` temp file and renamed it over the destination without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   intermediate, `0644` so the separate agent container can read the
   bind-mounted leaf-chain) — and defers their `docker compose up` to a
   second phase after the `OpenBao` TLS transition, so the agents never
-  start against a still-plaintext listener. The loopback / no-TLS path is
+  start against a still-plaintext listener. That deferred apply runs
+  inside the init rollback envelope: if it (or a later step) fails,
+  rollback stops and removes the two agent containers and restores
+  `state.json`, so a failed TLS init never leaves the agents running with
+  a TLS `VAULT_ADDR`/`ca_cert` (or `state.json` pointing at HTTPS) against
+  a rolled-back plaintext `OpenBao`. The loopback / no-TLS path is
   unchanged: `http://`, no `VAULT_CACERT`, HCL `ca_cert` absent, single
   phase.
 - Fixed `bootroot rotate approle-secret-id` re-owning the service

--- a/src/commands/init/constants.rs
+++ b/src/commands/init/constants.rs
@@ -46,6 +46,7 @@ pub(crate) const DEFAULT_DB_NAME: &str = "stepca";
 pub(crate) const CA_CERTS_DIR: &str = "certs";
 pub(crate) const CA_ROOT_CERT_FILENAME: &str = "root_ca.crt";
 pub(crate) const CA_INTERMEDIATE_CERT_FILENAME: &str = "intermediate_ca.crt";
+pub(crate) const CA_BUNDLE_FILENAME: &str = "ca-bundle.pem";
 
 pub(crate) const OPENBAO_EXPOSED_COMPOSE_OVERRIDE_NAME: &str = "docker-compose.openbao-exposed.yml";
 pub(crate) const HTTP01_EXPOSED_COMPOSE_OVERRIDE_NAME: &str = "docker-compose.http01-exposed.yml";

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -65,6 +65,17 @@ pub(super) struct InitRollback {
     /// Responder config compose override for restarting without the
     /// exposed port binding during rollback.
     pub(super) responder_compose_override: Option<PathBuf>,
+    /// Infra `OpenBao` agent compose override applied in the TLS case
+    /// (Phase 2, post-TLS-transition).  On rollback the two agent
+    /// containers are stopped and removed so they are not left running
+    /// with a TLS `VAULT_ADDR`/`ca_cert` against a rolled-back plaintext
+    /// `OpenBao`.
+    pub(super) openbao_agent_compose_override: Option<PathBuf>,
+    /// State file snapshot taken before the `OpenBao` TLS transition
+    /// persists the HTTPS URL and infra cert entries.  On rollback it
+    /// restores the pre-TLS `state.json` so it does not keep pointing at
+    /// an HTTPS URL / TLS certs after `OpenBao` is recreated on plaintext.
+    pub(super) state_backup: Option<RollbackFile>,
 }
 
 impl InitRollback {
@@ -108,6 +119,36 @@ impl InitRollback {
             ) {
                 eprintln!("Rollback: failed to recreate OpenBao: {err}");
             }
+        }
+
+        // Stop and remove the two infra OpenBao agents.  In the TLS
+        // case they were started (Phase 2) with an HTTPS `VAULT_ADDR`
+        // and `ca_cert`; OpenBao has just been recreated on plaintext,
+        // so leaving them up would keep them failing AppRole login with
+        // `400 Client sent an HTTP request to an HTTPS server`.  Removing
+        // them returns to the pre-Phase-2 state (agents not started).
+        if let Some(override_path) = &self.openbao_agent_compose_override
+            && let Some(compose_file) = &self.compose_file
+        {
+            let args = rollback_openbao_agent_docker_args(compose_file, override_path);
+            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            if let Err(err) = crate::commands::infra::run_docker(
+                &arg_refs,
+                "docker compose rm infra agents (rollback)",
+                messages,
+            ) {
+                eprintln!("Rollback: failed to remove infra OpenBao agents: {err}");
+            }
+        }
+
+        // Restore the pre-TLS `state.json` so it does not keep pointing
+        // at the HTTPS URL / TLS infra certs after OpenBao is back on
+        // plaintext.  Done after the container work so a failed restore
+        // does not skip the Docker teardown above.
+        if let Some(file) = &self.state_backup
+            && let Err(err) = rollback_file(file, messages)
+        {
+            eprintln!("Rollback: failed to restore {}: {err}", file.path.display());
         }
 
         // Restore the responder config (removing TLS fields) and
@@ -216,6 +257,31 @@ fn rollback_responder_docker_args(
     args.push("-d".to_string());
     args.push(crate::commands::constants::RESPONDER_SERVICE_NAME.to_string());
     args
+}
+
+/// Builds the Docker Compose arguments for tearing down the infra
+/// `OpenBao` agents during rollback.
+///
+/// Returns `["compose", "-f", <compose>, "-f", <override>, "rm", "-s",
+/// "-f", <stepca>, <responder>]` so the two agent containers are
+/// stopped and removed.  They were started with a TLS `VAULT_ADDR`/
+/// `ca_cert` that a rolled-back plaintext `OpenBao` cannot serve.
+fn rollback_openbao_agent_docker_args(
+    compose_file: &std::path::Path,
+    override_path: &std::path::Path,
+) -> Vec<String> {
+    vec![
+        "compose".to_string(),
+        "-f".to_string(),
+        compose_file.to_string_lossy().into_owned(),
+        "-f".to_string(),
+        override_path.to_string_lossy().into_owned(),
+        "rm".to_string(),
+        "-s".to_string(),
+        "-f".to_string(),
+        super::constants::OPENBAO_AGENT_STEPCA_SERVICE.to_string(),
+        super::constants::OPENBAO_AGENT_RESPONDER_SERVICE.to_string(),
+    ]
 }
 
 fn rollback_file(file: &RollbackFile, messages: &Messages) -> Result<()> {
@@ -445,6 +511,74 @@ mod rollback_tests {
         assert!(
             args.iter().any(|a| a.ends_with("override.yml")),
             "rollback must include config override when original config existed: {args:?}"
+        );
+    }
+
+    /// Regression: the infra-agent rollback teardown must `rm -s -f`
+    /// both agent services (stop then remove) using the compose file
+    /// plus the agent override, so agents started in the TLS Phase 2
+    /// are not left running against a rolled-back plaintext `OpenBao`.
+    #[test]
+    fn rollback_agent_args_remove_both_services() {
+        use std::path::PathBuf;
+
+        let compose = PathBuf::from("docker-compose.yml");
+        let override_path = PathBuf::from("secrets/openbao/agent.override.yml");
+        let args = super::rollback_openbao_agent_docker_args(&compose, &override_path);
+
+        assert_eq!(args.first().map(String::as_str), Some("compose"));
+        assert!(
+            args.contains(&"rm".to_string())
+                && args.contains(&"-s".to_string())
+                && args.contains(&"-f".to_string()),
+            "rollback must stop and force-remove the agents: {args:?}"
+        );
+        assert!(
+            args.iter()
+                .any(|a| a == crate::commands::init::constants::OPENBAO_AGENT_STEPCA_SERVICE)
+                && args
+                    .iter()
+                    .any(|a| a == crate::commands::init::constants::OPENBAO_AGENT_RESPONDER_SERVICE),
+            "rollback must target both infra agent services: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a.ends_with("agent.override.yml")),
+            "rollback must pass the agent override so its services are defined: {args:?}"
+        );
+    }
+
+    /// Regression: rollback must restore the pre-TLS `state.json` so it
+    /// does not keep pointing at the HTTPS URL / TLS infra certs after
+    /// `OpenBao` is recreated on plaintext.  Guards the failure window
+    /// opened by the deferred TLS Phase-2 agent apply.
+    #[tokio::test]
+    async fn rollback_restores_state_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let messages = crate::i18n::test_messages();
+
+        let state_path = dir.path().join("state.json");
+        let plaintext_state = "{\"openbao_url\":\"http://127.0.0.1:8200\"}\n";
+        std::fs::write(&state_path, plaintext_state).unwrap();
+        // Simulate the HTTPS save that happened before the failure.
+        std::fs::write(&state_path, "{\"openbao_url\":\"https://host:8200\"}\n").unwrap();
+
+        let rollback = InitRollback {
+            state_backup: Some(RollbackFile {
+                path: state_path.clone(),
+                original: Some(plaintext_state.to_string()),
+            }),
+            // No compose_file — skips the container teardown in tests.
+            compose_file: None,
+            ..Default::default()
+        };
+
+        let client = OpenBaoClient::new("http://127.0.0.1:1").unwrap();
+        rollback.rollback(&client, "secret", &messages).await;
+
+        let restored = std::fs::read_to_string(&state_path).unwrap();
+        assert_eq!(
+            restored, plaintext_state,
+            "state.json must be restored to its pre-TLS content after rollback"
         );
     }
 }

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use bootroot::cert_group::CertGroupPolicy;
 use bootroot::fs_util;
 use bootroot::openbao::OpenBaoClient;
 use bootroot::openbao::SecretIdOptions;
@@ -15,9 +16,10 @@ use super::super::constants::openbao_constants::{
     RECOMMENDED_SECRET_ID_TTL, TOKEN_TTL,
 };
 use super::super::constants::{
-    OPENBAO_AGENT_COMPOSE_OVERRIDE_NAME, OPENBAO_AGENT_CONFIG_NAME, OPENBAO_AGENT_DIR,
-    OPENBAO_AGENT_RESPONDER_DIR, OPENBAO_AGENT_RESPONDER_SERVICE, OPENBAO_AGENT_ROLE_ID_NAME,
-    OPENBAO_AGENT_SECRET_ID_NAME, OPENBAO_AGENT_STEPCA_DIR, OPENBAO_AGENT_STEPCA_SERVICE,
+    CA_BUNDLE_FILENAME, CA_CERTS_DIR, OPENBAO_AGENT_COMPOSE_OVERRIDE_NAME,
+    OPENBAO_AGENT_CONFIG_NAME, OPENBAO_AGENT_DIR, OPENBAO_AGENT_RESPONDER_DIR,
+    OPENBAO_AGENT_RESPONDER_SERVICE, OPENBAO_AGENT_ROLE_ID_NAME, OPENBAO_AGENT_SECRET_ID_NAME,
+    OPENBAO_AGENT_STEPCA_DIR, OPENBAO_AGENT_STEPCA_SERVICE,
 };
 use super::super::paths::{
     OpenBaoAgentPaths, StepCaTemplatePaths, compose_has_openbao, resolve_openbao_agent_addr,
@@ -34,6 +36,7 @@ use crate::commands::openbao_unseal::read_unseal_keys_from_file;
 use crate::i18n::Messages;
 
 const INIT_AGENT_TOKEN_PATH: &str = "/openbao/secrets/openbao/token";
+const OPENBAO_AGENT_SECRETS_MOUNT: &str = "/openbao/secrets";
 
 pub(super) async fn bootstrap_openbao(
     client: &mut OpenBaoClient,
@@ -604,6 +607,10 @@ async fn write_openbao_secrets(
     Ok(())
 }
 
+// Each argument is a distinct init-time input (paths, role outputs,
+// templates, TLS gate); bundling them into a struct would only move the
+// same fields behind an indirection used at a single call site.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn setup_openbao_agents(
     compose_file: &Path,
     secrets_dir: &Path,
@@ -611,16 +618,31 @@ pub(super) async fn setup_openbao_agents(
     role_outputs: &[AppRoleOutput],
     stepca_templates: &StepCaTemplatePaths,
     responder_template: &Path,
+    tls_required: bool,
     messages: &Messages,
 ) -> Result<OpenBaoAgentPaths> {
     let compose_has_openbao = compose_has_openbao(compose_file, messages)?;
-    let openbao_agent_addr = resolve_openbao_agent_addr(openbao_url, compose_has_openbao);
+    let mut openbao_agent_addr = resolve_openbao_agent_addr(openbao_url, compose_has_openbao);
+    // The infra agents are generated *before* OpenBao flips to TLS
+    // (`orchestrator.rs`), so `openbao_url` — and therefore the resolved
+    // agent address — is still `http://`.  When OpenBao is provisioned
+    // TLS, force `https://` here: the override's `VAULT_ADDR` env
+    // overrides the HCL `vault.address`, so the scheme must be corrected
+    // at the point the override is minted, not in the scheme-preserving
+    // `resolve_openbao_agent_addr` helper.
+    let ca_cert_container_path = if tls_required {
+        openbao_agent_addr = force_https_scheme(&openbao_agent_addr);
+        Some(provision_agent_ca_bundle(secrets_dir, messages).await?)
+    } else {
+        None
+    };
     let mut openbao_agent_paths = write_openbao_agent_files(
         secrets_dir,
         &openbao_agent_addr,
         role_outputs,
         stepca_templates,
         responder_template,
+        ca_cert_container_path.as_deref(),
         messages,
     )
     .await?;
@@ -634,10 +656,43 @@ pub(super) async fn setup_openbao_agents(
     openbao_agent_paths
         .compose_override_path
         .clone_from(&openbao_agent_override);
-    if let Some(override_path) = openbao_agent_override.as_ref() {
+    // Two-phase bring-up in the TLS case: generate the agent files and
+    // override in their final TLS form here, but defer the agent
+    // `docker compose up` to the post-TLS-transition phase in the
+    // orchestrator.  Starting the agents now — while OpenBao is still
+    // plaintext — would make them try to speak HTTPS to a plaintext
+    // server and fail their init-time render, breaking init.  The
+    // plaintext-loopback path keeps the single-phase apply.
+    if !tls_required && let Some(override_path) = openbao_agent_override.as_ref() {
         apply_openbao_agent_compose_override(compose_file, override_path, messages)?;
     }
     Ok(openbao_agent_paths)
+}
+
+/// Writes the leaf-chain CA bundle the infra agents use to verify the
+/// step-ca-signed `OpenBao` TLS leaf and returns its container-internal
+/// path.
+///
+/// The `OpenBao` TLS listener presents a leaf-only certificate, so the
+/// agent needs root **and** intermediate concatenated to build the
+/// chain.  Reuses [`compute_ca_bundle_pem`] (root + intermediate) and
+/// writes `secrets/certs/ca-bundle.pem` at `0644` via
+/// [`fs_util::write_ca_bundle`] so the separate agent container can read
+/// the bind-mounted file.
+async fn provision_agent_ca_bundle(secrets_dir: &Path, messages: &Messages) -> Result<String> {
+    let ca_bundle_pem = compute_ca_bundle_pem(secrets_dir, messages).await?;
+    let bundle_path = secrets_dir.join(CA_CERTS_DIR).join(CA_BUNDLE_FILENAME);
+    fs_util::write_ca_bundle(&bundle_path, &ca_bundle_pem, CertGroupPolicy::none()).await?;
+    to_container_path(secrets_dir, &bundle_path, OPENBAO_AGENT_SECRETS_MOUNT)
+}
+
+/// Rewrites an `http://` agent address to `https://`, leaving any other
+/// scheme untouched.
+fn force_https_scheme(addr: &str) -> String {
+    match addr.strip_prefix("http://") {
+        Some(rest) => format!("https://{rest}"),
+        None => addr.to_string(),
+    }
 }
 
 async fn write_openbao_agent_files(
@@ -646,6 +701,7 @@ async fn write_openbao_agent_files(
     role_outputs: &[AppRoleOutput],
     stepca_templates: &StepCaTemplatePaths,
     responder_template: &Path,
+    ca_cert: Option<&str>,
     messages: &Messages,
 ) -> Result<OpenBaoAgentPaths> {
     let base_dir = secrets_dir.join(OPENBAO_AGENT_DIR);
@@ -690,7 +746,7 @@ async fn write_openbao_agent_files(
 
     let stepca_agent_config = stepca_dir.join(OPENBAO_AGENT_CONFIG_NAME);
     let responder_agent_config = responder_dir.join(OPENBAO_AGENT_CONFIG_NAME);
-    let mount = "/openbao/secrets";
+    let mount = OPENBAO_AGENT_SECRETS_MOUNT;
     let password_template =
         to_container_path(secrets_dir, &stepca_templates.password_template_path, mount)?;
     let ca_json_template =
@@ -715,12 +771,14 @@ async fn write_openbao_agent_files(
             (password_template, password_output),
             (ca_json_template, ca_json_output),
         ],
+        ca_cert,
     );
     let responder_config = build_openbao_agent_config(
         openbao_addr,
         "/openbao/secrets/openbao/responder/role_id",
         "/openbao/secrets/openbao/responder/secret_id",
         &[(responder_template, responder_output)],
+        ca_cert,
     );
     tokio::fs::write(&stepca_agent_config, stepca_config)
         .await
@@ -747,6 +805,7 @@ fn build_openbao_agent_config(
     role_id_path: &str,
     secret_id_path: &str,
     templates: &[(String, String)],
+    ca_cert: Option<&str>,
 ) -> String {
     // Every template here renders secret material (password, CA signing
     // key JSON, responder config), so all stay at 0600.
@@ -766,7 +825,7 @@ fn build_openbao_agent_config(
         mount_path: None,
         render_interval: bootroot::openbao::STATIC_SECRET_RENDER_INTERVAL,
         templates: &tpl_specs,
-        ca_cert: None,
+        ca_cert,
     })
 }
 
@@ -886,12 +945,30 @@ mod tests {
         POLICY_BOOTROOT_AGENT, POLICY_BOOTROOT_INFRA_ROTATE, POLICY_BOOTROOT_RUNTIME_ROTATE,
         POLICY_BOOTROOT_RUNTIME_SERVICE_ADD,
     };
+    use super::super::super::constants::{CA_INTERMEDIATE_CERT_FILENAME, CA_ROOT_CERT_FILENAME};
     use super::super::super::paths::resolve_openbao_agent_addr;
     use super::super::super::types::{AppRoleLabel, AppRoleOutput};
     use super::super::responder_setup::write_responder_files;
     use super::super::stepca_setup::write_stepca_templates;
-    use super::super::test_support::test_messages;
+    use super::super::test_support::{test_cert_pem, test_messages};
     use super::*;
+
+    fn stepca_and_responder_roles() -> Vec<AppRoleOutput> {
+        vec![
+            AppRoleOutput {
+                label: AppRoleLabel::Stepca,
+                role_name: "bootroot-stepca-role".to_string(),
+                role_id: "stepca-role-id".to_string(),
+                secret_id: "stepca-secret-id".to_string(),
+            },
+            AppRoleOutput {
+                label: AppRoleLabel::Responder,
+                role_name: "bootroot-responder-role".to_string(),
+                role_id: "responder-role-id".to_string(),
+                secret_id: "responder-secret-id".to_string(),
+            },
+        ]
+    }
 
     #[tokio::test]
     async fn test_write_openbao_agent_files_writes_configs() {
@@ -917,20 +994,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        let role_outputs = vec![
-            AppRoleOutput {
-                label: AppRoleLabel::Stepca,
-                role_name: "bootroot-stepca-role".to_string(),
-                role_id: "stepca-role-id".to_string(),
-                secret_id: "stepca-secret-id".to_string(),
-            },
-            AppRoleOutput {
-                label: AppRoleLabel::Responder,
-                role_name: "bootroot-responder-role".to_string(),
-                role_id: "responder-role-id".to_string(),
-                secret_id: "responder-secret-id".to_string(),
-            },
-        ];
+        let role_outputs = stepca_and_responder_roles();
 
         let paths = write_openbao_agent_files(
             &secrets_dir,
@@ -938,6 +1002,7 @@ mod tests {
             &role_outputs,
             &stepca_templates,
             &responder_paths.template_path,
+            None,
             &messages,
         )
         .await
@@ -948,6 +1013,118 @@ mod tests {
         assert!(stepca_config.contains("role_id_file_path"));
         assert!(stepca_config.contains("password.txt.ctmpl"));
         assert!(responder_config.contains("responder.toml.ctmpl"));
+        // Loopback / no-TLS path: the HCL must not carry any CA trust.
+        assert!(!stepca_config.contains("ca_cert"));
+        assert!(!responder_config.contains("ca_cert"));
+    }
+
+    /// TLS path: `setup_openbao_agents` must generate both agent files
+    /// and the compose override in their final TLS form (https +
+    /// HCL `ca_cert` + provisioned `certs/ca-bundle.pem`) but must NOT
+    /// run the agent `docker compose up` — that is deferred to the
+    /// post-TLS-transition phase.  The test asserting timing relies on
+    /// this call succeeding without any docker interaction: if a
+    /// refactor moved the apply back before the TLS-skip guard, this
+    /// call would invoke `docker compose up` and fail.
+    #[tokio::test]
+    async fn test_setup_openbao_agents_tls_generates_https_ca_trust_without_apply() {
+        let temp_dir = tempdir().unwrap();
+        let secrets_dir = temp_dir.path().join("secrets");
+        fs::create_dir_all(secrets_dir.join("config")).unwrap();
+        fs::write(
+            secrets_dir.join("config").join("ca.json"),
+            r#"{
+                "authority":{"provisioners":[{"type":"ACME","name":"acme"}]},
+                "db":{"type":"postgresql","dataSource":"old"}
+            }"#,
+        )
+        .unwrap();
+        // Root + intermediate certs feed the agent CA bundle.
+        let certs_dir = secrets_dir.join(CA_CERTS_DIR);
+        fs::create_dir_all(&certs_dir).unwrap();
+        fs::write(
+            certs_dir.join(CA_ROOT_CERT_FILENAME),
+            test_cert_pem("root.example"),
+        )
+        .unwrap();
+        fs::write(
+            certs_dir.join(CA_INTERMEDIATE_CERT_FILENAME),
+            test_cert_pem("intermediate.example"),
+        )
+        .unwrap();
+
+        let compose_file = temp_dir.path().join("docker-compose.yml");
+        fs::write(
+            &compose_file,
+            "services:\n  openbao:\n    image: openbao/openbao:latest\n",
+        )
+        .unwrap();
+
+        let messages = test_messages();
+        let stepca_templates =
+            write_stepca_templates(&secrets_dir, "secret", "24h", "acme", &messages)
+                .await
+                .unwrap();
+        let responder_paths =
+            write_responder_files(&secrets_dir, "secret", "hmac-123", false, &messages)
+                .await
+                .unwrap();
+        let role_outputs = stepca_and_responder_roles();
+
+        let paths = setup_openbao_agents(
+            &compose_file,
+            &secrets_dir,
+            // http:// input — the setup must force https:// for TLS.
+            "http://127.0.0.1:8200",
+            &role_outputs,
+            &stepca_templates,
+            &responder_paths.template_path,
+            true,
+            &messages,
+        )
+        .await
+        .unwrap();
+
+        let stepca_config = fs::read_to_string(&paths.stepca_agent_config).unwrap();
+        let responder_config = fs::read_to_string(&paths.responder_agent_config).unwrap();
+        let expected_ca = format!("/openbao/secrets/{CA_CERTS_DIR}/{CA_BUNDLE_FILENAME}");
+        assert!(
+            stepca_config.contains(&format!("ca_cert = \"{expected_ca}\"")),
+            "stepca HCL must reference the CA bundle: {stepca_config}"
+        );
+        assert!(
+            responder_config.contains(&format!("ca_cert = \"{expected_ca}\"")),
+            "responder HCL must reference the CA bundle: {responder_config}"
+        );
+        assert!(stepca_config.contains("https://bootroot-openbao:8200"));
+        assert!(responder_config.contains("https://bootroot-openbao:8200"));
+
+        let override_path = paths.compose_override_path.expect("override path");
+        let override_contents = fs::read_to_string(&override_path).unwrap();
+        assert!(
+            override_contents.contains("VAULT_ADDR=https://bootroot-openbao:8200"),
+            "override must force https VAULT_ADDR: {override_contents}"
+        );
+
+        // The provisioned bundle must exist and carry root + intermediate.
+        let bundle = fs::read_to_string(certs_dir.join(CA_BUNDLE_FILENAME)).unwrap();
+        assert_eq!(
+            bundle.matches("BEGIN CERTIFICATE").count(),
+            2,
+            "ca-bundle.pem must concatenate root and intermediate"
+        );
+    }
+
+    #[test]
+    fn test_force_https_scheme_upgrades_http_only() {
+        assert_eq!(
+            force_https_scheme("http://bootroot-openbao:8200"),
+            "https://bootroot-openbao:8200"
+        );
+        assert_eq!(
+            force_https_scheme("https://bootroot-openbao:8200"),
+            "https://bootroot-openbao:8200"
+        );
     }
 
     #[tokio::test]
@@ -984,6 +1161,9 @@ services:
             contents.contains("user:"),
             "compose override must set user for infra OBA containers"
         );
+        // Loopback / no-TLS path keeps http and adds no CA env.
+        assert!(contents.contains("VAULT_ADDR=http://openbao:8200"));
+        assert!(!contents.contains("VAULT_CACERT"));
     }
 
     #[test]
@@ -1105,6 +1285,7 @@ services:
                 "/openbao/templates/password.ctmpl".to_string(),
                 "/openbao/secrets/password.txt".to_string(),
             )],
+            None,
         );
         assert!(
             config.contains("template_config"),

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -747,6 +747,20 @@ async fn run_init_inner(
         // never depend on the external advertise address being
         // hairpin-reachable.  The advertise address is consumed
         // separately by remote bootstrap artifact generation.
+        //
+        // Snapshot the pre-TLS `state.json` (still the plaintext URL,
+        // no infra cert entries) before persisting the HTTPS URL, so
+        // rollback can restore it if the deferred agent apply below or
+        // any later fallible step fails after OpenBao has been recreated
+        // on plaintext.
+        rollback.state_backup = Some(RollbackFile {
+            path: state_path.clone(),
+            original: if state_path.exists() {
+                Some(std::fs::read_to_string(&state_path)?)
+            } else {
+                None
+            },
+        });
         state.openbao_url = client_url_from_bind_addr(&bind_addr);
         state
             .save(&state_path)
@@ -758,6 +772,11 @@ async fn run_init_inner(
         // generated their files/override in TLS form but skipped this
         // `docker compose up` while OpenBao was still plaintext.
         if let Some(override_path) = openbao_agent_paths.compose_override_path.as_ref() {
+            // Register the override for rollback *before* applying it so
+            // that even a partial `docker compose up` (one agent started,
+            // the other not) is torn down when a failure triggers
+            // rollback.
+            rollback.openbao_agent_compose_override = Some(override_path.clone());
             apply_openbao_agent_compose_override(
                 &args.compose.compose_file,
                 override_path,

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -17,8 +17,9 @@ use super::http01_admin_tls::{
     build_http01_admin_tls_sans, issue_http01_admin_tls_cert, record_http01_admin_infra_cert,
 };
 use super::openbao_setup::{
-    bootstrap_openbao, configure_openbao, setup_openbao_agents, validate_rotate_bound_cidrs,
-    validate_secret_id_ttl, write_ca_trust_fingerprints_with_retry,
+    apply_openbao_agent_compose_override, bootstrap_openbao, configure_openbao,
+    setup_openbao_agents, validate_rotate_bound_cidrs, validate_secret_id_ttl,
+    write_ca_trust_fingerprints_with_retry,
 };
 use super::openbao_tls::{
     build_openbao_tls_sans, issue_openbao_tls_cert, record_openbao_infra_cert,
@@ -529,6 +530,11 @@ async fn run_init_inner(
         messages,
     )
     .await?;
+    // `bind_intent` is true exactly for a non-loopback OpenBao bind,
+    // which mandates `--openbao-tls-required` and later triggers the
+    // OpenBao TLS transition below.  Thread it in so the infra agents
+    // are generated to speak TLS (https + CA trust) and their
+    // `docker compose up` is deferred to the post-TLS-transition phase.
     let openbao_agent_paths = setup_openbao_agents(
         &args.compose.compose_file,
         &secrets_dir,
@@ -536,6 +542,7 @@ async fn run_init_inner(
         &role_outputs,
         &stepca_templates,
         &responder_paths.template_path,
+        bind_intent,
         messages,
     )
     .await?;
@@ -744,6 +751,19 @@ async fn run_init_inner(
         state
             .save(&state_path)
             .with_context(|| messages.error_serialize_state_failed())?;
+
+        // Phase 2 of the infra-agent bring-up: OpenBao now serves TLS,
+        // so apply the deferred agent override to start (and let the two
+        // infra agents authenticate over) HTTPS.  `setup_openbao_agents`
+        // generated their files/override in TLS form but skipped this
+        // `docker compose up` while OpenBao was still plaintext.
+        if let Some(override_path) = openbao_agent_paths.compose_override_path.as_ref() {
+            apply_openbao_agent_compose_override(
+                &args.compose.compose_file,
+                override_path,
+                messages,
+            )?;
+        }
         state.openbao_url
     } else {
         args.openbao.openbao_url.clone()


### PR DESCRIPTION
## Summary

When OpenBao is provisioned with a native-TLS listener via `infra install --openbao-bind <non-loopback>:8200 --openbao-tls-required`, the two infra OpenBao Agents (`bootroot-openbao-agent-stepca` / `-responder`) had no way to speak TLS to OpenBao:

- The compose override pinned `VAULT_ADDR=http://bootroot-openbao:8200` (whose env value overrides the agent HCL `vault.address`), because the agents are minted *before* the OpenBao TLS transition.
- No CA trust was wired — the HCL was built with `ca_cert: None` and the override emitted no `VAULT_CACERT`.

The breakage was latent: both agents render once at init and coast on the init-time token, so nothing re-renders until something forces it (`rotate responder-hmac`, `rotate stepca-password`, a host reboot, or an agent restart after the token TTL). The first forced re-render then failed AppRole login with `400 Client sent an HTTP request to an HTTPS server`, silently stalling certificate reissuance/renewal fleet-wide.

## Changes

- **Force `https://` in the override** for the TLS case. The scheme is forced in the override generator (`setup_openbao_agents`), not in the scheme-preserving `resolve_openbao_agent_addr` helper, so that helper's tests keep passing.
- **Wire CA trust via HCL** (`vault { ca_cert = ... }`) pointing at a container path `/openbao/secrets/certs/ca-bundle.pem`, using the existing `AgentConfigParams.ca_cert` field rather than emitting a second `VAULT_CACERT` env — keeps the override minimal and uses the already-tested built-in.
- **Provision the leaf-chain bundle**: reuse `compute_ca_bundle_pem` (root + intermediate) and write `secrets/certs/ca-bundle.pem` via `fs_util::write_ca_bundle` at `0644` so the separate agent container can read the bind-mounted file. The OpenBao TLS listener presents a leaf-only cert, so both root and intermediate are needed to build the chain.
- **Two-phase bring-up in the TLS case**: Phase 1 (at setup) generates the agent files/override in final TLS form but defers the agent `docker compose up`; Phase 2 (after the OpenBao TLS transition) applies the override so the agents only ever start against an HTTPS listener. The plaintext-loopback path keeps the single-phase apply.
- **Gating** on `bind_intent`, threaded into `setup_openbao_agents` — true exactly for a non-loopback bind, which mandates `--openbao-tls-required` and later triggers the TLS transition.
- **Rollback safety for TLS Phase 2**: the deferred agent apply now runs inside the rollback envelope. The agent override is registered for rollback *before* the `docker compose up` (so even a partial apply is covered), and the pre-TLS `state.json` is snapshotted before the HTTPS URL is persisted. On rollback the two infra agent containers are stopped and removed (`docker compose rm -s -f`) and `state.json` is restored, so a failure in the deferred apply or any later step never leaves the agents running with a TLS `VAULT_ADDR`/`ca_cert` (or `state.json` pointing at HTTPS) against a rolled-back plaintext OpenBao.

The loopback / no-TLS path is unchanged: `http://`, no `VAULT_CACERT`, HCL `ca_cert` absent, single-phase apply, and no agent rollback tracking (the agents are never started against a still-plaintext OpenBao there).

Closes #698

## Test plan

- [x] `cargo clippy --all-targets` clean, `cargo fmt --check` clean
- [x] TLS path unit test: `setup_openbao_agents` generates both agent HCLs with `ca_cert` referencing `/openbao/secrets/certs/ca-bundle.pem`, `https://bootroot-openbao:8200` in HCL and override, and `certs/ca-bundle.pem` containing root **and** intermediate — **without** running `docker compose up` (timing assertion, guards against a refactor moving the apply back before the TLS transition)
- [x] Loopback path unit test: override keeps `http://`, no `VAULT_CACERT`, HCL `ca_cert` absent
- [x] `resolve_openbao_agent_addr` scheme-preservation tests still pass (scheme forced in the override generator, not the helper)
- [x] `force_https_scheme` upgrades `http://` only, leaves `https://` untouched
- [x] Rollback unit tests: teardown args `rm -s -f` both agent services (with the agent override passed so the services are defined), and the pre-TLS `state.json` is restored on rollback
- [x] E2E on a TLS deployment: `init` completes cleanly (agents not started against plaintext OpenBao, up and rendering only after the TLS transition)
- [x] E2E: `docker restart bootroot-openbao-agent-responder` (and `-stepca`) re-authenticates over TLS with no `400 Client sent an HTTP request to an HTTPS server`
- [x] E2E: `rotate responder-hmac` completes (agent renders the new `responder.toml`) and subsequent HTTP-01 token registration / certificate reissuance succeeds fleet-wide

