### PR TITLE
Run step-ca helpers as secrets owner and sweep root-owned files (#716)

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -66,8 +66,10 @@ If you are not using `bootroot infra install`, you can initialize manually:
 mkdir -p secrets
 printf "%s" "<your-password>" > secrets/password.txt
 
-# Run init inside a container (example)
-docker run --user root --rm -v $(pwd)/secrets:/home/step smallstep/step-ca \
+# Run init inside a container as the owner of ./secrets (example)
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v $(pwd)/secrets:/home/step smallstep/step-ca \
   step ca init \
   --name "Bootroot CA" \
   --provisioner "admin" \
@@ -77,6 +79,15 @@ docker run --user root --rm -v $(pwd)/secrets:/home/step smallstep/step-ca \
   --provisioner-password-file /home/step/password.txt \
   --acme
 ```
+
+Run the container as the owner of `secrets/`, not as `root`.
+`--user $(id -u):$(id -g)` uses your own uid/gid, which is correct when you
+own `secrets/` (as you do after the `mkdir` above). Everything Bootroot runs
+against `secrets/` runs as that directory's owner — the OpenBao Agent
+sidecars that render `password.txt` and `config/ca.json` into it, and every
+`step` helper container — so material created as `root` would diverge from
+the rest of the tree. Bootroot now repairs such divergence on its next run,
+but the manual path should not create the problem in the first place.
 
 `<your-password>` protects (encrypts) the CA keys. In production use a strong
 password and keep this file out of logs and repositories. In production we

--- a/docs/ko/installation.md
+++ b/docs/ko/installation.md
@@ -58,7 +58,10 @@ bootroot infra up
 mkdir -p secrets
 printf "%s" "<your-password>" > secrets/password.txt
 
-docker run --user root --rm -v $(pwd)/secrets:/home/step smallstep/step-ca \
+# ./secrets 디렉터리 소유자로 컨테이너에서 init 실행(예시)
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v $(pwd)/secrets:/home/step smallstep/step-ca \
   step ca init \
   --name "Bootroot CA" \
   --provisioner "admin" \
@@ -68,6 +71,15 @@ docker run --user root --rm -v $(pwd)/secrets:/home/step smallstep/step-ca \
   --provisioner-password-file /home/step/password.txt \
   --acme
 ```
+
+컨테이너는 `root`가 아니라 `secrets/` 디렉터리 소유자로 실행하세요.
+`--user $(id -u):$(id -g)`는 여러분 자신의 uid/gid를 사용하며, 위의
+`mkdir`로 `secrets/`를 직접 소유하게 되므로 올바른 값입니다. Bootroot가
+`secrets/`에 대해 실행하는 모든 것 — `password.txt`와 `config/ca.json`을
+렌더링하는 OpenBao Agent 사이드카, 그리고 모든 `step` 헬퍼 컨테이너 —
+은 그 디렉터리 소유자로 실행됩니다. 따라서 `root`로 생성된 자료는
+나머지 트리와 어긋나게 됩니다. Bootroot는 이제 다음 실행 시 이런 어긋남을
+복구하지만, 수동 경로에서 애초에 문제를 만들지 않는 것이 좋습니다.
 
 `<your-password>`는 CA 키를 보호(암호화)하는 비밀번호입니다. 운영에서는
 충분히 강한 비밀번호로 설정하고, 해당 파일은 외부에 노출되지 않도록

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -996,6 +996,14 @@ run_rotations_with_verification() {
   assert_fingerprint_changed "$WEB_SERVICE" "after-stepca-password" "after-db"
   assert_fingerprint_changed "$REMOTE_SERVICE" "after-stepca-password" "after-db"
 
+  # Reseed root-owned CA keys before CA rotation. The earlier
+  # `rotate stepca-password` already converged the tree, so without
+  # reseeding here the CA rotation would run on an already-repaired tree
+  # and would not exercise the sweep's placement in `rotate ca-key`
+  # (before its host-side Phase 1 backup reads the keys).
+  log_phase "reseed-root-owned-ca-keys"
+  seed_root_owned_ca_keys
+
   log_phase "rotate-ca-key"
   run_bootroot rotate \
     --compose-file "$COMPOSE_FILE" \
@@ -1011,6 +1019,10 @@ run_rotations_with_verification() {
   assert_fingerprint_changed "$EDGE_SERVICE" "after-db" "after-ca-key"
   assert_fingerprint_changed "$WEB_SERVICE" "after-db" "after-ca-key"
   assert_fingerprint_changed "$REMOTE_SERVICE" "after-db" "after-ca-key"
+  # CA rotation reads (Phase 1 host-side backup) and rewrites the CA keys
+  # as the secrets-directory owner after the ownership sweep, so the
+  # reseeded root-owned keys must be converged back to owner-owned.
+  assert_no_root_owned_secrets "rotate ca-key"
 
   log_phase "rotate-ca-key-full"
   run_bootroot rotate \

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -730,6 +730,40 @@ assert_fingerprint_changed() {
   fi
 }
 
+# Simulates a legacy host: CA keys left root-owned by a pre-#716 rotation
+# (or the old `--user root` manual-init example), with the secrets/
+# directory itself still host-owned. Only the keys go root-owned — the
+# certs stay host-owned so the OpenBao client can still read the trust
+# bundle before the rotation's ownership sweep runs. A CA-touching
+# rotation must converge this back to owner-owned.
+seed_root_owned_ca_keys() {
+  local cid img
+  cid="$(docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps -a -q step-ca | tr -d '\n')"
+  [ -n "$cid" ] || fail "step-ca container not found for root-owned seeding"
+  img="$(docker inspect --format '{{.Config.Image}}' "$cid")"
+  [ -n "$img" ] || fail "could not resolve step-ca image for root-owned seeding"
+  docker run --rm --user root -v "$SECRETS_DIR:/mnt" "$img" \
+    chown 0:0 /mnt/secrets/root_ca_key /mnt/secrets/intermediate_ca_key \
+    >>"$RUN_LOG" 2>&1 || fail "failed to seed root-owned CA keys"
+}
+
+# Asserts that no entry under secrets/ is root-owned. Every `step` helper
+# container now runs as the secrets-directory owner and the ownership
+# sweep repairs any legacy root-owned material, so after a CA-touching
+# rotation the tree must be fully owner-owned.
+assert_no_root_owned_secrets() {
+  local label="$1"
+  local root_owned
+  root_owned="$(find "$SECRETS_DIR" -uid 0 -print 2>/dev/null || true)"
+  if [ -n "$root_owned" ]; then
+    {
+      echo "root-owned entries under secrets/ after ${label}:"
+      echo "$root_owned"
+    } >>"$RUN_LOG"
+    fail "root-owned entries remain under secrets/ after ${label}"
+  fi
+}
+
 copy_remote_materials() {
   local control_service_dir="$SECRETS_DIR/services/$REMOTE_SERVICE"
   local remote_service_dir="$REMOTE_DIR/secrets/services/$REMOTE_SERVICE"
@@ -908,6 +942,12 @@ run_rotations_with_verification() {
   assert_fingerprint_changed "$WEB_SERVICE" "initial" "after-responder-hmac"
   assert_fingerprint_changed "$REMOTE_SERVICE" "initial" "after-responder-hmac"
 
+  # Legacy-host simulation: leave the CA keys root-owned before rotating,
+  # as a host that rotated (or ran the documented manual init) before #716
+  # would. The rotation must still succeed and converge ownership.
+  log_phase "seed-root-owned-ca-keys"
+  seed_root_owned_ca_keys
+
   log_phase "rotate-stepca-password"
   run_bootroot rotate \
     --compose-file "$COMPOSE_FILE" \
@@ -923,6 +963,10 @@ run_rotations_with_verification() {
   assert_fingerprint_changed "$EDGE_SERVICE" "after-responder-hmac" "after-stepca-password"
   assert_fingerprint_changed "$WEB_SERVICE" "after-responder-hmac" "after-stepca-password"
   assert_fingerprint_changed "$REMOTE_SERVICE" "after-responder-hmac" "after-stepca-password"
+  # step-ca password rotation re-encrypts the CA keys in place. It now
+  # runs as the secrets-directory owner (after the ownership sweep), so no
+  # key may be left root-owned.
+  assert_no_root_owned_secrets "rotate stepca-password"
 
   log_phase "rotate-db"
   # Build admin DSN from ca.json so the password matches the current

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -199,11 +199,8 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
     if should_sweep_secrets_ownership(&args.services, &args.compose_file.compose_file, messages)? {
         let sweep_secrets_dir = resolve_effective_secrets_dir(&state_path, compose_dir)
             .unwrap_or_else(|| compose_dir.join("secrets"));
-        sweep_secrets_ownership(
-            &args.compose_file.compose_file,
-            &sweep_secrets_dir,
-            messages,
-        )?;
+        let image = resolve_stepca_image(&args.compose_file.compose_file, messages)?;
+        sweep_secrets_ownership(&sweep_secrets_dir, &image, messages)?;
     }
 
     // Auto-detect unseal key file if not explicitly specified.
@@ -566,7 +563,8 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     // rotation or manual init. Runs after `up` so the step-ca server
     // image it reuses exists (loaded from archive or built by `up`).
     if should_sweep_secrets_ownership(&args.services, &args.compose_file.compose_file, messages)? {
-        sweep_secrets_ownership(&args.compose_file.compose_file, &secrets_dir, messages)?;
+        let image = resolve_stepca_image(&args.compose_file.compose_file, messages)?;
+        sweep_secrets_ownership(&secrets_dir, &image, messages)?;
     }
 
     // Collect readiness but skip step-ca (it has no config yet).
@@ -713,9 +711,16 @@ fn resolve_stepca_image(compose_file: &Path, messages: &Messages) -> Result<Stri
 /// the scoping guarantees — it mounts only the secrets directory and does
 /// not follow symlinks out of it. The sweep is a no-op on a tree whose
 /// ownership is already correct.
+///
+/// `image` names the container image to run `chown` in. Callers pass an
+/// image the flow already has on hand so the sweep introduces no new
+/// dependency: the `infra` flows resolve the compose step-ca server image
+/// (see [`resolve_stepca_image`]) after `up` has made it available, while
+/// the `rotate` flows pass the same `smallstep/step-ca` image their `step`
+/// helpers already run.
 pub(crate) fn sweep_secrets_ownership(
-    compose_file: &Path,
     secrets_dir: &Path,
+    image: &str,
     messages: &Messages,
 ) -> Result<()> {
     let mount_root = std::fs::canonicalize(secrets_dir)
@@ -726,8 +731,7 @@ pub(crate) fn sweep_secrets_ownership(
     let meta = std::fs::metadata(secrets_dir)
         .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
     let user_arg = format!("{}:{}", meta.uid(), meta.gid());
-    let image = resolve_stepca_image(compose_file, messages)?;
-    let args = build_ownership_sweep_args(&mount, &user_arg, &image);
+    let args = build_ownership_sweep_args(&mount, &user_arg, image);
     run_docker(&args, "docker secrets ownership sweep", messages)?;
     Ok(())
 }

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -666,10 +666,18 @@ fn build_ownership_sweep_args<'a>(
         // container at all. Do not "fix" this to a non-root user.
         "--user",
         "root",
+        // Run `chown` directly instead of through the image's default
+        // entrypoint. The `rotate` flows reuse the `smallstep/step-ca`
+        // helper image here, whose entrypoint would otherwise print a
+        // spurious "there is no ca.json config file" warning — the sweep
+        // deliberately mounts only the secrets subtree, not `/home/step`.
+        // Overriding the entrypoint keeps the sweep visibly just a scoped
+        // `chown` container and off the step-ca init path.
+        "--entrypoint",
+        "chown",
         "-v",
         mount,
         image,
-        "chown",
         "-R",
         // Change the symlink itself rather than its referent, so the
         // sweep never follows a link out of the mounted secrets tree.
@@ -1832,7 +1840,9 @@ mod tests {
     #[test]
     fn build_ownership_sweep_args_scoped_and_no_symlink_following() {
         let mount = "/host/secrets:/secrets";
-        let args = build_ownership_sweep_args(mount, "1000:1000", "bootroot-step-ca:0.29.0");
+        let image = "bootroot-step-ca:0.29.0";
+        let args = build_ownership_sweep_args(mount, "1000:1000", image);
+        let image_pos = args.iter().position(|a| *a == image).expect("image");
 
         // Exactly one bind mount, and it is the secrets directory.
         let mounts: Vec<&&str> = args
@@ -1846,8 +1856,17 @@ mod tests {
             "no host-root or extra mounts"
         );
 
+        // The sweep overrides the image entrypoint so it runs `chown`
+        // directly, never the step-ca init path that would warn about a
+        // missing ca.json under the (deliberately unmounted) /home/step.
+        let ep_pos = args
+            .iter()
+            .position(|a| *a == "--entrypoint")
+            .expect("--entrypoint");
+        assert_eq!(args.get(ep_pos + 1), Some(&"chown"));
+        assert!(ep_pos < image_pos, "--entrypoint precedes the image");
+
         // chown recurses but does not dereference symlinks.
-        assert!(args.contains(&"chown"));
         assert!(args.contains(&"-R"));
         assert!(args.contains(&"--no-dereference"));
         assert!(args.contains(&"1000:1000"));

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -1,4 +1,5 @@
 use std::io::IsTerminal;
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::time::Duration;
@@ -188,6 +189,22 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
     up_args.extend(["up", "-d"]);
     up_args.extend(&svc_refs);
     run_docker(&up_args, "docker compose up", messages)?;
+
+    // Converge secrets ownership so an operator who upgrades and then only
+    // ever runs `infra up` also repairs any root-owned CA material. Runs
+    // after `up` so the step-ca server image it reuses already exists;
+    // step-ca still runs as root here, so a briefly root-owned key does
+    // not stop it, and the readiness check below is unaffected. On a
+    // legacy tree with `ca.json` the server stays up throughout.
+    if should_sweep_secrets_ownership(&args.services, &args.compose_file.compose_file, messages)? {
+        let sweep_secrets_dir = resolve_effective_secrets_dir(&state_path, compose_dir)
+            .unwrap_or_else(|| compose_dir.join("secrets"));
+        sweep_secrets_ownership(
+            &args.compose_file.compose_file,
+            &sweep_secrets_dir,
+            messages,
+        )?;
+    }
 
     // Auto-detect unseal key file if not explicitly specified.
     // Resolve relative to the compose file directory so custom
@@ -544,6 +561,14 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     };
     run_docker_with_env(&up_args, &host_port_env_refs, up_label, messages)?;
 
+    // Converge secrets ownership before returning so the stack this
+    // command brings up has no root-owned CA material left by an earlier
+    // rotation or manual init. Runs after `up` so the step-ca server
+    // image it reuses exists (loaded from archive or built by `up`).
+    if should_sweep_secrets_ownership(&args.services, &args.compose_file.compose_file, messages)? {
+        sweep_secrets_ownership(&args.compose_file.compose_file, &secrets_dir, messages)?;
+    }
+
     // Collect readiness but skip step-ca (it has no config yet).
     let prereq_services: Vec<String> = args
         .services
@@ -594,6 +619,116 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     println!("{}", messages.infra_install_stepca_not_checked());
 
     println!("{}", messages.infra_install_completed());
+    Ok(())
+}
+
+/// Mount point for the secrets directory inside the ownership-sweep
+/// container. Only the host secrets directory is mounted here — nothing
+/// else in the tree is reachable from inside the sweep.
+const OWNERSHIP_SWEEP_MOUNT: &str = "/secrets";
+
+/// Returns whether the secrets-ownership sweep should run for an `infra`
+/// flow.
+///
+/// Gated on step-ca being genuinely in play: both requested via
+/// `--services` and declared by the compose file. On a topology without
+/// step-ca there is no CA material under `secrets/` to repair, and the
+/// step-ca server image the sweep reuses does not exist there either, so
+/// an ungated sweep would fail rather than merely no-op.
+fn should_sweep_secrets_ownership(
+    services: &[String],
+    compose_file: &Path,
+    messages: &Messages,
+) -> Result<bool> {
+    if !services.iter().any(|s| s == "step-ca") {
+        return Ok(false);
+    }
+    compose_has_stepca(compose_file, messages)
+}
+
+/// Builds the `docker run` argv for the ownership sweep.
+///
+/// Kept pure so tests can assert it mounts ONLY the secrets directory and
+/// uses `--no-dereference`, so `chown -R` never follows a symlink out of
+/// that mount.
+fn build_ownership_sweep_args<'a>(
+    mount: &'a str,
+    user_arg: &'a str,
+    image: &'a str,
+) -> Vec<&'a str> {
+    vec![
+        "run",
+        "--rm",
+        // Intentional root: this container runs `chown`, NOT a `step`
+        // subcommand. The `step` helpers must run as the secrets-directory
+        // owner; this one needs root to repair files that a prior
+        // `--user root` run (an old rotation or the pre-fix manual-init
+        // example) left root-owned. A running bootroot process cannot
+        // chown files it does not own, which is why the repair needs a
+        // container at all. Do not "fix" this to a non-root user.
+        "--user",
+        "root",
+        "-v",
+        mount,
+        image,
+        "chown",
+        "-R",
+        // Change the symlink itself rather than its referent, so the
+        // sweep never follows a link out of the mounted secrets tree.
+        "--no-dereference",
+        user_arg,
+        OWNERSHIP_SWEEP_MOUNT,
+    ]
+}
+
+/// Resolves the image the compose stack uses for its `step-ca` service by
+/// inspecting the container Compose created for it.
+///
+/// Reusing exactly that image is what keeps the sweep from introducing
+/// any image a flow did not already bring up: it is loaded from the
+/// archive on the air-gapped path and built by `up --build` on the
+/// fresh-source path, and in both the sweep runs only after `up`, so the
+/// image already exists.
+fn resolve_stepca_image(compose_file: &Path, messages: &Messages) -> Result<String> {
+    let container_id =
+        docker_compose_output(compose_file, None, &["ps", "-a", "-q", "step-ca"], messages)?;
+    let container_id = container_id.trim();
+    if container_id.is_empty() {
+        anyhow::bail!(messages.error_service_no_container("step-ca"));
+    }
+    let image = docker_output(
+        &["inspect", "--format", "{{.Config.Image}}", container_id],
+        messages,
+    )?;
+    Ok(image.trim().to_string())
+}
+
+/// Re-owns every entry under `secrets/` to the directory's own uid/gid
+/// via a one-shot root container, repairing files a prior `--user root`
+/// step helper (rotation or the documented manual init) left root-owned.
+///
+/// This is the single intentional root container in the CA tooling: it
+/// runs `chown`, so it needs root, whereas every `step` helper runs as
+/// the secrets-directory owner. See [`build_ownership_sweep_args`] for
+/// the scoping guarantees — it mounts only the secrets directory and does
+/// not follow symlinks out of it. The sweep is a no-op on a tree whose
+/// ownership is already correct.
+pub(crate) fn sweep_secrets_ownership(
+    compose_file: &Path,
+    secrets_dir: &Path,
+    messages: &Messages,
+) -> Result<()> {
+    let mount_root = std::fs::canonicalize(secrets_dir)
+        .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
+    let mount = format!("{}:{OWNERSHIP_SWEEP_MOUNT}", mount_root.display());
+    // Ownership follows the directory's own owner, never a fixed uid: the
+    // host user and the OpenBao Agents share this directory.
+    let meta = std::fs::metadata(secrets_dir)
+        .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
+    let user_arg = format!("{}:{}", meta.uid(), meta.gid());
+    let image = resolve_stepca_image(compose_file, messages)?;
+    let args = build_ownership_sweep_args(&mount, &user_arg, &image);
+    run_docker(&args, "docker secrets ownership sweep", messages)?;
     Ok(())
 }
 
@@ -1645,7 +1780,81 @@ pub(crate) fn docker_output(args: &[&str], messages: &Messages) -> Result<String
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::*;
+    use crate::i18n::test_messages;
+
+    const COMPOSE_WITH_STEPCA: &str = "services:\n  openbao:\n    image: openbao/openbao\n  \
+        step-ca:\n    image: bootroot-step-ca:0.29.0\n";
+    const COMPOSE_WITHOUT_STEPCA: &str =
+        "services:\n  openbao:\n    image: openbao/openbao\n  postgres:\n    image: postgres\n";
+
+    fn write_compose(contents: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("docker-compose.yml");
+        std::fs::write(&path, contents).expect("write compose");
+        (dir, path)
+    }
+
+    /// The sweep must run only when step-ca is both requested via
+    /// `--services` and declared by the compose file — otherwise there is
+    /// no CA material to repair and the reused image does not exist.
+    #[test]
+    fn should_sweep_secrets_ownership_requires_service_and_compose() {
+        let messages = test_messages();
+        let (_dir, with_stepca) = write_compose(COMPOSE_WITH_STEPCA);
+        let (_dir2, without_stepca) = write_compose(COMPOSE_WITHOUT_STEPCA);
+        let with_service = vec!["openbao".to_string(), "step-ca".to_string()];
+        let without_service = vec!["openbao".to_string(), "postgres".to_string()];
+
+        assert!(
+            should_sweep_secrets_ownership(&with_service, &with_stepca, &messages).unwrap(),
+            "runs when step-ca is requested and declared"
+        );
+        assert!(
+            !should_sweep_secrets_ownership(&without_service, &with_stepca, &messages).unwrap(),
+            "skipped when step-ca absent from --services"
+        );
+        assert!(
+            !should_sweep_secrets_ownership(&with_service, &without_stepca, &messages).unwrap(),
+            "skipped when compose declares no step-ca service"
+        );
+    }
+
+    /// The sweep container must mount ONLY the secrets directory and chown
+    /// with `--no-dereference` so it never follows a symlink out of the
+    /// mount. It is also the one deliberately-root container.
+    #[test]
+    fn build_ownership_sweep_args_scoped_and_no_symlink_following() {
+        let mount = "/host/secrets:/secrets";
+        let args = build_ownership_sweep_args(mount, "1000:1000", "bootroot-step-ca:0.29.0");
+
+        // Exactly one bind mount, and it is the secrets directory.
+        let mounts: Vec<&&str> = args
+            .iter()
+            .zip(args.iter().skip(1))
+            .filter_map(|(a, b)| (*a == "-v").then_some(b))
+            .collect();
+        assert_eq!(mounts, vec![&mount]);
+        assert!(
+            !args.iter().any(|a| a.contains(":/host") || *a == "/"),
+            "no host-root or extra mounts"
+        );
+
+        // chown recurses but does not dereference symlinks.
+        assert!(args.contains(&"chown"));
+        assert!(args.contains(&"-R"));
+        assert!(args.contains(&"--no-dereference"));
+        assert!(args.contains(&"1000:1000"));
+
+        // The sweep is the intentional root container.
+        let user_pos = args.iter().position(|a| *a == "--user").expect("--user");
+        assert_eq!(args.get(user_pos + 1), Some(&"root"));
+
+        // The chown target is the mount point, nothing outside it.
+        assert_eq!(args.last(), Some(&OWNERSHIP_SWEEP_MOUNT));
+    }
 
     #[test]
     fn build_compose_up_args_defaults_to_build() {

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -1110,8 +1110,12 @@ async fn rebuilt_admin_dsn_for_kv(
     )?))
 }
 
-/// Fixes file ownership and permissions in the secrets directory after
-/// `step ca init` which runs as root inside Docker.
+/// Normalises file and directory modes under the secrets directory to
+/// the expected 0700 (directories) / 0600 (key material) values.
+///
+/// This adjusts modes only; it does not change ownership. Every `step`
+/// helper container already runs as the secrets-directory owner, so the
+/// material it creates is host-owned and needs only its modes tightened.
 async fn fix_secrets_permissions(secrets_dir: &Path) -> Result<()> {
     fix_permissions_recursive(secrets_dir).await
 }

--- a/src/commands/rotate.rs
+++ b/src/commands/rotate.rs
@@ -21,6 +21,11 @@ use crate::i18n::Messages;
 use crate::state::StateFile;
 
 pub(super) const ROLE_ID_FILENAME: &str = "role_id";
+/// Image the `step` helper containers run in the `rotate` flows. The
+/// ownership sweep reuses it so it adds no dependency the flow did not
+/// already have (unlike the compose step-ca *server* image, which is not
+/// present on the air-gapped rotate host).
+pub(super) const STEP_CA_HELPER_IMAGE: &str = "smallstep/step-ca";
 pub(super) const OPENBAO_AGENT_STEPCA_CONTAINER: &str = "bootroot-openbao-agent-stepca";
 pub(super) const OPENBAO_AGENT_RESPONDER_CONTAINER: &str = "bootroot-openbao-agent-responder";
 pub(super) const ROOT_CA_COMMON_NAME: &str = "Bootroot Root CA";

--- a/src/commands/rotate/ca.rs
+++ b/src/commands/rotate/ca.rs
@@ -11,7 +11,7 @@ use super::helpers::{
 };
 use super::{
     INTERMEDIATE_CA_COMMON_NAME, OPENBAO_AGENT_RESPONDER_CONTAINER, OPENBAO_AGENT_STEPCA_CONTAINER,
-    ROOT_CA_COMMON_NAME, RotateContext, RotateOutcome,
+    ROOT_CA_COMMON_NAME, RotateContext, RotateOutcome, STEP_CA_HELPER_IMAGE,
 };
 use crate::cli::args::{RotateCaKeyArgs, RotateForceReissueArgs, RotateSkipPhase};
 use crate::commands::infra::run_docker;
@@ -39,17 +39,6 @@ pub(super) async fn rotate_ca_key(
     auto_confirm: bool,
     messages: &Messages,
 ) -> Result<()> {
-    // Converge secrets ownership before touching any key material. A host
-    // that rotated (or ran the documented manual init) before this change
-    // can carry root-owned keys the invoking user cannot even read, which
-    // would fail the host-side Phase 1 backup below. The sweep repairs
-    // that in place and is a no-op when ownership is already correct.
-    crate::commands::infra::sweep_secrets_ownership(
-        &ctx.compose_file,
-        ctx.paths.secrets_dir(),
-        messages,
-    )?;
-
     // Phase 0 — Pre-flight
     ensure_file_exists(&ctx.paths.root_cert(), messages)?;
     ensure_file_exists(&ctx.paths.intermediate_cert(), messages)?;
@@ -119,6 +108,21 @@ pub(super) async fn rotate_ca_key(
             phase: 0,
         }
     };
+
+    // Converge secrets ownership before reading or rewriting any key
+    // material. A host that rotated (or ran the documented manual init)
+    // before this change can carry root-owned keys the invoking user
+    // cannot even read, which would fail the host-side Phase 1 backup
+    // below and, on resume, the later key reads. The sweep repairs that in
+    // place and is a no-op when ownership is already correct. It reuses the
+    // `smallstep/step-ca` image the `step` helpers already run, so it adds
+    // no new dependency. Runs unconditionally (not gated on `start_phase`)
+    // so a resumed rotation converges too.
+    crate::commands::infra::sweep_secrets_ownership(
+        ctx.paths.secrets_dir(),
+        STEP_CA_HELPER_IMAGE,
+        messages,
+    )?;
 
     // Phase 1 — Backup
     if start_phase < 1 {

--- a/src/commands/rotate/ca.rs
+++ b/src/commands/rotate/ca.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -38,6 +39,17 @@ pub(super) async fn rotate_ca_key(
     auto_confirm: bool,
     messages: &Messages,
 ) -> Result<()> {
+    // Converge secrets ownership before touching any key material. A host
+    // that rotated (or ran the documented manual init) before this change
+    // can carry root-owned keys the invoking user cannot even read, which
+    // would fail the host-side Phase 1 backup below. The sweep repairs
+    // that in place and is a no-op when ownership is already correct.
+    crate::commands::infra::sweep_secrets_ownership(
+        &ctx.compose_file,
+        ctx.paths.secrets_dir(),
+        messages,
+    )?;
+
     // Phase 0 — Pre-flight
     ensure_file_exists(&ctx.paths.root_cert(), messages)?;
     ensure_file_exists(&ctx.paths.intermediate_cert(), messages)?;
@@ -399,18 +411,27 @@ async fn concat_unique_ca_certs(
     Ok(bundle)
 }
 
-fn generate_new_root(ctx: &RotateContext, messages: &Messages) -> Result<()> {
-    let mount_root = fs::canonicalize(ctx.paths.secrets_dir()).with_context(|| {
-        messages.error_resolve_path_failed(&ctx.paths.secrets_dir().display().to_string())
-    })?;
-    let mount = format!("{}:/home/step", mount_root.display());
-    let args = vec![
+/// Resolves the `--user <uid>:<gid>` value for a `step` helper container
+/// from the owner of `secrets_dir`. Every `step` subcommand bootroot runs
+/// against `secrets/` runs as that owner so the material it writes matches
+/// the host ownership kept by the `OpenBao` Agent sidecars — never `root`.
+fn owner_user_arg(secrets_dir: &Path, messages: &Messages) -> Result<String> {
+    let meta = fs::metadata(secrets_dir)
+        .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
+    Ok(format!("{}:{}", meta.uid(), meta.gid()))
+}
+
+/// Builds the `docker run` argv that regenerates the root CA as the
+/// secrets-directory owner. Kept pure so tests can assert it carries
+/// `--user <uid>:<gid>` rather than `--user root`.
+fn generate_root_docker_args(mount: &str, user_arg: &str) -> Vec<String> {
+    [
         "run",
         "--user",
-        "root",
+        user_arg,
         "--rm",
         "-v",
-        &mount,
+        mount,
         "smallstep/step-ca",
         "step",
         "certificate",
@@ -423,23 +444,23 @@ fn generate_new_root(ctx: &RotateContext, messages: &Messages) -> Result<()> {
         "--password-file",
         "/home/step/password.txt",
         "--force",
-    ];
-    run_docker(&args, "docker step certificate create (root)", messages)?;
-    Ok(())
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
-fn generate_new_intermediate(ctx: &RotateContext, messages: &Messages) -> Result<()> {
-    let mount_root = fs::canonicalize(ctx.paths.secrets_dir()).with_context(|| {
-        messages.error_resolve_path_failed(&ctx.paths.secrets_dir().display().to_string())
-    })?;
-    let mount = format!("{}:/home/step", mount_root.display());
-    let args = vec![
+/// Builds the `docker run` argv that regenerates the intermediate CA as
+/// the secrets-directory owner. Kept pure so tests can assert it carries
+/// `--user <uid>:<gid>` rather than `--user root`.
+fn generate_intermediate_docker_args(mount: &str, user_arg: &str) -> Vec<String> {
+    [
         "run",
         "--user",
-        "root",
+        user_arg,
         "--rm",
         "-v",
-        &mount,
+        mount,
         "smallstep/step-ca",
         "step",
         "certificate",
@@ -458,8 +479,33 @@ fn generate_new_intermediate(ctx: &RotateContext, messages: &Messages) -> Result
         "--ca-password-file",
         "/home/step/password.txt",
         "--force",
-    ];
-    run_docker(&args, "docker step certificate create", messages)?;
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+fn generate_new_root(ctx: &RotateContext, messages: &Messages) -> Result<()> {
+    let secrets_dir = ctx.paths.secrets_dir();
+    let mount_root = fs::canonicalize(secrets_dir)
+        .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
+    let mount = format!("{}:/home/step", mount_root.display());
+    let user_arg = owner_user_arg(secrets_dir, messages)?;
+    let args = generate_root_docker_args(&mount, &user_arg);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_docker(&arg_refs, "docker step certificate create (root)", messages)?;
+    Ok(())
+}
+
+fn generate_new_intermediate(ctx: &RotateContext, messages: &Messages) -> Result<()> {
+    let secrets_dir = ctx.paths.secrets_dir();
+    let mount_root = fs::canonicalize(secrets_dir)
+        .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
+    let mount = format!("{}:/home/step", mount_root.display());
+    let user_arg = owner_user_arg(secrets_dir, messages)?;
+    let args = generate_intermediate_docker_args(&mount, &user_arg);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_docker(&arg_refs, "docker step certificate create", messages)?;
     Ok(())
 }
 
@@ -1378,6 +1424,50 @@ mod tests {
         let mut params = CertificateParams::new(vec![cn.to_string()]).expect("leaf params");
         params.distinguished_name.push(DnType::CommonName, cn);
         params.signed_by(&key, issuer).expect("sign leaf").pem()
+    }
+
+    /// The root-CA regeneration container must run as the secrets-directory
+    /// owner, so the `--user` value is the resolved `uid:gid` and never
+    /// `root` — otherwise the regenerated key would land root-owned.
+    #[test]
+    fn generate_root_docker_args_run_as_owner_not_root() {
+        let args = generate_root_docker_args("/host/secrets:/home/step", "1000:1000");
+        let user_pos = args
+            .iter()
+            .position(|a| a == "--user")
+            .expect("--user present");
+        assert_eq!(
+            args.get(user_pos + 1).map(String::as_str),
+            Some("1000:1000")
+        );
+        assert!(!args.iter().any(|a| a == "root"));
+    }
+
+    /// The intermediate-CA regeneration container must likewise run as the
+    /// secrets-directory owner rather than `root`.
+    #[test]
+    fn generate_intermediate_docker_args_run_as_owner_not_root() {
+        let args = generate_intermediate_docker_args("/host/secrets:/home/step", "1000:1000");
+        let user_pos = args
+            .iter()
+            .position(|a| a == "--user")
+            .expect("--user present");
+        assert_eq!(
+            args.get(user_pos + 1).map(String::as_str),
+            Some("1000:1000")
+        );
+        assert!(!args.iter().any(|a| a == "root"));
+    }
+
+    /// `owner_user_arg` resolves the `uid:gid` from the secrets directory
+    /// owner. In tests that is the invoking user, which is not root.
+    #[test]
+    fn owner_user_arg_resolves_directory_owner() {
+        let dir = tempdir().expect("tempdir");
+        let messages = test_messages();
+        let user_arg = owner_user_arg(dir.path(), &messages).expect("owner uid:gid");
+        assert!(user_arg.contains(':'));
+        assert_ne!(user_arg, "root");
     }
 
     /// Regression for issue #619: in a mixed registry where one service

--- a/src/commands/rotate/stepca_password.rs
+++ b/src/commands/rotate/stepca_password.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -30,6 +31,18 @@ pub(super) async fn rotate_stepca_password(
     confirm_action(
         messages.prompt_rotate_stepca_password(),
         auto_confirm,
+        messages,
+    )?;
+
+    // Converge secrets ownership before re-encrypting any key in place.
+    // `step crypto change-pass` now runs as the secrets-directory owner
+    // (below), so a key left root-owned by an earlier `--user root`
+    // rotation would otherwise become unreadable to it. The sweep repairs
+    // that first, keeping this flow working exactly as it does today, and
+    // is a no-op when ownership is already correct.
+    crate::commands::infra::sweep_secrets_ownership(
+        &ctx.compose_file,
+        ctx.paths.secrets_dir(),
         messages,
     )?;
 
@@ -101,13 +114,20 @@ pub(super) fn change_stepca_passphrase(
     let mount_root = fs::canonicalize(secrets_dir)
         .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
     let mount = format!("{}:/home/step", mount_root.display());
+    // Run as the owner of secrets_dir so the re-encrypted key file matches
+    // host ownership, keeping every `step` helper container in agreement
+    // with the OpenBao Agent sidecars that render into the same directory
+    // as that owner.
+    let meta = fs::metadata(secrets_dir)
+        .with_context(|| messages.error_resolve_path_failed(&secrets_dir.display().to_string()))?;
+    let user_arg = format!("{}:{}", meta.uid(), meta.gid());
     let key_container = to_container_path(secrets_dir, key_path, "/home/step")?;
     let pwd_container = to_container_path(secrets_dir, current_password, "/home/step")?;
     let new_pwd_container = to_container_path(secrets_dir, new_password, "/home/step")?;
     let args = vec![
         "run",
         "--user",
-        "root",
+        &user_arg,
         "--rm",
         "-v",
         &*mount,
@@ -171,10 +191,14 @@ mod tests {
         let args: Vec<&str> = logged_args.lines().collect();
         let mount_root = fs::canonicalize(&secrets_dir).expect("canonicalize secrets dir");
         let expected_mount = format!("{}:/home/step", mount_root.display());
+        // The container must run as the secrets-directory owner, not root,
+        // so the re-encrypted key stays host-owned like the rest of the tree.
+        let meta = fs::metadata(&secrets_dir).expect("stat secrets dir");
+        let expected_user = format!("{}:{}", meta.uid(), meta.gid());
         let expected = vec![
             "run",
             "--user",
-            "root",
+            expected_user.as_str(),
             "--rm",
             "-v",
             expected_mount.as_str(),

--- a/src/commands/rotate/stepca_password.rs
+++ b/src/commands/rotate/stepca_password.rs
@@ -36,6 +36,21 @@ pub(super) async fn rotate_stepca_password(
         messages,
     )?;
 
+    let secrets_dir = ctx.paths.secrets_dir();
+    let password_path = ctx.paths.stepca_password();
+    let new_password_path = ctx.paths.stepca_password_new();
+    let root_key = ctx.paths.stepca_root_key();
+    let intermediate_key = ctx.paths.stepca_intermediate_key();
+
+    // Keep the local "missing file" preflight first, before any container
+    // runs: an uninitialized or broken tree must fail with a clear local
+    // error rather than pulling/running the helper image. This mirrors the
+    // CA rotation flow, which also sweeps only after its Phase 0
+    // `ensure_file_exists` checks.
+    ensure_file_exists(&password_path, messages)?;
+    ensure_file_exists(&root_key, messages)?;
+    ensure_file_exists(&intermediate_key, messages)?;
+
     // Converge secrets ownership before re-encrypting any key in place.
     // `step crypto change-pass` now runs as the secrets-directory owner
     // (below), so a key left root-owned by an earlier `--user root`
@@ -49,16 +64,6 @@ pub(super) async fn rotate_stepca_password(
         STEP_CA_HELPER_IMAGE,
         messages,
     )?;
-
-    let secrets_dir = ctx.paths.secrets_dir();
-    let password_path = ctx.paths.stepca_password();
-    let new_password_path = ctx.paths.stepca_password_new();
-    let root_key = ctx.paths.stepca_root_key();
-    let intermediate_key = ctx.paths.stepca_intermediate_key();
-
-    ensure_file_exists(&password_path, messages)?;
-    ensure_file_exists(&root_key, messages)?;
-    ensure_file_exists(&intermediate_key, messages)?;
 
     fs_util::ensure_secrets_dir(secrets_dir).await?;
     write_secret_file(&new_password_path, &new_password, messages).await?;

--- a/src/commands/rotate/stepca_password.rs
+++ b/src/commands/rotate/stepca_password.rs
@@ -10,7 +10,9 @@ use super::helpers::{
     confirm_action, ensure_file_exists, restart_compose_service, restart_container,
     wait_for_rendered_file, write_secret_file,
 };
-use super::{OPENBAO_AGENT_STEPCA_CONTAINER, RENDERED_FILE_TIMEOUT, RotateContext};
+use super::{
+    OPENBAO_AGENT_STEPCA_CONTAINER, RENDERED_FILE_TIMEOUT, RotateContext, STEP_CA_HELPER_IMAGE,
+};
 use crate::cli::args::RotateStepcaPasswordArgs;
 use crate::commands::infra::run_docker;
 use crate::commands::init::{PATH_STEPCA_PASSWORD, SECRET_BYTES, to_container_path};
@@ -39,10 +41,12 @@ pub(super) async fn rotate_stepca_password(
     // (below), so a key left root-owned by an earlier `--user root`
     // rotation would otherwise become unreadable to it. The sweep repairs
     // that first, keeping this flow working exactly as it does today, and
-    // is a no-op when ownership is already correct.
+    // is a no-op when ownership is already correct. It reuses the
+    // `smallstep/step-ca` image the `step` helpers already run, so it adds
+    // no new dependency.
     crate::commands::infra::sweep_secrets_ownership(
-        &ctx.compose_file,
         ctx.paths.secrets_dir(),
+        STEP_CA_HELPER_IMAGE,
         messages,
     )?;
 

--- a/tests/bootroot_rotate.rs
+++ b/tests/bootroot_rotate.rs
@@ -3647,11 +3647,18 @@ async fn test_rotate_ca_key_full_mode_state_records_full() {
         .mount(&openbao)
         .await;
 
-    // Use a fake docker that fails on root cert generation so Phase 2 fails
-    // but Phase 1 (backup) completes, creating rotation-state.json
+    // Use a fake docker that succeeds on the pre-Phase-1 ownership sweep
+    // (`chown`) but fails on root cert generation so Phase 2 fails while
+    // Phase 1 (backup) completes, creating rotation-state.json.
     let bin_dir = temp_dir.path().join("bin");
     fs::create_dir_all(&bin_dir).expect("create bin dir");
-    let fake_docker = "#!/bin/sh\nexit 1\n";
+    let fake_docker = r#"#!/bin/sh
+set -eu
+case "$*" in
+  *"step certificate create"*) exit 1 ;;
+esac
+exit 0
+"#;
     fs::write(bin_dir.join("docker"), fake_docker).expect("write fake docker");
     fs::set_permissions(bin_dir.join("docker"), fs::Permissions::from_mode(0o700)).expect("chmod");
 


### PR DESCRIPTION
## Summary

The one-shot `step` helper containers that write into `secrets/` disagreed on who they run as. `init`'s helpers already pass `--user <uid>:<gid>` resolved from the secrets-directory owner, but the rotate flows still ran `--user root`, leaving root-owned key material behind. This diverges from the OpenBao Agent sidecars (which render into the same directory as the owner uid) and is about to become fatal once the step-ca server moves to a non-root uid. It already breaks `rotate ca-key`'s host-side Phase 1 backup on any host that rotated before this change.

This PR:

- Switches both `rotate ca` sites (`generate_new_root`, `generate_new_intermediate`) and the `rotate stepca-password` `step crypto change-pass` site from `--user root` to `--user <uid>:<gid>` derived from the secrets-directory owner, matching the existing `init` pattern. The `docker run` argv builders are extracted as pure functions so tests can assert them.
- Adds a shared ownership sweep — a single one-shot **root** container that `chown -R --no-dereference`s everything under `secrets/` back to the directory's own uid/gid — implemented once in `src/commands/infra.rs` and wired into `infra install`, `infra up`, and both `rotate` flows so a legacy host with root-owned material converges instead of failing or aborting.
- Picks the sweep's image per flow so it adds **no** new image dependency anywhere. The `infra` flows reuse the compose stack's own step-ca server image (resolved by inspecting the container Compose created) and run the sweep after `up`, so that image already exists on both the air-gapped and fresh-source install paths. The `rotate` flows instead reuse the `smallstep/step-ca` image their own `step` helpers already run, which keeps the sweep off `docker compose ps` and lets it run before Phase 1 reads or rewrites any key material.
- Gates the sweep in the `infra` flows on step-ca being both requested via `--services` and declared by the compose file (`compose_has_stepca`), mounts only the secrets directory, and uses `--no-dereference` so it never follows a symlink out of the mount. Its root user is the one intentional root container, kept visibly distinct from the `step` helpers and commented as such.
- Updates the "Manual alternative" manual-init example in `docs/en/installation.md` and `docs/ko/installation.md` to run as the secrets-directory owner (`--user $(id -u):$(id -g)`) with prose explaining the always-true reason (everything bootroot runs against `secrets/` runs as that directory's owner), leaving the image reference untouched.
- Fixes the stale `fix_secrets_permissions` doc comment to describe mode normalisation instead of a root `step ca init`.
- Adds a legacy-host simulation (`seed_root_owned_ca_keys` / `assert_no_root_owned_secrets`) to the local lifecycle E2E script.

Closes #716

## Test plan

- [x] Unit test: the `docker run` argv built by `rotate/ca.rs` and `rotate/stepca_password.rs` carries `--user <uid>:<gid>`, not `--user root`.
- [x] Unit test: the sweep's container invocation mounts only the secrets directory and uses `--no-dereference` (no symlink following).
- [x] Unit test: the sweep is skipped when step-ca is absent from `--services`, and again when the compose file declares no step-ca service.
- [x] `cargo clippy` clean and `rustfmt` clean.
- [x] `grep -rn -- "--user root" docs/` returns nothing.
- [ ] E2E happy path: `infra install` + `init`, then `rotate` CA + password rotation; assert no entry under `secrets/` is root-owned.
- [ ] E2E legacy-host simulation: seed root-owned CA keys, run both `rotate` flows; assert both succeed and every entry is owner-owned.
- [ ] E2E ownership convergence: seed a root-owned file, run `infra install` and `infra up`; assert converged and each command keeps its existing contract.
- [ ] E2E legacy upgrade: initialized tree with seeded root-owned entries, run `infra up`; assert it returns with step-ca running and ownership converged (readiness-vs-sweep race).
- [x] `scripts/preflight/extra/deploy-no-build-smoke.sh` still passes with its existing image archives (air-gapped path adds no image).
- [x] Fresh source install: `docker image rm bootroot-step-ca:0.29.0`, then `infra install` from a clean checkout succeeds (sweep not ordered before `up --build`).
- [x] `--services openbao,postgres`: sweep does not run and pulls nothing on both `infra install` and `infra up`.
- [x] Manual-init example from both docs run verbatim against a scratch dir produces no root-owned entries.
- [ ] All CI jobs green: `check`, `test-core`, `test-docker-e2e-matrix`, and `run-extended` (needs manual dispatch).


