### PR TITLE
Add per-prompt non-interactive confirmation flags to init (#735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -834,6 +834,28 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `bootroot init` accepts `--overwrite-password`, `--overwrite-ca-json`,
+  `--overwrite-state` and `--confirm-db-provision`, one per confirmation
+  in the pre-flight block that previously could only be answered from a
+  TTY (#735). Each flag answers exactly its own prompt as if the
+  operator had typed `y`; the four are mutually independent, none
+  implies another, and passing one whose condition does not hold (an
+  overwrite flag for a file that is not there, or
+  `--confirm-db-provision` without `--enable db-provision`) is a silent
+  no-op rather than an error. Without them nothing changes: the prompts
+  still fire and an empty or non-`y` answer still cancels the run, and
+  `--reinit-mode` keeps suppressing all four on its own so
+  `reinit --yes` stays non-interactive. This unblocks automated
+  installs, which previously had to either let `init` cancel — after
+  `bootstrap_openbao` had already initialised OpenBao and minted a root
+  token — or delete the `state.json` that `infra install --stepca-bind`
+  / `--openbao-bind` had written seconds earlier to record the bind
+  intent. That intent is what `init` derives step-ca's certificate SANs
+  from (#733), so dropping it left the CA serving a certificate without
+  the address it is published on and every off-host consumer failing TLS
+  hostname verification. Documented in the `init` section of
+  `docs/{en,ko}/cli.md`.
+
 - `bootroot infra install` accepts `--openbao-host-port`,
   `--stepca-host-port` and `--http01-admin-host-port`, so the OpenBao,
   step-ca and HTTP-01 responder host-side ports are configurable the way

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -526,6 +526,35 @@ Input priority is **CLI flags > environment variables > prompts/defaults**.
   fallback is also suppressed (the keys are already in the summary
   JSON, and echoing would leak them into CI logs). Conflicts with
   `--save-unseal-keys` (#603).
+- `--overwrite-password`: skip the "Overwrite password.txt?" prompt and
+  overwrite the file. Equivalent to answering `y` at the prompt. Silent
+  no-op when `<secrets_dir>/password.txt` does not exist (#735).
+- `--overwrite-ca-json`: skip the "Overwrite ca.json?" prompt and
+  overwrite the file. Equivalent to answering `y` at the prompt. Silent
+  no-op when `<secrets_dir>/config/ca.json` does not exist (#735).
+- `--overwrite-state`: skip the "Overwrite state.json?" prompt and
+  overwrite the file. Equivalent to answering `y` at the prompt. Silent
+  no-op when `state.json` does not exist. Needed by automated installs:
+  `infra install --stepca-bind`/`--openbao-bind` writes `state.json`
+  itself to record the bind intent, so the file `init` asks about is
+  the intent the same run recorded seconds earlier — and deleting it
+  instead would drop the intent that `init` derives step-ca's
+  certificate SANs from (#735).
+- `--confirm-db-provision`: skip the "Provision PostgreSQL
+  role/database?" prompt and provision. Equivalent to answering `y` at
+  the prompt. Does not enable the feature — a silent no-op unless
+  `--enable db-provision` is also passed (#735).
+
+The four flags above are mutually independent: each suppresses exactly
+its own prompt, none implies another, and without them the prompts fire
+as before (an empty or non-`y` answer still cancels the run).
+`--reinit-mode` continues to suppress all four on its own, so
+`reinit --yes` stays non-interactive. Set the flags that apply and
+`init` clears its pre-flight confirmations with stdin closed; the other
+prompts on the run still need their own flags (`--no-eab` or
+`--eab-kid`/`--eab-hmac`, `--save-unseal-keys` or
+`--no-save-unseal-keys`, and `--root-token`/`--unseal-key` where the
+OpenBao state requires them).
 
 If a previous `init` failed mid-flight and rolled back, OpenBao may
 remain initialised in its volume while bootroot has no usable root

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -518,6 +518,37 @@ OpenBao 초기화/언실/정책/AppRole 구성, step-ca 초기화, 시크릿 등
   stdout으로 평문 출력하는 경로도 함께 억제되어(요약 JSON에
   이미 들어 있고, CI 로그로 유출될 위험을 차단) 출력되지 않습니다.
   `--save-unseal-keys`와 함께 사용할 수 없습니다(#603).
+- `--overwrite-password`: "Overwrite password.txt?" 프롬프트를 건너뛰고
+  파일을 덮어씁니다. 프롬프트에 `y`를 입력한 것과 동등합니다.
+  `<secrets_dir>/password.txt`가 없으면 아무 일도 하지 않습니다(#735).
+- `--overwrite-ca-json`: "Overwrite ca.json?" 프롬프트를 건너뛰고
+  파일을 덮어씁니다. 프롬프트에 `y`를 입력한 것과 동등합니다.
+  `<secrets_dir>/config/ca.json`이 없으면 아무 일도 하지
+  않습니다(#735).
+- `--overwrite-state`: "Overwrite state.json?" 프롬프트를 건너뛰고
+  파일을 덮어씁니다. 프롬프트에 `y`를 입력한 것과 동등합니다.
+  `state.json`이 없으면 아무 일도 하지 않습니다. 자동화된 설치에
+  필요합니다: `infra install --stepca-bind`/`--openbao-bind`가 바인드
+  의도를 기록하려고 `state.json`을 직접 쓰므로, `init`이 묻는 파일은
+  같은 실행이 몇 초 전에 기록한 그 의도입니다. 대신 파일을 지우면
+  `init`이 step-ca 인증서 SAN을 유도하는 근거인 의도가 사라집니다
+  (#735).
+- `--confirm-db-provision`: "Provision PostgreSQL role/database?"
+  프롬프트를 건너뛰고 프로비저닝을 진행합니다. 프롬프트에 `y`를 입력한
+  것과 동등합니다. 이 플래그가 기능을 켜지는 않으므로
+  `--enable db-provision`을 함께 주지 않으면 아무 일도 하지
+  않습니다(#735).
+
+위 네 플래그는 서로 독립적입니다. 각 플래그는 자기 프롬프트만
+억제하며 다른 플래그를 함의하지 않고, 플래그가 없으면 프롬프트는
+종전대로 동작합니다(빈 입력이나 `y`가 아닌 답은 여전히 실행을
+취소합니다). `--reinit-mode`는 지금처럼 네 프롬프트를 단독으로
+억제하므로 `reinit --yes`는 계속 비대화형입니다. 해당하는 플래그를
+지정하면 `init`은 stdin이 닫힌 상태에서도 사전 확인 단계를 통과합니다.
+같은 실행의 다른 프롬프트에는 각자의 플래그가 여전히 필요합니다
+(`--no-eab` 또는 `--eab-kid`/`--eab-hmac`, `--save-unseal-keys` 또는
+`--no-save-unseal-keys`, OpenBao 상태에 따라
+`--root-token`/`--unseal-key`).
 
 이전 `init`이 중간에 실패하고 롤백되었다면 OpenBao는 볼륨에 초기화된
 상태로 남아 있는 반면 bootroot에는 사용 가능한 root token이 없을 수

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -392,10 +392,11 @@ run_first_init() {
   wait_for_postgres_admin
   wait_for_openbao_listening "http://127.0.0.1:8200"
   # `infra install` writes state.json (to record the bind intent) before
-  # init runs, so init's overwrite-state prompt fires under
-  # default-yes-no semantics.  Pipe `y` answers to clear that prompt and
-  # any ca.json / password.txt prompt on rerun.
-  if ! printf 'y\ny\ny\n' | BOOTROOT_LANG=en run_bootroot init \
+  # init runs, so init's overwrite-state prompt fires; ca.json and
+  # password.txt prompt too on a rerun, and `db-provision` adds its own
+  # confirmation.  Answer all four with their per-prompt flags and run
+  # with stdin closed, which proves the run needs no TTY (#735).
+  if ! BOOTROOT_LANG=en run_bootroot init \
     --compose-file "$COMPOSE_FILE" \
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$summary_json" \
@@ -404,10 +405,14 @@ run_first_init() {
     --http-hmac "$DEFAULT_HTTP_HMAC" \
     --no-eab \
     --save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
+    --confirm-db-provision \
     --db-user "step" \
     --db-name "stepca" \
     --responder-url "http://localhost:8080" \
-    --skip responder-check >"$raw_log" 2>&1; then
+    --skip responder-check </dev/null >"$raw_log" 2>&1; then
     {
       echo "bootroot init failed (raw tail):"
       tail -n 200 "$raw_log" || true
@@ -436,7 +441,11 @@ run_second_init() {
 
   wait_for_postgres_admin
   wait_for_openbao_listening "http://127.0.0.1:8200"
-  if ! printf 'y\ny\ny\n' | BOOTROOT_LANG=en run_bootroot init \
+  # `db-provision` is off here, so `--confirm-db-provision` is
+  # deliberately not passed: the three overwrite flags are enough to run
+  # with stdin closed, which also shows the confirmation flag is
+  # independent of the feature rather than implied by it (#735).
+  if ! BOOTROOT_LANG=en run_bootroot init \
     --compose-file "$COMPOSE_FILE" \
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$summary_json" \
@@ -448,8 +457,11 @@ run_second_init() {
     --db-dsn "$db_dsn" \
     --no-eab \
     --save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
     --responder-url "http://localhost:8080" \
-    --skip responder-check >"$raw_log" 2>&1; then
+    --skip responder-check </dev/null >"$raw_log" 2>&1; then
     {
       echo "second bootroot init failed (raw tail):"
       tail -n 200 "$raw_log" || true

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1204,7 +1204,7 @@ pub(crate) struct InitArgs {
     /// Equivalent to answering `y` at that prompt.  No-op when
     /// `state.json` does not exist.  Needed by automated installs, where
     /// the `state.json` in place is the bind intent that `infra install
-    /// --stepca-bind` / `--openbao-bind` recorded moments earlier
+    /// --stepca-bind` / `--openbao-bind` recorded moments earlier.
     #[arg(long = "overwrite-state")]
     pub(crate) overwrite_state: bool,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1041,8 +1041,10 @@ pub(crate) enum InitSkipPhase {
 
 // Each boolean flag corresponds to an explicit, per-prompt
 // non-interactive opt-out on the `init` surface (`--no-eab`,
-// `--save-unseal-keys`, `--no-save-unseal-keys`, plus the internal
-// `reinit_mode`).  Per the project pattern (#588 §3b), `init` uses
+// `--save-unseal-keys`, `--no-save-unseal-keys`,
+// `--overwrite-password`, `--overwrite-ca-json`, `--overwrite-state`,
+// `--confirm-db-provision`, plus the internal `reinit_mode`).  Per the
+// project pattern (#588 §3b), `init` uses
 // per-prompt explicit flags rather than a global `--yes`, so refactoring
 // them into a single state enum would obscure the clap-level mutual
 // exclusivity (`conflicts_with`) and `requires = "summary_json"`
@@ -1185,6 +1187,33 @@ pub(crate) struct InitArgs {
         conflicts_with = "save_unseal_keys"
     )]
     pub(crate) no_save_unseal_keys: bool,
+
+    /// Skip the "Overwrite password.txt?" prompt and overwrite the file.
+    /// Equivalent to answering `y` at that prompt.  No-op when
+    /// `<secrets_dir>/password.txt` does not exist.
+    #[arg(long = "overwrite-password")]
+    pub(crate) overwrite_password: bool,
+
+    /// Skip the "Overwrite ca.json?" prompt and overwrite the file.
+    /// Equivalent to answering `y` at that prompt.  No-op when
+    /// `<secrets_dir>/config/ca.json` does not exist.
+    #[arg(long = "overwrite-ca-json")]
+    pub(crate) overwrite_ca_json: bool,
+
+    /// Skip the "Overwrite state.json?" prompt and overwrite the file.
+    /// Equivalent to answering `y` at that prompt.  No-op when
+    /// `state.json` does not exist.  Needed by automated installs, where
+    /// the `state.json` in place is the bind intent that `infra install
+    /// --stepca-bind` / `--openbao-bind` recorded moments earlier
+    #[arg(long = "overwrite-state")]
+    pub(crate) overwrite_state: bool,
+
+    /// Skip the "Provision `PostgreSQL` role/database?" prompt and
+    /// provision.  Equivalent to answering `y` at that prompt.  Does not
+    /// enable the feature: no-op unless `--enable db-provision` is also
+    /// passed.
+    #[arg(long = "confirm-db-provision")]
+    pub(crate) confirm_db_provision: bool,
 
     /// Internal: invoked from `bootroot reinit`.  Suppresses overwrite
     /// prompts for files that the reinit caller has already decided to
@@ -2139,6 +2168,80 @@ mod tests {
             result.is_err(),
             "--save-unseal-keys and --no-save-unseal-keys must be mutually exclusive"
         );
+    }
+
+    /// Closes #735: each pre-flight confirmation flag parses on its own
+    /// and leaves the other three unset — none implies another.
+    #[test]
+    fn test_cli_parses_init_preflight_confirmation_flags_individually() {
+        for (flag, pick) in [
+            ("--overwrite-password", 0),
+            ("--overwrite-ca-json", 1),
+            ("--overwrite-state", 2),
+            ("--confirm-db-provision", 3),
+        ] {
+            let cli = Cli::parse_from(["bootroot", "init", flag]);
+            match cli.command {
+                CliCommand::Init(args) => {
+                    let set = [
+                        args.overwrite_password,
+                        args.overwrite_ca_json,
+                        args.overwrite_state,
+                        args.confirm_db_provision,
+                    ];
+                    for (index, value) in set.iter().enumerate() {
+                        assert_eq!(
+                            *value,
+                            index == pick,
+                            "{flag} must set only its own field (index {index})"
+                        );
+                    }
+                }
+                _ => panic!("expected init"),
+            }
+        }
+    }
+
+    /// All four pre-flight confirmation flags are mutually independent,
+    /// so clap must accept them together with no conflict.
+    #[test]
+    fn test_cli_parses_init_all_preflight_confirmation_flags_together() {
+        let cli = Cli::parse_from([
+            "bootroot",
+            "init",
+            "--overwrite-password",
+            "--overwrite-ca-json",
+            "--overwrite-state",
+            "--confirm-db-provision",
+            "--enable",
+            "db-provision",
+        ]);
+        match cli.command {
+            CliCommand::Init(args) => {
+                assert!(args.overwrite_password);
+                assert!(args.overwrite_ca_json);
+                assert!(args.overwrite_state);
+                assert!(args.confirm_db_provision);
+                assert!(args.has_feature(InitFeature::DbProvision));
+            }
+            _ => panic!("expected init"),
+        }
+    }
+
+    /// Default `init` leaves all four pre-flight confirmation flags
+    /// false — the interactive prompt path stays unchanged.
+    #[test]
+    fn test_cli_init_default_preflight_confirmation_flags_unset() {
+        let cli = Cli::parse_from(["bootroot", "init"]);
+        match cli.command {
+            CliCommand::Init(args) => {
+                assert!(!args.overwrite_password);
+                assert!(!args.overwrite_ca_json);
+                assert!(!args.overwrite_state);
+                assert!(!args.confirm_db_provision);
+            }
+            _ => panic!("expected init"),
+        }
     }
 
     /// Default `init` (no save-unseal-keys flag) leaves both fields

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -770,6 +770,10 @@ pub(super) mod test_support {
             no_eab: false,
             save_unseal_keys: false,
             no_save_unseal_keys: false,
+            overwrite_password: false,
+            overwrite_ca_json: false,
+            overwrite_state: false,
+            confirm_db_provision: false,
             reinit_mode: false,
             root_token_output: None,
         }

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -1409,14 +1409,25 @@ mod tests {
     use super::super::test_support::{default_init_args, test_messages};
     use super::*;
 
-    fn plan_with(password: bool, ca_json: bool, state: bool) -> InitPlan {
+    /// Every pre-flight condition an `InitPlan` can carry, so
+    /// `plan_with(ALL_ARTIFACTS)` reads as "all three files exist".
+    const ALL_ARTIFACTS: &[PreflightPrompt] = &[
+        PreflightPrompt::OverwritePassword,
+        PreflightPrompt::OverwriteCaJson,
+        PreflightPrompt::OverwriteState,
+    ];
+
+    /// Builds a plan whose overwrite conditions hold for exactly the
+    /// artifacts in `existing`, naming each condition rather than
+    /// relying on the reader to track positional booleans.
+    fn plan_with(existing: &[PreflightPrompt]) -> InitPlan {
         InitPlan {
             openbao_url: "http://localhost:8200".to_string(),
             kv_mount: "secret".to_string(),
             secrets_dir: std::path::PathBuf::from("secrets"),
-            overwrite_password: password,
-            overwrite_ca_json: ca_json,
-            overwrite_state: state,
+            overwrite_password: existing.contains(&PreflightPrompt::OverwritePassword),
+            overwrite_ca_json: existing.contains(&PreflightPrompt::OverwriteCaJson),
+            overwrite_state: existing.contains(&PreflightPrompt::OverwriteState),
         }
     }
 
@@ -1425,7 +1436,7 @@ mod tests {
     #[test]
     fn preflight_prompts_asks_nothing_when_no_condition_holds() {
         let args = default_init_args();
-        assert!(preflight_prompts(&args, &plan_with(false, false, false)).is_empty());
+        assert!(preflight_prompts(&args, &plan_with(&[])).is_empty());
 
         // Closes #735: a flag whose condition does not hold is a silent
         // no-op, not an error and not a behaviour change.
@@ -1434,7 +1445,7 @@ mod tests {
         args.overwrite_ca_json = true;
         args.overwrite_state = true;
         args.confirm_db_provision = true;
-        assert!(preflight_prompts(&args, &plan_with(false, false, false)).is_empty());
+        assert!(preflight_prompts(&args, &plan_with(&[])).is_empty());
     }
 
     /// Every condition holds and no flag answers it: all four prompts
@@ -1444,7 +1455,7 @@ mod tests {
         let mut args = default_init_args();
         args.enable.push(InitFeature::DbProvision);
         assert_eq!(
-            preflight_prompts(&args, &plan_with(true, true, true)),
+            preflight_prompts(&args, &plan_with(ALL_ARTIFACTS)),
             vec![
                 PreflightPrompt::OverwritePassword,
                 PreflightPrompt::OverwriteCaJson,
@@ -1458,7 +1469,7 @@ mod tests {
     /// caller that sets one still gets asked about the other three.
     #[test]
     fn preflight_prompts_flags_suppress_only_their_own_prompt() {
-        let plan = plan_with(true, true, true);
+        let plan = plan_with(ALL_ARTIFACTS);
         let all = [
             PreflightPrompt::OverwritePassword,
             PreflightPrompt::OverwriteCaJson,
@@ -1496,7 +1507,7 @@ mod tests {
         args.overwrite_state = true;
         args.confirm_db_provision = true;
         assert!(
-            preflight_prompts(&args, &plan_with(true, true, true)).is_empty(),
+            preflight_prompts(&args, &plan_with(ALL_ARTIFACTS)).is_empty(),
             "all four flags together must leave no prompt to read from stdin"
         );
     }
@@ -1506,7 +1517,7 @@ mod tests {
     /// not answer any overwrite prompt.
     #[test]
     fn preflight_prompts_overwrite_and_db_provision_flags_stay_disjoint() {
-        let plan = plan_with(true, true, true);
+        let plan = plan_with(ALL_ARTIFACTS);
 
         let mut args = default_init_args();
         args.enable.push(InitFeature::DbProvision);
@@ -1537,7 +1548,7 @@ mod tests {
     /// file: `--confirm-db-provision` alone never enables it.
     #[test]
     fn preflight_prompts_db_provision_follows_the_feature() {
-        let plan = plan_with(false, false, false);
+        let plan = plan_with(&[]);
 
         let args = default_init_args();
         assert!(preflight_prompts(&args, &plan).is_empty());
@@ -1560,7 +1571,7 @@ mod tests {
         let mut args = default_init_args();
         args.enable.push(InitFeature::DbProvision);
         args.reinit_mode = true;
-        assert!(preflight_prompts(&args, &plan_with(true, true, true)).is_empty());
+        assert!(preflight_prompts(&args, &plan_with(ALL_ARTIFACTS)).is_empty());
     }
 
     /// Each prompt renders its own message, so the loop in

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -1484,6 +1484,55 @@ mod tests {
         }
     }
 
+    /// Closes #735: the whole pre-flight block clears with every
+    /// condition holding once all four flags are set, which is what lets
+    /// an automated install run `init` with stdin closed.
+    #[test]
+    fn preflight_prompts_all_flags_clear_every_prompt() {
+        let mut args = default_init_args();
+        args.enable.push(InitFeature::DbProvision);
+        args.overwrite_password = true;
+        args.overwrite_ca_json = true;
+        args.overwrite_state = true;
+        args.confirm_db_provision = true;
+        assert!(
+            preflight_prompts(&args, &plan_with(true, true, true)).is_empty(),
+            "all four flags together must leave no prompt to read from stdin"
+        );
+    }
+
+    /// Closes #735: the three overwrite flags alone do not answer the
+    /// db-provision confirmation, and `--confirm-db-provision` alone does
+    /// not answer any overwrite prompt.
+    #[test]
+    fn preflight_prompts_overwrite_and_db_provision_flags_stay_disjoint() {
+        let plan = plan_with(true, true, true);
+
+        let mut args = default_init_args();
+        args.enable.push(InitFeature::DbProvision);
+        args.overwrite_password = true;
+        args.overwrite_ca_json = true;
+        args.overwrite_state = true;
+        assert_eq!(
+            preflight_prompts(&args, &plan),
+            vec![PreflightPrompt::DbProvision],
+            "the overwrite flags must not answer the db-provision confirmation"
+        );
+
+        let mut args = default_init_args();
+        args.enable.push(InitFeature::DbProvision);
+        args.confirm_db_provision = true;
+        assert_eq!(
+            preflight_prompts(&args, &plan),
+            vec![
+                PreflightPrompt::OverwritePassword,
+                PreflightPrompt::OverwriteCaJson,
+                PreflightPrompt::OverwriteState,
+            ],
+            "--confirm-db-provision must not answer any overwrite prompt"
+        );
+    }
+
     /// The db-provision confirmation is gated on the feature, not on any
     /// file: `--confirm-db-provision` alone never enables it.
     #[test]

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -26,7 +26,7 @@ use super::openbao_tls::{
     build_openbao_tls_sans, issue_openbao_tls_cert, record_openbao_infra_cert,
     write_openbao_hcl_with_tls,
 };
-use super::prompts::confirm_overwrite;
+use super::prompts::{confirm_overwrite, should_confirm};
 use super::responder_setup::{
     apply_responder_compose_override, verify_responder, write_responder_compose_override,
     write_responder_files,
@@ -335,6 +335,67 @@ async fn write_root_token_file(path: &Path, token: &str) -> Result<()> {
     Ok(())
 }
 
+/// One of the confirmations init asks before it starts writing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreflightPrompt {
+    OverwritePassword,
+    OverwriteCaJson,
+    OverwriteState,
+    DbProvision,
+}
+
+impl PreflightPrompt {
+    fn message(self, messages: &Messages) -> &str {
+        match self {
+            Self::OverwritePassword => messages.prompt_confirm_overwrite_password(),
+            Self::OverwriteCaJson => messages.prompt_confirm_overwrite_ca_json(),
+            Self::OverwriteState => messages.prompt_confirm_overwrite_state(),
+            Self::DbProvision => messages.prompt_confirm_db_provision(),
+        }
+    }
+}
+
+/// Decides which pre-flight confirmations `run_init_inner` must ask, in
+/// the order it asks them.
+///
+/// Each prompt is gated on its own condition (file existence for the
+/// three overwrite prompts, the `db-provision` feature for the fourth)
+/// and answered non-interactively by its own flag alone, so no flag
+/// implies another.  Under reinit mode the operator has already
+/// authorized destructive recovery at the `reinit` level, and reinit
+/// explicitly preserves `password.txt`, `ca.json`, and the
+/// (just-rewritten) `state.json` — suppressing all four keeps
+/// `reinit --yes` non-interactive.
+fn preflight_prompts(args: &InitArgs, plan: &InitPlan) -> Vec<PreflightPrompt> {
+    let reinit = args.reinit_mode;
+    [
+        (
+            PreflightPrompt::OverwritePassword,
+            plan.overwrite_password,
+            args.overwrite_password,
+        ),
+        (
+            PreflightPrompt::OverwriteCaJson,
+            plan.overwrite_ca_json,
+            args.overwrite_ca_json,
+        ),
+        (
+            PreflightPrompt::OverwriteState,
+            plan.overwrite_state,
+            args.overwrite_state,
+        ),
+        (
+            PreflightPrompt::DbProvision,
+            args.has_feature(InitFeature::DbProvision),
+            args.confirm_db_provision,
+        ),
+    ]
+    .into_iter()
+    .filter(|&(_, condition, confirmed)| should_confirm(condition, confirmed, reinit))
+    .map(|(prompt, _, _)| prompt)
+    .collect()
+}
+
 #[allow(clippy::too_many_lines)]
 // Keep init flow in one place to preserve ordering across subsystems.
 async fn run_init_inner(
@@ -362,23 +423,8 @@ async fn run_init_inner(
         overwrite_state,
     };
     print_init_plan(&plan, messages);
-    // Under reinit mode the operator has already authorized destructive
-    // recovery at the `reinit` level, and reinit explicitly preserves
-    // `password.txt`, `ca.json`, and the (just-rewritten) `state.json`.
-    // Skipping these prompts keeps `reinit --yes` non-interactive.
-    if !args.reinit_mode {
-        if overwrite_password {
-            confirm_overwrite(messages.prompt_confirm_overwrite_password(), messages)?;
-        }
-        if overwrite_ca_json {
-            confirm_overwrite(messages.prompt_confirm_overwrite_ca_json(), messages)?;
-        }
-        if overwrite_state {
-            confirm_overwrite(messages.prompt_confirm_overwrite_state(), messages)?;
-        }
-        if args.has_feature(InitFeature::DbProvision) {
-            confirm_overwrite(messages.prompt_confirm_db_provision(), messages)?;
-        }
+    for prompt in preflight_prompts(args, &plan) {
+        confirm_overwrite(prompt.message(messages), messages)?;
     }
 
     // Load .env into the process environment so that
@@ -1362,6 +1408,132 @@ fn validate_http01_exposed_override_for_init(
 mod tests {
     use super::super::test_support::{default_init_args, test_messages};
     use super::*;
+
+    fn plan_with(password: bool, ca_json: bool, state: bool) -> InitPlan {
+        InitPlan {
+            openbao_url: "http://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+            secrets_dir: std::path::PathBuf::from("secrets"),
+            overwrite_password: password,
+            overwrite_ca_json: ca_json,
+            overwrite_state: state,
+        }
+    }
+
+    /// Nothing on disk and no `db-provision`: the pre-flight block asks
+    /// nothing, whatever the new flags say.
+    #[test]
+    fn preflight_prompts_asks_nothing_when_no_condition_holds() {
+        let args = default_init_args();
+        assert!(preflight_prompts(&args, &plan_with(false, false, false)).is_empty());
+
+        // Closes #735: a flag whose condition does not hold is a silent
+        // no-op, not an error and not a behaviour change.
+        let mut args = default_init_args();
+        args.overwrite_password = true;
+        args.overwrite_ca_json = true;
+        args.overwrite_state = true;
+        args.confirm_db_provision = true;
+        assert!(preflight_prompts(&args, &plan_with(false, false, false)).is_empty());
+    }
+
+    /// Every condition holds and no flag answers it: all four prompts
+    /// fire, in the order init has always asked them.
+    #[test]
+    fn preflight_prompts_asks_all_four_without_flags() {
+        let mut args = default_init_args();
+        args.enable.push(InitFeature::DbProvision);
+        assert_eq!(
+            preflight_prompts(&args, &plan_with(true, true, true)),
+            vec![
+                PreflightPrompt::OverwritePassword,
+                PreflightPrompt::OverwriteCaJson,
+                PreflightPrompt::OverwriteState,
+                PreflightPrompt::DbProvision,
+            ]
+        );
+    }
+
+    /// Closes #735: each flag suppresses exactly its own prompt, so a
+    /// caller that sets one still gets asked about the other three.
+    #[test]
+    fn preflight_prompts_flags_suppress_only_their_own_prompt() {
+        let plan = plan_with(true, true, true);
+        let all = [
+            PreflightPrompt::OverwritePassword,
+            PreflightPrompt::OverwriteCaJson,
+            PreflightPrompt::OverwriteState,
+            PreflightPrompt::DbProvision,
+        ];
+
+        for suppressed in all {
+            let mut args = default_init_args();
+            args.enable.push(InitFeature::DbProvision);
+            match suppressed {
+                PreflightPrompt::OverwritePassword => args.overwrite_password = true,
+                PreflightPrompt::OverwriteCaJson => args.overwrite_ca_json = true,
+                PreflightPrompt::OverwriteState => args.overwrite_state = true,
+                PreflightPrompt::DbProvision => args.confirm_db_provision = true,
+            }
+            let expected: Vec<_> = all.iter().copied().filter(|&p| p != suppressed).collect();
+            assert_eq!(
+                preflight_prompts(&args, &plan),
+                expected,
+                "{suppressed:?} must suppress only its own prompt"
+            );
+        }
+    }
+
+    /// The db-provision confirmation is gated on the feature, not on any
+    /// file: `--confirm-db-provision` alone never enables it.
+    #[test]
+    fn preflight_prompts_db_provision_follows_the_feature() {
+        let plan = plan_with(false, false, false);
+
+        let args = default_init_args();
+        assert!(preflight_prompts(&args, &plan).is_empty());
+
+        let mut args = default_init_args();
+        args.enable.push(InitFeature::DbProvision);
+        assert_eq!(
+            preflight_prompts(&args, &plan),
+            vec![PreflightPrompt::DbProvision]
+        );
+
+        args.confirm_db_provision = true;
+        assert!(preflight_prompts(&args, &plan).is_empty());
+    }
+
+    /// `--reinit-mode` suppresses all four prompts on its own, so
+    /// `reinit --yes` stays non-interactive without the new flags.
+    #[test]
+    fn preflight_prompts_reinit_mode_suppresses_everything() {
+        let mut args = default_init_args();
+        args.enable.push(InitFeature::DbProvision);
+        args.reinit_mode = true;
+        assert!(preflight_prompts(&args, &plan_with(true, true, true)).is_empty());
+    }
+
+    /// Each prompt renders its own message, so the loop in
+    /// `run_init_inner` cannot ask about the wrong file.
+    #[test]
+    fn preflight_prompt_messages_are_distinct() {
+        let messages = test_messages();
+        let rendered = [
+            PreflightPrompt::OverwritePassword.message(&messages),
+            PreflightPrompt::OverwriteCaJson.message(&messages),
+            PreflightPrompt::OverwriteState.message(&messages),
+            PreflightPrompt::DbProvision.message(&messages),
+        ];
+        assert_eq!(
+            rendered
+                .iter()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            rendered.len(),
+            "each pre-flight prompt must render its own message"
+        );
+    }
 
     /// Closes #588 §5a: when `OpenBao` is already initialised but no
     /// usable root token is supplied, `init` must abort with the

--- a/src/commands/init/steps/prompts.rs
+++ b/src/commands/init/steps/prompts.rs
@@ -63,3 +63,55 @@ pub(super) fn confirm_overwrite(prompt: &str, messages: &Messages) -> Result<()>
     }
     anyhow::bail!(messages.error_operation_cancelled());
 }
+
+/// Decides whether one of init's pre-flight confirmations must be shown.
+///
+/// `condition` is what the prompt guards — file existence for the three
+/// overwrite prompts, `has_feature(InitFeature::DbProvision)` for the
+/// db-provision confirmation.  `confirmed` is that prompt's own
+/// non-interactive flag (`--overwrite-password`, `--overwrite-ca-json`,
+/// `--overwrite-state`, `--confirm-db-provision`), which answers `y` on
+/// the operator's behalf.  `reinit_mode` suppresses every prompt in the
+/// block because `reinit` has already taken the operator's decision.
+///
+/// Each prompt is gated independently: no flag implies another, and a
+/// flag whose `condition` is false is a silent no-op.
+pub(super) const fn should_confirm(condition: bool, confirmed: bool, reinit_mode: bool) -> bool {
+    condition && !confirmed && !reinit_mode
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_confirm;
+
+    /// A prompt whose condition does not hold never fires, whatever the
+    /// flag says — passing a flag for an absent file is a silent no-op.
+    #[test]
+    fn test_should_confirm_skips_when_condition_absent() {
+        assert!(!should_confirm(false, false, false));
+        assert!(!should_confirm(false, true, false));
+        assert!(!should_confirm(false, false, true));
+        assert!(!should_confirm(false, true, true));
+    }
+
+    /// Condition holds and no flag answers it: the interactive default
+    /// is preserved and the prompt fires.
+    #[test]
+    fn test_should_confirm_prompts_when_condition_holds_and_flag_unset() {
+        assert!(should_confirm(true, false, false));
+    }
+
+    /// The prompt's own flag answers it as if the operator typed `y`.
+    #[test]
+    fn test_should_confirm_skips_when_flag_set() {
+        assert!(!should_confirm(true, true, false));
+    }
+
+    /// `reinit_mode` suppresses the prompt on its own, regardless of the
+    /// per-prompt flag, so `reinit --yes` stays non-interactive.
+    #[test]
+    fn test_should_confirm_skips_under_reinit_mode() {
+        assert!(!should_confirm(true, false, true));
+        assert!(!should_confirm(true, true, true));
+    }
+}

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -1000,6 +1000,12 @@ fn init_args_for_reinit(
         no_eab: args.no_eab,
         save_unseal_keys: false,
         no_save_unseal_keys: false,
+        // `reinit_mode` already suppresses the four pre-flight
+        // confirmations, so reinit never needs the per-prompt flags.
+        overwrite_password: false,
+        overwrite_ca_json: false,
+        overwrite_state: false,
+        confirm_db_provision: false,
         reinit_mode: true,
         root_token_output: args.root_token_output.clone(),
     })

--- a/tests/bootroot_cli.rs
+++ b/tests/bootroot_cli.rs
@@ -106,6 +106,22 @@ fn test_help_lists_subcommands() {
     assert!(stdout.contains("verify"));
 }
 
+/// Closes #735: every pre-flight confirmation flag is discoverable from
+/// `init --help`, so an operator automating the install can find them.
+#[test]
+fn test_init_help_lists_preflight_confirmation_flags() {
+    let (stdout, _stderr, code) = run(&["init", "--help"]);
+    assert_eq!(code, 0);
+    for flag in [
+        "--overwrite-password",
+        "--overwrite-ca-json",
+        "--overwrite-state",
+        "--confirm-db-provision",
+    ] {
+        assert!(stdout.contains(flag), "init --help must document {flag}");
+    }
+}
+
 #[test]
 fn test_status_command_message() {
     let (stdout, _stderr, code) = run(&["--help"]);


### PR DESCRIPTION
## Summary

`bootroot init` runs four confirmations in its pre-flight block — three that guard overwriting `password.txt`, `ca.json` and `state.json`, plus one that confirms PostgreSQL role/database provisioning. None could be answered without a TTY, so an automated install had to either let `init` cancel (after `bootstrap_openbao` had already initialised OpenBao and minted a root token) or delete the `state.json` that `infra install --stepca-bind` / `--openbao-bind` had just written to record the bind intent — the same intent `init` derives step-ca's certificate SANs from.

This PR adds one explicit, per-prompt flag for each confirmation:

| flag | prompt it answers | gated on |
| --- | --- | --- |
| `--overwrite-password` | `Overwrite password.txt? [y/N]:` | `password.txt` exists |
| `--overwrite-ca-json` | `Overwrite ca.json? [y/N]:` | `ca.json` exists |
| `--overwrite-state` | `Overwrite state.json? [y/N]:` | `state.json` exists |
| `--confirm-db-provision` | `Provision PostgreSQL role/database? [y/N]:` | `--enable db-provision` was passed |

- The gating decision is a pure predicate, `should_confirm(condition, confirmed, reinit_mode)` in `src/commands/init/steps/prompts.rs`, so it is unit-testable without an `OpenBaoClient` or a full init run. `run_init_inner` now builds its prompt list through `preflight_prompts`, which pairs each `PreflightPrompt` variant with its own condition and its own flag.
- The four flags are mutually independent: no `conflicts_with`, no `requires`, and none implies another. A flag whose condition does not hold is a silent no-op.
- The interactive default is untouched. Without a flag the prompt still fires, and an empty or non-`y` answer still cancels with the existing operation-cancelled error. `--reinit-mode` keeps suppressing all four on its own, so `reinit --yes` stays non-interactive.
- `scripts/impl/run-stepca-san.sh` drops the `printf 'y\ny\ny\n'` workaround: both `init` invocations now run with stdin from `/dev/null`. `run_first_init` passes the three overwrite flags plus `--confirm-db-provision`; `run_second_init` passes the three overwrite flags only, which also demonstrates the confirmation flag is independent of the feature rather than implied by it.
- `docs/en/cli.md` and `docs/ko/cli.md` document all four flags alongside the existing `--no-eab` / `--save-unseal-keys` entries, and a CHANGELOG entry was added. The `#[allow(clippy::struct_excessive_bools)]` justification above `InitArgs` was updated to name the new booleans.

Closes #735

## Test plan

- [x] `--overwrite-password`, `--overwrite-ca-json`, `--overwrite-state` and `--confirm-db-provision` parse, default to `false`, and appear in `init --help` (`tests/bootroot_cli.rs::test_init_help_lists_preflight_confirmation_flags`)
- [x] Each flag sets only its own field and any combination parses with no clap conflict (`src/cli/args.rs::test_cli_parses_init_preflight_confirmation_flags_individually`, `..._all_preflight_confirmation_flags_together`, `test_cli_init_default_preflight_confirmation_flags_unset`)
- [x] Prompt-gating truth table for each overwrite prompt: condition absent → no prompt; condition present and flag unset → prompt; flag set → no prompt; `reinit_mode` → no prompt regardless (`src/commands/init/steps/prompts.rs` tests)
- [x] Same truth table for the db-provision confirmation, whose condition is `has_feature(InitFeature::DbProvision)` rather than a file (`src/commands/init/steps/orchestrator.rs::preflight_prompts` tests)
- [x] Each flag suppresses exactly its own prompt — `--overwrite-state` alone with `password.txt` present still fires the password prompt; `--confirm-db-provision` neither enables the feature nor suppresses any overwrite prompt
- [x] Passing a flag whose condition does not hold is a silent no-op, not an error
- [x] Without any new flag the prompts still fire and a non-`y` answer still cancels
- [x] `--reinit-mode` suppresses all four regardless of the flags; `reinit` passes them as `false` (`src/commands/reinit.rs::init_args_for_reinit`). Also exercised end to end by the green `Docker E2E (reinit-recovery)` scenario, which drives `reinit --yes` non-interactively.
- [x] `cargo test --bin bootroot` — 877 passed, 0 failed
- [x] `cargo fmt --check` clean and `cargo clippy --all-targets --all-features -- -D warnings` warning-free (`scripts/preflight/ci/check.sh` passes; the only warning is the pre-existing allowed `RUSTSEC-2025-0134` advisory)
- [x] `scripts/impl/run-stepca-san.sh` scenarios A and B stay green with stdin closed — verified through `Docker E2E (stepca-san)` on `5379a87` (run [30251565079](https://github.com/aicers/bootroot/actions/runs/30251565079)). The uploaded artifact shows both scenarios reaching the `done` phase with no fatal in `run.log`, `state.json`'s `stepca_bind_addr` = `172.17.0.1:9000`, `ca.json`'s `dnsNames` = `["localhost","bootroot-ca","stepca.internal","172.17.0.1"]` (still that set after the post-render stability re-check), `IP Address:172.17.0.1` in the `subjectAltName` read off the live listener in **both** scenarios, and the ACME directory fetched over verified TLS in both — scenario B through the CA bundle captured *before* the repair, which is what pins the unchanged fingerprints.
- [x] `scripts/preflight/ci/e2e-matrix.sh` — the SAN harness is Linux-only (`ensure_bind_host_available` needs `ip`, and the bind host is the `docker0` gateway `172.17.0.1`; neither exists under Docker Desktop on macOS), so this was verified through its CI equivalent: all seven Docker E2E scenarios — local-hosts, local-no-hosts, remote-hosts, remote-no-hosts, rotation, reinit-recovery and stepca-san — are green on `5379a87`.
- [x] End to end: `infra install --stepca-bind <addr>` followed by a non-interactive `init` leaves the bind intent intact, so `ca.json`'s `dnsNames` and the served certificate both carry `<addr>`. Verified in CI (above) **and** reproduced locally on macOS against a real stack brought up on free host ports (`--openbao-host-port 8210 --stepca-host-port 9020 --postgres-host-port 5442 --http01-admin-host-port 8090`, bind `172.30.1.73:9010`):
  - `init … </dev/null` with the four flags exited `0`; `state.json`'s `stepca_bind_addr` stayed `172.30.1.73:9010`, `ca.json`'s `dnsNames` came out `["localhost","bootroot-ca","stepca.internal","172.30.1.73"]`, and `ca.json.ctmpl` carried the address too.
  - step-ca served `X509v3 Subject Alternative Name: DNS:localhost, DNS:bootroot-ca, DNS:stepca.internal, IP Address:172.30.1.73` on the published non-loopback address, and `curl --cacert <bundle> https://172.30.1.73:9010/acme/acme/directory` returned the directory with no hostname-verification error.
  - On that fresh install only `state.json` existed at prompt time, so `--overwrite-password` and `--overwrite-ca-json` were observed as live silent no-ops.
  - Negative controls on the same stack, all with stdin closed: no flags → `Overwrite password.txt? [y/N]:` fires and the run exits `1` with `Operation cancelled`; `--overwrite-state` alone → the password prompt still fires and still cancels; the three overwrite flags with `db-provision` off (the `run_second_init` shape) → exits `0`; `--confirm-db-provision` without `--enable db-provision` → exits `0`, provisions nothing, and the root CA fingerprint is unchanged.
