### PR TITLE
Parameterise core service host ports at infra install (#731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -779,6 +779,31 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `bootroot infra install` accepts `--openbao-host-port`,
+  `--stepca-host-port` and `--http01-admin-host-port`, so the OpenBao,
+  step-ca and HTTP-01 responder host-side ports are configurable the way
+  `--postgres-host-port` already was (#731). Both compose files now
+  publish `127.0.0.1:${OPENBAO_HOST_PORT:-8200}:8200`,
+  `127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000` and
+  `127.0.0.1:${HTTP01_ADMIN_HOST_PORT:-8080}:8080`, and each value
+  resolves with the precedence Docker Compose itself applies: the flag,
+  else the process environment, else `<compose-dir>/.env`, else today's
+  default. A supplied flag is upserted into `.env` and injected into the
+  `docker compose` subprocesses so it wins over an inherited shell
+  variable. The `infra install` port preflight now pre-binds the
+  *resolved* ports instead of the literals 8200 / 9000 / 8080, which
+  previously refused a second bootroot instance on the host even when
+  the caller staged its own compose file, and each remediation message
+  names the busy port, the `.env` variable and the flag. Defaults are
+  unchanged, publication stays loopback-only, and the `--*-bind` flags
+  keep their existing semantics. When the OpenBao host port moves and
+  `--openbao-url` is left at its default, `infra install`, `init`,
+  `status` and `reinit` follow it automatically (a recorded non-loopback
+  OpenBao bind intent still wins during `reinit`); step-ca and HTTP-01
+  client URLs are not derived and still need `--responder-url` /
+  `--agent-server` / `--agent-responder-url`. Container names in the
+  shipped compose files remain fixed.
+
 - `bootroot service add` gained a `--secret-id-path <ABSOLUTE_PATH>`
   override for `local-file` delivery (#722). It relocates the service's
   `secret_id`, its sibling `role_id`, and (when EAB is configured)

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -21,7 +21,7 @@ services:
     container_name: bootroot-openbao
     restart: always
     ports:
-      - "127.0.0.1:8200:8200"
+      - "127.0.0.1:${OPENBAO_HOST_PORT:-8200}:8200"
     expose:
       - "9101"
     volumes:
@@ -65,7 +65,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000"
     expose:
       - "9102"
     # The official image ships a HEALTHCHECK that runs `step ca health`
@@ -89,7 +89,7 @@ services:
     container_name: bootroot-http01
     restart: always
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:${HTTP01_ADMIN_HOST_PORT:-8080}:8080"
     volumes:
       - ./responder.toml.compose:/app/responder.toml:ro
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: bootroot-openbao
     restart: always
     ports:
-      - "127.0.0.1:8200:8200"
+      - "127.0.0.1:${OPENBAO_HOST_PORT:-8200}:8200"
     expose:
       - "9101"
     volumes:
@@ -48,7 +48,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000"
     expose:
       - "9102"
     # The official image ships a HEALTHCHECK that runs `step ca health`
@@ -75,7 +75,7 @@ services:
     container_name: bootroot-http01
     restart: always
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:${HTTP01_ADMIN_HOST_PORT:-8080}:8080"
     volumes:
       - ./responder.toml.compose:/app/responder.toml:ro
     command:

--- a/docs/en/cli-examples.md
+++ b/docs/en/cli-examples.md
@@ -7,9 +7,19 @@ environment may differ.
 ## Prerequisites
 
 - Docker/Docker Compose installed
-- Ports 80/443/8200/9000/5433/8080 available (host-side `PostgreSQL`
-  publishes on 5433 by default; override with `POSTGRES_HOST_PORT` or
-  `bootroot infra install --postgres-host-port <N>`)
+- Ports 80/443/8200/9000/5433/8080 available. Every core service's
+  host-side port is overridable, so this list is the default rather
+  than a requirement: `OPENBAO_HOST_PORT` /
+  `--openbao-host-port` (8200), `STEPCA_HOST_PORT` /
+  `--stepca-host-port` (9000), `POSTGRES_HOST_PORT` /
+  `--postgres-host-port` (5433) and `HTTP01_ADMIN_HOST_PORT` /
+  `--http01-admin-host-port` (8080), each set in `<compose-dir>/.env`,
+  in the process environment, or on `bootroot infra install`. Ports
+  80/443 belong to the ACME HTTP-01 challenge and are not part of this
+  set. A non-default OpenBao host port is picked up automatically by
+  `init`, `status` and `reinit`; step-ca and HTTP-01 client URLs are
+  not derived and need `--responder-url` / `--agent-server` /
+  `--agent-responder-url`
 
 The Docker daemon should be configured to **start on reboot**. bootroot's
 containers use restart policies, but Docker itself must be managed by the OS

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -210,12 +210,58 @@ and `--no-build` uses them as-is instead of rebuilding from source. See
   Overrides `POSTGRES_HOST_PORT` from `.env` and the process
   environment. When unset, the published default is **5433** so
   bootroot does not claim the conventional 5432 out of the box.
+- `--openbao-host-port <N>`: host-side OpenBao published port.
+  Overrides `OPENBAO_HOST_PORT` from `.env` and the process
+  environment. Default **8200**.
+- `--stepca-host-port <N>`: host-side step-ca published port.
+  Overrides `STEPCA_HOST_PORT` from `.env` and the process
+  environment. Default **9000**.
+- `--http01-admin-host-port <N>`: host-side HTTP-01 responder admin API
+  published port. Overrides `HTTP01_ADMIN_HOST_PORT` from `.env` and the
+  process environment. Default **8080**.
+
+#### Host-side published ports
+
+All four core services publish through a compose interpolation
+(`${OPENBAO_HOST_PORT:-8200}`, `${STEPCA_HOST_PORT:-9000}`,
+`${HTTP01_ADMIN_HOST_PORT:-8080}`, `${POSTGRES_HOST_PORT:-5433}`), so
+two bootroot instances can share a host. Each value is resolved with the
+same precedence Docker Compose applies: the flag, else the process
+environment, else `<compose-dir>/.env`, else the compile-time default.
+An unparseable value falls through to the next source. A flag that is
+supplied is upserted into `<compose-dir>/.env` and injected into the
+`docker compose` subprocesses, so it wins over an inherited shell
+variable.
+
+Only the host-side port number is configurable. The publication stays
+loopback-only (`127.0.0.1:`); non-loopback publication remains the job
+of `--openbao-bind` / `--stepca-bind` / `--http01-admin-bind`, which
+carry their own port for the override files they write. The two are
+independent and may both be supplied. Container names in the shipped
+compose files are still fixed, so a second instance on the same host
+needs its own compose file for those.
+
+A non-default OpenBao host port is picked up automatically: `bootroot
+init`, `bootroot status`, `bootroot reinit`, and `infra install`'s own
+`state.json` writes derive the OpenBao URL from it whenever
+`--openbao-url` is left at its default `http://localhost:8200`. An
+explicitly supplied `--openbao-url` is always used verbatim, and a
+recorded non-loopback OpenBao bind intent still wins over the host port
+during `reinit`. `rotate` and `service` read `state.openbao_url`, so
+they follow once `init` has recorded it.
+
+step-ca and HTTP-01 client URLs are **not** derived from their host
+ports. A deployment running step-ca or the responder on a non-default
+host port must pass `--responder-url`, `--agent-server` and
+`--agent-responder-url` explicitly.
 
 Before invoking `docker compose up`, `infra install` runs a TCP bind
 preflight on every host-side port the active compose stack publishes
-(`PostgreSQL`, `OpenBao`, `step-ca`, `bootroot-http01`). On collision
+(`PostgreSQL`, `OpenBao`, `step-ca`, `bootroot-http01`), using the
+resolved port for each — not the compose default. On collision
 it aborts with the busy port, a best-effort PID/command hint via
-`lsof`, and the recommended remediation, instead of leaving earlier
+`lsof`, and the recommended remediation naming both the `.env`
+variable and the flag, instead of leaving earlier
 services running while a later one fails to bind (#588 §4). The
 preflight always checks the localhost ports because `infra install`
 runs `docker compose up` against the base compose file only —

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -216,6 +216,25 @@ single-host guardrails:
   `127.0.0.1:5433:5432` — the published default; override with
   `POSTGRES_HOST_PORT`), not `0.0.0.0` or bare `5433:5432`.
 
+The same applies to the other core services: `docker-compose.yml` and
+`docker-compose.deploy.yml` publish `127.0.0.1:${OPENBAO_HOST_PORT:-8200}:8200`,
+`127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000` and
+`127.0.0.1:${HTTP01_ADMIN_HOST_PORT:-8080}:8080`. Only the host-side port
+number is configurable — set the variable in `<compose-dir>/.env` or in the
+process environment, or pass `--openbao-host-port` / `--stepca-host-port` /
+`--http01-admin-host-port` to `bootroot infra install`, which upserts it into
+`.env` for you. So the "ports that must be free" list (8200, 9000, 8080, 5433)
+is a set of defaults, not a requirement, and two bootroot instances can share a
+host once each also has its own container names (the shipped compose files pin
+those, so the second instance needs its own compose file).
+
+`bootroot init`, `bootroot status` and `bootroot reinit` pick up a non-default
+OpenBao host port automatically whenever `--openbao-url` is left at its default.
+step-ca and HTTP-01 client URLs are not derived from their host ports: pass
+`--responder-url`, `--agent-server` and `--agent-responder-url` explicitly when
+those services run on non-default ports. See `docs/en/cli.md` for the full
+resolution order.
+
 If these conditions are violated, `bootroot init`, `bootroot infra up`, and
 `bootroot rotate db` fail fast.
 

--- a/docs/ko/cli-examples.md
+++ b/docs/ko/cli-examples.md
@@ -7,9 +7,19 @@
 ## 사전 준비
 
 - Docker/Docker Compose 설치
-- 80/443/8200/9000/5433/8080 포트 사용 가능 (호스트 측 `PostgreSQL`은
-  기본값 5433을 사용합니다. `POSTGRES_HOST_PORT` 또는
-  `bootroot infra install --postgres-host-port <N>`로 재정의 가능)
+- 80/443/8200/9000/5433/8080 포트 사용 가능. 핵심 서비스의 호스트 측
+  포트는 모두 재정의할 수 있으므로 이 목록은 요구 사항이 아니라
+  기본값입니다. `OPENBAO_HOST_PORT` / `--openbao-host-port`(8200),
+  `STEPCA_HOST_PORT` / `--stepca-host-port`(9000),
+  `POSTGRES_HOST_PORT` / `--postgres-host-port`(5433),
+  `HTTP01_ADMIN_HOST_PORT` / `--http01-admin-host-port`(8080)을
+  `<compose-dir>/.env`, 프로세스 환경 변수, 또는
+  `bootroot infra install` 플래그로 지정하면 됩니다. 80/443은 ACME
+  HTTP-01 챌린지용이며 이 목록과 별개입니다. 기본값이 아닌 OpenBao
+  호스트 포트는 `init`, `status`, `reinit`이 자동으로 반영합니다.
+  step-ca와 HTTP-01 클라이언트 URL은 유도되지 않으므로
+  `--responder-url` / `--agent-server` / `--agent-responder-url`을
+  직접 지정해야 합니다
 
 Docker 데몬은 **재부팅 시 자동 시작**되도록 설정되어 있어야 합니다.
 bootroot가 제공하는 컨테이너들은 `restart` 정책으로 자동 재기동되지만,

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -206,12 +206,58 @@ bootroot infra up
   `.env`의 `POSTGRES_HOST_PORT`와 프로세스 환경 변수보다 우선합니다.
   미지정 시 게시 기본값은 **5433**으로, 통상적인 5432 포트는
   운영자 측 애플리케이션 DB가 사용할 수 있도록 비워 둡니다.
+- `--openbao-host-port <N>`: 호스트 측 OpenBao 게시 포트입니다.
+  `.env`의 `OPENBAO_HOST_PORT`와 프로세스 환경 변수보다 우선합니다.
+  기본값은 **8200**입니다.
+- `--stepca-host-port <N>`: 호스트 측 step-ca 게시 포트입니다.
+  `.env`의 `STEPCA_HOST_PORT`와 프로세스 환경 변수보다 우선합니다.
+  기본값은 **9000**입니다.
+- `--http01-admin-host-port <N>`: 호스트 측 HTTP-01 응답기 admin API
+  게시 포트입니다. `.env`의 `HTTP01_ADMIN_HOST_PORT`와 프로세스 환경
+  변수보다 우선합니다. 기본값은 **8080**입니다.
+
+#### 호스트 측 게시 포트
+
+네 개의 핵심 서비스는 모두 compose 보간
+(`${OPENBAO_HOST_PORT:-8200}`, `${STEPCA_HOST_PORT:-9000}`,
+`${HTTP01_ADMIN_HOST_PORT:-8080}`, `${POSTGRES_HOST_PORT:-5433}`)을
+통해 포트를 게시하므로, 두 개의 bootroot 인스턴스가 한 호스트를
+공유할 수 있습니다. 각 값은 Docker Compose와 동일한 우선순위로
+결정됩니다. 플래그 → 프로세스 환경 변수 → `<compose-dir>/.env` →
+컴파일 시 기본값 순이며, 파싱할 수 없는 값은 다음 소스로 넘어갑니다.
+플래그를 지정하면 그 값이 `<compose-dir>/.env`에 upsert되고
+`docker compose` 하위 프로세스 환경에도 주입되므로, 셸에서 상속된
+변수보다 우선합니다.
+
+설정 가능한 것은 호스트 측 포트 번호뿐입니다. 게시는 계속
+루프백 전용(`127.0.0.1:`)이며, 비루프백 게시는 여전히
+`--openbao-bind` / `--stepca-bind` / `--http01-admin-bind`의 역할로,
+이들 플래그는 자신이 작성하는 override 파일용 포트를 따로 지닙니다.
+두 계열은 독립적이므로 함께 지정할 수 있습니다. 배포되는 compose
+파일의 컨테이너 이름은 여전히 고정되어 있으므로, 같은 호스트의 두
+번째 인스턴스는 자체 compose 파일이 필요합니다.
+
+기본값이 아닌 OpenBao 호스트 포트는 자동으로 반영됩니다.
+`--openbao-url`을 기본값 `http://localhost:8200` 그대로 두면
+`bootroot init`, `bootroot status`, `bootroot reinit`, 그리고
+`infra install`이 기록하는 `state.json`이 모두 그 포트로 OpenBao URL을
+유도합니다. 명시적으로 지정한 `--openbao-url`은 항상 그대로 사용되며,
+`reinit`에서는 기록된 비루프백 OpenBao 바인드 의도가 호스트 포트보다
+우선합니다. `rotate`와 `service`는 `state.openbao_url`을 읽으므로
+`init`이 값을 기록하면 자동으로 따라갑니다.
+
+step-ca와 HTTP-01 클라이언트 URL은 호스트 포트에서 유도되지
+**않습니다**. step-ca나 응답기를 기본값이 아닌 호스트 포트로 실행하는
+배포에서는 `--responder-url`, `--agent-server`,
+`--agent-responder-url`을 명시적으로 전달해야 합니다.
 
 `docker compose up` 호출 전, `infra install`은 활성 compose
 스택이 게시하는 모든 호스트 측 포트(`PostgreSQL`, `OpenBao`,
 `step-ca`, `bootroot-http01`)에 대해 TCP 바인드 사전 점검을
-수행합니다. 충돌 시 사용 중인 포트와 `lsof` 기반의 PID/명령
-힌트, 권장 조치를 표시한 뒤 즉시 중단되어, 일부 서비스가 바인드에
+수행합니다. 이때 compose 기본값이 아니라 각 서비스의 결정된
+포트를 검사합니다. 충돌 시 사용 중인 포트와 `lsof` 기반의 PID/명령
+힌트, 그리고 `.env` 변수와 플래그를 모두 안내하는 권장 조치를
+표시한 뒤 즉시 중단되어, 일부 서비스가 바인드에
 실패한 채 다른 서비스만 실행되는 부분 상태를 방지합니다(#588 §4).
 `infra install`은 베이스 compose 파일로만 `docker compose up`을
 호출하므로(즉, `--openbao-bind` / `--http01-admin-bind` /

--- a/docs/ko/installation.md
+++ b/docs/ko/installation.md
@@ -218,6 +218,28 @@ DB DSN이 `secrets/config/ca.json`에 자동으로 기록됩니다.
   `POSTGRES_HOST_PORT`로 재정의 가능).
   `0.0.0.0` 바인딩 또는 `5433:5432` 형태는 허용되지 않습니다.
 
+다른 핵심 서비스도 마찬가지입니다. `docker-compose.yml`과
+`docker-compose.deploy.yml`은
+`127.0.0.1:${OPENBAO_HOST_PORT:-8200}:8200`,
+`127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000`,
+`127.0.0.1:${HTTP01_ADMIN_HOST_PORT:-8080}:8080`으로 게시합니다.
+설정 가능한 것은 호스트 측 포트 번호뿐이며, `<compose-dir>/.env`나
+프로세스 환경 변수에 값을 지정하거나 `bootroot infra install`에
+`--openbao-host-port` / `--stepca-host-port` /
+`--http01-admin-host-port`를 전달하면 됩니다(이 경우 `.env`에도
+자동으로 upsert됩니다). 따라서 "비어 있어야 하는 포트"
+목록(8200, 9000, 8080, 5433)은 요구 사항이 아니라 기본값이며,
+컨테이너 이름까지 분리하면 두 개의 bootroot 인스턴스가 한 호스트를
+공유할 수 있습니다(배포되는 compose 파일은 컨테이너 이름이 고정되어
+있으므로 두 번째 인스턴스는 자체 compose 파일이 필요합니다).
+
+`--openbao-url`을 기본값으로 두면 `bootroot init`, `bootroot status`,
+`bootroot reinit`이 기본값이 아닌 OpenBao 호스트 포트를 자동으로
+반영합니다. step-ca와 HTTP-01 클라이언트 URL은 호스트 포트에서
+유도되지 않으므로, 해당 서비스가 기본값이 아닌 포트로 동작한다면
+`--responder-url`, `--agent-server`, `--agent-responder-url`을 직접
+전달해야 합니다. 전체 우선순위는 `docs/ko/cli.md`를 참고하세요.
+
 위 조건을 위반하면 `bootroot init`, `bootroot infra up`,
 `bootroot rotate db`는 즉시 실패합니다.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -911,6 +911,27 @@ pub(crate) struct InfraInstallArgs {
     #[arg(long = "postgres-host-port")]
     pub(crate) postgres_host_port: Option<u16>,
 
+    /// Host-side `OpenBao` published port. Overrides `OPENBAO_HOST_PORT`
+    /// from `.env` and the process environment. The publication stays
+    /// loopback-only; only the host-side port number changes.
+    /// When unset, the published default is 8200.
+    #[arg(long = "openbao-host-port")]
+    pub(crate) openbao_host_port: Option<u16>,
+
+    /// Host-side step-ca published port. Overrides `STEPCA_HOST_PORT`
+    /// from `.env` and the process environment. The publication stays
+    /// loopback-only; only the host-side port number changes.
+    /// When unset, the published default is 9000.
+    #[arg(long = "stepca-host-port")]
+    pub(crate) stepca_host_port: Option<u16>,
+
+    /// Host-side HTTP-01 responder admin API published port. Overrides
+    /// `HTTP01_ADMIN_HOST_PORT` from `.env` and the process environment.
+    /// The publication stays loopback-only; only the host-side port
+    /// number changes. When unset, the published default is 8080.
+    #[arg(long = "http01-admin-host-port")]
+    pub(crate) http01_admin_host_port: Option<u16>,
+
     /// Skip building images: run `docker compose up --no-build` so the
     /// already-loaded image is used as-is and the command fails loudly
     /// when a tagged image is absent. The default builds the local
@@ -1027,7 +1048,7 @@ pub(crate) enum InitSkipPhase {
 // exclusivity (`conflicts_with`) and `requires = "summary_json"`
 // constraints that this surface relies on.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub(crate) struct InitArgs {
     #[command(flatten)]
     pub(crate) openbao: OpenBaoArgs,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,6 +10,7 @@ pub(crate) mod init;
 pub(crate) mod monitoring;
 pub(crate) mod openbao_auth;
 pub(crate) mod openbao_unseal;
+pub(crate) mod openbao_url;
 pub(crate) mod reinit;
 pub(crate) mod rotate;
 pub(crate) mod service;

--- a/src/commands/guardrails.rs
+++ b/src/commands/guardrails.rs
@@ -1392,6 +1392,44 @@ mod tests {
         assert!(!is_single_host_db_host("10.0.0.15"));
     }
 
+    /// Closes #731: the shipped compose files publish their core
+    /// services through `${*_HOST_PORT:-<default>}` interpolations.  The
+    /// loopback guardrail keys off the `127.0.0.1:` prefix, which the
+    /// interpolation leaves in place, so both files must still pass.
+    #[test]
+    fn shipped_compose_files_pass_the_localhost_binding_guardrail() {
+        let messages = crate::i18n::test_messages();
+        for name in ["docker-compose.yml", "docker-compose.deploy.yml"] {
+            let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(name);
+            ensure_all_services_localhost_binding(&path, &messages)
+                .unwrap_or_else(|err| panic!("{name} must pass the guardrail: {err}"));
+        }
+    }
+
+    /// Closes #731: interpolating the host port must not weaken the
+    /// guardrail — a non-loopback publication is still rejected for each
+    /// guarded service.
+    #[test]
+    fn interpolated_host_port_without_loopback_prefix_is_still_unsafe() {
+        for (service, mapping) in [
+            ("postgres:", "${POSTGRES_HOST_PORT:-5433}:5432"),
+            ("openbao:", "0.0.0.0:${OPENBAO_HOST_PORT:-8200}:8200"),
+            (
+                "bootroot-http01:",
+                "0.0.0.0:${HTTP01_ADMIN_HOST_PORT:-8080}:8080",
+            ),
+        ] {
+            let name = service.trim_end_matches(':');
+            let compose = format!(
+                "services:\n  {name}:\n    image: example\n    ports:\n      - \"{mapping}\"\n"
+            );
+            assert!(
+                has_unsafe_port_binding_for_service(&compose, service),
+                "{mapping} must still be rejected for {service}"
+            );
+        }
+    }
+
     #[test]
     fn has_unsafe_postgres_port_binding_accepts_localhost_bind() {
         let compose = r#"

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -823,8 +823,8 @@ fn preflight_host_port(host: &str, port: u16, remediation: &str) -> Result<()> {
     }
 }
 
-/// Host-side published ports of the four core services, each resolved
-/// with the precedence Docker Compose itself applies to the matching
+/// Carries the host-side published ports of the four core services, each
+/// resolved with the precedence Docker Compose itself applies to the matching
 /// `${*_HOST_PORT:-<default>}` interpolation in the compose file: the
 /// `infra install` flag, else the process environment, else
 /// `<compose_dir>/.env`, else the compile-time default.

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -5,6 +5,11 @@ use std::process::Command as ProcessCommand;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use bootroot::db::POSTGRES_HOST_PORT_ENV;
+use bootroot::host_port::{
+    HTTP01_ADMIN_HOST_PORT_ENV, OPENBAO_HOST_PORT_ENV, STEPCA_HOST_PORT_ENV,
+    resolve_http01_admin_host_port, resolve_openbao_host_port, resolve_stepca_host_port,
+};
 use bootroot::openbao::OpenBaoClient;
 
 use crate::cli::args::{InfraInstallArgs, InfraUpArgs};
@@ -30,6 +35,7 @@ use crate::commands::init::{
     compose_has_stepca,
 };
 use crate::commands::openbao_unseal::{prompt_unseal_keys_interactive, read_unseal_keys_from_file};
+use crate::commands::openbao_url::effective_openbao_url;
 use crate::i18n::Messages;
 use crate::state::StateFile;
 
@@ -139,11 +145,13 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
 
     // Derive the effective OpenBao URL.  When the non-loopback override
     // is active, OpenBao listens on the bind address with TLS, so the
-    // default http://localhost:8200 no longer reaches it.
+    // default http://localhost:8200 no longer reaches it.  Otherwise
+    // OpenBao is on loopback, where a configured host port moves it —
+    // the unseal helpers below would talk to nothing without this.
     let effective_openbao_url = if openbao_override.is_some() {
         effective_openbao_url_from_state(&state_path).unwrap_or_else(|| args.openbao_url.clone())
     } else {
-        args.openbao_url.clone()
+        crate::commands::openbao_url::effective_openbao_url(&args.openbao_url, compose_dir, None)
     };
 
     let loaded_archives = if let Some(dir) = args.image_archive_dir.as_deref() {
@@ -435,6 +443,17 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     }
     println!("{}", messages.infra_install_dirs_created());
 
+    // Resolve the host-side published ports once: the preflight binds
+    // them, the `.env` upsert and the compose subprocess environment
+    // below propagate the flag-supplied ones, and the OpenBao port
+    // decides the endpoint recorded in `state.json`.
+    let host_ports = HostPorts::resolve(args, compose_dir);
+    let host_port_entries = host_port_flag_entries(args);
+    // The install-time OpenBao endpoint.  `infra install` always brings
+    // OpenBao up on loopback (any `--openbao-bind` override is deferred
+    // to `infra up` / `init`), so only the host port moves here.
+    let openbao_url = effective_openbao_url(&args.openbao_url, compose_dir, args.openbao_host_port);
+
     // Generate compose override and persist bind intent when the operator
     // opts into a non-loopback OpenBao address.  The override is NOT
     // applied yet — OpenBao starts on 127.0.0.1:8200 as usual.  The
@@ -446,12 +465,12 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
             compose_dir,
             bind_addr,
             args.openbao_advertise_addr.as_deref(),
-            &args.openbao_url,
+            &openbao_url,
             messages,
         )?;
         println!("{}", messages.info_openbao_bind_intent_recorded(bind_addr));
     } else {
-        clear_openbao_bind_intent(compose_dir, &args.openbao_url, messages)?;
+        clear_openbao_bind_intent(compose_dir, &openbao_url, messages)?;
     }
 
     if let Some(ref bind_addr) = http01_admin_bind {
@@ -460,7 +479,7 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
             compose_dir,
             bind_addr,
             args.http01_admin_advertise_addr.as_deref(),
-            &args.openbao_url,
+            &openbao_url,
             messages,
         )?;
         println!(
@@ -476,12 +495,21 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
         save_stepca_bind_intent(
             bind_addr,
             args.stepca_advertise_addr.as_deref(),
-            &args.openbao_url,
+            &openbao_url,
             messages,
         )?;
         println!("{}", messages.info_stepca_bind_intent_recorded(bind_addr));
     } else {
         clear_stepca_bind_intent(compose_dir, messages)?;
+    }
+
+    // A host-port-derived endpoint has to reach a pre-existing
+    // `state.json` even when none of the intent writers above rewrote
+    // it.  Gated on the derivation actually having fired so an
+    // operator-supplied `--openbao-url` is never persisted where it
+    // would not have been before.
+    if openbao_url != args.openbao_url {
+        sync_state_openbao_url_to(&StateFile::default_path(), &openbao_url, messages)?;
     }
 
     // Docker Compose reads .env from the compose file's directory.
@@ -490,41 +518,7 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     // owned by a non-default uid is readable. `secrets_dir` was just
     // created (or already existed) above, so its owner is the intended one.
     let stepca_user = stepca_user_from_secrets_dir(&secrets_dir, messages)?;
-    if env_path.exists() {
-        // Existing deployment: upsert the step-ca uid/gid so a host whose
-        // `.env` predates this variable still runs step-ca as the `secrets/`
-        // owner rather than the 1000:1000 interpolation default.
-        crate::commands::dotenv::update_dotenv_key(
-            &env_path,
-            STEPCA_USER_ENV_KEY,
-            &stepca_user,
-            messages,
-        )?;
-        if let Some(port) = args.postgres_host_port {
-            crate::commands::dotenv::update_dotenv_key(
-                &env_path,
-                "POSTGRES_HOST_PORT",
-                &port.to_string(),
-                messages,
-            )?;
-        }
-    } else {
-        let postgres_password = bootroot::utils::generate_secret(32)
-            .with_context(|| messages.error_generate_secret_failed())?;
-        let mut entries: Vec<(&str, &str)> = vec![
-            ("POSTGRES_USER", DEFAULT_POSTGRES_USER),
-            ("POSTGRES_PASSWORD", &postgres_password),
-            ("POSTGRES_DB", DEFAULT_POSTGRES_DB),
-            ("GRAFANA_ADMIN_PASSWORD", DEFAULT_GRAFANA_ADMIN_PASSWORD),
-            (STEPCA_USER_ENV_KEY, &stepca_user),
-        ];
-        let host_port_str = args.postgres_host_port.map(|p| p.to_string());
-        if let Some(ref s) = host_port_str {
-            entries.push(("POSTGRES_HOST_PORT", s));
-        }
-        write_dotenv(&env_path, &entries, messages)?;
-        println!("{}", messages.infra_install_env_written());
-    }
+    write_install_dotenv(&env_path, &stepca_user, &host_port_entries, messages)?;
 
     // Pre-bind the host-side ports the active compose stack will publish
     // so that a collision aborts before `docker compose up` half-creates
@@ -539,10 +533,7 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     // bind is still on 127.0.0.1; the preflight must check those
     // localhost ports regardless of whether an override intent was
     // recorded.
-    let postgres_host_port = args
-        .postgres_host_port
-        .unwrap_or_else(|| bootroot::db::resolve_postgres_host_port(compose_dir));
-    preflight_compose_published_ports(&args.services, postgres_host_port)?;
+    preflight_compose_published_ports(&args.services, host_ports)?;
 
     // Load local images or pull + build.
     let loaded_archives = if let Some(dir) = args.image_archive_dir.as_deref() {
@@ -554,17 +545,13 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     let compose_str = args.compose_file.compose_file.to_string_lossy();
     let svc_refs: Vec<&str> = args.services.iter().map(String::as_str).collect();
 
-    // Build the compose process environment.  When the operator passed
-    // `--postgres-host-port`, override any inherited `POSTGRES_HOST_PORT`
-    // for the compose subprocess so the flag wins regardless of shell
-    // env (Docker Compose otherwise prefers shell env over `.env`).
-    let host_port_env: Vec<(String, String)> = args
-        .postgres_host_port
-        .map(|p| vec![("POSTGRES_HOST_PORT".to_string(), p.to_string())])
-        .unwrap_or_default();
-    let host_port_env_refs: Vec<(&str, &str)> = host_port_env
+    // Build the compose process environment.  When the operator passed a
+    // `--*-host-port` flag, override any inherited value of the matching
+    // variable for the compose subprocess so the flag wins regardless of
+    // shell env (Docker Compose otherwise prefers shell env over `.env`).
+    let host_port_env_refs: Vec<(&str, &str)> = host_port_entries
         .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .map(|(key, value)| (*key, value.as_str()))
         .collect();
 
     if should_pull_before_up(loaded_archives, args.no_build) {
@@ -836,6 +823,120 @@ fn preflight_host_port(host: &str, port: u16, remediation: &str) -> Result<()> {
     }
 }
 
+/// Host-side published ports of the four core services, each resolved
+/// with the precedence Docker Compose itself applies to the matching
+/// `${*_HOST_PORT:-<default>}` interpolation in the compose file: the
+/// `infra install` flag, else the process environment, else
+/// `<compose_dir>/.env`, else the compile-time default.
+#[derive(Debug, Clone, Copy)]
+struct HostPorts {
+    postgres: u16,
+    openbao: u16,
+    stepca: u16,
+    http01_admin: u16,
+}
+
+impl HostPorts {
+    /// Resolves every core service's host-side published port for an
+    /// `infra install` run.
+    fn resolve(args: &InfraInstallArgs, compose_dir: &Path) -> Self {
+        Self {
+            postgres: args
+                .postgres_host_port
+                .unwrap_or_else(|| bootroot::db::resolve_postgres_host_port(compose_dir)),
+            openbao: args
+                .openbao_host_port
+                .unwrap_or_else(|| resolve_openbao_host_port(compose_dir)),
+            stepca: args
+                .stepca_host_port
+                .unwrap_or_else(|| resolve_stepca_host_port(compose_dir)),
+            http01_admin: args
+                .http01_admin_host_port
+                .unwrap_or_else(|| resolve_http01_admin_host_port(compose_dir)),
+        }
+    }
+}
+
+/// Creates or updates the compose `.env` that `infra install` leaves
+/// behind.
+///
+/// On an existing `.env` only the keys this command owns are upserted,
+/// so operator-authored entries (and the `PostgreSQL` credentials a
+/// previous install generated) survive untouched.  A fresh `.env` gets
+/// the full set, including a newly generated `PostgreSQL` password.
+///
+/// `host_port_entries` carries only the host-port flags the operator
+/// supplied — see [`host_port_flag_entries`]; an unset flag leaves the
+/// variable absent so the compose interpolation default applies.
+fn write_install_dotenv(
+    env_path: &Path,
+    stepca_user: &str,
+    host_port_entries: &[(&'static str, String)],
+    messages: &Messages,
+) -> Result<()> {
+    if env_path.exists() {
+        // Existing deployment: upsert the step-ca uid/gid so a host whose
+        // `.env` predates this variable still runs step-ca as the `secrets/`
+        // owner rather than the 1000:1000 interpolation default.
+        crate::commands::dotenv::update_dotenv_key(
+            env_path,
+            STEPCA_USER_ENV_KEY,
+            stepca_user,
+            messages,
+        )?;
+        for (key, value) in host_port_entries {
+            crate::commands::dotenv::update_dotenv_key(env_path, key, value, messages)?;
+        }
+        return Ok(());
+    }
+    let postgres_password = bootroot::utils::generate_secret(32)
+        .with_context(|| messages.error_generate_secret_failed())?;
+    let mut entries: Vec<(&str, &str)> = vec![
+        ("POSTGRES_USER", DEFAULT_POSTGRES_USER),
+        ("POSTGRES_PASSWORD", &postgres_password),
+        ("POSTGRES_DB", DEFAULT_POSTGRES_DB),
+        ("GRAFANA_ADMIN_PASSWORD", DEFAULT_GRAFANA_ADMIN_PASSWORD),
+        (STEPCA_USER_ENV_KEY, stepca_user),
+    ];
+    entries.extend(
+        host_port_entries
+            .iter()
+            .map(|(key, value)| (*key, value.as_str())),
+    );
+    write_dotenv(env_path, &entries, messages)?;
+    println!("{}", messages.infra_install_env_written());
+    Ok(())
+}
+
+/// Returns the `(variable, value)` pairs for the host-port flags the
+/// operator actually supplied.
+///
+/// The same list feeds both durable records of the choice: the `.env`
+/// upsert Docker Compose reads on every later invocation, and the
+/// environment of the `docker compose` subprocesses this install spawns
+/// (where it must win over an inherited shell variable, which Compose
+/// would otherwise prefer over `.env`).
+fn host_port_flag_entries(args: &InfraInstallArgs) -> Vec<(&'static str, String)> {
+    [
+        (POSTGRES_HOST_PORT_ENV, args.postgres_host_port),
+        (OPENBAO_HOST_PORT_ENV, args.openbao_host_port),
+        (STEPCA_HOST_PORT_ENV, args.stepca_host_port),
+        (HTTP01_ADMIN_HOST_PORT_ENV, args.http01_admin_host_port),
+    ]
+    .into_iter()
+    .filter_map(|(key, port)| port.map(|port| (key, port.to_string())))
+    .collect()
+}
+
+/// Builds the remediation sentence appended to a failed port pre-bind.
+///
+/// Names the concrete port plus both ways of moving it — the `.env`
+/// variable and the `infra install` flag — so the operator does not have
+/// to look either up.
+fn host_port_remediation(port: u16, env_key: &str, flag: &str) -> String {
+    format!("free port {port}, set {env_key}=<unused-port> in .env, or pass {flag} <unused-port>")
+}
+
 /// Pre-binds every host-side port the active compose stack will publish.
 /// The bound services list is derived from `services` so a partial install
 /// (e.g. `--services openbao`) only checks the ports it will actually
@@ -847,40 +948,32 @@ fn preflight_host_port(host: &str, port: u16, remediation: &str) -> Result<()> {
 /// layered in until `infra up` / `init`.  So the install-time bind is
 /// always on 127.0.0.1, and the preflight always checks the localhost
 /// ports regardless of any recorded override intent.
-fn preflight_compose_published_ports(services: &[String], postgres_host_port: u16) -> Result<()> {
-    // Static map of compose-declared host ports for the core services.
-    // Kept in sync with docker-compose.yml — adding a published port to
-    // a core service requires a matching entry here.
-    let postgres_remediation = format!(
-        "free port {postgres_host_port}, set POSTGRES_HOST_PORT=<unused-port> in .env, \
-         or pass --postgres-host-port <unused-port>"
-    );
-    let openbao_remediation = "free port 8200 or stop the conflicting listener before retrying \
-         `bootroot infra install`"
-        .to_string();
-    let stepca_remediation = "free port 9000 or stop the conflicting listener before retrying \
-         `bootroot infra install`"
-        .to_string();
-    let http01_remediation = "free port 8080 or stop the conflicting listener before retrying \
-         `bootroot infra install`"
-        .to_string();
-
+fn preflight_compose_published_ports(services: &[String], ports: HostPorts) -> Result<()> {
+    // Every core service publishes its host port through a
+    // `${*_HOST_PORT:-<default>}` interpolation, so the preflight binds
+    // the *resolved* port rather than a constant. Adding a published
+    // port to a core service requires a matching arm here.
     for service in services {
-        match service.as_str() {
-            "postgres" => {
-                preflight_host_port("127.0.0.1", postgres_host_port, &postgres_remediation)?;
-            }
-            "openbao" => {
-                preflight_host_port("127.0.0.1", 8200, &openbao_remediation)?;
-            }
-            "step-ca" => {
-                preflight_host_port("127.0.0.1", 9000, &stepca_remediation)?;
-            }
-            "bootroot-http01" => {
-                preflight_host_port("127.0.0.1", 8080, &http01_remediation)?;
-            }
-            _ => {}
-        }
+        let (port, env_key, flag) = match service.as_str() {
+            "postgres" => (
+                ports.postgres,
+                POSTGRES_HOST_PORT_ENV,
+                "--postgres-host-port",
+            ),
+            "openbao" => (ports.openbao, OPENBAO_HOST_PORT_ENV, "--openbao-host-port"),
+            "step-ca" => (ports.stepca, STEPCA_HOST_PORT_ENV, "--stepca-host-port"),
+            RESPONDER_SERVICE_NAME => (
+                ports.http01_admin,
+                HTTP01_ADMIN_HOST_PORT_ENV,
+                "--http01-admin-host-port",
+            ),
+            _ => continue,
+        };
+        preflight_host_port(
+            "127.0.0.1",
+            port,
+            &host_port_remediation(port, env_key, flag),
+        )?;
     }
     Ok(())
 }
@@ -1422,6 +1515,10 @@ fn clear_openbao_bind_intent_to(
     }
     let mut state = StateFile::load(state_path)?;
     if state.openbao_bind_addr.is_none() {
+        // Nothing to clear.  A moved OpenBao host port still has to
+        // reach the recorded endpoint; `sync_state_openbao_url_to`
+        // handles that after every intent writer has run, so that this
+        // early return keeps `state.json` untouched on a plain install.
         return Ok(());
     }
     state.openbao_bind_addr = None;
@@ -1499,6 +1596,11 @@ fn save_http01_admin_bind_intent_to(
             ..Default::default()
         }
     };
+    // Record the install-time OpenBao endpoint on the pre-existing-state
+    // path too: it carries the resolved OpenBao host port, and the
+    // openbao arm of `run_infra_install` has already reset the URL for
+    // any bind intent by the time this runs.
+    state.openbao_url = openbao_url.to_string();
     state.http01_admin_bind_addr = Some(bind_addr.to_string());
     state.http01_admin_advertise_addr = advertise_addr.map(str::to_string);
     // Clear stale infra-cert entry — the previous cert has the wrong
@@ -1612,8 +1714,44 @@ fn save_stepca_bind_intent_to(
             ..Default::default()
         }
     };
+    // Record the install-time OpenBao endpoint on the pre-existing-state
+    // path too: it carries the resolved OpenBao host port, and the
+    // openbao arm of `run_infra_install` has already reset the URL for
+    // any bind intent by the time this runs.
+    state.openbao_url = openbao_url.to_string();
     state.stepca_bind_addr = Some(bind_addr.to_string());
     state.stepca_advertise_addr = advertise_addr.map(str::to_string);
+    state
+        .save(state_path)
+        .with_context(|| messages.error_serialize_state_failed())
+}
+
+/// Points an existing `state.json` at the `OpenBao` endpoint this
+/// install publishes.
+///
+/// Runs after the bind-intent writers, which already record the endpoint
+/// on every path except one: `clear_openbao_bind_intent_to` returns early
+/// when there is no intent to clear, so a `state.json` written by an
+/// earlier `init` would keep the old port after the operator moved
+/// `OPENBAO_HOST_PORT`.
+///
+/// Deliberately a no-op when no state file exists.  `.env` is the durable
+/// record of the host port, and creating a state file here would make the
+/// next `bootroot init` prompt to overwrite existing state after what is
+/// otherwise a fresh install.
+fn sync_state_openbao_url_to(
+    state_path: &Path,
+    openbao_url: &str,
+    messages: &Messages,
+) -> Result<()> {
+    if !state_path.exists() {
+        return Ok(());
+    }
+    let mut state = StateFile::load(state_path)?;
+    if state.openbao_url == openbao_url {
+        return Ok(());
+    }
+    state.openbao_url = openbao_url.to_string();
     state
         .save(state_path)
         .with_context(|| messages.error_serialize_state_failed())
@@ -2191,15 +2329,397 @@ mod tests {
             // Port already in use on this host (e.g. a real openbao
             // running locally); the preflight must still detect the
             // collision rather than skip it.
-            let err = preflight_compose_published_ports(&["openbao".to_string()], 5433)
-                .expect_err("preflight must abort when 8200 is busy");
+            let err =
+                preflight_compose_published_ports(&["openbao".to_string()], default_host_ports())
+                    .expect_err("preflight must abort when 8200 is busy");
             assert!(err.to_string().contains("8200"), "{err}");
             return;
         }
         drop(listener);
         // 8200 free: the preflight succeeds without any "override skip".
-        preflight_compose_published_ports(&["openbao".to_string()], 5433)
+        preflight_compose_published_ports(&["openbao".to_string()], default_host_ports())
             .expect("free 8200 must pass preflight");
+    }
+
+    /// The compose-declared defaults, for tests that only exercise one
+    /// service and want the rest left alone.
+    fn default_host_ports() -> HostPorts {
+        HostPorts {
+            postgres: bootroot::db::DEFAULT_POSTGRES_HOST_PORT,
+            openbao: bootroot::host_port::DEFAULT_OPENBAO_HOST_PORT,
+            stepca: bootroot::host_port::DEFAULT_STEPCA_HOST_PORT,
+            http01_admin: bootroot::host_port::DEFAULT_HTTP01_ADMIN_HOST_PORT,
+        }
+    }
+
+    /// `infra install` args with every optional field unset, so a test
+    /// can set just the ones it exercises.
+    fn install_args(compose_file: PathBuf) -> InfraInstallArgs {
+        InfraInstallArgs {
+            compose_file: crate::cli::args::ComposeFileArgs { compose_file },
+            services: default_infra_services(),
+            image_archive_dir: None,
+            restart_policy: "always".to_string(),
+            openbao_url: "http://localhost:8200".to_string(),
+            openbao_bind: None,
+            openbao_tls_required: false,
+            openbao_bind_wildcard: false,
+            openbao_advertise_addr: None,
+            http01_admin_bind: None,
+            http01_admin_tls_required: false,
+            http01_admin_bind_wildcard: false,
+            http01_admin_advertise_addr: None,
+            stepca_bind: None,
+            stepca_bind_wildcard: false,
+            stepca_advertise_addr: None,
+            postgres_host_port: None,
+            openbao_host_port: None,
+            stepca_host_port: None,
+            http01_admin_host_port: None,
+            no_build: false,
+        }
+    }
+
+    /// Replaces one service's port in an otherwise-default `HostPorts`.
+    fn host_ports_with(service: &str, port: u16) -> HostPorts {
+        let mut ports = default_host_ports();
+        match service {
+            "openbao" => ports.openbao = port,
+            "step-ca" => ports.stepca = port,
+            RESPONDER_SERVICE_NAME => ports.http01_admin = port,
+            other => panic!("unexpected service {other}"),
+        }
+        ports
+    }
+
+    /// Returns a port that was free a moment ago.  Callers must tolerate
+    /// the ephemeral-port allocator handing it to somebody else, exactly
+    /// as `preflight_host_port_succeeds_when_free` does.
+    fn free_port() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        listener.local_addr().expect("addr").port()
+    }
+
+    /// The three services this issue parameterised, with the `.env`
+    /// variable and flag their remediation must name.
+    fn parameterised_services() -> [(&'static str, &'static str, &'static str); 3] {
+        [
+            ("openbao", OPENBAO_HOST_PORT_ENV, "--openbao-host-port"),
+            ("step-ca", STEPCA_HOST_PORT_ENV, "--stepca-host-port"),
+            (
+                RESPONDER_SERVICE_NAME,
+                HTTP01_ADMIN_HOST_PORT_ENV,
+                "--http01-admin-host-port",
+            ),
+        ]
+    }
+
+    /// Closes #731: the preflight binds the *resolved* host port, not
+    /// the compose default, so an install onto a moved port aborts on a
+    /// collision with that port.  The diagnostic names the port and both
+    /// ways of moving it.
+    #[test]
+    fn preflight_aborts_on_a_listener_on_the_resolved_port() {
+        for (service, env_key, flag) in parameterised_services() {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind sentinel");
+            let port = listener.local_addr().expect("addr").port();
+            let err = preflight_compose_published_ports(
+                &[service.to_string()],
+                host_ports_with(service, port),
+            )
+            .expect_err("a listener on the resolved port must abort the install");
+            let msg = err.to_string();
+            assert!(
+                msg.contains(&port.to_string()),
+                "{service} diagnostic must name the resolved port, got: {msg}"
+            );
+            assert!(
+                msg.contains(env_key),
+                "{service} diagnostic must name {env_key}, got: {msg}"
+            );
+            assert!(
+                msg.contains(flag),
+                "{service} diagnostic must name {flag}, got: {msg}"
+            );
+            drop(listener);
+        }
+    }
+
+    /// Closes #731: with the host port moved, a listener on the *default*
+    /// port is no longer the install's business.  Holding the default
+    /// port here (or finding it already held, which is the same
+    /// observation) must not make the preflight abort.
+    #[test]
+    fn preflight_ignores_the_default_port_once_the_resolved_port_differs() {
+        for (service, _, _) in parameterised_services() {
+            let default_port = match service {
+                "openbao" => bootroot::host_port::DEFAULT_OPENBAO_HOST_PORT,
+                "step-ca" => bootroot::host_port::DEFAULT_STEPCA_HOST_PORT,
+                _ => bootroot::host_port::DEFAULT_HTTP01_ADMIN_HOST_PORT,
+            };
+            // Either we hold the default port for the duration of the
+            // check, or somebody else already does.
+            let _sentinel = std::net::TcpListener::bind(("127.0.0.1", default_port)).ok();
+            // Retry to absorb the ephemeral-port allocator handing our
+            // just-released port to another process.
+            let mut last_err: Option<anyhow::Error> = None;
+            let mut passed = false;
+            for _ in 0..16 {
+                let resolved = free_port();
+                assert_ne!(resolved, default_port, "ephemeral port must differ");
+                match preflight_compose_published_ports(
+                    &[service.to_string()],
+                    host_ports_with(service, resolved),
+                ) {
+                    Ok(()) => {
+                        passed = true;
+                        break;
+                    }
+                    Err(err) => last_err = Some(err),
+                }
+            }
+            assert!(
+                passed,
+                "{service} preflight must ignore the default port: {}",
+                last_err.expect("at least one attempt failed")
+            );
+        }
+    }
+
+    /// Closes #731: `HostPorts::resolve` follows flag → process env →
+    /// `.env` → compile-time default, per service.
+    #[test]
+    fn host_ports_resolve_prefers_the_flag_then_the_env_file() {
+        let _env = crate::commands::openbao_url::test_env::HostPortEnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "OPENBAO_HOST_PORT=18200\nSTEPCA_HOST_PORT=19000\n",
+        )
+        .unwrap();
+        let mut args = install_args(dir.path().join("docker-compose.yml"));
+        args.openbao_host_port = Some(28200);
+        let ports = HostPorts::resolve(&args, dir.path());
+        assert_eq!(ports.openbao, 28200, "the flag wins");
+        assert_eq!(ports.stepca, 19000, "`.env` is consulted");
+        assert_eq!(
+            ports.http01_admin,
+            bootroot::host_port::DEFAULT_HTTP01_ADMIN_HOST_PORT,
+            "an unconfigured service keeps the compose default"
+        );
+    }
+
+    /// Closes #731: only the flags the operator actually supplied are
+    /// propagated to `.env` and to the compose subprocess environment.
+    #[test]
+    fn host_port_flag_entries_lists_only_supplied_flags() {
+        let mut args = install_args(PathBuf::from("docker-compose.yml"));
+        assert!(
+            host_port_flag_entries(&args).is_empty(),
+            "no flags supplied means no entries"
+        );
+        args.postgres_host_port = Some(15433);
+        args.openbao_host_port = Some(18200);
+        args.stepca_host_port = Some(19000);
+        args.http01_admin_host_port = Some(18080);
+        let entries = host_port_flag_entries(&args);
+        assert_eq!(
+            entries,
+            vec![
+                (POSTGRES_HOST_PORT_ENV, "15433".to_string()),
+                (OPENBAO_HOST_PORT_ENV, "18200".to_string()),
+                (STEPCA_HOST_PORT_ENV, "19000".to_string()),
+                (HTTP01_ADMIN_HOST_PORT_ENV, "18080".to_string()),
+            ]
+        );
+    }
+
+    /// Closes #731: the host-port flags are upserted into an existing
+    /// `.env` without disturbing the other keys in it.
+    #[test]
+    fn install_dotenv_upserts_host_ports_into_an_existing_env() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        std::fs::write(
+            &env_path,
+            "POSTGRES_PASSWORD=keepme\nOPENBAO_HOST_PORT=8200\nOPERATOR_KEY=untouched\n",
+        )
+        .unwrap();
+        let entries = vec![
+            (OPENBAO_HOST_PORT_ENV, "18200".to_string()),
+            (STEPCA_HOST_PORT_ENV, "19000".to_string()),
+            (HTTP01_ADMIN_HOST_PORT_ENV, "18080".to_string()),
+        ];
+        write_install_dotenv(&env_path, "1000:1000", &entries, &messages).unwrap();
+        let contents = std::fs::read_to_string(&env_path).unwrap();
+        assert!(
+            contents.contains("OPENBAO_HOST_PORT=18200"),
+            "existing key must be rewritten, got: {contents}"
+        );
+        assert!(
+            contents.contains("STEPCA_HOST_PORT=19000")
+                && contents.contains("HTTP01_ADMIN_HOST_PORT=18080"),
+            "absent keys must be appended, got: {contents}"
+        );
+        assert!(
+            contents.contains("POSTGRES_PASSWORD=keepme")
+                && contents.contains("OPERATOR_KEY=untouched"),
+            "unrelated keys must survive, got: {contents}"
+        );
+        assert!(
+            contents.contains("BOOTROOT_STEPCA_USER=1000:1000"),
+            "the step-ca uid/gid upsert must still happen, got: {contents}"
+        );
+    }
+
+    /// Closes #731: the same flags land in a freshly written `.env`,
+    /// alongside the generated `PostgreSQL` credentials.
+    #[test]
+    fn install_dotenv_writes_host_ports_into_a_fresh_env() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        let entries = vec![
+            (POSTGRES_HOST_PORT_ENV, "15433".to_string()),
+            (OPENBAO_HOST_PORT_ENV, "18200".to_string()),
+            (STEPCA_HOST_PORT_ENV, "19000".to_string()),
+            (HTTP01_ADMIN_HOST_PORT_ENV, "18080".to_string()),
+        ];
+        write_install_dotenv(&env_path, "1000:1000", &entries, &messages).unwrap();
+        let contents = std::fs::read_to_string(&env_path).unwrap();
+        for expected in [
+            "POSTGRES_HOST_PORT=15433",
+            "OPENBAO_HOST_PORT=18200",
+            "STEPCA_HOST_PORT=19000",
+            "HTTP01_ADMIN_HOST_PORT=18080",
+            "POSTGRES_USER=step",
+        ] {
+            assert!(
+                contents.contains(expected),
+                "fresh .env must contain {expected}, got: {contents}"
+            );
+        }
+    }
+
+    /// Closes #731: an unset flag leaves its variable out of `.env`
+    /// entirely, so the compose interpolation default applies.
+    #[test]
+    fn install_dotenv_omits_unsupplied_host_ports() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        write_install_dotenv(&env_path, "1000:1000", &[], &messages).unwrap();
+        let contents = std::fs::read_to_string(&env_path).unwrap();
+        assert!(
+            !contents.contains("OPENBAO_HOST_PORT"),
+            "unset flags must not be written, got: {contents}"
+        );
+    }
+
+    /// Closes #731: a resolved `OpenBao` host port reaches a pre-existing
+    /// `state.json` even when no bind intent was touched.
+    #[test]
+    fn sync_state_openbao_url_updates_an_existing_state_file() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let state = StateFile {
+            openbao_url: "http://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+            ..Default::default()
+        };
+        state.save(&state_path).unwrap();
+
+        sync_state_openbao_url_to(&state_path, "http://localhost:18200", &messages).unwrap();
+
+        let reloaded = StateFile::load(&state_path).unwrap();
+        assert_eq!(reloaded.openbao_url, "http://localhost:18200");
+    }
+
+    /// Closes #731: a host-port-only install must not start writing a
+    /// `state.json` where it writes none today — that would make the
+    /// next `bootroot init` prompt to overwrite existing state.
+    #[test]
+    fn sync_state_openbao_url_creates_no_state_file() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+
+        sync_state_openbao_url_to(&state_path, "http://localhost:18200", &messages).unwrap();
+
+        assert!(
+            !state_path.exists(),
+            "no state file may be created by the host-port sync"
+        );
+    }
+
+    /// Closes #731: the http01 and step-ca savers record the
+    /// install-time `OpenBao` endpoint on the pre-existing-state path too,
+    /// not just when they create the file.
+    #[test]
+    fn bind_intent_savers_record_the_resolved_openbao_url() {
+        let messages = crate::i18n::test_messages();
+        let moved_url = "http://localhost:18200";
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        StateFile {
+            openbao_url: "http://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+            ..Default::default()
+        }
+        .save(&state_path)
+        .unwrap();
+        save_http01_admin_bind_intent_to(
+            &state_path,
+            dir.path(),
+            "192.168.1.10:8080",
+            None,
+            moved_url,
+            &messages,
+        )
+        .unwrap();
+        assert_eq!(
+            StateFile::load(&state_path).unwrap().openbao_url,
+            moved_url,
+            "http01 saver must record the resolved URL on an existing state file"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        StateFile {
+            openbao_url: "http://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+            ..Default::default()
+        }
+        .save(&state_path)
+        .unwrap();
+        save_stepca_bind_intent_to(&state_path, "192.168.1.10:9000", None, moved_url, &messages)
+            .unwrap();
+        assert_eq!(
+            StateFile::load(&state_path).unwrap().openbao_url,
+            moved_url,
+            "step-ca saver must record the resolved URL on an existing state file"
+        );
+
+        // Fresh-state path, for both savers.
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        save_openbao_bind_intent_to(
+            &state_path,
+            dir.path(),
+            "192.168.1.10:8200",
+            None,
+            moved_url,
+            &messages,
+        )
+        .unwrap();
+        assert_eq!(
+            StateFile::load(&state_path).unwrap().openbao_url,
+            moved_url,
+            "a newly created state file must carry the resolved URL"
+        );
     }
 
     #[test]
@@ -4311,6 +4831,9 @@ tls_key_path = \"/app/bootroot-http01/tls/server.key\"
             stepca_bind_wildcard: false,
             stepca_advertise_addr: None,
             postgres_host_port: None,
+            openbao_host_port: None,
+            stepca_host_port: None,
+            http01_admin_host_port: None,
             no_build: false,
         };
         let err = run_infra_install(&args, &messages).unwrap_err();

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -37,6 +38,7 @@ use super::stepca_setup::{
 };
 use crate::cli::args::{InitArgs, InitFeature};
 use crate::cli::output::{print_init_plan, print_init_summary};
+use crate::commands::compose_file::compose_file_dir;
 use crate::commands::constants::RESPONDER_SERVICE_NAME;
 use crate::commands::guardrails::{
     client_url_from_bind_addr, ensure_all_services_localhost_binding, validate_http01_admin_tls,
@@ -52,10 +54,40 @@ use crate::commands::init::{
     HTTP01_EXPOSED_COMPOSE_OVERRIDE_NAME, OPENBAO_EXPOSED_COMPOSE_OVERRIDE_NAME, OPENBAO_HCL_PATH,
     OPENBAO_TLS_CERT_PATH, OPENBAO_TLS_KEY_PATH, RESPONDER_CONFIG_DIR, RESPONDER_CONFIG_NAME,
 };
+use crate::commands::openbao_url::effective_openbao_url;
 use crate::i18n::Messages;
 use crate::state::StateFile;
 
+/// Returns `args` with `openbao_url` rewritten to the endpoint the
+/// configured `OpenBao` host port publishes, borrowing them unchanged
+/// when the CLI value already names it.
+///
+/// Only the port is derived: `infra install` resets `OpenBao` to
+/// plaintext loopback even when a non-loopback bind intent is recorded,
+/// and `run_init_inner`'s own bind-intent-gated branch takes over once
+/// the TLS certificate has been issued.
+fn args_with_effective_openbao_url(args: &InitArgs) -> Cow<'_, InitArgs> {
+    let compose_dir = compose_file_dir(&args.compose.compose_file);
+    let url = effective_openbao_url(&args.openbao.openbao_url, &compose_dir, None);
+    if url == args.openbao.openbao_url {
+        return Cow::Borrowed(args);
+    }
+    let mut resolved = args.clone();
+    resolved.openbao.openbao_url = url;
+    Cow::Owned(resolved)
+}
+
 pub(crate) async fn run_init(args: &InitArgs, messages: &Messages) -> Result<()> {
+    // Point the whole init flow at the OpenBao host port the compose
+    // stack actually publishes.  The first client below is built before
+    // any `state.json` value is consulted, so without this a second
+    // bootroot instance on the same host would health-check — and then
+    // initialise against — the first instance's OpenBao.  An
+    // operator-supplied `--openbao-url` is left untouched, as is the
+    // later bind-intent-gated rewrite in `run_init_inner`.
+    let resolved = args_with_effective_openbao_url(args);
+    let args = resolved.as_ref();
+
     if let Some(warning) = validate_secret_id_ttl(&args.secret_id_ttl, messages)? {
         eprintln!("{warning}");
     }
@@ -1304,6 +1336,43 @@ mod tests {
         assert!(
             msg.contains("--root-token") && msg.contains("--openbao-only"),
             "diagnostic must name the recovery options, got: {msg}"
+        );
+    }
+
+    /// Closes #731: `init` builds its first `OpenBaoClient` before any
+    /// `state.json` value is consulted, so the CLI default has to pick
+    /// up a non-default `OPENBAO_HOST_PORT` from the compose
+    /// directory's `.env`.  Without this a second bootroot instance on
+    /// the same host would initialise against the first one's `OpenBao`.
+    #[test]
+    fn init_args_follow_the_configured_openbao_host_port() {
+        let _env = crate::commands::openbao_url::test_env::HostPortEnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18200\n").expect("write .env");
+        let mut args = default_init_args();
+        args.compose.compose_file = dir.path().join("docker-compose.yml");
+        let resolved = args_with_effective_openbao_url(&args);
+        assert_eq!(resolved.openbao.openbao_url, "http://localhost:18200");
+    }
+
+    /// Closes #731: an operator-supplied `--openbao-url` is used
+    /// verbatim, and the unchanged case borrows instead of cloning.
+    #[test]
+    fn init_args_keep_an_explicit_openbao_url() {
+        let _env = crate::commands::openbao_url::test_env::HostPortEnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18200\n").expect("write .env");
+        let mut args = default_init_args();
+        args.compose.compose_file = dir.path().join("docker-compose.yml");
+        args.openbao.openbao_url = "https://openbao.internal:8200".to_string();
+        let resolved = args_with_effective_openbao_url(&args);
+        assert_eq!(
+            resolved.openbao.openbao_url,
+            "https://openbao.internal:8200"
+        );
+        assert!(
+            matches!(resolved, Cow::Borrowed(_)),
+            "an unchanged URL must not clone the args"
         );
     }
 

--- a/src/commands/openbao_url.rs
+++ b/src/commands/openbao_url.rs
@@ -1,0 +1,218 @@
+//! Derivation of the effective `OpenBao` API URL from the configured
+//! host port.
+//!
+//! `OpenBao`'s host-side published port is configurable (`--openbao-host-port`,
+//! `OPENBAO_HOST_PORT` in the process environment or in `<compose_dir>/.env`),
+//! but the `--openbao-url` CLI default is the literal
+//! [`DEFAULT_OPENBAO_URL`].  Left alone, a command started against a
+//! non-default host port would talk to nothing — or, on a host shared with a
+//! second bootroot instance, to that instance's `OpenBao`.  Every command
+//! that builds a client straight from the CLI value routes it through
+//! [`effective_openbao_url`] first.
+
+use std::path::Path;
+
+use bootroot::host_port::resolve_openbao_host_port;
+
+use crate::commands::init::DEFAULT_OPENBAO_URL;
+
+/// Returns the `OpenBao` URL a command should actually talk to.
+///
+/// An operator-supplied `--openbao-url` is always honoured verbatim: the
+/// derivation fires only when `cli_url` is exactly [`DEFAULT_OPENBAO_URL`].
+/// In that case the default's port is replaced by the resolved host port —
+/// `host_port` when the command has a flag that carries one, else the
+/// process environment, else `<compose_dir>/.env`, else 8200 (see
+/// [`resolve_openbao_host_port`]).
+pub(crate) fn effective_openbao_url(
+    cli_url: &str,
+    compose_dir: &Path,
+    host_port: Option<u16>,
+) -> String {
+    if cli_url != DEFAULT_OPENBAO_URL {
+        return cli_url.to_string();
+    }
+    let port = host_port.unwrap_or_else(|| resolve_openbao_host_port(compose_dir));
+    let Some((prefix, _)) = DEFAULT_OPENBAO_URL.rsplit_once(':') else {
+        return cli_url.to_string();
+    };
+    format!("{prefix}:{port}")
+}
+
+/// Shared test guard for the host-port environment variables.
+///
+/// The variables are process-global, so a test that *sets* one and a
+/// test that merely *reads* one (through the resolvers, from a `.env`
+/// file) interfere across modules unless both hold the same lock.  Every
+/// binary-crate test that touches `OPENBAO_HOST_PORT`,
+/// `STEPCA_HOST_PORT` or `HTTP01_ADMIN_HOST_PORT` — in either direction
+/// — takes this guard.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+
+    use bootroot::host_port::{
+        HTTP01_ADMIN_HOST_PORT_ENV, OPENBAO_HOST_PORT_ENV, STEPCA_HOST_PORT_ENV,
+    };
+
+    const GUARDED_KEYS: [&str; 3] = [
+        OPENBAO_HOST_PORT_ENV,
+        STEPCA_HOST_PORT_ENV,
+        HTTP01_ADMIN_HOST_PORT_ENV,
+    ];
+
+    /// Clears the guarded variables for the lifetime of the guard and
+    /// restores their pre-test values on drop.
+    pub(crate) struct HostPortEnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl HostPortEnvGuard {
+        pub(crate) fn new() -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            let previous = GUARDED_KEYS
+                .iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect();
+            for key in GUARDED_KEYS {
+                // SAFETY: removal is serialized by the mutex held above.
+                unsafe {
+                    std::env::remove_var(key);
+                }
+            }
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+
+        pub(crate) fn set(&self, key: &str, value: &str) {
+            assert!(
+                self.previous.iter().any(|(tracked, _)| *tracked == key),
+                "{key} is not tracked by the guard and would leak into other tests"
+            );
+            // SAFETY: mutation is serialized by the mutex held by `_lock`.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+    }
+
+    impl Drop for HostPortEnvGuard {
+        fn drop(&mut self) {
+            for (key, previous) in &self.previous {
+                // SAFETY: restored inside the shared mutex held by `_lock`.
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bootroot::host_port::OPENBAO_HOST_PORT_ENV;
+
+    use super::test_env::HostPortEnvGuard;
+    use super::*;
+
+    const NON_DEFAULT_URL: &str = "https://openbao.internal:8200";
+
+    struct EnvGuard(HostPortEnvGuard);
+
+    impl EnvGuard {
+        fn new() -> Self {
+            Self(HostPortEnvGuard::new())
+        }
+
+        fn set(&self, value: &str) {
+            self.0.set(OPENBAO_HOST_PORT_ENV, value);
+        }
+    }
+
+    #[test]
+    fn default_url_takes_the_flag_supplied_port() {
+        let _guard = EnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            effective_openbao_url(DEFAULT_OPENBAO_URL, dir.path(), Some(18200)),
+            "http://localhost:18200"
+        );
+    }
+
+    #[test]
+    fn default_url_takes_the_process_env_port() {
+        let guard = EnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        guard.set("18201");
+        assert_eq!(
+            effective_openbao_url(DEFAULT_OPENBAO_URL, dir.path(), None),
+            "http://localhost:18201"
+        );
+    }
+
+    #[test]
+    fn default_url_takes_the_env_file_port() {
+        let _guard = EnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18202\n").expect("write .env");
+        assert_eq!(
+            effective_openbao_url(DEFAULT_OPENBAO_URL, dir.path(), None),
+            "http://localhost:18202"
+        );
+    }
+
+    #[test]
+    fn flag_wins_over_process_env_and_env_file() {
+        let guard = EnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18203\n").expect("write .env");
+        guard.set("18204");
+        assert_eq!(
+            effective_openbao_url(DEFAULT_OPENBAO_URL, dir.path(), Some(18205)),
+            "http://localhost:18205"
+        );
+    }
+
+    #[test]
+    fn default_url_unchanged_when_nothing_is_configured() {
+        let _guard = EnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            effective_openbao_url(DEFAULT_OPENBAO_URL, dir.path(), None),
+            DEFAULT_OPENBAO_URL
+        );
+    }
+
+    #[test]
+    fn non_default_url_is_never_rewritten() {
+        let guard = EnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        // .env source.
+        std::fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18206\n").expect("write .env");
+        assert_eq!(
+            effective_openbao_url(NON_DEFAULT_URL, dir.path(), None),
+            NON_DEFAULT_URL
+        );
+        // Process-environment source.
+        guard.set("18207");
+        assert_eq!(
+            effective_openbao_url(NON_DEFAULT_URL, dir.path(), None),
+            NON_DEFAULT_URL
+        );
+        // Flag source.
+        assert_eq!(
+            effective_openbao_url(NON_DEFAULT_URL, dir.path(), Some(18208)),
+            NON_DEFAULT_URL
+        );
+    }
+}

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -17,6 +17,7 @@ use crate::commands::compose_file::compose_file_dir;
 use crate::commands::guardrails::client_url_from_bind_addr;
 use crate::commands::infra::run_infra_up;
 use crate::commands::init::{OPENBAO_CONTAINER_NAME, compose_has_openbao, prompt_yes_no, run_init};
+use crate::commands::openbao_url::effective_openbao_url;
 use crate::i18n::Messages;
 use crate::state::StateFile;
 
@@ -76,6 +77,16 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
     //    init pass URL is derived from the snapshotted `openbao_bind_addr`
     //    in `init_args_for_reinit` when present.
     reject_explicit_openbao_url(&args.openbao.openbao_url, messages)?;
+
+    // The check above guarantees the CLI default, so this only ever
+    // fills in the configured OpenBao host port. It feeds the
+    // intermediate `state.json` and the `infra up` unseal client; the
+    // second init pass derives its own URL in `init_args_for_reinit`,
+    // where a snapshotted non-loopback bind intent outranks the port.
+    let openbao = OpenBaoArgs {
+        openbao_url: effective_openbao_url(&args.openbao.openbao_url, &compose_dir, None),
+        kv_mount: args.openbao.kv_mount.clone(),
+    };
 
     // 2. Scope check: refuse external OpenBao / project mismatch.
     verify_compose_managed_openbao(
@@ -160,7 +171,7 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
     write_minimal_state(
         &state_path,
         &snapshot,
-        &args.openbao,
+        &openbao,
         &effective_secrets_dir,
         messages,
     )?;
@@ -173,7 +184,7 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
         services: vec![OPENBAO_COMPOSE_SERVICE.to_string()],
         image_archive_dir: None,
         restart_policy: "always".to_string(),
-        openbao_url: args.openbao.openbao_url.clone(),
+        openbao_url: openbao.openbao_url.clone(),
         openbao_unseal_from_file: None,
     };
     run_infra_up(&infra_args, messages).await?;
@@ -933,10 +944,21 @@ fn init_args_for_reinit(
     effective_secrets_dir: &Path,
 ) -> Box<InitArgs> {
     let mut openbao = args.openbao.clone();
-    if openbao.openbao_url == crate::commands::init::DEFAULT_OPENBAO_URL
-        && let Some(bind) = snapshot.openbao_bind_addr.as_deref()
-    {
-        openbao.openbao_url = client_url_from_bind_addr(bind);
+    if openbao.openbao_url == crate::commands::init::DEFAULT_OPENBAO_URL {
+        // A snapshotted non-loopback bind outranks the host port: the
+        // restored deployment serves on the bind address, and the
+        // host-port publication in the base compose file is not what
+        // the second init pass has to reach.  Order matters — deriving
+        // the host-port URL first would break this equality check and
+        // silently point a destructive recovery at a dead endpoint.
+        openbao.openbao_url = match snapshot.openbao_bind_addr.as_deref() {
+            Some(bind) => client_url_from_bind_addr(bind),
+            None => effective_openbao_url(
+                &openbao.openbao_url,
+                &compose_file_dir(&args.compose.compose_file),
+                None,
+            ),
+        };
     }
     let db_dsn = preserved_db_dsn_from_ca_json(effective_secrets_dir);
     let stepca_provisioner = preserved_stepca_provisioner_from_ca_json(effective_secrets_dir)
@@ -1972,6 +1994,82 @@ mod tests {
         assert_eq!(
             init_args.openbao.openbao_url, "https://192.168.1.10:8200",
             "non-loopback bind intent must drive the init client URL"
+        );
+    }
+
+    /// Closes #731: with no snapshotted `openbao_bind_addr`, the second
+    /// init pass targets the configured `OpenBao` host port instead of the
+    /// CLI default's literal 8200.
+    #[test]
+    fn init_args_for_reinit_carries_the_resolved_host_port() {
+        let _env = crate::commands::openbao_url::test_env::HostPortEnvGuard::new();
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18200\n").unwrap();
+        let reinit_args = ReinitArgs {
+            openbao: OpenBaoArgs {
+                openbao_url: crate::commands::init::DEFAULT_OPENBAO_URL.to_string(),
+                kv_mount: "secret".to_string(),
+            },
+            secrets_dir: SecretsDirArgs {
+                secrets_dir: PathBuf::from("secrets"),
+            },
+            compose: ComposeFileArgs {
+                compose_file: dir.path().join("docker-compose.yml"),
+            },
+            yes: true,
+            root_token_output: None,
+            enable: Vec::new(),
+            skip: Vec::new(),
+            summary_json: None,
+            no_eab: true,
+        };
+        let init_args = init_args_for_reinit(
+            &reinit_args,
+            &DeploymentIntent::default(),
+            &reinit_args.secrets_dir.secrets_dir,
+        );
+        assert_eq!(init_args.openbao.openbao_url, "http://localhost:18200");
+    }
+
+    /// Closes #731: a snapshotted non-loopback bind intent outranks the
+    /// host port.  Deriving the host-port URL first would break the
+    /// `DEFAULT_OPENBAO_URL` equality gate and silently point a
+    /// destructive recovery at an endpoint that no longer serves.
+    #[test]
+    fn init_args_for_reinit_prefers_the_bind_addr_over_the_host_port() {
+        let _env = crate::commands::openbao_url::test_env::HostPortEnvGuard::new();
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18200\n").unwrap();
+        let reinit_args = ReinitArgs {
+            openbao: OpenBaoArgs {
+                openbao_url: crate::commands::init::DEFAULT_OPENBAO_URL.to_string(),
+                kv_mount: "secret".to_string(),
+            },
+            secrets_dir: SecretsDirArgs {
+                secrets_dir: PathBuf::from("secrets"),
+            },
+            compose: ComposeFileArgs {
+                compose_file: dir.path().join("docker-compose.yml"),
+            },
+            yes: true,
+            root_token_output: None,
+            enable: Vec::new(),
+            skip: Vec::new(),
+            summary_json: None,
+            no_eab: true,
+        };
+        let snapshot = DeploymentIntent {
+            openbao_bind_addr: Some("192.168.1.10:8200".to_string()),
+            ..DeploymentIntent::default()
+        };
+        let init_args = init_args_for_reinit(
+            &reinit_args,
+            &snapshot,
+            &reinit_args.secrets_dir.secrets_dir,
+        );
+        assert_eq!(
+            init_args.openbao.openbao_url, "https://192.168.1.10:8200",
+            "a recorded non-loopback bind intent must win over the host port"
         );
     }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -6,6 +6,7 @@ use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
 use crate::cli::args::StatusArgs;
+use crate::commands::compose_file::compose_file_dir;
 use crate::commands::infra::{
     ContainerReadiness, collect_container_failures, collect_readiness, default_infra_services,
 };
@@ -14,6 +15,7 @@ use crate::commands::init::{
     APPROLE_BOOTROOT_STEPCA, PATH_AGENT_EAB, PATH_CA_TRUST, PATH_RESPONDER_HMAC, PATH_STEPCA_DB,
     PATH_STEPCA_PASSWORD, SECRET_ID_TTL, parse_ttl_to_secs,
 };
+use crate::commands::openbao_url::effective_openbao_url;
 use crate::i18n::Messages;
 use crate::state::StateFile;
 
@@ -28,12 +30,11 @@ pub(crate) async fn run_status(args: &StatusArgs, messages: &Messages) -> Result
     } else {
         None
     };
+    let openbao_url = status_openbao_url(args);
     let mut client = match state.as_ref().map(StateFile::secrets_dir) {
-        Some(secrets_dir) => {
-            OpenBaoClient::with_local_trust(&args.openbao.openbao_url, secrets_dir)
-                .with_context(|| messages.error_openbao_client_create_failed())?
-        }
-        None => OpenBaoClient::new(&args.openbao.openbao_url)
+        Some(secrets_dir) => OpenBaoClient::with_local_trust(&openbao_url, secrets_dir)
+            .with_context(|| messages.error_openbao_client_create_failed())?,
+        None => OpenBaoClient::new(&openbao_url)
             .with_context(|| messages.error_openbao_client_create_failed())?,
     };
     let openbao_health = client
@@ -122,6 +123,20 @@ pub(crate) async fn run_status(args: &StatusArgs, messages: &Messages) -> Result
     }
 
     Ok(())
+}
+
+/// Returns the `OpenBao` endpoint `status` reports on.
+///
+/// Talks to the host port this compose stack publishes rather than the
+/// CLI default's literal 8200, which on a shared host would report
+/// another bootroot instance's `OpenBao`.  An explicit `--openbao-url`
+/// is still honoured verbatim.
+fn status_openbao_url(args: &StatusArgs) -> String {
+    effective_openbao_url(
+        &args.openbao.openbao_url,
+        &compose_file_dir(&args.compose.compose_file),
+        None,
+    )
 }
 
 fn load_service_statuses(messages: &Messages) -> Result<Vec<ServiceStatusEntry>> {
@@ -371,6 +386,45 @@ mod tests {
             last_secret_id_rotation: last_secret_id_rotation.map(str::to_string),
             ..Default::default()
         }
+    }
+
+    fn status_args(compose_file: std::path::PathBuf, openbao_url: &str) -> StatusArgs {
+        StatusArgs {
+            compose: crate::cli::args::ComposeFileArgs { compose_file },
+            openbao: crate::cli::args::OpenBaoArgs {
+                openbao_url: openbao_url.to_string(),
+                kv_mount: "secret".to_string(),
+            },
+            root_token: crate::cli::args::RootTokenArgs { root_token: None },
+        }
+    }
+
+    /// Closes #731: `status` follows a non-default `OPENBAO_HOST_PORT`
+    /// recorded in the compose directory's `.env`.
+    #[test]
+    fn status_openbao_url_follows_the_configured_host_port() {
+        let _env = crate::commands::openbao_url::test_env::HostPortEnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18200\n").expect("write .env");
+        let args = status_args(
+            dir.path().join("docker-compose.yml"),
+            crate::commands::init::DEFAULT_OPENBAO_URL,
+        );
+        assert_eq!(status_openbao_url(&args), "http://localhost:18200");
+    }
+
+    /// Closes #731: an operator-supplied `--openbao-url` is used
+    /// verbatim, whatever the configured host port is.
+    #[test]
+    fn status_openbao_url_honours_an_explicit_url() {
+        let _env = crate::commands::openbao_url::test_env::HostPortEnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".env"), "OPENBAO_HOST_PORT=18200\n").expect("write .env");
+        let args = status_args(
+            dir.path().join("docker-compose.yml"),
+            "https://openbao.internal:8200",
+        );
+        assert_eq!(status_openbao_url(&args), "https://openbao.internal:8200");
     }
 
     fn rfc3339(ts: OffsetDateTime) -> String {

--- a/src/db.rs
+++ b/src/db.rs
@@ -175,8 +175,8 @@ pub fn for_host_runtime_with_port(dsn: &str, port: u16) -> Result<String> {
 /// than erroring — the caller is translating a DSN, not validating the
 /// environment.
 ///
-/// Thin wrapper over [`crate::host_port::resolve_host_port`], which the
-/// other core services share.
+/// Thin wrapper over the shared resolver in [`crate::host_port`], which the
+/// other core services use through their own resolvers.
 #[must_use]
 pub fn resolve_postgres_host_port(compose_dir: &Path) -> u16 {
     crate::host_port::resolve_host_port(

--- a/src/db.rs
+++ b/src/db.rs
@@ -164,7 +164,7 @@ pub fn for_host_runtime_with_port(dsn: &str, port: u16) -> Result<String> {
 }
 
 /// Resolves the host-side `PostgreSQL` port with the same precedence Docker
-/// Compose uses for `${POSTGRES_HOST_PORT:-5432}` in the compose file port
+/// Compose uses for `${POSTGRES_HOST_PORT:-5433}` in the compose file port
 /// mapping:
 ///
 /// 1. process environment `POSTGRES_HOST_PORT` (non-empty), else
@@ -174,48 +174,16 @@ pub fn for_host_runtime_with_port(dsn: &str, port: u16) -> Result<String> {
 /// A present-but-unparseable value falls through to the next source rather
 /// than erroring — the caller is translating a DSN, not validating the
 /// environment.
+///
+/// Thin wrapper over [`crate::host_port::resolve_host_port`], which the
+/// other core services share.
 #[must_use]
 pub fn resolve_postgres_host_port(compose_dir: &Path) -> u16 {
-    if let Ok(value) = std::env::var(POSTGRES_HOST_PORT_ENV)
-        && !value.is_empty()
-        && let Ok(port) = value.parse::<u16>()
-    {
-        return port;
-    }
-    if let Some(port) = read_env_file_value(compose_dir, POSTGRES_HOST_PORT_ENV)
-        .and_then(|value| value.parse::<u16>().ok())
-    {
-        return port;
-    }
-    DEFAULT_POSTGRES_HOST_PORT
-}
-
-fn read_env_file_value(compose_dir: &Path, key: &str) -> Option<String> {
-    let contents = std::fs::read_to_string(compose_dir.join(".env")).ok()?;
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        let (k, v) = trimmed.split_once('=')?;
-        if k.trim() != key {
-            continue;
-        }
-        let value = v.trim();
-        let stripped = if value.len() >= 2
-            && ((value.starts_with('"') && value.ends_with('"'))
-                || (value.starts_with('\'') && value.ends_with('\'')))
-        {
-            &value[1..value.len() - 1]
-        } else {
-            value
-        };
-        if stripped.is_empty() {
-            return None;
-        }
-        return Some(stripped.to_string());
-    }
-    None
+    crate::host_port::resolve_host_port(
+        compose_dir,
+        POSTGRES_HOST_PORT_ENV,
+        DEFAULT_POSTGRES_HOST_PORT,
+    )
 }
 
 /// Returns the admin DSN that should be persisted to KV after running

--- a/src/host_port.rs
+++ b/src/host_port.rs
@@ -10,22 +10,25 @@
 
 use std::path::Path;
 
-/// Environment variable that controls `OpenBao`'s host-side published port.
+/// Names the environment variable that controls `OpenBao`'s host-side
+/// published port.
 pub const OPENBAO_HOST_PORT_ENV: &str = "OPENBAO_HOST_PORT";
-/// Fallback `OpenBao` host port when `OPENBAO_HOST_PORT` is unset.
+/// Defines the `OpenBao` host port used when `OPENBAO_HOST_PORT` is unset.
 ///
 /// Matches the published default in `docker-compose.yml`.
 pub const DEFAULT_OPENBAO_HOST_PORT: u16 = 8200;
-/// Environment variable that controls step-ca's host-side published port.
+/// Names the environment variable that controls step-ca's host-side
+/// published port.
 pub const STEPCA_HOST_PORT_ENV: &str = "STEPCA_HOST_PORT";
-/// Fallback step-ca host port when `STEPCA_HOST_PORT` is unset.
+/// Defines the step-ca host port used when `STEPCA_HOST_PORT` is unset.
 ///
 /// Matches the published default in `docker-compose.yml`.
 pub const DEFAULT_STEPCA_HOST_PORT: u16 = 9000;
-/// Environment variable that controls the HTTP-01 responder admin API's
-/// host-side published port.
+/// Names the environment variable that controls the HTTP-01 responder admin
+/// API's host-side published port.
 pub const HTTP01_ADMIN_HOST_PORT_ENV: &str = "HTTP01_ADMIN_HOST_PORT";
-/// Fallback HTTP-01 admin host port when `HTTP01_ADMIN_HOST_PORT` is unset.
+/// Defines the HTTP-01 admin host port used when `HTTP01_ADMIN_HOST_PORT` is
+/// unset.
 ///
 /// Matches the published default in `docker-compose.yml`.
 pub const DEFAULT_HTTP01_ADMIN_HOST_PORT: u16 = 8080;
@@ -40,8 +43,12 @@ pub const DEFAULT_HTTP01_ADMIN_HOST_PORT: u16 = 8080;
 /// A present-but-unparseable value falls through to the next source
 /// rather than erroring — the caller is deriving an endpoint, not
 /// validating the environment.
+///
+/// Crate-internal: the exported surface is the per-service resolvers
+/// below, which pin the `(key, default)` pair to what the compose files
+/// actually interpolate.
 #[must_use]
-pub fn resolve_host_port(compose_dir: &Path, key: &str, default: u16) -> u16 {
+pub(crate) fn resolve_host_port(compose_dir: &Path, key: &str, default: u16) -> u16 {
     if let Ok(value) = std::env::var(key)
         && !value.is_empty()
         && let Ok(port) = value.parse::<u16>()
@@ -56,8 +63,10 @@ pub fn resolve_host_port(compose_dir: &Path, key: &str, default: u16) -> u16 {
     default
 }
 
-/// Resolves the host-side `OpenBao` port.  See [`resolve_host_port`] for
-/// the precedence rules.
+/// Resolves the host-side `OpenBao` port: process environment
+/// [`OPENBAO_HOST_PORT_ENV`] (non-empty), else the same key from
+/// `compose_dir/.env`, else [`DEFAULT_OPENBAO_HOST_PORT`].  An
+/// unparseable value falls through to the next source.
 #[must_use]
 pub fn resolve_openbao_host_port(compose_dir: &Path) -> u16 {
     resolve_host_port(
@@ -67,15 +76,19 @@ pub fn resolve_openbao_host_port(compose_dir: &Path) -> u16 {
     )
 }
 
-/// Resolves the host-side step-ca port.  See [`resolve_host_port`] for
-/// the precedence rules.
+/// Resolves the host-side step-ca port: process environment
+/// [`STEPCA_HOST_PORT_ENV`] (non-empty), else the same key from
+/// `compose_dir/.env`, else [`DEFAULT_STEPCA_HOST_PORT`].  An unparseable
+/// value falls through to the next source.
 #[must_use]
 pub fn resolve_stepca_host_port(compose_dir: &Path) -> u16 {
     resolve_host_port(compose_dir, STEPCA_HOST_PORT_ENV, DEFAULT_STEPCA_HOST_PORT)
 }
 
-/// Resolves the host-side HTTP-01 admin API port.  See
-/// [`resolve_host_port`] for the precedence rules.
+/// Resolves the host-side HTTP-01 admin API port: process environment
+/// [`HTTP01_ADMIN_HOST_PORT_ENV`] (non-empty), else the same key from
+/// `compose_dir/.env`, else [`DEFAULT_HTTP01_ADMIN_HOST_PORT`].  An
+/// unparseable value falls through to the next source.
 #[must_use]
 pub fn resolve_http01_admin_host_port(compose_dir: &Path) -> u16 {
     resolve_host_port(

--- a/src/host_port.rs
+++ b/src/host_port.rs
@@ -1,0 +1,298 @@
+//! Resolution of the host-side ports the compose stack publishes.
+//!
+//! Every core service publishes its host-side port through a
+//! `${<NAME>_HOST_PORT:-<default>}` interpolation in `docker-compose.yml`
+//! and `docker-compose.deploy.yml`, so two bootroot instances can share a
+//! host.  The helpers here reproduce Docker Compose's own precedence for
+//! those interpolations — process environment first, then the `.env` file
+//! sitting next to the compose file, then the compile-time default — so
+//! host-side tooling agrees with what Compose actually published.
+
+use std::path::Path;
+
+/// Environment variable that controls `OpenBao`'s host-side published port.
+pub const OPENBAO_HOST_PORT_ENV: &str = "OPENBAO_HOST_PORT";
+/// Fallback `OpenBao` host port when `OPENBAO_HOST_PORT` is unset.
+///
+/// Matches the published default in `docker-compose.yml`.
+pub const DEFAULT_OPENBAO_HOST_PORT: u16 = 8200;
+/// Environment variable that controls step-ca's host-side published port.
+pub const STEPCA_HOST_PORT_ENV: &str = "STEPCA_HOST_PORT";
+/// Fallback step-ca host port when `STEPCA_HOST_PORT` is unset.
+///
+/// Matches the published default in `docker-compose.yml`.
+pub const DEFAULT_STEPCA_HOST_PORT: u16 = 9000;
+/// Environment variable that controls the HTTP-01 responder admin API's
+/// host-side published port.
+pub const HTTP01_ADMIN_HOST_PORT_ENV: &str = "HTTP01_ADMIN_HOST_PORT";
+/// Fallback HTTP-01 admin host port when `HTTP01_ADMIN_HOST_PORT` is unset.
+///
+/// Matches the published default in `docker-compose.yml`.
+pub const DEFAULT_HTTP01_ADMIN_HOST_PORT: u16 = 8080;
+
+/// Resolves a host-side published port with the same precedence Docker
+/// Compose uses for a `${<key>:-<default>}` port mapping:
+///
+/// 1. process environment `key` (non-empty), else
+/// 2. `key` from `compose_dir/.env`, else
+/// 3. `default`.
+///
+/// A present-but-unparseable value falls through to the next source
+/// rather than erroring — the caller is deriving an endpoint, not
+/// validating the environment.
+#[must_use]
+pub fn resolve_host_port(compose_dir: &Path, key: &str, default: u16) -> u16 {
+    if let Ok(value) = std::env::var(key)
+        && !value.is_empty()
+        && let Ok(port) = value.parse::<u16>()
+    {
+        return port;
+    }
+    if let Some(port) =
+        read_env_file_value(compose_dir, key).and_then(|value| value.parse::<u16>().ok())
+    {
+        return port;
+    }
+    default
+}
+
+/// Resolves the host-side `OpenBao` port.  See [`resolve_host_port`] for
+/// the precedence rules.
+#[must_use]
+pub fn resolve_openbao_host_port(compose_dir: &Path) -> u16 {
+    resolve_host_port(
+        compose_dir,
+        OPENBAO_HOST_PORT_ENV,
+        DEFAULT_OPENBAO_HOST_PORT,
+    )
+}
+
+/// Resolves the host-side step-ca port.  See [`resolve_host_port`] for
+/// the precedence rules.
+#[must_use]
+pub fn resolve_stepca_host_port(compose_dir: &Path) -> u16 {
+    resolve_host_port(compose_dir, STEPCA_HOST_PORT_ENV, DEFAULT_STEPCA_HOST_PORT)
+}
+
+/// Resolves the host-side HTTP-01 admin API port.  See
+/// [`resolve_host_port`] for the precedence rules.
+#[must_use]
+pub fn resolve_http01_admin_host_port(compose_dir: &Path) -> u16 {
+    resolve_host_port(
+        compose_dir,
+        HTTP01_ADMIN_HOST_PORT_ENV,
+        DEFAULT_HTTP01_ADMIN_HOST_PORT,
+    )
+}
+
+/// Reads a single `key=value` entry out of `compose_dir/.env`.
+///
+/// Returns `None` when the file is unreadable, the key is absent, or the
+/// value is empty — every one of which means "fall through to the next
+/// source" for the callers above.  Surrounding single or double quotes
+/// are stripped, matching how Compose reads its `.env`.
+#[must_use]
+pub fn read_env_file_value(compose_dir: &Path, key: &str) -> Option<String> {
+    let contents = std::fs::read_to_string(compose_dir.join(".env")).ok()?;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let (k, v) = trimmed.split_once('=')?;
+        if k.trim() != key {
+            continue;
+        }
+        let value = v.trim();
+        let stripped = value
+            .strip_prefix('"')
+            .and_then(|inner| inner.strip_suffix('"'))
+            .or_else(|| {
+                value
+                    .strip_prefix('\'')
+                    .and_then(|inner| inner.strip_suffix('\''))
+            })
+            .unwrap_or(value);
+        if stripped.is_empty() {
+            return None;
+        }
+        return Some(stripped.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+
+    use super::*;
+
+    const TEST_KEYS: [&str; 3] = [
+        OPENBAO_HOST_PORT_ENV,
+        STEPCA_HOST_PORT_ENV,
+        HTTP01_ADMIN_HOST_PORT_ENV,
+    ];
+
+    /// Serialises every test that touches the host-port environment
+    /// variables and restores their pre-test values on drop.
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            let previous = TEST_KEYS
+                .iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect();
+            for key in TEST_KEYS {
+                // SAFETY: removal is serialized by the mutex held above.
+                unsafe {
+                    std::env::remove_var(key);
+                }
+            }
+            Self {
+                _lock: lock,
+                previous,
+            }
+        }
+
+        fn set(&self, key: &str, value: &str) {
+            assert!(
+                self.previous.iter().any(|(tracked, _)| *tracked == key),
+                "{key} is not tracked by the guard and would leak into other tests"
+            );
+            // SAFETY: mutation is serialized by the mutex held by `_lock`.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, previous) in &self.previous {
+                // SAFETY: restored inside the shared mutex held by `_lock`.
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
+    /// One new variable, as `(env key, compile-time default, resolver)`.
+    type ResolverCase = (&'static str, u16, fn(&Path) -> u16);
+
+    /// Every variable this module adds.
+    fn cases() -> Vec<ResolverCase> {
+        vec![
+            (
+                OPENBAO_HOST_PORT_ENV,
+                DEFAULT_OPENBAO_HOST_PORT,
+                resolve_openbao_host_port as fn(&Path) -> u16,
+            ),
+            (
+                STEPCA_HOST_PORT_ENV,
+                DEFAULT_STEPCA_HOST_PORT,
+                resolve_stepca_host_port as fn(&Path) -> u16,
+            ),
+            (
+                HTTP01_ADMIN_HOST_PORT_ENV,
+                DEFAULT_HTTP01_ADMIN_HOST_PORT,
+                resolve_http01_admin_host_port as fn(&Path) -> u16,
+            ),
+        ]
+    }
+
+    #[test]
+    fn process_env_wins_over_env_file() {
+        let guard = EnvGuard::new();
+        for (key, _, resolve) in cases() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            std::fs::write(dir.path().join(".env"), format!("{key}=19999\n")).expect("write .env");
+            guard.set(key, "17777");
+            assert_eq!(resolve(dir.path()), 17777, "{key} must prefer process env");
+        }
+    }
+
+    #[test]
+    fn env_file_used_when_process_env_unset() {
+        let _guard = EnvGuard::new();
+        for (key, _, resolve) in cases() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            std::fs::write(
+                dir.path().join(".env"),
+                format!("# comment\nOTHER=1\n{key}=\"18888\"\n"),
+            )
+            .expect("write .env");
+            assert_eq!(resolve(dir.path()), 18888, "{key} must read .env");
+        }
+    }
+
+    #[test]
+    fn default_used_when_nothing_set() {
+        let _guard = EnvGuard::new();
+        for (key, default, resolve) in cases() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            assert_eq!(resolve(dir.path()), default, "{key} must fall back");
+        }
+    }
+
+    #[test]
+    fn unparseable_process_env_falls_through_to_env_file() {
+        let guard = EnvGuard::new();
+        for (key, _, resolve) in cases() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            std::fs::write(dir.path().join(".env"), format!("{key}=16666\n")).expect("write .env");
+            guard.set(key, "not-a-port");
+            assert_eq!(
+                resolve(dir.path()),
+                16666,
+                "{key} must fall through to .env"
+            );
+        }
+    }
+
+    #[test]
+    fn unparseable_env_file_falls_through_to_default() {
+        let _guard = EnvGuard::new();
+        for (key, default, resolve) in cases() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            std::fs::write(dir.path().join(".env"), format!("{key}=99999999\n"))
+                .expect("write .env");
+            assert_eq!(resolve(dir.path()), default, "{key} must fall through");
+        }
+    }
+
+    #[test]
+    fn empty_process_env_falls_through_to_env_file() {
+        let guard = EnvGuard::new();
+        for (key, _, resolve) in cases() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            std::fs::write(dir.path().join(".env"), format!("{key}=15555\n")).expect("write .env");
+            guard.set(key, "");
+            assert_eq!(resolve(dir.path()), 15555, "{key} must ignore an empty env");
+        }
+    }
+
+    #[test]
+    fn read_env_file_value_ignores_empty_and_missing_keys() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".env"), "EMPTY=\nQUOTED='7'\n").expect("write .env");
+        assert_eq!(read_env_file_value(dir.path(), "EMPTY"), None);
+        assert_eq!(read_env_file_value(dir.path(), "MISSING"), None);
+        assert_eq!(
+            read_env_file_value(dir.path(), "QUOTED").as_deref(),
+            Some("7")
+        );
+    }
+}

--- a/src/host_port.rs
+++ b/src/host_port.rs
@@ -91,15 +91,21 @@ pub fn resolve_http01_admin_host_port(compose_dir: &Path) -> u16 {
 /// value is empty — every one of which means "fall through to the next
 /// source" for the callers above.  Surrounding single or double quotes
 /// are stripped, matching how Compose reads its `.env`.
+///
+/// A line carrying no `=` is skipped rather than ending the scan, so a
+/// stray operator-authored line cannot hide the keys below it and leave
+/// the preflight binding a port Compose never publishes.
 #[must_use]
-pub fn read_env_file_value(compose_dir: &Path, key: &str) -> Option<String> {
+fn read_env_file_value(compose_dir: &Path, key: &str) -> Option<String> {
     let contents = std::fs::read_to_string(compose_dir.join(".env")).ok()?;
     for line in contents.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        let (k, v) = trimmed.split_once('=')?;
+        let Some((k, v)) = trimmed.split_once('=') else {
+            continue;
+        };
         if k.trim() != key {
             continue;
         }
@@ -294,5 +300,20 @@ mod tests {
             read_env_file_value(dir.path(), "QUOTED").as_deref(),
             Some("7")
         );
+    }
+
+    /// A line carrying no `=` must not hide the keys after it — that
+    /// would silently drop the resolver back to the compile-time
+    /// default and preflight a port Compose never publishes.
+    #[test]
+    fn env_file_line_without_a_separator_does_not_end_the_scan() {
+        let _guard = EnvGuard::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join(".env"),
+            "MALFORMED\nOPENBAO_HOST_PORT=18200\n",
+        )
+        .expect("write .env");
+        assert_eq!(resolve_openbao_host_port(dir.path()), 18200);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod db;
 pub mod eab;
 pub mod fs_util;
 pub mod hooks;
+pub mod host_port;
 pub mod input_validation;
 pub mod kv_payload;
 pub mod locale;

--- a/tests/docker_compose_security.rs
+++ b/tests/docker_compose_security.rs
@@ -11,6 +11,41 @@ fn postgres_port_is_bound_to_localhost_by_default() {
     );
 }
 
+/// The host-side port of every core service is interpolated so two
+/// bootroot instances can share a host (issue #731), and `infra install`'s
+/// preflight resolves the same `(variable, default)` pairs rather than
+/// parsing the YAML. Drift between the two silently reintroduces the
+/// collision the preflight is meant to diagnose.
+const INTERPOLATED_PORT_MAPPINGS: [&str; 3] = [
+    r#""127.0.0.1:${OPENBAO_HOST_PORT:-8200}:8200""#,
+    r#""127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000""#,
+    r#""127.0.0.1:${HTTP01_ADMIN_HOST_PORT:-8080}:8080""#,
+];
+
+#[test]
+fn core_service_host_ports_are_interpolated_with_todays_defaults() {
+    let compose_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docker-compose.yml");
+    let compose = fs::read_to_string(compose_path).expect("read docker-compose.yml");
+    for mapping in INTERPOLATED_PORT_MAPPINGS {
+        assert!(
+            compose.contains(mapping),
+            "docker-compose.yml must publish {mapping} verbatim (issue #731)"
+        );
+    }
+}
+
+#[test]
+fn deploy_core_service_host_ports_are_interpolated_with_todays_defaults() {
+    let compose_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docker-compose.deploy.yml");
+    let compose = fs::read_to_string(compose_path).expect("read docker-compose.deploy.yml");
+    for mapping in INTERPOLATED_PORT_MAPPINGS {
+        assert!(
+            compose.contains(mapping),
+            "docker-compose.deploy.yml must publish {mapping} verbatim (issue #731)"
+        );
+    }
+}
+
 #[test]
 fn postgres_volume_uses_postgresql_root_for_postgres_18() {
     let compose_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docker-compose.yml");


### PR DESCRIPTION
## Summary

`infra install` published OpenBao, step-ca and the HTTP-01 responder on hardcoded host ports, and its preflight pre-bound those same constants regardless of what the compose file being installed actually declared. A caller staging its own compose file could rewrite the published ports there and still be refused by the preflight, so two bootroot instances could not share a host.

- **Compose files.** `docker-compose.yml` and `docker-compose.deploy.yml` now publish through `${OPENBAO_HOST_PORT:-8200}`, `${STEPCA_HOST_PORT:-9000}` and `${HTTP01_ADMIN_HOST_PORT:-8080}`. The `127.0.0.1:` prefix and the container-side ports are unchanged.
- **Shared resolver.** The `resolve_postgres_host_port` logic is generalised into `src/host_port.rs`, keyed on `(env var name, default)`. The generic form is `pub(crate)`; the exported surface is one resolver per core service, each pinning the `(key, default)` pair to what the compose files actually interpolate. Precedence is process environment → `<compose_dir>/.env` → compile-time default; an unparseable value falls through rather than erroring, and a `.env` line carrying no `=` is skipped rather than ending the scan, so a stray operator-authored line cannot hide the keys below it and leave the preflight binding a port Compose never published. `resolve_postgres_host_port` and `DEFAULT_POSTGRES_HOST_PORT` keep working unchanged for their existing callers, now as a thin wrapper over the shared helper.
- **CLI flags.** `--openbao-host-port`, `--stepca-host-port` and `--http01-admin-host-port` mirror `--postgres-host-port` exactly: no clap `env` binding, upserted into `.env` on both the pre-existing and fresh-`.env` paths, and injected into the environment of every `docker compose` subprocess so the flag wins over an inherited shell variable.
- **Preflight.** `preflight_compose_published_ports` binds the resolved port per service (flag → env → `.env` → default) instead of a constant, and each remediation string now names the concrete port, the `.env` variable and the flag.
- **Effective OpenBao URL.** A new helper in `src/commands/openbao_url.rs` returns an operator-supplied URL verbatim, and otherwise replaces the port of `DEFAULT_OPENBAO_URL` with the resolved OpenBao host port. Applied at `infra install` (including the existing-state paths of the bind-intent savers/clearers, which previously preserved a stale `state.openbao_url`), `infra up`, `init`, `status` and `reinit`. A snapshotted non-loopback `openbao_bind_addr` still outranks the host-port derivation in `init_args_for_reinit`, and `reinit` still rejects a non-default `--openbao-url`. `infra install` writes `state.json` in exactly the cases it does today and no others.
- **Docs and changelog.** English and Korean `cli.md`, `cli-examples.md` and `installation.md` document the three flags and variables, note that the "ports that must be free" lists are overridable, and state that step-ca and HTTP-01 client URLs are not derived automatically. `CHANGELOG.md` has an unreleased entry.

Out-of-scope items from the issue (`container_name` collisions, parsing ports out of an arbitrary `--compose-file`, deriving step-ca/HTTP-01 client URLs, the loopback-only publication policy, Grafana ports) are untouched.

Closes #731

## Test plan

- [x] Unit tests for the shared resolver, per variable: process environment wins over `.env`; `.env` used when the environment is unset; compile-time default when neither is set; unparseable value falls through. Plus a regression test that a `.env` line without a separator does not hide the keys after it. Environment manipulation is guarded by a shared `Mutex`.
- [x] Unit tests for `preflight_compose_published_ports`: a listener on the *resolved* port aborts, a listener on the *default* port does not when the resolved port differs, for each of openbao / step-ca / bootroot-http01.
- [x] Unit test asserting each of the three remediation strings contains the resolved port, the `.env` variable name and the flag name.
- [x] Unit tests for the effective-URL helper: default URL with a flag port, an environment port, a `.env` port, and nothing set; non-default URL unchanged under each source.
- [x] Tests asserting `state.json`'s `openbao_url` carries the resolved port on a newly created state file, on a pre-existing one with no bind intent, and on a pre-existing one with a bind intent — covering the http01 and step-ca savers specifically.
- [x] Test asserting a host-port-only `infra install` leaves no `state.json` behind.
- [x] Tests asserting `init` and `status` resolve the effective URL from a non-default `OPENBAO_HOST_PORT`.
- [x] Tests for `reinit`: host-port-derived URL with no snapshotted bind addr; `client_url_from_bind_addr` wins with a non-loopback snapshot; non-default `--openbao-url` still rejected. `init_args_for_reinit_rewrites_url_from_non_loopback_bind` passes unedited.
- [x] `tests/docker_compose_security.rs` drift guard asserting each interpolated mapping appears verbatim in both compose files.
- [x] `.env` upsert tests for each new flag on both the pre-existing and fresh paths, asserting unrelated keys survive.
- [x] Guardrail regression tests: both shipped compose files still pass `ensure_all_services_localhost_binding` with the interpolated mappings in place, and an interpolated mapping without the `127.0.0.1:` prefix is still rejected for postgres, openbao and bootroot-http01.
- [x] `cargo test --bin bootroot` — 842 passed. `cargo test --lib` — 398 passed. `docker_compose_security` — 7 passed. Full `cargo test` — all 31 suites green, 0 failures.
- [x] `cargo clippy --all-targets --all-features` warning-free; `cargo fmt --check` clean.
- [x] `docker compose config` resolves cleanly for both files with the variables unset, and publishes 18200 / 19000 / 18080 / 15433 when set to non-default values.
- [x] `scripts/preflight/run-all.sh`. Its host-independent stages pass locally: `ci/check.sh` (fmt, clippy, Python lint, Biome, markdownlint, docs build, `cargo audit` — one pre-existing allowed `rustls-pemfile` unmaintained warning), `validate-deploy-compose.sh`, and `ci/test-core.sh`'s unit stage (`cargo test` — all 31 suites green, 0 failures). The Docker stages cannot run on this host: ports 8200/9000/8080/5433 are held by another bootroot instance, and `scripts/preflight/ci/*` and `extra/cli-scenarios.sh` hardcode those ports in their client URLs, so the new flags cannot move them out of the way. They are covered in CI instead — all six `Docker E2E` matrix jobs in `ci.yml` (`local-hosts`, `local-no-hosts`, `remote-hosts`, `remote-no-hosts`, `rotation`, `reinit-recovery`) are green on this branch, and `run-extended` was manually dispatched on `sehkone/issue-731` (it has no PR trigger) and passed — run 30225875524, dispatched at `0d9d7f5`; the only commit after it, `49cdff1`, changes rustdoc wording and one `pub` → `pub(crate)` in `src/host_port.rs` and touches no runtime behaviour.
- [x] Manual check on a host where 8200 / 9000 / 8080 / 5433 are bound by a first bootroot instance (a real bootroot stack in a separate VM, forwarded onto this host's loopback):
  - Without the flags, `infra install` fails exactly as the issue reports: `host port 127.0.0.1:8200 is already in use (Address already in use (os error 48)) (listener: pid 1867 (OrbStack Helper)); free port 8200, set OPENBAO_HOST_PORT=<unused-port> in .env, or pass --openbao-host-port <unused-port>` — the rewritten remediation naming the port, the variable and the flag.
  - With container names namespaced via a staged `--compose-file` and all four flags (`--openbao-host-port 18200 --stepca-host-port 19000 --http01-admin-host-port 18080 --postgres-host-port 15433`), the install clears the preflight and publishes `127.0.0.1:18200->8200`, `127.0.0.1:19000->9000`, `127.0.0.1:18080->8080`, `127.0.0.1:15433->5432`. `.env` gained exactly the four keys with the pre-existing entries untouched, and **no `state.json` was created**.
  - Going further than the checklist required: a full `infra install` + `bootroot init` on the same moved ports completed end to end. `init` printed `OpenBao URL: http://localhost:18200` and wrote `state.json` with `openbao_url: http://localhost:18200`; two independent bootroot instances then ran side by side with distinct step-ca roots (`60:44:45:…` vs `57:71:6A:…`) and distinct responders.
  - Discriminating checks that the derivation is real rather than an accidental fallback: with `OPENBAO_HOST_PORT=18299` (nothing listening) `status` reports `health: unreachable` instead of silently reaching the live 8200 belonging to the other instance, and an explicit `--openbao-url http://localhost:18299` is honoured verbatim rather than rewritten to `.env`'s live 18200.
  - Torn down with `bootroot clean -y`; `.env` restored and the first instance untouched.



