### PR TITLE
Add deploy no-build smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Build all binaries
         run: cargo build --bins
 
+      - name: Deploy Compose No-Build Smoke
+        run: ./scripts/preflight/extra/deploy-no-build-smoke.sh
+
       - name: Install Infrastructure
         run: cargo run --bin bootroot -- infra install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -725,6 +725,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     the preflight run) asserts the deploy compose renders with no `build:`
     keys and resolves from a directory staging only those files with no
     source tree present.
+  - `scripts/preflight/extra/deploy-no-build-smoke.sh` exercises the real
+    `bootroot infra install --compose-file docker-compose.deploy.yml` path
+    with `--image-archive-dir <dir> --no-build` from a source-tree-free staging
+    directory, loads image archives, and asserts the install never runs
+    `docker compose pull` or `up --build`. (Closes #706)
 - `bootroot service add` and `bootroot service update` can now register a
   `--reload-style` preset hook **and** a `--post-renew-command` custom hook
   in one invocation, instead of rejecting the combination as mutually

--- a/scripts/preflight/extra/deploy-no-build-smoke.sh
+++ b/scripts/preflight/extra/deploy-no-build-smoke.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+BOOTROOT_BIN="${BOOTROOT_BIN:-$ROOT_DIR/target/debug/bootroot}"
+BOOTROOT_VERSION="$(
+  awk -F' = ' '$1 == "version" { gsub(/"/, "", $2); print $2; exit }' Cargo.toml
+)"
+
+OPENBAO_IMAGE="${OPENBAO_IMAGE:-openbao/openbao:latest}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:18}"
+BOOTROOT_STEP_CA_IMAGE="${BOOTROOT_STEP_CA_IMAGE:-bootroot-step-ca:0.29.0}"
+BOOTROOT_HTTP01_IMAGE="${BOOTROOT_HTTP01_IMAGE:-bootroot-http01-responder:$BOOTROOT_VERSION}"
+
+STAGE_DIR="$(mktemp -d)"
+ARCHIVE_DIR="$STAGE_DIR/images"
+SHIM_DIR="$STAGE_DIR/bin"
+DOCKER_LOG="$STAGE_DIR/docker-argv.log"
+REAL_DOCKER="$(command -v docker)"
+
+log() {
+  printf "[deploy-no-build-smoke] %s\n" "$*"
+}
+
+fail() {
+  printf "[deploy-no-build-smoke] ERROR: %s\n" "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -f "$STAGE_DIR/docker-compose.deploy.yml" ]; then
+    (
+      cd "$STAGE_DIR"
+      POSTGRES_PASSWORD=cleanup-only \
+        GRAFANA_ADMIN_PASSWORD=cleanup-only \
+        "$REAL_DOCKER" compose -f docker-compose.deploy.yml down -v --remove-orphans \
+        >/dev/null 2>&1 || true
+    )
+  fi
+  rm -rf "$STAGE_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+build_bootroot_binary() {
+  if [ -x "$BOOTROOT_BIN" ] &&
+    "$BOOTROOT_BIN" infra install --help | grep -q -- '--no-build'; then
+    return
+  fi
+  log "building bootroot binary"
+  cargo build --bin bootroot
+}
+
+reset_existing_stack() {
+  log "stopping any existing bootroot compose stack"
+  POSTGRES_PASSWORD=cleanup-only \
+    GRAFANA_ADMIN_PASSWORD=cleanup-only \
+    docker compose -f docker-compose.yml down -v --remove-orphans \
+    >/dev/null 2>&1 || true
+  POSTGRES_PASSWORD=cleanup-only \
+    GRAFANA_ADMIN_PASSWORD=cleanup-only \
+    docker compose -f docker-compose.deploy.yml down -v --remove-orphans \
+    >/dev/null 2>&1 || true
+}
+
+ensure_install_ports_free() {
+  local port
+  for port in 8200 9000 8080 5433; do
+    if bash -c ": >/dev/tcp/127.0.0.1/$port" >/dev/null 2>&1; then
+      fail "host port 127.0.0.1:$port is already in use; stop the listener first"
+    fi
+  done
+}
+
+prepare_images() {
+  log "pulling third-party images for archive preparation"
+  docker pull "$OPENBAO_IMAGE"
+  docker pull "$POSTGRES_IMAGE"
+
+  log "building bootroot infra images"
+  POSTGRES_PASSWORD=build-only \
+    GRAFANA_ADMIN_PASSWORD=build-only \
+    docker compose -f docker-compose.yml build step-ca bootroot-http01
+  docker tag bootroot-http01-responder:latest "$BOOTROOT_HTTP01_IMAGE"
+
+  mkdir -p "$ARCHIVE_DIR"
+  log "saving image archives under $ARCHIVE_DIR"
+  docker save -o "$ARCHIVE_DIR/openbao.tar" "$OPENBAO_IMAGE"
+  docker save -o "$ARCHIVE_DIR/postgres.tar" "$POSTGRES_IMAGE"
+  docker save -o "$ARCHIVE_DIR/step-ca.tar" "$BOOTROOT_STEP_CA_IMAGE"
+  docker save -o "$ARCHIVE_DIR/http01.tar" "$BOOTROOT_HTTP01_IMAGE"
+}
+
+stage_payload() {
+  log "staging deploy payload in $STAGE_DIR"
+  cp docker-compose.deploy.yml "$STAGE_DIR/"
+  mkdir -p "$STAGE_DIR/openbao" "$SHIM_DIR"
+  cp openbao/openbao.hcl "$STAGE_DIR/openbao/openbao.hcl"
+  cp responder.toml.compose "$STAGE_DIR/responder.toml.compose"
+
+  cat >"$SHIM_DIR/docker" <<EOF
+#!/usr/bin/env bash
+{
+  printf '%q ' "\$@"
+  printf '\\n'
+} >>"$DOCKER_LOG"
+exec "$REAL_DOCKER" "\$@"
+EOF
+  chmod +x "$SHIM_DIR/docker"
+}
+
+run_install() {
+  log "running deploy compose install from staged directory"
+  (
+    cd "$STAGE_DIR"
+    PATH="$SHIM_DIR:$PATH" \
+      OPENBAO_IMAGE="$OPENBAO_IMAGE" \
+      POSTGRES_IMAGE="$POSTGRES_IMAGE" \
+      BOOTROOT_STEP_CA_IMAGE="$BOOTROOT_STEP_CA_IMAGE" \
+      BOOTROOT_HTTP01_IMAGE="$BOOTROOT_HTTP01_IMAGE" \
+      "$BOOTROOT_BIN" infra install \
+        --compose-file docker-compose.deploy.yml \
+        --image-archive-dir "$ARCHIVE_DIR" \
+        --no-build
+  )
+}
+
+assert_no_build_contract() {
+  log "verifying docker invocations"
+  [ -s "$DOCKER_LOG" ] || fail "docker shim did not record any invocations"
+
+  if grep -Eq '(^| )compose( |.* )pull( |$)' "$DOCKER_LOG"; then
+    cat "$DOCKER_LOG" >&2
+    fail "infra install attempted docker compose pull under --no-build"
+  fi
+
+  if grep -Eq '(^| )--build( |$)' "$DOCKER_LOG"; then
+    cat "$DOCKER_LOG" >&2
+    fail "infra install passed --build under --no-build"
+  fi
+
+  local archive
+  for archive in openbao postgres step-ca http01; do
+    if ! grep -Eq "(^| )load -i .*${archive}\\.tar" "$DOCKER_LOG"; then
+      cat "$DOCKER_LOG" >&2
+      fail "image archive was not loaded: ${archive}.tar"
+    fi
+  done
+
+  if ! grep -Eq 'compose -f docker-compose\.deploy\.yml up --no-build --pull never -d openbao postgres step-ca bootroot-http01' "$DOCKER_LOG"; then
+    cat "$DOCKER_LOG" >&2
+    fail "compose up did not use --no-build --pull never for the default install services"
+  fi
+}
+
+require_cmd cargo
+require_cmd docker
+
+reset_existing_stack
+ensure_install_ports_free
+build_bootroot_binary
+prepare_images
+stage_payload
+run_install
+assert_no_build_contract
+
+log "deploy compose no-build smoke passed"

--- a/scripts/preflight/run-all.sh
+++ b/scripts/preflight/run-all.sh
@@ -11,6 +11,9 @@ echo "--- ci/check.sh ---"
 echo "--- validate-deploy-compose.sh ---"
 "$SCRIPT_DIR/../validate-deploy-compose.sh"
 
+echo "--- extra/deploy-no-build-smoke.sh ---"
+"$SCRIPT_DIR/extra/deploy-no-build-smoke.sh"
+
 echo "--- ci/test-core.sh ---"
 "$SCRIPT_DIR/ci/test-core.sh"
 


### PR DESCRIPTION
## Summary

Adds an automated smoke check for the #704 deploy-compose no-build path so the real install flow is covered, not just `docker compose config` rendering.

The new `scripts/preflight/extra/deploy-no-build-smoke.sh` stages only `docker-compose.deploy.yml`, `openbao/openbao.hcl`, `responder.toml.compose`, and image archives in a temp directory, then runs `bootroot infra install --compose-file docker-compose.deploy.yml --image-archive-dir <dir> --no-build` from that source-tree-free directory. A Docker shim records install-time Docker invocations and asserts the command loads all four default-service image archives, never runs `docker compose pull`, and runs `docker compose up --no-build --pull never` instead of `up --build`.

The smoke is wired into the `test-core` CI job after `cargo build --bins` and into `scripts/preflight/run-all.sh`. The changelog notes the new regression coverage.

Closes #706

## Test plan

- `bash -n scripts/preflight/extra/deploy-no-build-smoke.sh`
- `scripts/validate-deploy-compose.sh`
- `cargo test -q no_build`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`

I attempted to run the full new smoke locally, but this workstation has `127.0.0.1:8200` already held by the local Docker/OrbStack proxy, so the script correctly aborts before the expensive image-preparation phase with a busy-port diagnostic. CI should exercise the full smoke on a clean runner.