### PR TITLE
Scope Compose to an explicit instance identity (#745)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,7 @@ jobs:
           # rendered config (with the correct HMAC) is preserved.
           RESPONDER_OVERRIDE="$BOOTROOT_SECRETS_DIR/responder/docker-compose.responder.override.yml"
           docker compose \
+            -p "${COMPOSE_PROJECT_NAME:-bootroot}" \
             -f docker-compose.yml \
             -f "$RESPONDER_OVERRIDE" \
             -f docker-compose.test.yml \
@@ -371,7 +372,9 @@ jobs:
 
       - name: Cleanup
         if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.test.yml down
+        run: >-
+          docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}"
+          -f docker-compose.yml -f docker-compose.test.yml down
 
   test-docker-e2e-matrix:
     name: Docker E2E (${{ matrix.scenario.label }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -918,6 +918,25 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `bootroot infra install --instance-name <name>` gives an install an
+  explicit identity and threads it through every `docker compose`
+  invocation as `-p <name>`, so two installs on one host stop sharing a
+  Compose project — and therefore volumes. Previously neither compose
+  file set a top-level `name:` and no invocation passed `-p`, so both
+  installs landed in the project Compose derives from the compose
+  directory's basename and the second one adopted the first's containers
+  and volumes silently. The value is validated (lowercase ASCII letters,
+  digits and `-`, starting with a letter or digit, at most 39 characters
+  — derived so `<name>-openbao-agent-responder` fits a 63-octet DNS
+  label) and recorded as `BOOTROOT_INSTANCE` in the compose directory's
+  `.env`. Every other compose-driving command — `status`, `infra up`,
+  `init`, `reinit`, `clean`, `ca restart`, `rotate infra-cert`,
+  `monitoring up`/`status`/`down` — reads the project back from the
+  `.env` beside the compose file it was handed, with no flag of its own
+  and regardless of the process working directory. Container names are
+  still literal, so a second co-located install with a distinct identity
+  now fails loudly with Docker's container-name-already-in-use error
+  instead of cannibalising the first. (Closes #745)
 - `bootroot init` accepts `--overwrite-password`, `--overwrite-ca-json`,
   `--overwrite-state` and `--confirm-db-provision`, one per confirmation
   in the pre-flight block that previously could only be answered from a
@@ -1821,6 +1840,31 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- All 25 `docker compose` invocation sites now build their argument
+  vector through one shared constructor, which is what emits `-p`; a
+  test fails when a compose vector is built anywhere else. `clean` and
+  `reinit` no longer derive the project from the `bootroot-openbao`
+  container's `com.docker.compose.project` label or from the compose
+  directory's basename — both fold onto the shared resolver, whose order
+  is `--instance-name`, then `COMPOSE_PROJECT_NAME` from the
+  environment, then `BOOTROOT_INSTANCE` from `.env`, then the literal
+  `bootroot`. `reinit` still reads the live container's project label as
+  the "what is" side of its mismatch check, so that check stays a real
+  comparison. An exported `COMPOSE_PROJECT_NAME` still overrides the
+  project for a single invocation, is used verbatim without
+  instance-name validation, and is never recorded — the E2E harness
+  keeps isolating scenarios exactly as before. Only an *exported*
+  variable counts: `init` loads the compose directory's `.env` into its
+  process environment part-way through, and that load now skips
+  `COMPOSE_PROJECT_NAME` so a `.env`-authored value cannot become an
+  override for the second half of the run and split one `init` across two
+  compose projects. One consequence: a fresh install in a directory not
+  named `bootroot` now lands in project `bootroot` rather than the
+  normalised basename.
+- `dns_alias` now filters the HTTP-01 responder lookup on
+  `com.docker.compose.project` as well as the service label, and errors
+  instead of taking the first match when more than one container still
+  matches. (Closes #745)
 - Pinned the `bootroot-http01-responder` builder to
   `rust:1.97.1-slim-bookworm` and dropped the nightly toolchain install.
   The builder previously floated on `rust:slim-bookworm` and then made

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -168,6 +168,18 @@ and `--no-build` uses them as-is instead of rebuilding from source. See
 ### Inputs
 
 - `--compose-file`: compose file path (default `docker-compose.yml`)
+- `--instance-name <name>`: this install's identity (default `bootroot`).
+  It names the Docker Compose project, so the created containers carry
+  `com.docker.compose.project=<name>` and the created volumes are
+  `<name>_openbao-data`, `<name>_postgres-data`, and so on. The value is
+  recorded as `BOOTROOT_INSTANCE` in the compose directory's `.env`;
+  every later command — `status`, `infra up`, `init`, `reinit`, `clean`,
+  `rotate`, `monitoring …` — reads it back from there and has no flag of
+  its own. Allowed: lowercase ASCII letters, digits and `-`, starting
+  with a letter or digit, at most 39 characters (the limit leaves room
+  for the longest container-name suffix inside a 63-octet DNS label).
+  Re-running `infra install` without the flag keeps the recorded value
+  instead of resetting it to `bootroot`.
 - `--services`: services to start (default `openbao,postgres,step-ca,bootroot-http01`)
 - `--image-archive-dir`: local image archive directory (optional).
   When set, every `.tar`/`.tgz`/`.tar.gz` archive in the directory is
@@ -234,6 +246,42 @@ and `--no-build` uses them as-is instead of rebuilding from source. See
 - `--http01-admin-host-port <N>`: host-side HTTP-01 responder admin API
   published port. Overrides `HTTP01_ADMIN_HOST_PORT` from `.env` and the
   process environment. Default **8080**.
+
+#### Instance identity and the Compose project
+
+`--instance-name` is the whole identity of an install. bootroot passes it
+to every `docker compose` invocation as `-p <name>`, so an install that
+declares one stops sharing another install's project — and therefore its
+volumes.
+
+The project a command acts on is resolved in this order:
+
+1. `--instance-name`, on `infra install` only;
+2. `COMPOSE_PROJECT_NAME` from the invoking environment, when non-empty;
+3. `BOOTROOT_INSTANCE` from the `.env` beside the compose file the
+   command was handed;
+4. the literal `bootroot`.
+
+An exported `COMPOSE_PROJECT_NAME` overrides the Compose project name for
+a single invocation and nothing else. It is Docker Compose's own feature:
+it is used verbatim, is **not** validated against the `--instance-name`
+rules, and is **never** recorded in `.env`. A fresh install run under one
+creates the stack in the exported project but still records the identity
+it would have had without it, so every later command against that stack
+needs the same variable exported. Use it for throwaway stacks (this
+repository's E2E harness does); use `--instance-name` for anything
+durable.
+
+Co-locating two bootroot instances on one host requires giving each a
+distinct `--instance-name`. Two installs that both take the default
+identity share one project and one set of volumes, and the second adopts
+the first's containers.
+
+Container names are still literal (`bootroot-openbao`, `bootroot-ca`, …)
+and do not yet follow the identity. A second co-located install with a
+distinct `--instance-name` therefore fails loudly with Docker's
+container-name-already-in-use error rather than silently taking over the
+first instance's containers, and the first instance is left untouched.
 
 #### Host-side published ports
 
@@ -2219,13 +2267,17 @@ operator-managed runbook for those.
 
 - Refuses to run when the compose file does not declare an
   `openbao` service, or when an existing `bootroot-openbao`
-  container's compose labels do not match the project derived from
-  the current work directory. A container that exists but is missing
-  either compose label (`com.docker.compose.project`,
-  `com.docker.compose.service`) is also rejected — it cannot be
-  proven to belong to this work directory's compose project, and
-  must not be collapsed into the stuck-after-`clean --openbao-only`
-  recovery path.
+  container's compose labels do not match the project the shared
+  resolver returns for the compose directory (the recorded
+  `BOOTROOT_INSTANCE`, an exported `COMPOSE_PROJECT_NAME`, or the
+  `bootroot` default — see
+  [Instance identity and the Compose project](#instance-identity-and-the-compose-project)).
+  The resolver deliberately never consults the container's own project
+  label, so the comparison stays a real one. A container that exists but
+  is missing either compose label (`com.docker.compose.project`,
+  `com.docker.compose.service`) is also rejected — it cannot be proven
+  to belong to this install's compose project, and must not be collapsed
+  into the stuck-after-`clean --openbao-only` recovery path.
 - Snapshots deployment-intent fields from `state.json` (OpenBao /
   HTTP-01 admin bind/advertise addresses, `infra_certs`, `secrets_dir`)
   before any destructive operation.

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -187,7 +187,14 @@ POSTGRES_USER=step
 POSTGRES_PASSWORD=<random-32-byte-hex>
 POSTGRES_DB=stepca
 GRAFANA_ADMIN_PASSWORD=admin
+BOOTROOT_INSTANCE=bootroot
 ```
+
+`BOOTROOT_INSTANCE` is the install's identity — the Docker Compose
+project every later command operates on. `bootroot infra install
+--instance-name <name>` sets it; every other command reads it back from
+here. See
+[Instance identity and the Compose project](cli.md#instance-identity-and-the-compose-project).
 
 Choose `sslmode` based on your environment:
 

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -163,6 +163,17 @@ bootroot infra up
 ### 입력
 
 - `--compose-file`: compose 파일 경로 (기본값 `docker-compose.yml`)
+- `--instance-name <name>`: 이 설치본의 정체성 (기본값 `bootroot`).
+  Docker Compose 프로젝트 이름이 되므로, 생성되는 컨테이너에는
+  `com.docker.compose.project=<name>` 레이블이 붙고 볼륨은
+  `<name>_openbao-data`, `<name>_postgres-data` 등으로 만들어집니다.
+  값은 compose 디렉터리의 `.env`에 `BOOTROOT_INSTANCE`로 기록되며,
+  이후 모든 명령(`status`, `infra up`, `init`, `reinit`, `clean`,
+  `rotate`, `monitoring …`)이 자체 플래그 없이 그곳에서 다시 읽습니다.
+  허용 형식: 소문자 ASCII 문자, 숫자, `-`이며 문자 또는 숫자로 시작하고
+  최대 39자입니다(63옥텟 DNS 레이블 안에서 가장 긴 컨테이너 이름
+  접미사를 담을 수 있도록 도출된 한계). 플래그 없이 `infra install`을
+  다시 실행하면 기록된 값을 `bootroot`로 되돌리지 않고 유지합니다.
 - `--services`: 기동 대상 서비스 목록 (기본값 `openbao,postgres,step-ca,bootroot-http01`)
 - `--image-archive-dir`: 로컬 이미지 아카이브 디렉터리(선택).
   설정하면 디렉터리 내 모든 `.tar`/`.tgz`/`.tar.gz` 아카이브를
@@ -230,6 +241,40 @@ bootroot infra up
 - `--http01-admin-host-port <N>`: 호스트 측 HTTP-01 응답기 admin API
   게시 포트입니다. `.env`의 `HTTP01_ADMIN_HOST_PORT`와 프로세스 환경
   변수보다 우선합니다. 기본값은 **8080**입니다.
+
+#### 인스턴스 정체성과 Compose 프로젝트
+
+`--instance-name`은 설치본의 정체성 전체입니다. bootroot는 모든
+`docker compose` 호출에 `-p <name>`으로 전달하므로, 정체성을 선언한
+설치본은 다른 설치본의 프로젝트 — 따라서 볼륨 — 를 더 이상 공유하지
+않습니다.
+
+명령이 대상으로 삼는 프로젝트는 다음 순서로 결정됩니다.
+
+1. `--instance-name` (`infra install`에만 존재);
+2. 호출 환경의 `COMPOSE_PROJECT_NAME`(비어 있지 않은 경우);
+3. 명령에 전달된 compose 파일 옆 `.env`의 `BOOTROOT_INSTANCE`;
+4. 리터럴 `bootroot`.
+
+내보낸 `COMPOSE_PROJECT_NAME`은 단일 호출에 한해 Compose 프로젝트
+이름만 덮어씁니다. 이는 Docker Compose 자체 기능이므로 값이 그대로
+사용되며, `--instance-name` 규칙으로 **검증되지 않고** `.env`에
+**기록되지도 않습니다**. 이 변수를 내보낸 상태로 새로 설치하면 스택은
+내보낸 프로젝트에 생성되지만 기록되는 정체성은 변수가 없었을 때의
+값이므로, 이후 그 스택을 다루는 모든 명령에도 같은 변수를 내보내야
+합니다. 일회성 스택에는 이 변수를(이 저장소의 E2E 하니스가 그렇게
+합니다), 지속적인 설치에는 `--instance-name`을 사용하세요.
+
+한 호스트에 두 bootroot 인스턴스를 함께 두려면 각각에 서로 다른
+`--instance-name`을 지정해야 합니다. 둘 다 기본 정체성을 취하면 하나의
+프로젝트와 하나의 볼륨 집합을 공유하며, 두 번째 설치가 첫 번째의
+컨테이너를 가져갑니다.
+
+컨테이너 이름은 아직 리터럴(`bootroot-openbao`, `bootroot-ca`, …)이며
+정체성을 따르지 않습니다. 따라서 서로 다른 `--instance-name`으로 같은
+호스트에 두 번째로 설치하면 첫 번째 인스턴스의 컨테이너를 조용히
+가져가는 대신 Docker의 "컨테이너 이름 사용 중" 오류로 명확히 실패하고,
+첫 번째 인스턴스는 그대로 유지됩니다.
 
 #### 호스트 측 게시 포트
 
@@ -2120,13 +2165,18 @@ bootroot clean --openbao-only --yes
 ### 동작
 
 - compose 파일이 `openbao` 서비스를 정의하지 않거나 기존
-  `bootroot-openbao` 컨테이너의 compose 라벨이 현재 작업 디렉터리에서
-  파생된 프로젝트와 일치하지 않으면 실행을 거부합니다. 컨테이너가
-  존재하지만 compose 라벨(`com.docker.compose.project`,
-  `com.docker.compose.service`) 중 하나라도 누락된 경우에도 거부합니다 —
-  해당 컨테이너는 이 작업 디렉터리의 compose 프로젝트에 속한다고
-  증명할 수 없으며, `clean --openbao-only` 이후의 stuck 복구 경로로
-  취급해서는 안 됩니다.
+  `bootroot-openbao` 컨테이너의 compose 라벨이 공용 리졸버가 compose
+  디렉터리에 대해 반환한 프로젝트(기록된 `BOOTROOT_INSTANCE`, 내보낸
+  `COMPOSE_PROJECT_NAME`, 또는 `bootroot` 기본값 — `infra install`의
+  "인스턴스 정체성과 Compose 프로젝트" 절 참고)와 일치하지 않으면
+  실행을 거부합니다. 리졸버는 컨테이너 자신의
+  프로젝트 라벨을 절대 참조하지 않으므로 이 비교는 실제 비교로
+  남습니다. 컨테이너가 존재하지만 compose
+  라벨(`com.docker.compose.project`, `com.docker.compose.service`) 중
+  하나라도 누락된 경우에도 거부합니다 — 해당 컨테이너는 이 설치본의
+  compose 프로젝트에 속한다고 증명할 수 없으며,
+  `clean --openbao-only` 이후의 stuck 복구 경로로 취급해서는 안
+  됩니다.
 - 파괴적 동작 전에 `state.json`에서 배포 의도 필드를 스냅샷합니다.
 - 스냅샷이 non-default `secrets_dir`을 기록한 경우 (예: 이전 init이
   `--secrets-dir secrets-custom`으로 실행됨), 스냅샷이 CLI 기본값보다

--- a/docs/ko/installation.md
+++ b/docs/ko/installation.md
@@ -183,7 +183,14 @@ POSTGRES_USER=step
 POSTGRES_PASSWORD=<random-32-byte-hex>
 POSTGRES_DB=stepca
 GRAFANA_ADMIN_PASSWORD=admin
+BOOTROOT_INSTANCE=bootroot
 ```
+
+`BOOTROOT_INSTANCE`는 설치본의 정체성이며, 이후 모든 명령이 대상으로
+삼는 Docker Compose 프로젝트입니다. `bootroot infra install
+--instance-name <name>`으로 설정하고, 다른 모든 명령은 여기서 다시
+읽습니다. 자세한 내용은 [CLI](cli.md)의 "인스턴스 정체성과 Compose
+프로젝트" 절을 참고하세요.
 
 `sslmode`는 환경 정책에 맞게 `disable`, `require`, `verify-full` 중에서
 선택합니다. 운영에서는 `require` 또는 `verify-full`을 권장합니다.

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -99,7 +99,7 @@ fail() {
 }
 
 compose() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
 }
 
 run_bootroot() {
@@ -273,7 +273,7 @@ YAML
   # that recreating bootroot-http01 preserves both the rendered config
   # mount and the DNS aliases.
   local responder_override="$SECRETS_DIR/responder/docker-compose.responder.override.yml"
-  local -a compose_args=(-f "$COMPOSE_FILE" -f "$override")
+  local -a compose_args=(-p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$override")
   if [ -f "$responder_override" ]; then
     compose_args+=(-f "$responder_override")
   fi

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -145,7 +145,7 @@ infra_services() {
 
 service_container_id() {
   local service="$1"
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps -q "$service" | tr -d '\n'
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps -q "$service" | tr -d '\n'
 }
 
 is_service_ready() {
@@ -195,12 +195,12 @@ wait_for_infra_ready() {
 }
 
 compose_down() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
 }
 
 capture_artifacts() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
   docker logs bootroot-openbao-agent-stepca >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
   docker logs bootroot-openbao-agent-responder >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
 }
@@ -491,7 +491,7 @@ YAML
   # that recreating bootroot-http01 preserves both the rendered config
   # mount and the DNS aliases.
   local responder_override="$SECRETS_DIR/responder/docker-compose.responder.override.yml"
-  local -a compose_args=(-f "$COMPOSE_FILE" -f "$override")
+  local -a compose_args=(-p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$override")
   if [ -f "$responder_override" ]; then
     compose_args+=(-f "$responder_override")
   fi
@@ -738,7 +738,7 @@ assert_fingerprint_changed() {
 # rotation must converge this back to owner-owned.
 seed_root_owned_ca_keys() {
   local cid img
-  cid="$(docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps -a -q step-ca | tr -d '\n')"
+  cid="$(docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps -a -q step-ca | tr -d '\n')"
   [ -n "$cid" ] || fail "step-ca container not found for root-owned seeding"
   img="$(docker inspect --format '{{.Config.Image}}' "$cid")"
   [ -n "$img" ] || fail "could not resolve step-ca image for root-owned seeding"

--- a/scripts/impl/run-openbao-tls-no-delta.sh
+++ b/scripts/impl/run-openbao-tls-no-delta.sh
@@ -135,7 +135,7 @@ on_error() {
 # ---------------------------------------------------------------------------
 
 compose() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
 }
 
 compose_down() {
@@ -305,7 +305,7 @@ apply_exposed_override_by_hand() {
   if grep -q 'tls_cert_file' "$OPENBAO_REPO_HCL"; then
     fail "openbao.hcl already carries a TLS listener before init (see $OPENBAO_REPO_HCL)"
   fi
-  docker compose -f "$COMPOSE_FILE" -f "$EXPOSED_OVERRIDE_PATH" up -d openbao \
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$EXPOSED_OVERRIDE_PATH" up -d openbao \
     >>"$RUN_LOG" 2>&1 || fail "failed to apply the openbao-exposed override by hand"
   # The override replaces the base compose port list (`ports: !override`),
   # so from here on OpenBao is published only on the bind address — which

--- a/scripts/impl/run-openbao-tls-reown.sh
+++ b/scripts/impl/run-openbao-tls-reown.sh
@@ -146,7 +146,7 @@ on_error() {
 # ---------------------------------------------------------------------------
 
 compose() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
 }
 
 compose_down() {
@@ -338,7 +338,7 @@ apply_exposed_override() {
   log_phase "apply-override"
   [ -f "$EXPOSED_OVERRIDE_PATH" ] \
     || fail "expected infra install to write $EXPOSED_OVERRIDE_PATH"
-  docker compose -f "$COMPOSE_FILE" -f "$EXPOSED_OVERRIDE_PATH" up -d openbao \
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$EXPOSED_OVERRIDE_PATH" up -d openbao \
     >>"$RUN_LOG" 2>&1 || fail "failed to apply the openbao-exposed override"
   wait_for_openbao_listening "http://${OPENBAO_BIND_ADDR}"
 }

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -130,7 +130,7 @@ on_error() {
 # ---------------------------------------------------------------------------
 
 compose() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
 }
 
 compose_down() {
@@ -597,13 +597,14 @@ scenario_c_rsync_clone_stale_state() {
   # state.json keeps pointing at a "previous-host" OpenBao that no
   # longer exists locally — the canonical rsync-clone trap.
   docker rm -f "$OPENBAO_CONTAINER_NAME" >/dev/null 2>&1 || true
-  local project_basename
-  project_basename="$(basename "$ROOT_DIR" | tr -c 'a-zA-Z0-9_-' '_' | tr '[:upper:]' '[:lower:]')"
-  # `docker compose` derives the project name from the work-dir
-  # basename when COMPOSE_PROJECT_NAME is unset; the volume is named
-  # <project>_openbao-data.  Honour COMPOSE_PROJECT_NAME when set so
-  # the harness can run under a custom project.
-  local project="${COMPOSE_PROJECT_NAME:-$project_basename}"
+  # bootroot passes an explicit `-p` on every `docker compose`
+  # invocation, resolved from `--instance-name`, then COMPOSE_PROJECT_NAME,
+  # then BOOTROOT_INSTANCE in the compose directory's .env, then the
+  # literal `bootroot`.  The volume is named <project>_openbao-data, so
+  # mirror that order here: honour COMPOSE_PROJECT_NAME when the harness
+  # sets one, otherwise fall back to the same fixed default bootroot
+  # uses.  The work-dir basename is deliberately NOT consulted.
+  local project="${COMPOSE_PROJECT_NAME:-bootroot}"
   for vol in "${project}_openbao-data" "${project}_openbao-audit"; do
     docker volume rm "$vol" >/dev/null 2>&1 || true
   done

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -130,12 +130,12 @@ ensure_prerequisites() {
 }
 
 compose_down() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
 }
 
 capture_artifacts() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
   docker logs bootroot-openbao-agent-stepca >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
   docker logs bootroot-openbao-agent-responder >>"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
 }
@@ -375,7 +375,7 @@ YAML
   # that recreating bootroot-http01 preserves both the rendered config
   # mount and the DNS aliases.
   local responder_override="$SECRETS_DIR/responder/docker-compose.responder.override.yml"
-  local -a compose_args=(-f "$COMPOSE_FILE" -f "$override")
+  local -a compose_args=(-p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$override")
   if [ -f "$responder_override" ]; then
     compose_args+=(-f "$responder_override")
   fi

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -124,7 +124,7 @@ on_error() {
 # ---------------------------------------------------------------------------
 
 compose() {
-  docker compose -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f "$COMPOSE_FILE" -f "$COMPOSE_TEST_FILE" "$@"
 }
 
 compose_down() {

--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -9,7 +9,7 @@ BOOTROOT_SECRETS_DIR="$ROOT_DIR/secrets"
 
 cleanup() {
   echo "[test-core] cleanup"
-  docker compose "${COMPOSE_FILES[@]}" down 2>/dev/null || true
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" "${COMPOSE_FILES[@]}" down 2>/dev/null || true
 }
 trap cleanup EXIT
 

--- a/scripts/preflight/extra/agent-scenarios.sh
+++ b/scripts/preflight/extra/agent-scenarios.sh
@@ -7,7 +7,17 @@ cd "$ROOT_DIR"
 SCENARIO="${1:-all}"
 TIMEOUT_SECS="${TIMEOUT_SECS:-180}"
 TMP_DIR="${TMP_DIR:-$ROOT_DIR/tmp/scenarios}"
-COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.test.yml)
+# bootroot passes an explicit `-p` on every `docker compose` invocation,
+# resolved from COMPOSE_PROJECT_NAME, then BOOTROOT_INSTANCE in the compose
+# directory's .env, then the literal `bootroot`. Pin the same project here so
+# this script and bootroot agree on one set of volumes; letting Compose derive
+# it from this checkout's directory basename would silently split them apart
+# whenever the checkout is not named `bootroot` (a git worktree, say).
+COMPOSE_ARGS=(
+  -p "${COMPOSE_PROJECT_NAME:-bootroot}"
+  -f docker-compose.yml
+  -f docker-compose.test.yml
+)
 AGENT_BIN="${BOOTROOT_AGENT_BIN:-$ROOT_DIR/target/debug/bootroot-agent}"
 AGENT_BUILT=0
 
@@ -106,7 +116,7 @@ published_endpoint() {
 
   # Take the first mapping: a wildcard bind can be listed once per address
   # family, and either entry is reachable over loopback.
-  addr="$($compose_cmd "${COMPOSE_FILES[@]}" port "$service" "$container_port" 2>/dev/null | head -n 1)"
+  addr="$($compose_cmd "${COMPOSE_ARGS[@]}" port "$service" "$container_port" 2>/dev/null | head -n 1)"
   addr="${addr%$'\r'}"
   if [ -z "$addr" ]; then
     fail "$service does not publish container port $container_port; is the stack up?"
@@ -285,7 +295,7 @@ compose_up() {
   local compose_cmd
   compose_cmd="$(detect_compose)"
   log "Starting compose stack"
-  $compose_cmd "${COMPOSE_FILES[@]}" up --build -d
+  $compose_cmd "${COMPOSE_ARGS[@]}" up --build -d
 
   # Read the published endpoints now, while every service is up. Scenarios
   # stop individual services afterwards, and the ports do not move.
@@ -416,7 +426,7 @@ YAML
 
   local compose_cmd
   compose_cmd="$(detect_compose)"
-  $compose_cmd "${COMPOSE_FILES[@]}" -f "$compose_override" up -d bootroot-http01
+  $compose_cmd "${COMPOSE_ARGS[@]}" -f "$compose_override" up -d bootroot-http01
 
   local cfg="$TMP_DIR/agent.toml.multi-example"
   cat <<'TOML' > "$cfg"
@@ -493,7 +503,7 @@ YAML
 
   local compose_cmd
   compose_cmd="$(detect_compose)"
-  $compose_cmd "${COMPOSE_FILES[@]}" -f "$compose_override" up -d bootroot-http01
+  $compose_cmd "${COMPOSE_ARGS[@]}" -f "$compose_override" up -d bootroot-http01
 
   local cfg_local="$TMP_DIR/agent.toml.topology-a.local"
   local cfg_remote1="$TMP_DIR/agent.toml.topology-a.remote1"
@@ -561,7 +571,7 @@ scenario_fail_responder_down() {
 
   local compose_cmd
   compose_cmd="$(detect_compose)"
-  $compose_cmd "${COMPOSE_FILES[@]}" stop bootroot-http01
+  $compose_cmd "${COMPOSE_ARGS[@]}" stop bootroot-http01
 
   local cfg="$ROOT_DIR/agent.toml.compose"
   local output
@@ -573,7 +583,7 @@ scenario_fail_responder_down() {
     fi
   fi
 
-  $compose_cmd "${COMPOSE_FILES[@]}" up -d bootroot-http01
+  $compose_cmd "${COMPOSE_ARGS[@]}" up -d bootroot-http01
   log "responder-down failure ok"
 }
 
@@ -602,7 +612,7 @@ YAML
 
   local compose_cmd
   compose_cmd="$(detect_compose)"
-  $compose_cmd "${COMPOSE_FILES[@]}" -f "$compose_override" up -d bootroot-http01
+  $compose_cmd "${COMPOSE_ARGS[@]}" -f "$compose_override" up -d bootroot-http01
 
   local cfg="$ROOT_DIR/agent.toml.compose"
   local output
@@ -614,7 +624,7 @@ YAML
     fi
   fi
 
-  $compose_cmd "${COMPOSE_FILES[@]}" up -d bootroot-http01
+  $compose_cmd "${COMPOSE_ARGS[@]}" up -d bootroot-http01
   log "hmac-mismatch failure ok"
 }
 
@@ -757,7 +767,7 @@ scenario_fail_step_ca_down() {
 
   local compose_cmd
   compose_cmd="$(detect_compose)"
-  $compose_cmd "${COMPOSE_FILES[@]}" stop step-ca
+  $compose_cmd "${COMPOSE_ARGS[@]}" stop step-ca
 
   local cfg="$ROOT_DIR/agent.toml.compose"
   local output
@@ -771,7 +781,7 @@ scenario_fail_step_ca_down() {
     fi
   fi
 
-  $compose_cmd "${COMPOSE_FILES[@]}" up -d step-ca
+  $compose_cmd "${COMPOSE_ARGS[@]}" up -d step-ca
   log "step-ca-down failure ok"
 }
 
@@ -841,7 +851,7 @@ scenario_fail_db_outage() {
 
   local compose_cmd
   compose_cmd="$(detect_compose)"
-  $compose_cmd "${COMPOSE_FILES[@]}" stop postgres
+  $compose_cmd "${COMPOSE_ARGS[@]}" stop postgres
 
   local cfg="$ROOT_DIR/agent.toml.compose"
   local output
@@ -855,7 +865,7 @@ scenario_fail_db_outage() {
     fi
   fi
 
-  $compose_cmd "${COMPOSE_FILES[@]}" up -d postgres
+  $compose_cmd "${COMPOSE_ARGS[@]}" up -d postgres
   log "db-outage failure ok"
 }
 
@@ -889,7 +899,7 @@ YAML
 
   local compose_cmd
   compose_cmd="$(detect_compose)"
-  $compose_cmd "${COMPOSE_FILES[@]}" -f "$compose_override" up -d step-ca
+  $compose_cmd "${COMPOSE_ARGS[@]}" -f "$compose_override" up -d step-ca
 
   local cfg="$ROOT_DIR/agent.toml.compose"
   local output
@@ -901,7 +911,7 @@ YAML
     fi
   fi
 
-  $compose_cmd "${COMPOSE_FILES[@]}" up -d step-ca
+  $compose_cmd "${COMPOSE_ARGS[@]}" up -d step-ca
   log "eab-required failure ok"
 }
 

--- a/scripts/preflight/extra/cli-scenarios.sh
+++ b/scripts/preflight/extra/cli-scenarios.sh
@@ -65,7 +65,7 @@ run_cli_tests() {
 
 reset_openbao() {
   log "Resetting OpenBao state"
-  docker compose -f docker-compose.yml -f docker-compose.test.yml down -v --remove-orphans \
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f docker-compose.yml -f docker-compose.test.yml down -v --remove-orphans \
     >/dev/null 2>&1 || true
 }
 

--- a/scripts/preflight/extra/deploy-no-build-smoke.sh
+++ b/scripts/preflight/extra/deploy-no-build-smoke.sh
@@ -60,11 +60,11 @@ reset_existing_stack() {
   log "stopping any existing bootroot compose stack"
   POSTGRES_PASSWORD=cleanup-only \
     GRAFANA_ADMIN_PASSWORD=cleanup-only \
-    docker compose -f docker-compose.yml down -v --remove-orphans \
+    docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f docker-compose.yml down -v --remove-orphans \
     >/dev/null 2>&1 || true
   POSTGRES_PASSWORD=cleanup-only \
     GRAFANA_ADMIN_PASSWORD=cleanup-only \
-    docker compose -f docker-compose.deploy.yml down -v --remove-orphans \
+    docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f docker-compose.deploy.yml down -v --remove-orphans \
     >/dev/null 2>&1 || true
 }
 

--- a/scripts/preflight/extra/deploy-no-build-smoke.sh
+++ b/scripts/preflight/extra/deploy-no-build-smoke.sh
@@ -14,6 +14,11 @@ POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:18.4}"
 BOOTROOT_STEP_CA_IMAGE="${BOOTROOT_STEP_CA_IMAGE:-smallstep/step-ca:0.30.2}"
 BOOTROOT_HTTP01_IMAGE="${BOOTROOT_HTTP01_IMAGE:-bootroot-http01-responder:$BOOTROOT_VERSION}"
 
+# The install under test resolves its Compose project from
+# `COMPOSE_PROJECT_NAME` when exported and falls back to the literal
+# `bootroot`, so mirror that order here rather than hard-coding one side.
+COMPOSE_PROJECT="${COMPOSE_PROJECT_NAME:-bootroot}"
+
 STAGE_DIR="$(mktemp -d)"
 ARCHIVE_DIR="$STAGE_DIR/images"
 SHIM_DIR="$STAGE_DIR/bin"
@@ -35,7 +40,7 @@ cleanup() {
       cd "$STAGE_DIR"
       POSTGRES_PASSWORD=cleanup-only \
         GRAFANA_ADMIN_PASSWORD=cleanup-only \
-        "$REAL_DOCKER" compose -f docker-compose.deploy.yml down -v --remove-orphans \
+        "$REAL_DOCKER" compose -p "$COMPOSE_PROJECT" -f docker-compose.deploy.yml down -v --remove-orphans \
         >/dev/null 2>&1 || true
     )
   fi
@@ -60,11 +65,11 @@ reset_existing_stack() {
   log "stopping any existing bootroot compose stack"
   POSTGRES_PASSWORD=cleanup-only \
     GRAFANA_ADMIN_PASSWORD=cleanup-only \
-    docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f docker-compose.yml down -v --remove-orphans \
+    docker compose -p "$COMPOSE_PROJECT" -f docker-compose.yml down -v --remove-orphans \
     >/dev/null 2>&1 || true
   POSTGRES_PASSWORD=cleanup-only \
     GRAFANA_ADMIN_PASSWORD=cleanup-only \
-    docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" -f docker-compose.deploy.yml down -v --remove-orphans \
+    docker compose -p "$COMPOSE_PROJECT" -f docker-compose.deploy.yml down -v --remove-orphans \
     >/dev/null 2>&1 || true
 }
 
@@ -153,7 +158,7 @@ assert_no_build_contract() {
     fi
   done
 
-  if ! grep -Eq 'compose -f docker-compose\.deploy\.yml up --no-build --pull never -d openbao postgres step-ca bootroot-http01' "$DOCKER_LOG"; then
+  if ! grep -Eq "compose -f docker-compose\\.deploy\\.yml -p ${COMPOSE_PROJECT} up --no-build --pull never -d openbao postgres step-ca bootroot-http01" "$DOCKER_LOG"; then
     cat "$DOCKER_LOG" >&2
     fail "compose up did not use --no-build --pull never for the default install services"
   fi

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -821,6 +821,20 @@ pub(crate) struct InfraInstallArgs {
     #[command(flatten)]
     pub(crate) compose_file: ComposeFileArgs,
 
+    /// Identity of this install. Names the Docker Compose project, so two
+    /// installs on one host stop sharing containers and volumes. Lowercase
+    /// ASCII letters, digits and `-`, starting with a letter or digit, at
+    /// most 39 characters. Recorded as `BOOTROOT_INSTANCE` in the compose
+    /// directory's `.env`; every later command reads it back from there.
+    /// When unset, a previously recorded identity is kept, otherwise
+    /// `bootroot` applies
+    // `allow_hyphen_values` so a leading `-` reaches the validator and is
+    // rejected with the error naming the allowed character set and the
+    // length limit, rather than clap's generic "unexpected argument" for
+    // what it would otherwise read as a flag.
+    #[arg(long = "instance-name", allow_hyphen_values = true)]
+    pub(crate) instance_name: Option<String>,
+
     /// Comma-separated list of services to start
     #[arg(
         long,
@@ -1631,6 +1645,35 @@ mod tests {
                 assert_eq!(args.services, vec!["openbao", "postgres"]);
             }
             _ => panic!("expected infra up"),
+        }
+    }
+
+    /// A leading `-` is one of the values the identity rules reject, so
+    /// the parser has to hand it to the validator rather than reading it
+    /// as a flag: clap's "unexpected argument" names neither the allowed
+    /// character set nor the length limit, and the operator would be left
+    /// guessing which rule they broke.
+    #[test]
+    fn instance_name_accepts_a_leading_hyphen_for_the_validator_to_reject() {
+        for argv in [
+            vec![
+                "bootroot",
+                "infra",
+                "install",
+                "--instance-name",
+                "-insight",
+            ],
+            vec!["bootroot", "infra", "install", "--instance-name=-insight"],
+        ] {
+            let cli = Cli::try_parse_from(&argv).unwrap_or_else(|err| {
+                panic!("{argv:?} must reach the validator, not clap's parse error: {err}")
+            });
+            match cli.command {
+                CliCommand::Infra(InfraCommand::Install(args)) => {
+                    assert_eq!(args.instance_name.as_deref(), Some("-insight"));
+                }
+                _ => panic!("expected infra install"),
+            }
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,7 @@
 pub(crate) mod ca;
 pub(crate) mod clean;
 pub(crate) mod compose_file;
+pub(crate) mod compose_project;
 pub(crate) mod constants;
 pub(crate) mod dns_alias;
 pub(crate) mod dotenv;

--- a/src/commands/ca.rs
+++ b/src/commands/ca.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 
 use crate::cli::args::{CaRestartArgs, CaUpdateArgs};
+use crate::commands::compose_project::{compose_args, resolve_compose_project};
 use crate::commands::infra::{collect_container_failures, collect_readiness, run_docker};
 use crate::commands::init::{
     RESPONDER_TEMPLATE_DIR, STEPCA_CA_JSON_TEMPLATE_NAME, set_acme_cert_duration,
@@ -57,18 +58,24 @@ pub(crate) fn run_ca_update(args: &CaUpdateArgs, messages: &Messages) -> Result<
 
 pub(crate) fn run_ca_restart(args: &CaRestartArgs, messages: &Messages) -> Result<()> {
     let compose_str = args.compose_file.compose_file.to_string_lossy();
-    let restart_args = ["compose", "-f", &*compose_str, "restart", STEP_CA_SERVICE];
+    let project = resolve_compose_project(&args.compose_file.compose_file, None, messages)?;
+    let restart_args = compose_args(
+        &project,
+        &[&compose_str],
+        None,
+        &["restart", STEP_CA_SERVICE],
+    );
     run_docker(&restart_args, "docker compose restart step-ca", messages)?;
-    wait_for_stepca_ready(&args.compose_file.compose_file, messages)?;
+    wait_for_stepca_ready(&args.compose_file.compose_file, &project, messages)?;
     println!("step-ca has been restarted.");
     Ok(())
 }
 
-fn wait_for_stepca_ready(compose_file: &Path, messages: &Messages) -> Result<()> {
+fn wait_for_stepca_ready(compose_file: &Path, project: &str, messages: &Messages) -> Result<()> {
     let services = [STEP_CA_SERVICE.to_string()];
     let deadline = Instant::now() + READINESS_TIMEOUT;
     loop {
-        let failures = match collect_readiness(compose_file, None, &services, messages) {
+        let failures = match collect_readiness(compose_file, project, None, &services, messages) {
             Ok(readiness) => collect_container_failures(&readiness),
             Err(err) => vec![err.to_string()],
         };

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -5,8 +5,9 @@ use anyhow::{Context, Result};
 
 use crate::cli::args::CleanArgs;
 use crate::commands::compose_file::compose_file_dir;
+use crate::commands::compose_project::{compose_args, resolve_compose_project_for_dir};
 use crate::commands::infra::run_docker;
-use crate::commands::init::{OPENBAO_CONTAINER_NAME, prompt_yes_no};
+use crate::commands::init::prompt_yes_no;
 use crate::i18n::Messages;
 use crate::state::StateFile;
 
@@ -45,21 +46,27 @@ pub(crate) fn run_clean(args: &CleanArgs, messages: &Messages) -> Result<()> {
     let compose_dir = compose_dir.as_path();
 
     let compose_str = args.compose_file.compose_file.to_string_lossy();
-    let mut down_args: Vec<&str> = vec!["compose", "-f", &compose_str];
+    let project = resolve_compose_project_for_dir(compose_dir, None, messages)?;
+    let mut down_files: Vec<&str> = vec![&compose_str];
 
     let agent_override_path = compose_dir.join(OPENBAO_AGENT_OVERRIDE);
     let agent_override_str = agent_override_path.to_string_lossy();
     if agent_override_path.exists() {
-        down_args.extend(["-f", &*agent_override_str]);
+        down_files.push(&agent_override_str);
     }
 
     let exposed_override_path = compose_dir.join(OPENBAO_EXPOSED_OVERRIDE);
     let exposed_override_str = exposed_override_path.to_string_lossy();
     if exposed_override_path.exists() {
-        down_args.extend(["-f", &*exposed_override_str]);
+        down_files.push(&exposed_override_str);
     }
 
-    down_args.extend(["down", "-v", "--remove-orphans"]);
+    let down_args = compose_args(
+        &project,
+        &down_files,
+        None,
+        &["down", "-v", "--remove-orphans"],
+    );
     run_docker(&down_args, "docker compose down", messages)?;
 
     remove_clean_artifacts(compose_dir, &StateFile::default_path(), messages)?;
@@ -101,15 +108,15 @@ pub(crate) fn remove_openbao_container_and_volumes(
     let compose_dir = compose_file_dir(compose_file);
     let compose_dir = compose_dir.as_path();
 
-    // Discover the compose project name BEFORE removing the container,
-    // while the label is still readable. Falling back to the compose-dir
-    // basename matches docker compose's default project-naming rule and
-    // covers the case where the container is already gone.
-    let project = resolve_compose_project(compose_dir, &inspect_label_via_docker)?;
+    // The project the containers and volumes were created under is now
+    // known without asking the daemon: every invocation passes an
+    // explicit `-p` derived from this same resolver, so the removal and
+    // the next `docker compose up` cannot disagree.
+    let project = resolve_compose_project_for_dir(compose_dir, None, messages)?;
 
-    let stop_args = ["compose", "-f", &compose_str, "stop", "openbao"];
+    let stop_args = compose_args(&project, &[&compose_str], None, &["stop", "openbao"]);
     let _ = run_docker(&stop_args, "docker compose stop openbao", messages);
-    let rm_args = ["compose", "-f", &compose_str, "rm", "-fsv", "openbao"];
+    let rm_args = compose_args(&project, &[&compose_str], None, &["rm", "-fsv", "openbao"]);
     run_docker(&rm_args, "docker compose rm openbao", messages)?;
 
     // Remove ONLY the openbao-owned named volumes. `docker compose down
@@ -122,61 +129,6 @@ pub(crate) fn remove_openbao_container_and_volumes(
         run_docker(&vol_args, &format!("docker volume rm {full}"), messages)?;
     }
     Ok(())
-}
-
-/// Resolves the docker compose project name. Tries the openbao
-/// container's `com.docker.compose.project` label first; if the
-/// container is not present, honours `COMPOSE_PROJECT_NAME` so volume
-/// removal targets the same project that `docker compose up` will
-/// create under (otherwise reinit could wipe `<basename>_openbao-data`
-/// while `infra up` recreated `<env>_openbao-data`, leaving the real
-/// volume intact); only then falls back to the compose-dir basename
-/// normalised the same way docker compose itself derives the default
-/// project name (lowercased; characters outside `[a-z0-9_-]` stripped).
-pub(crate) fn resolve_compose_project(
-    compose_dir: &Path,
-    inspect: &dyn Fn(&str, &str) -> Result<Option<String>>,
-) -> Result<String> {
-    if let Some(value) = inspect(OPENBAO_CONTAINER_NAME, COMPOSE_PROJECT_LABEL)? {
-        return Ok(value);
-    }
-    if let Ok(env_value) = std::env::var("COMPOSE_PROJECT_NAME")
-        && !env_value.is_empty()
-    {
-        return Ok(env_value);
-    }
-    let canonical =
-        std::fs::canonicalize(compose_dir).unwrap_or_else(|_| compose_dir.to_path_buf());
-    let basename = canonical
-        .file_name()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "could not derive compose project name from {}",
-                compose_dir.display()
-            )
-        })?;
-    let normalised = normalise_compose_project_name(basename);
-    if normalised.is_empty() {
-        anyhow::bail!(
-            "could not derive a valid compose project name from {}; restart the openbao container so its `{COMPOSE_PROJECT_LABEL}` label is readable",
-            compose_dir.display()
-        );
-    }
-    Ok(normalised)
-}
-
-/// Normalises a directory name into a docker compose project name.
-/// Mirrors compose's own rule: lowercase ASCII; drop characters that
-/// are not `[a-z0-9_-]`. (Compose itself also collapses leading
-/// separators; we do not, because the basename is unlikely to start
-/// with one and an empty result is rejected by the caller.)
-fn normalise_compose_project_name(input: &str) -> String {
-    input
-        .to_ascii_lowercase()
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
-        .collect()
 }
 
 /// Reports whether a container exists on the local docker daemon,
@@ -252,32 +204,16 @@ fn remove_file_if_exists(path: &Path, messages: &Messages) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{LazyLock, Mutex, MutexGuard};
-
     use super::*;
+    use crate::commands::compose_project::test_env::{ComposeProjectEnv, env_lock};
     use crate::i18n::Messages;
 
-    /// Serialises tests that mutate `COMPOSE_PROJECT_NAME` so the env
-    /// var is in a known state when `resolve_compose_project` is
-    /// exercised concurrently with the rest of the test suite.  Mirrors
-    /// the `ENV_LOCK` pattern in `commands/reinit.rs::tests`.
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        ENV_LOCK.lock().expect("test env lock must not be poisoned")
-    }
-
-    /// Test helper: clears `COMPOSE_PROJECT_NAME` so basename-fallback
-    /// tests exercise the documented fallback regardless of the
-    /// developer's ambient shell environment.  Callers must hold
-    /// `env_lock()`.
-    fn clear_compose_project_name() {
-        // SAFETY: `env::remove_var` mutates process-global state.  The
-        // caller serialises access via `env_lock()`.
-        unsafe {
-            std::env::remove_var("COMPOSE_PROJECT_NAME");
-        }
-    }
+    // The project-resolution tests below cover what the retired
+    // label-first / basename-last derivation covered, restated for the
+    // shared resolver in `commands::compose_project`.  Its former
+    // "basename normalises to empty" error case is deliberately gone
+    // rather than lost: the shared resolver never derives a name from the
+    // filesystem, so no input can reach it.
 
     /// Regression test: when the compose file lives in a subdirectory,
     /// `remove_clean_artifacts` must delete `state.json` at the
@@ -315,166 +251,83 @@ mod tests {
     }
 
     /// Closes #588 §5b regression: `--openbao-only` must scope volume
-    /// removal so the openbao container's label drives the project
-    /// prefix. Without this, the previous implementation ran
-    /// `docker compose down -v` and would have wiped `postgres-data`.
+    /// removal to the compose project so the previous `docker compose
+    /// down -v` cannot wipe `postgres-data`.  The project now comes from
+    /// the shared resolver rather than the container label, so the
+    /// recorded identity is what drives the `<project>_<volume>` prefix.
     #[test]
-    fn resolve_compose_project_uses_container_label_when_present() {
+    fn resolve_compose_project_uses_the_recorded_instance() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
         let dir = tempfile::tempdir().unwrap();
-        let lookup = |container: &str, label: &str| -> Result<Option<String>> {
-            assert_eq!(container, OPENBAO_CONTAINER_NAME);
-            assert_eq!(label, COMPOSE_PROJECT_LABEL);
-            Ok(Some("real-project-name".to_string()))
-        };
-        let project = resolve_compose_project(dir.path(), &lookup).unwrap();
+        std::fs::write(
+            dir.path().join(".env"),
+            "BOOTROOT_INSTANCE=real-project-name\n",
+        )
+        .unwrap();
+        let project =
+            resolve_compose_project_for_dir(dir.path(), None, &Messages::new("en").unwrap())
+                .unwrap();
         assert_eq!(project, "real-project-name");
     }
 
+    /// The basename derivation is gone: an install in a directory named
+    /// anything at all lands in the fixed default project, so `clean`
+    /// targets the same project a fresh `infra install` created.
     #[test]
-    fn resolve_compose_project_falls_back_to_compose_dir_basename() {
+    fn resolve_compose_project_falls_back_to_the_fixed_default() {
         let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        clear_compose_project_name();
+        let _env = ComposeProjectEnv::set(None);
         let root = tempfile::tempdir().unwrap();
         let dir = root.path().join("Bootroot.Stack");
         std::fs::create_dir(&dir).unwrap();
-        let lookup = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
-        let project = resolve_compose_project(&dir, &lookup).unwrap();
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        }
-        // Lowercased, non-`[a-z0-9_-]` stripped — matches docker
-        // compose's default project-name normalisation.
-        assert_eq!(project, "bootrootstack");
+        let project =
+            resolve_compose_project_for_dir(&dir, None, &Messages::new("en").unwrap()).unwrap();
+        assert_eq!(project, "bootroot");
     }
 
-    /// Closes the Round-8 bug: with the container label unavailable
-    /// (e.g. the stuck-after-`clean --openbao-only` recovery path),
-    /// volume removal must honour `COMPOSE_PROJECT_NAME` so the
-    /// `<env>_openbao-data` volume that `docker compose up` will
-    /// recreate is the same one reinit just wiped.  Without this the
-    /// basename-fallback would target `<basename>_openbao-data`,
-    /// leaving the real env-selected volume intact and recreating the
-    /// initialized-without-root-token failure mode.
+    /// The E2E harness exports `COMPOSE_PROJECT_NAME` for a whole
+    /// scenario; volume removal must target the project `docker compose
+    /// up` will recreate under, otherwise reinit wipes one volume while
+    /// the stack comes back on another.
     #[test]
-    fn resolve_compose_project_honours_env_var_when_label_absent() {
+    fn resolve_compose_project_honours_env_var_over_the_recorded_instance() {
         let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        // SAFETY: env mutation is serialised by `env_lock` above.
-        unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", "env-project") };
-        let root = tempfile::tempdir().unwrap();
-        let dir = root.path().join("BasenameWouldDiffer");
-        std::fs::create_dir(&dir).unwrap();
-        let lookup = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
-        let project = resolve_compose_project(&dir, &lookup).unwrap();
-        // Restore the prior env value before assertions so a failure
-        // does not leave the shared env mutated.
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        } else {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
-        }
+        let _env = ComposeProjectEnv::set(Some("env-project"));
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "BOOTROOT_INSTANCE=recorded\n").unwrap();
+        let project =
+            resolve_compose_project_for_dir(dir.path(), None, &Messages::new("en").unwrap())
+                .unwrap();
         assert_eq!(project, "env-project");
     }
 
-    /// The container label is authoritative for what to delete (the
-    /// resources were physically created under that project), so it
-    /// must win over a divergent `COMPOSE_PROJECT_NAME`.
-    #[test]
-    fn resolve_compose_project_prefers_container_label_over_env_var() {
-        let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        // SAFETY: env mutation is serialised by `env_lock` above.
-        unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", "env-project") };
-        let dir = tempfile::tempdir().unwrap();
-        let lookup =
-            |_: &str, _: &str| -> Result<Option<String>> { Ok(Some("label-project".to_string())) };
-        let project = resolve_compose_project(dir.path(), &lookup).unwrap();
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        } else {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
-        }
-        assert_eq!(project, "label-project");
-    }
-
-    #[test]
-    fn resolve_compose_project_errors_when_basename_normalises_to_empty() {
-        let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        clear_compose_project_name();
-        // A directory whose basename strips to empty under the
-        // normalisation rule (no ASCII alphanumerics) must not silently
-        // produce `_openbao-data` (which would target a nonexistent
-        // volume and mask the error).
-        let root = tempfile::tempdir().unwrap();
-        let dir = root.path().join("###");
-        std::fs::create_dir(&dir).unwrap();
-        let lookup = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
-        let err = resolve_compose_project(&dir, &lookup).unwrap_err();
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        }
-        assert!(err.to_string().contains("compose project name"));
-    }
-
-    #[test]
-    fn normalise_compose_project_name_strips_disallowed_chars() {
-        assert_eq!(normalise_compose_project_name("Foo.Bar"), "foobar");
-        assert_eq!(normalise_compose_project_name("foo_bar-baz"), "foo_bar-baz");
-        assert_eq!(normalise_compose_project_name("a/b\\c d"), "abcd");
-    }
-
-    /// Regression for #611: when `--compose-file` defaults to the
-    /// relative `docker-compose.yml`, the derived `compose_dir` flowing
-    /// into `resolve_compose_project` must canonicalise cleanly.  The
-    /// previous `compose_file.parent().unwrap_or(Path::new("."))` shape
-    /// returned `Some("")` here, then `canonicalize("")` failed and
-    /// `PathBuf::from("").file_name()` returned `None`, surfacing as
-    /// `could not derive compose project name from `.
+    /// Regression for #611: `--compose-file docker-compose.yml` derives a
+    /// `.`-relative compose dir, which the resolver must handle.  The old
+    /// derivation `canonicalize`d it; the shared one only reads the
+    /// `.env` beside it.
     #[test]
     fn resolve_compose_project_handles_dot_relative_compose_dir() {
         let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        clear_compose_project_name();
+        let _env = ComposeProjectEnv::set(None);
         let compose_dir = compose_file_dir(Path::new("docker-compose.yml"));
         assert_eq!(compose_dir, std::path::PathBuf::from("."));
-        let lookup = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
-        let result = resolve_compose_project(&compose_dir, &lookup);
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        }
-        let project = result.expect("resolve_compose_project must succeed for `.`");
+        let project =
+            resolve_compose_project_for_dir(&compose_dir, None, &Messages::new("en").unwrap())
+                .expect("resolve_compose_project_for_dir must succeed for `.`");
         assert!(!project.is_empty());
     }
 
-    /// Companion to the test above: when `COMPOSE_PROJECT_NAME` is set,
-    /// `remove_openbao_container_and_volumes` (which calls
-    /// `resolve_compose_project`) must honour it even when the
-    /// `compose_dir` is the helper-normalised `.`.
+    /// Companion to the test above: an exported `COMPOSE_PROJECT_NAME`
+    /// must still win when the compose dir is the helper-normalised `.`.
     #[test]
     fn resolve_compose_project_honours_env_var_for_dot_relative_compose_dir() {
         let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        // SAFETY: env mutation is serialised by `env_lock` above.
-        unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", "explicit-env-project") };
+        let _env = ComposeProjectEnv::set(Some("explicit-env-project"));
         let compose_dir = compose_file_dir(Path::new("docker-compose.yml"));
-        let lookup = |_: &str, _: &str| -> Result<Option<String>> { Ok(None) };
-        let result = resolve_compose_project(&compose_dir, &lookup);
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        } else {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
-        }
-        assert_eq!(result.unwrap(), "explicit-env-project");
+        let project =
+            resolve_compose_project_for_dir(&compose_dir, None, &Messages::new("en").unwrap())
+                .unwrap();
+        assert_eq!(project, "explicit-env-project");
     }
 }

--- a/src/commands/compose_project.rs
+++ b/src/commands/compose_project.rs
@@ -1,0 +1,584 @@
+//! The install identity and the `docker compose` project it selects.
+//!
+//! Two bootroot installs on one host used to land in the same Compose
+//! project — Compose derives the default project name from the compose
+//! file's directory basename, and both installs are conventionally called
+//! `bootroot` — so the second one adopted the first's volumes.  An install
+//! now declares an identity (`infra install --instance-name`), records it
+//! in the compose directory's `.env`, and every `docker compose`
+//! invocation is scoped to it with an explicit `-p`.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::commands::compose_file::compose_file_dir;
+use crate::commands::dotenv::read_dotenv;
+use crate::i18n::Messages;
+
+/// The `docker` subcommand every Compose invocation starts with.
+///
+/// Declared here — and only here — so that
+/// `every_compose_vector_is_built_by_the_shared_constructor` can assert
+/// the literal appears nowhere else in the tree: a hand-built vector at
+/// any one call site would silently lose the `-p` scoping.
+pub(crate) const DOCKER_COMPOSE_SUBCOMMAND: &str = "compose";
+
+/// `.env` key recording the install's instance identity.
+pub(crate) const INSTANCE_NAME_ENV_KEY: &str = "BOOTROOT_INSTANCE";
+
+/// Compose's own per-invocation project-name override.  It is a Compose
+/// feature, not a second identity: it is used verbatim, is never
+/// validated against the instance-name rules, and is never recorded.
+pub(crate) const COMPOSE_PROJECT_NAME_ENV: &str = "COMPOSE_PROJECT_NAME";
+
+/// Identity an install takes when it declares none.
+///
+/// A fixed literal rather than the compose directory's basename, so the
+/// identity is a property of the install and not of where it happens to
+/// sit: renaming the directory or checking the tree out elsewhere would
+/// otherwise silently orphan the previous project's volumes.
+pub(crate) const DEFAULT_INSTANCE_NAME: &str = "bootroot";
+
+/// Longest DNS label, in octets (RFC 1035).
+pub(crate) const DNS_LABEL_LIMIT: usize = 63;
+
+/// Longest suffix appended to the instance name when container names are
+/// made to follow the identity: `bootroot-openbao-agent-responder` minus
+/// the `bootroot` prefix.
+pub(crate) const LONGEST_CONTAINER_NAME_SUFFIX: &str = "-openbao-agent-responder";
+
+/// Maximum instance-name length.
+///
+/// Derived, not chosen: the name becomes a prefix on container names,
+/// which serve as DNS names on the compose network and as certificate
+/// SANs, so `<name><suffix>` must fit a DNS label.
+pub(crate) const MAX_INSTANCE_NAME_LEN: usize =
+    DNS_LABEL_LIMIT - LONGEST_CONTAINER_NAME_SUFFIX.len();
+
+/// Validates an `--instance-name` value.
+///
+/// Accepts lowercase ASCII letters, digits and `-`, starting with a
+/// letter or digit, up to [`MAX_INSTANCE_NAME_LEN`] characters.  Rejects
+/// anything else rather than silently normalising it, so an operator who
+/// mistypes an identity learns of it before the install creates a project
+/// under a name they did not ask for.
+pub(crate) fn validate_instance_name(name: &str, messages: &Messages) -> Result<()> {
+    let valid_charset = name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+    let valid_first = name
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+    if !valid_charset || !valid_first || name.len() > MAX_INSTANCE_NAME_LEN {
+        anyhow::bail!(messages.error_instance_name_invalid(name, MAX_INSTANCE_NAME_LEN));
+    }
+    Ok(())
+}
+
+/// Reads `BOOTROOT_INSTANCE` from the `.env` beside the compose file.
+///
+/// Returns `Ok(None)` when the file is absent or records no (non-empty)
+/// value; a malformed `.env` surfaces as an error rather than being
+/// silently treated as "no identity", which would target the default
+/// project instead of the recorded one.
+fn recorded_instance_name(compose_dir: &Path, messages: &Messages) -> Result<Option<String>> {
+    let env_path = compose_dir.join(".env");
+    if !env_path.exists() {
+        return Ok(None);
+    }
+    let entries = read_dotenv(&env_path, messages)?;
+    Ok(entries
+        .get(INSTANCE_NAME_ENV_KEY)
+        .filter(|value| !value.is_empty())
+        .cloned())
+}
+
+/// Returns `COMPOSE_PROJECT_NAME` from the invoking environment when it
+/// is set and non-empty.
+fn compose_project_name_override() -> Option<String> {
+    std::env::var(COMPOSE_PROJECT_NAME_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+/// Resolves the Compose project every command must operate on, given the
+/// directory of the compose file it was handed.
+///
+/// 1. `instance_name` — the `--instance-name` value, which only
+///    `infra install` can supply;
+/// 2. `COMPOSE_PROJECT_NAME` from the invoking environment, when
+///    non-empty.  Used verbatim and deliberately not validated: the E2E
+///    harness's per-run project names are longer than an instance name
+///    may be, and they must keep working;
+/// 3. `BOOTROOT_INSTANCE` from `<compose dir>/.env`;
+/// 4. the literal [`DEFAULT_INSTANCE_NAME`].
+pub(crate) fn resolve_compose_project_for_dir(
+    compose_dir: &Path,
+    instance_name: Option<&str>,
+    messages: &Messages,
+) -> Result<String> {
+    if let Some(name) = instance_name {
+        return Ok(name.to_string());
+    }
+    if let Some(project) = compose_project_name_override() {
+        return Ok(project);
+    }
+    if let Some(recorded) = recorded_instance_name(compose_dir, messages)? {
+        return Ok(recorded);
+    }
+    Ok(DEFAULT_INSTANCE_NAME.to_string())
+}
+
+/// [`resolve_compose_project_for_dir`] for callers holding the compose
+/// file itself.  The `.env` consulted is always the one beside that file,
+/// never one in the process working directory.
+pub(crate) fn resolve_compose_project(
+    compose_file: &Path,
+    instance_name: Option<&str>,
+    messages: &Messages,
+) -> Result<String> {
+    resolve_compose_project_for_dir(&compose_file_dir(compose_file), instance_name, messages)
+}
+
+/// Resolves the identity an `infra install` run must record in `.env`.
+///
+/// Deliberately ignores `COMPOSE_PROJECT_NAME`: that override selects the
+/// project for a single invocation and is not an identity, so an install
+/// run under one records the identity it would have had without it.  A
+/// re-run without `--instance-name` keeps whatever the `.env` already
+/// records instead of resetting it to the default.
+pub(crate) fn resolve_recorded_instance_name(
+    compose_dir: &Path,
+    instance_name: Option<&str>,
+    messages: &Messages,
+) -> Result<String> {
+    if let Some(name) = instance_name {
+        return Ok(name.to_string());
+    }
+    if let Some(recorded) = recorded_instance_name(compose_dir, messages)? {
+        return Ok(recorded);
+    }
+    Ok(DEFAULT_INSTANCE_NAME.to_string())
+}
+
+/// Builds a `docker compose` argument vector scoped to `project`.
+///
+/// The single constructor for every Compose invocation bootroot makes.
+/// `-p` is emitted as a compose-level flag — after the `-f` and
+/// `--profile` arguments, before the subcommand — because Compose only
+/// accepts it there.  Building a vector by hand at a call site instead
+/// would silently fall back to Compose's directory-derived default
+/// project and operate on another install's containers and volumes.
+pub(crate) fn compose_args(
+    project: &str,
+    files: &[&str],
+    profile: Option<&str>,
+    subcommand: &[&str],
+) -> Vec<String> {
+    let mut args = Vec::with_capacity(subcommand.len() + files.len() * 2 + 5);
+    args.push(DOCKER_COMPOSE_SUBCOMMAND.to_string());
+    for file in files {
+        args.push("-f".to_string());
+        args.push((*file).to_string());
+    }
+    if let Some(profile) = profile {
+        args.push("--profile".to_string());
+        args.push(profile.to_string());
+    }
+    args.push("-p".to_string());
+    args.push(project.to_string());
+    args.extend(subcommand.iter().map(|arg| (*arg).to_string()));
+    args
+}
+
+/// Test-only helpers for the process-global `COMPOSE_PROJECT_NAME`.
+///
+/// One lock for the whole crate: the resolver is exercised from several
+/// modules' tests, and a per-module mutex would let two of them mutate
+/// the same process-global variable concurrently.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::ffi::OsString;
+    use std::sync::{LazyLock, Mutex, MutexGuard};
+
+    use super::COMPOSE_PROJECT_NAME_ENV;
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    /// Serialises tests that mutate `COMPOSE_PROJECT_NAME`.
+    ///
+    /// A panicking test poisons the mutex; recovering the guard rather
+    /// than propagating the poison keeps one failure from cascading into
+    /// every other test that touches the variable.
+    pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// RAII guard restoring `COMPOSE_PROJECT_NAME` on drop, so a failing
+    /// assertion cannot leave the shared environment mutated.
+    pub(crate) struct ComposeProjectEnv {
+        prior: Option<OsString>,
+    }
+
+    impl ComposeProjectEnv {
+        /// Sets (or clears) `COMPOSE_PROJECT_NAME` for the duration of a
+        /// test.  Callers must hold [`env_lock`].
+        pub(crate) fn set(value: Option<&str>) -> Self {
+            let prior = std::env::var_os(COMPOSE_PROJECT_NAME_ENV);
+            match value {
+                // SAFETY: every call site holds `env_lock()`.
+                Some(value) => unsafe { std::env::set_var(COMPOSE_PROJECT_NAME_ENV, value) },
+                // SAFETY: as above.
+                None => unsafe { std::env::remove_var(COMPOSE_PROJECT_NAME_ENV) },
+            }
+            Self { prior }
+        }
+    }
+
+    impl Drop for ComposeProjectEnv {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                // SAFETY: the caller still holds `env_lock()`.
+                Some(prior) => unsafe { std::env::set_var(COMPOSE_PROJECT_NAME_ENV, prior) },
+                // SAFETY: as above.
+                None => unsafe { std::env::remove_var(COMPOSE_PROJECT_NAME_ENV) },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_env::{ComposeProjectEnv, env_lock};
+    use super::*;
+    use crate::i18n::test_messages;
+
+    fn write_dotenv_with_instance(dir: &Path, instance: &str) {
+        std::fs::write(
+            dir.join(".env"),
+            format!("{INSTANCE_NAME_ENV_KEY}={instance}\n"),
+        )
+        .expect("write .env");
+    }
+
+    #[test]
+    fn instance_name_accepts_the_documented_character_set() {
+        let messages = test_messages();
+        for name in ["bootroot", "insight", "a", "0", "a-b-c", "x9-7"] {
+            validate_instance_name(name, &messages)
+                .unwrap_or_else(|err| panic!("{name} must be accepted: {err}"));
+        }
+    }
+
+    #[test]
+    fn instance_name_rejects_invalid_values() {
+        let messages = test_messages();
+        for name in [
+            "Insight",
+            "in sight",
+            "-insight",
+            "insight_1",
+            "in.sight",
+            "",
+        ] {
+            assert!(
+                validate_instance_name(name, &messages).is_err(),
+                "{name:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn instance_name_length_boundaries() {
+        let messages = test_messages();
+        let accepted = "a".repeat(MAX_INSTANCE_NAME_LEN);
+        let rejected = "a".repeat(MAX_INSTANCE_NAME_LEN + 1);
+        validate_instance_name(&accepted, &messages).expect("39 characters must be accepted");
+        assert!(validate_instance_name(&rejected, &messages).is_err());
+        assert_eq!(MAX_INSTANCE_NAME_LEN, 39);
+    }
+
+    /// The error has to tell an operator both halves of the rule; a bare
+    /// "invalid name" leaves them guessing which one they broke.
+    #[test]
+    fn instance_name_error_names_the_charset_and_the_limit() {
+        for locale in ["en", "ko"] {
+            let messages = crate::i18n::Messages::new(locale).unwrap();
+            let err = validate_instance_name("Insight", &messages)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("Insight"), "{locale}: {err}");
+            assert!(err.contains("39"), "{locale}: {err}");
+            assert!(!err.contains('{'), "{locale} left a placeholder: {err}");
+        }
+    }
+
+    #[test]
+    fn flag_wins_over_compose_project_name() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(Some("env-project"));
+        let dir = tempfile::tempdir().unwrap();
+        write_dotenv_with_instance(dir.path(), "recorded");
+        let project =
+            resolve_compose_project_for_dir(dir.path(), Some("flag"), &test_messages()).unwrap();
+        assert_eq!(project, "flag");
+    }
+
+    #[test]
+    fn compose_project_name_wins_over_dotenv() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(Some("env-project"));
+        let dir = tempfile::tempdir().unwrap();
+        write_dotenv_with_instance(dir.path(), "recorded");
+        let project = resolve_compose_project_for_dir(dir.path(), None, &test_messages()).unwrap();
+        assert_eq!(project, "env-project");
+    }
+
+    #[test]
+    fn dotenv_wins_over_the_default() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+        let dir = tempfile::tempdir().unwrap();
+        write_dotenv_with_instance(dir.path(), "recorded");
+        let project = resolve_compose_project_for_dir(dir.path(), None, &test_messages()).unwrap();
+        assert_eq!(project, "recorded");
+    }
+
+    /// The fallback is a fixed literal, not the directory basename: an
+    /// install must land in the same project however its directory is
+    /// named.
+    #[test]
+    fn default_is_the_fixed_literal_regardless_of_directory_name() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("clumit-insight");
+        std::fs::create_dir(&dir).unwrap();
+        let project = resolve_compose_project_for_dir(&dir, None, &test_messages()).unwrap();
+        assert_eq!(project, DEFAULT_INSTANCE_NAME);
+    }
+
+    #[test]
+    fn empty_compose_project_name_is_treated_as_unset() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(Some(""));
+        let dir = tempfile::tempdir().unwrap();
+        write_dotenv_with_instance(dir.path(), "recorded");
+        let project = resolve_compose_project_for_dir(dir.path(), None, &test_messages()).unwrap();
+        assert_eq!(project, "recorded");
+    }
+
+    /// The E2E harness exports project names longer than an instance name
+    /// may be; the override is a Compose feature, not an identity, so it
+    /// is used verbatim without validation.
+    #[test]
+    fn compose_project_name_is_not_validated_as_an_instance_name() {
+        const HARNESS_PROJECT: &str = "bootroot-e2e-ci-openbao-tls-no-delta-1234567";
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(Some(HARNESS_PROJECT));
+        let messages = test_messages();
+        assert!(HARNESS_PROJECT.len() > MAX_INSTANCE_NAME_LEN);
+        assert!(validate_instance_name(HARNESS_PROJECT, &messages).is_err());
+        let dir = tempfile::tempdir().unwrap();
+        let project = resolve_compose_project_for_dir(dir.path(), None, &messages).unwrap();
+        assert_eq!(project, HARNESS_PROJECT);
+    }
+
+    /// The resolver must read the `.env` beside the compose file it was
+    /// handed, not one in the process working directory — a `clean`
+    /// pointed at another install's compose file would otherwise wipe the
+    /// wrong project's volumes.
+    #[test]
+    fn resolver_reads_the_dotenv_beside_the_given_compose_file() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+        let root = tempfile::tempdir().unwrap();
+        let here = root.path().join("here");
+        let there = root.path().join("there");
+        std::fs::create_dir(&here).unwrap();
+        std::fs::create_dir(&there).unwrap();
+        write_dotenv_with_instance(&here, "here-instance");
+        write_dotenv_with_instance(&there, "there-instance");
+
+        let project =
+            resolve_compose_project(&there.join("docker-compose.yml"), None, &test_messages())
+                .unwrap();
+        assert_eq!(project, "there-instance");
+    }
+
+    /// The recorded identity must ignore `COMPOSE_PROJECT_NAME`: a
+    /// throwaway harness project must not become the install's identity.
+    #[test]
+    fn recorded_identity_ignores_compose_project_name() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(Some("bootroot-e2e-ci-reinit-42"));
+        let dir = tempfile::tempdir().unwrap();
+        let recorded = resolve_recorded_instance_name(dir.path(), None, &test_messages()).unwrap();
+        assert_eq!(recorded, DEFAULT_INSTANCE_NAME);
+    }
+
+    #[test]
+    fn recorded_identity_preserves_the_existing_value_without_the_flag() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(Some("bootroot-e2e-ci-reinit-42"));
+        let dir = tempfile::tempdir().unwrap();
+        write_dotenv_with_instance(dir.path(), "insight");
+        let recorded = resolve_recorded_instance_name(dir.path(), None, &test_messages()).unwrap();
+        assert_eq!(recorded, "insight");
+    }
+
+    #[test]
+    fn recorded_identity_takes_the_flag_over_the_existing_value() {
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+        let dir = tempfile::tempdir().unwrap();
+        write_dotenv_with_instance(dir.path(), "insight");
+        let recorded =
+            resolve_recorded_instance_name(dir.path(), Some("security"), &test_messages()).unwrap();
+        assert_eq!(recorded, "security");
+    }
+
+    /// Collects every `.rs` file under `src/`.
+    fn rust_sources(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("src tree must be readable") {
+            let path = entry.expect("directory entry must be readable").path();
+            if path.is_dir() {
+                rust_sources(&path, out);
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Every Compose invocation must come from [`compose_args`]: a
+    /// hand-built vector loses the `-p` scoping silently and falls back
+    /// to Compose's directory-derived default project, so it would
+    /// operate on another install's containers and volumes.  The
+    /// subcommand literal is therefore written once, in this module, and
+    /// this test fails as soon as it reappears in argument position
+    /// anywhere else.
+    ///
+    /// The needles are the two shapes an argument vector puts it in — a
+    /// `&str` element (`"compose", "-f", …`) and an owned one
+    /// (`"compose".to_string()`).  A bare `"compose"` elsewhere (a
+    /// directory name in a fixture, a substring assertion on an error
+    /// message) is not an invocation and is deliberately not matched.
+    #[test]
+    fn every_compose_vector_is_built_by_the_shared_constructor() {
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let this_file = src.join("commands").join("compose_project.rs");
+        let mut files = Vec::new();
+        rust_sources(&src, &mut files);
+        assert!(
+            files.contains(&this_file),
+            "the source walk must reach this module"
+        );
+
+        let needles = [
+            format!("\"{DOCKER_COMPOSE_SUBCOMMAND}\","),
+            format!("\"{DOCKER_COMPOSE_SUBCOMMAND}\".to_string()"),
+        ];
+        let mut offenders = Vec::new();
+        for file in files {
+            if file == this_file {
+                continue;
+            }
+            let contents = std::fs::read_to_string(&file).expect("source file must be readable");
+            for (index, line) in contents.lines().enumerate() {
+                if needles.iter().any(|needle| line.contains(needle.as_str())) {
+                    offenders.push(format!("{}:{}", file.display(), index + 1));
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "docker compose argument vectors must be built by \
+             `compose_project::compose_args`, which is what emits `-p`; \
+             found the subcommand literal in argument position at: {}",
+            offenders.join(", ")
+        );
+    }
+
+    /// The guard above is only worth having if it actually fires; pin
+    /// that by running the same needles over a hand-built vector.
+    #[test]
+    fn the_constructor_guard_detects_a_hand_built_vector() {
+        let hand_built = r#"    let args = ["compose", "-f", &compose_str, "up", "-d"];"#;
+        let needle = format!("\"{DOCKER_COMPOSE_SUBCOMMAND}\",");
+        assert!(hand_built.contains(needle.as_str()));
+    }
+
+    /// Representative of the vectors dispatched through
+    /// `infra::run_docker_with_env` — `infra install`'s `up` and `pull`,
+    /// `init`'s service restarts, `clean`'s `down`.
+    #[test]
+    fn constructor_emits_project_at_the_compose_flag_position() {
+        let args = compose_args("insight", &["docker-compose.yml"], None, &["up", "-d"]);
+        assert_eq!(
+            args,
+            vec![
+                DOCKER_COMPOSE_SUBCOMMAND,
+                "-f",
+                "docker-compose.yml",
+                "-p",
+                "insight",
+                "up",
+                "-d",
+            ]
+        );
+    }
+
+    /// The readiness probe reaches Docker only through
+    /// `infra::docker_compose_output`, so this is the vector that decides
+    /// whether `status` reports on the project it was pointed at.
+    #[test]
+    fn constructor_scopes_the_readiness_probe_vector() {
+        let args = compose_args(
+            "insight",
+            &["docker-compose.yml"],
+            None,
+            &["ps", "-q", "openbao"],
+        );
+        let flags: Vec<&String> = args.iter().take_while(|arg| arg.as_str() != "ps").collect();
+        assert!(
+            flags.iter().any(|arg| arg.as_str() == "-p"),
+            "readiness probe lost its project scoping: {args:?}"
+        );
+        assert_eq!(args.last().map(String::as_str), Some("openbao"));
+    }
+
+    /// Representative of the vectors dispatched through the private
+    /// `monitoring::run_docker_with_env`, which are the only ones
+    /// carrying `--profile`: `-p` has to land after it and still before
+    /// the subcommand.
+    #[test]
+    fn constructor_places_project_after_files_and_profile() {
+        let args = compose_args(
+            "insight",
+            &["docker-compose.yml", "override.yml"],
+            Some("lan"),
+            &["ps", "-q", "grafana"],
+        );
+        assert_eq!(
+            args,
+            vec![
+                DOCKER_COMPOSE_SUBCOMMAND,
+                "-f",
+                "docker-compose.yml",
+                "-f",
+                "override.yml",
+                "--profile",
+                "lan",
+                "-p",
+                "insight",
+                "ps",
+                "-q",
+                "grafana",
+            ]
+        );
+    }
+}

--- a/src/commands/dns_alias.rs
+++ b/src/commands/dns_alias.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 
+use crate::commands::clean::{COMPOSE_PROJECT_LABEL, COMPOSE_SERVICE_LABEL};
 use crate::commands::constants::RESPONDER_SERVICE_NAME;
 use crate::commands::infra::{docker_output, run_docker};
 use crate::i18n::Messages;
@@ -30,12 +31,16 @@ pub(crate) fn collect_dns_aliases(state: &StateFile) -> Vec<String> {
 /// Collects all aliases (existing + new) and applies them to the
 /// `bootroot-http01` container by disconnecting and reconnecting
 /// it on its Docker network with the full alias set.
-pub(crate) fn register_dns_alias(state: &StateFile, messages: &Messages) -> Result<()> {
+pub(crate) fn register_dns_alias(
+    state: &StateFile,
+    project: &str,
+    messages: &Messages,
+) -> Result<()> {
     let aliases = collect_dns_aliases(state);
     if aliases.is_empty() {
         return Ok(());
     }
-    apply_dns_aliases(&aliases, messages)
+    apply_dns_aliases(&aliases, project, messages)
 }
 
 /// Refreshes the responder's HTTP-01 alias set from `state.json`,
@@ -49,9 +54,13 @@ pub(crate) fn register_dns_alias(state: &StateFile, messages: &Messages) -> Resu
 /// still reconnect the container with just the base
 /// `bootroot-http01` service alias rather than leaving the orphaned
 /// alias in place.
-pub(crate) fn reconcile_dns_aliases(state: &StateFile, messages: &Messages) -> Result<()> {
+pub(crate) fn reconcile_dns_aliases(
+    state: &StateFile,
+    project: &str,
+    messages: &Messages,
+) -> Result<()> {
     let aliases = collect_dns_aliases(state);
-    apply_dns_aliases(&aliases, messages)
+    apply_dns_aliases(&aliases, project, messages)
 }
 
 /// Replays all DNS aliases from `state.json` onto the running
@@ -59,13 +68,17 @@ pub(crate) fn reconcile_dns_aliases(state: &StateFile, messages: &Messages) -> R
 ///
 /// Intended for use after `infra up` to restore aliases that were
 /// lost during a container restart.
-pub(crate) fn replay_dns_aliases(state: &StateFile, messages: &Messages) -> Result<()> {
+pub(crate) fn replay_dns_aliases(
+    state: &StateFile,
+    project: &str,
+    messages: &Messages,
+) -> Result<()> {
     let aliases = collect_dns_aliases(state);
     if aliases.is_empty() {
         return Ok(());
     }
     println!("{}", messages.dns_alias_replaying(aliases.len()));
-    apply_dns_aliases(&aliases, messages)
+    apply_dns_aliases(&aliases, project, messages)
 }
 
 /// Applies all DNS aliases to the `bootroot-http01` container at runtime.
@@ -79,8 +92,8 @@ pub(crate) fn replay_dns_aliases(state: &StateFile, messages: &Messages) -> Resu
 /// to the network (including when aliases could not be applied).
 /// Returns `Err` only when the container is left detached from the
 /// network (disconnect succeeded but both reconnect and rollback failed).
-fn apply_dns_aliases(aliases: &[String], messages: &Messages) -> Result<()> {
-    let Ok(container_id) = find_responder_container(messages) else {
+fn apply_dns_aliases(aliases: &[String], project: &str, messages: &Messages) -> Result<()> {
+    let Some(container_id) = find_responder_container(project, messages)? else {
         eprintln!("{}", messages.dns_alias_responder_not_running());
         return Ok(());
     };
@@ -152,18 +165,63 @@ fn apply_dns_aliases(aliases: &[String], messages: &Messages) -> Result<()> {
     Ok(())
 }
 
-/// Finds the container ID for the `bootroot-http01` service.
-fn find_responder_container(messages: &Messages) -> Result<String> {
-    let label = format!("com.docker.compose.service={RESPONDER_SERVICE_NAME}");
-    let label_filter = format!("label={label}");
-    let output = docker_output(&["ps", "-q", "-f", &label_filter], messages)?;
-    let id = output.trim().to_string();
-    if id.is_empty() {
-        anyhow::bail!(messages.dns_alias_responder_not_running());
+/// Finds the container ID of `project`'s HTTP-01 responder.
+///
+/// Filtering on the service label alone matches every co-located
+/// instance's responder, and rewiring an arbitrary one would move another
+/// instance's DNS aliases.  The project label narrows the match to this
+/// install; if more than one container still matches, that is a state no
+/// arbitrary choice can make correct, so it is reported rather than
+/// guessed at.
+///
+/// Returns `Ok(None)` when the responder is simply not running — the
+/// caller warns and carries on — and `Err` when the filter is ambiguous,
+/// which is a hard failure rather than something to skip past.
+fn find_responder_container(project: &str, messages: &Messages) -> Result<Option<String>> {
+    let args = responder_lookup_args(project);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let Ok(output) = docker_output(&arg_refs, messages) else {
+        return Ok(None);
+    };
+    select_responder_container(&output, project, messages)
+}
+
+/// Builds the `docker ps` argument vector that narrows the responder
+/// lookup to `project`.
+///
+/// Split out from the Docker call so a test can assert the project
+/// filter is actually passed, rather than re-deriving the string it
+/// expects.
+fn responder_lookup_args(project: &str) -> Vec<String> {
+    vec![
+        "ps".to_string(),
+        "-q".to_string(),
+        "-f".to_string(),
+        format!("label={COMPOSE_SERVICE_LABEL}={RESPONDER_SERVICE_NAME}"),
+        "-f".to_string(),
+        format!("label={COMPOSE_PROJECT_LABEL}={project}"),
+    ]
+}
+
+/// Picks the single container ID out of `docker ps -q` output.
+///
+/// Split out from the Docker call so the ambiguity rule is unit-testable
+/// without a daemon.
+fn select_responder_container(
+    output: &str,
+    project: &str,
+    messages: &Messages,
+) -> Result<Option<String>> {
+    let ids: Vec<&str> = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    match ids.as_slice() {
+        [] => Ok(None),
+        [id] => Ok(Some((*id).to_string())),
+        _ => anyhow::bail!(messages.dns_alias_responder_ambiguous(ids.len(), project)),
     }
-    // If multiple lines are returned (shouldn't happen in normal usage),
-    // take the first one.
-    Ok(id.lines().next().unwrap_or_default().trim().to_string())
 }
 
 /// Discovers the Docker network the container is attached to.
@@ -190,6 +248,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use crate::i18n::Messages;
     use crate::state::{DeliveryMode, ServiceEntry, ServiceRoleEntry, StateFile};
 
     fn sample_entry(name: &str, instance_id: Option<&str>) -> ServiceEntry {
@@ -217,6 +276,57 @@ mod tests {
             agent_server: None,
             agent_responder_url: None,
             cert_group_gid: None,
+        }
+    }
+
+    /// The lookup must filter on the compose project as well as the
+    /// service, otherwise a co-located instance's responder matches too
+    /// and `dns_alias` would rewire an arbitrary one.
+    #[test]
+    fn responder_lookup_filters_on_the_project_label() {
+        assert_eq!(
+            responder_lookup_args("insight"),
+            vec![
+                "ps",
+                "-q",
+                "-f",
+                "label=com.docker.compose.service=bootroot-http01",
+                "-f",
+                "label=com.docker.compose.project=insight",
+            ]
+        );
+    }
+
+    #[test]
+    fn responder_lookup_returns_the_single_match() {
+        let messages = crate::i18n::test_messages();
+        let id = select_responder_container("abc123\n", "insight", &messages).unwrap();
+        assert_eq!(id.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn responder_lookup_reports_no_container_as_not_running() {
+        let messages = crate::i18n::test_messages();
+        assert!(
+            select_responder_container("\n  \n", "insight", &messages)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// Two matches is a state no arbitrary choice can make correct, so
+    /// it must be an error naming the project rather than "take the
+    /// first line".
+    #[test]
+    fn responder_lookup_errors_on_an_ambiguous_match() {
+        for locale in ["en", "ko"] {
+            let messages = Messages::new(locale).unwrap();
+            let err = select_responder_container("abc123\ndef456\n", "insight", &messages)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("insight"), "{locale}: {err}");
+            assert!(err.contains('2'), "{locale}: {err}");
+            assert!(!err.contains('{'), "{locale} left a placeholder: {err}");
         }
     }
 

--- a/src/commands/dotenv.rs
+++ b/src/commands/dotenv.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use crate::commands::compose_project::COMPOSE_PROJECT_NAME_ENV;
 use crate::i18n::Messages;
 
 /// Reads a `.env` file and returns key-value pairs.
@@ -66,12 +67,28 @@ pub(crate) fn write_dotenv(
 /// Only sets variables that are not already present in the process
 /// environment, preserving Docker Compose's precedence semantics (process
 /// env > `.env` file).
+///
+/// [`COMPOSE_PROJECT_NAME_ENV`] is deliberately excluded.  The compose
+/// project resolver reads it from the *invoking* environment, and `init`
+/// resolves the project once before calling this and then lets several
+/// sub-steps re-resolve it afterwards.  Promoting a `.env`-authored value
+/// into the process environment here would make those later resolutions
+/// disagree with the first, so `init` would bring the core services up in
+/// one project and the agent sidecars, the responder override and the
+/// `OpenBao` TLS recreate up in another — a different compose network, so
+/// DNS to step-ca would break.  The key is not otherwise needed: every
+/// compose invocation passes an explicit `-p`, which outranks the
+/// variable, and Compose reads the `.env` beside the compose file for its
+/// own interpolation regardless.
 pub(crate) fn load_dotenv_into_env(path: &Path, messages: &Messages) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }
     let map = read_dotenv(path, messages)?;
     for (key, value) in &map {
+        if key == COMPOSE_PROJECT_NAME_ENV {
+            continue;
+        }
         if std::env::var(key).is_err() {
             // SAFETY: called once during single-threaded init setup,
             // before any worker threads are spawned.
@@ -223,6 +240,88 @@ mod tests {
         assert_eq!(std::env::var(&key).unwrap(), "already_set");
 
         // Clean up.
+        unsafe {
+            std::env::remove_var(&key);
+        }
+    }
+
+    /// `init` resolves the compose project once before this load and
+    /// then lets the agent-sidecar override, the responder override, the
+    /// `OpenBao` TLS recreate, the DB-password rotation and rollback
+    /// re-resolve it afterwards.  Promoting a `.env`-authored
+    /// `COMPOSE_PROJECT_NAME` into the process environment would make
+    /// those later resolutions return a different project than the
+    /// first, splitting one `init` run across two compose networks.  The
+    /// resolver's second step reads the *invoking* environment, and a
+    /// `.env` key is not that.
+    #[test]
+    fn load_dotenv_into_env_never_promotes_compose_project_name() {
+        use crate::commands::compose_project::{
+            COMPOSE_PROJECT_NAME_ENV, resolve_compose_project_for_dir,
+            test_env::{ComposeProjectEnv, env_lock},
+        };
+
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".env");
+        let messages = test_messages();
+        std::fs::write(
+            &path,
+            format!("{COMPOSE_PROJECT_NAME_ENV}=from-dotenv\nBOOTROOT_INSTANCE=insight\n"),
+        )
+        .unwrap();
+
+        let before = resolve_compose_project_for_dir(dir.path(), None, &messages).unwrap();
+        load_dotenv_into_env(&path, &messages).unwrap();
+        let after = resolve_compose_project_for_dir(dir.path(), None, &messages).unwrap();
+
+        assert!(
+            std::env::var(COMPOSE_PROJECT_NAME_ENV).is_err(),
+            "a .env-authored {COMPOSE_PROJECT_NAME_ENV} must not reach the process environment"
+        );
+        assert_eq!(
+            (before.as_str(), after.as_str()),
+            ("insight", "insight"),
+            "the resolved project must not change across the .env load"
+        );
+    }
+
+    /// The exclusion is scoped to that one key: everything else `.env`
+    /// carries still has to reach the process environment, which is the
+    /// whole point of the load (`POSTGRES_PASSWORD` for the DSN builders).
+    #[test]
+    fn load_dotenv_into_env_still_loads_other_keys_alongside_it() {
+        use crate::commands::compose_project::{
+            COMPOSE_PROJECT_NAME_ENV,
+            test_env::{ComposeProjectEnv, env_lock},
+        };
+
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".env");
+        let messages = test_messages();
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time is before UNIX_EPOCH")
+            .as_nanos();
+        let key = format!("DOTENV_ALONGSIDE_{nonce}");
+        std::fs::write(
+            &path,
+            format!("{COMPOSE_PROJECT_NAME_ENV}=from-dotenv\n{key}=from_file\n"),
+        )
+        .unwrap();
+
+        // SAFETY: test-only, unique key avoids interference.
+        unsafe {
+            std::env::remove_var(&key);
+        }
+        load_dotenv_into_env(&path, &messages).unwrap();
+        assert_eq!(std::env::var(&key).unwrap(), "from_file");
+        assert!(std::env::var(COMPOSE_PROJECT_NAME_ENV).is_err());
+
+        // SAFETY: as above.
         unsafe {
             std::env::remove_var(&key);
         }

--- a/src/commands/infra.rs
+++ b/src/commands/infra.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::io::IsTerminal;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -13,6 +14,10 @@ use bootroot::host_port::{
 use bootroot::openbao::OpenBaoClient;
 
 use crate::cli::args::{InfraInstallArgs, InfraUpArgs};
+use crate::commands::compose_project::{
+    INSTANCE_NAME_ENV_KEY, compose_args, resolve_compose_project, resolve_recorded_instance_name,
+    validate_instance_name,
+};
 use crate::commands::constants::RESPONDER_SERVICE_NAME;
 use crate::commands::dns_alias::replay_dns_aliases;
 use crate::commands::dotenv::write_dotenv;
@@ -77,20 +82,21 @@ const OPENBAO_API_WAIT_DELAY: Duration = Duration::from_millis(500);
 /// reaches the network under an air-gapped install and would silently
 /// substitute a registry image for the preloaded/release payload. Plain
 /// `up` (no `--no-build`) would instead silently build a missing image.
-fn build_compose_up_args<'a>(
-    compose_str: &'a str,
+fn build_compose_up_args(
+    project: &str,
+    compose_str: &str,
     no_build: bool,
-    svc_refs: &[&'a str],
-) -> Vec<&'a str> {
-    let mut up_args: Vec<&str> = vec!["compose", "-f", compose_str, "up"];
+    svc_refs: &[&str],
+) -> Vec<String> {
+    let mut tail: Vec<&str> = vec!["up"];
     if no_build {
-        up_args.extend(["--no-build", "--pull", "never"]);
+        tail.extend(["--no-build", "--pull", "never"]);
     } else {
-        up_args.push("--build");
+        tail.push("--build");
     }
-    up_args.push("-d");
-    up_args.extend(svc_refs);
-    up_args
+    tail.push("-d");
+    tail.extend(svc_refs);
+    compose_args(project, &[compose_str], None, &tail)
 }
 
 /// Determines whether `infra install` runs the preliminary `docker compose
@@ -173,16 +179,15 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
 
     let compose_str = args.compose_file.compose_file.to_string_lossy();
     let svc_refs: Vec<&str> = args.services.iter().map(String::as_str).collect();
+    // `infra up` has no identity flag of its own: the project comes from
+    // the `.env` beside the compose file it was handed (or an exported
+    // `COMPOSE_PROJECT_NAME`).
+    let project = resolve_compose_project(&args.compose_file.compose_file, None, messages)?;
 
     if loaded_archives == 0 {
-        let mut pull_args: Vec<&str> = vec![
-            "compose",
-            "-f",
-            &compose_str,
-            "pull",
-            "--ignore-pull-failures",
-        ];
-        pull_args.extend(&svc_refs);
+        let mut pull_tail: Vec<&str> = vec!["pull", "--ignore-pull-failures"];
+        pull_tail.extend(&svc_refs);
+        let pull_args = compose_args(&project, &[&compose_str], None, &pull_tail);
         run_docker(&pull_args, "docker compose pull", messages)?;
     }
 
@@ -198,23 +203,24 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
     let stepca_override_str = stepca_override
         .as_ref()
         .map(|p| p.to_string_lossy().into_owned());
-    let mut up_args: Vec<&str> = vec!["compose", "-f", &compose_str];
+    let mut up_files: Vec<&str> = vec![&compose_str];
     if let Some(ref s) = openbao_override_str {
-        up_args.extend(["-f", s.as_str()]);
+        up_files.push(s.as_str());
     }
     // Mount the TLS-enabled responder config before applying the
     // exposed-port override so the container starts with TLS active.
     if let Some(ref s) = responder_config_override_str {
-        up_args.extend(["-f", s.as_str()]);
+        up_files.push(s.as_str());
     }
     if let Some(ref s) = http01_override_str {
-        up_args.extend(["-f", s.as_str()]);
+        up_files.push(s.as_str());
     }
     if let Some(ref s) = stepca_override_str {
-        up_args.extend(["-f", s.as_str()]);
+        up_files.push(s.as_str());
     }
-    up_args.extend(["up", "-d"]);
-    up_args.extend(&svc_refs);
+    let mut up_tail: Vec<&str> = vec!["up", "-d"];
+    up_tail.extend(&svc_refs);
+    let up_args = compose_args(&project, &up_files, None, &up_tail);
     run_docker(&up_args, "docker compose up", messages)?;
 
     // Converge secrets ownership so an operator who upgrades and then only
@@ -228,7 +234,7 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
     if should_sweep_secrets_ownership(&args.services, &args.compose_file.compose_file, messages)? {
         let sweep_secrets_dir = resolve_effective_secrets_dir(&state_path, compose_dir)
             .unwrap_or_else(|| compose_dir.join("secrets"));
-        let image = resolve_stepca_image(&args.compose_file.compose_file, messages)?;
+        let image = resolve_stepca_image(&args.compose_file.compose_file, &project, messages)?;
         sweep_secrets_ownership(&sweep_secrets_dir, &image, messages)?;
     }
 
@@ -276,6 +282,7 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
 
     let readiness = collect_readiness(
         &args.compose_file.compose_file,
+        &project,
         None,
         &args.services,
         messages,
@@ -298,7 +305,7 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
     if state_path.exists()
         && let Ok(state) = StateFile::load(&state_path)
     {
-        replay_dns_aliases(&state, messages)?;
+        replay_dns_aliases(&state, &project, messages)?;
     }
 
     println!("{}", messages.infra_up_completed());
@@ -307,6 +314,12 @@ pub(crate) async fn run_infra_up(args: &InfraUpArgs, messages: &Messages) -> Res
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) -> Result<()> {
+    // Validate the declared identity before anything is written: a
+    // rejected name must leave no `.env` behind.
+    if let Some(ref instance_name) = args.instance_name {
+        validate_instance_name(instance_name, messages)?;
+    }
+
     ensure_all_services_localhost_binding(&args.compose_file.compose_file, messages)?;
 
     // Validate and resolve OpenBao non-loopback bind intent.
@@ -518,7 +531,20 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     // owned by a non-default uid is readable. `secrets_dir` was just
     // created (or already existed) above, so its owner is the intended one.
     let stepca_user = stepca_user_from_secrets_dir(&secrets_dir, messages)?;
-    write_install_dotenv(&env_path, &stepca_user, &host_port_entries, messages)?;
+    // The identity this install records.  Deliberately resolved before
+    // the `.env` write and independently of `COMPOSE_PROJECT_NAME`: that
+    // override selects the project for one invocation and is never an
+    // identity, so an install run under one still records what it would
+    // have recorded without it.
+    let instance_name =
+        resolve_recorded_instance_name(compose_dir, args.instance_name.as_deref(), messages)?;
+    write_install_dotenv(
+        &env_path,
+        &stepca_user,
+        &instance_name,
+        &host_port_entries,
+        messages,
+    )?;
 
     // Pre-bind the host-side ports the active compose stack will publish
     // so that a collision aborts before `docker compose up` half-creates
@@ -554,15 +580,20 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
         .map(|(key, value)| (*key, value.as_str()))
         .collect();
 
+    // The project this install acts on.  The declared identity wins, then
+    // an exported `COMPOSE_PROJECT_NAME`, then the identity just recorded
+    // in `.env` — so a harness that exports the variable still gets its
+    // own throwaway project while `.env` keeps the durable identity.
+    let project = resolve_compose_project(
+        &args.compose_file.compose_file,
+        args.instance_name.as_deref(),
+        messages,
+    )?;
+
     if should_pull_before_up(loaded_archives, args.no_build) {
-        let mut pull_args: Vec<&str> = vec![
-            "compose",
-            "-f",
-            &compose_str,
-            "pull",
-            "--ignore-pull-failures",
-        ];
-        pull_args.extend(&svc_refs);
+        let mut pull_tail: Vec<&str> = vec!["pull", "--ignore-pull-failures"];
+        pull_tail.extend(&svc_refs);
+        let pull_args = compose_args(&project, &[&compose_str], None, &pull_tail);
         run_docker_with_env(
             &pull_args,
             &host_port_env_refs,
@@ -575,7 +606,7 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     // official prebuilt image and is pulled, not built. `--no-build` with
     // `--pull never` uses the pre-loaded images exactly as-is for an
     // air-gapped install, never reaching a registry.
-    let up_args = build_compose_up_args(&compose_str, args.no_build, &svc_refs);
+    let up_args = build_compose_up_args(&project, &compose_str, args.no_build, &svc_refs);
     let up_label = if args.no_build {
         "docker compose up --no-build --pull never"
     } else {
@@ -589,7 +620,7 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
     // image it reuses exists (pulled by `up`, or loaded from the archive
     // on the air-gapped path).
     if should_sweep_secrets_ownership(&args.services, &args.compose_file.compose_file, messages)? {
-        let image = resolve_stepca_image(&args.compose_file.compose_file, messages)?;
+        let image = resolve_stepca_image(&args.compose_file.compose_file, &project, messages)?;
         sweep_secrets_ownership(&secrets_dir, &image, messages)?;
     }
 
@@ -602,6 +633,7 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
         .collect();
     let readiness = collect_readiness(
         &args.compose_file.compose_file,
+        &project,
         None,
         &prereq_services,
         messages,
@@ -622,6 +654,7 @@ pub(crate) fn run_infra_install(args: &InfraInstallArgs, messages: &Messages) ->
         let stepca_services = vec!["step-ca".to_string()];
         if let Ok(stepca_readiness) = collect_readiness(
             &args.compose_file.compose_file,
+            &project,
             None,
             &stepca_services,
             messages,
@@ -721,9 +754,20 @@ fn build_ownership_sweep_args<'a>(
 /// the networked path and loaded from the archive on the air-gapped
 /// path, and in both the sweep runs only after `up`, so the image
 /// already exists.
-fn resolve_stepca_image(compose_file: &Path, messages: &Messages) -> Result<String> {
-    let container_id =
-        docker_compose_output(compose_file, None, &["ps", "-a", "-q", "step-ca"], messages)?;
+///
+/// `project` is the one the caller just brought the stack up under, not
+/// a freshly resolved one: `infra install --instance-name` outranks the
+/// `COMPOSE_PROJECT_NAME` the resolver would otherwise return, so
+/// re-resolving here would probe a different project than `up` created
+/// and report step-ca as having no container.
+fn resolve_stepca_image(compose_file: &Path, project: &str, messages: &Messages) -> Result<String> {
+    let container_id = docker_compose_output(
+        compose_file,
+        project,
+        None,
+        &["ps", "-a", "-q", "step-ca"],
+        messages,
+    )?;
     let container_id = container_id.trim();
     if container_id.is_empty() {
         anyhow::bail!(messages.error_service_no_container("step-ca"));
@@ -868,9 +912,14 @@ impl HostPorts {
 /// `host_port_entries` carries only the host-port flags the operator
 /// supplied — see [`host_port_flag_entries`]; an unset flag leaves the
 /// variable absent so the compose interpolation default applies.
+///
+/// `instance_name` is the install's identity.  Both paths carry it, so
+/// every later compose-driving command can read the project back from
+/// the `.env` beside the compose file without a flag of its own.
 fn write_install_dotenv(
     env_path: &Path,
     stepca_user: &str,
+    instance_name: &str,
     host_port_entries: &[(&'static str, String)],
     messages: &Messages,
 ) -> Result<()> {
@@ -882,6 +931,14 @@ fn write_install_dotenv(
             env_path,
             STEPCA_USER_ENV_KEY,
             stepca_user,
+            messages,
+        )?;
+        // Upsert rather than append so a re-run with `--instance-name`
+        // rewrites the recorded identity instead of duplicating the key.
+        crate::commands::dotenv::update_dotenv_key(
+            env_path,
+            INSTANCE_NAME_ENV_KEY,
+            instance_name,
             messages,
         )?;
         for (key, value) in host_port_entries {
@@ -897,6 +954,7 @@ fn write_install_dotenv(
         ("POSTGRES_DB", DEFAULT_POSTGRES_DB),
         ("GRAFANA_ADMIN_PASSWORD", DEFAULT_GRAFANA_ADMIN_PASSWORD),
         (STEPCA_USER_ENV_KEY, stepca_user),
+        (INSTANCE_NAME_ENV_KEY, instance_name),
     ];
     entries.extend(
         host_port_entries
@@ -1018,7 +1076,8 @@ fn best_effort_listening_pid(port: u16) -> Option<String> {
 /// it may not be bootstrapped yet during the `init` flow.
 pub(crate) fn ensure_init_prereqs_ready(compose_file: &Path, messages: &Messages) -> Result<()> {
     let services = vec!["openbao".to_string(), "postgres".to_string()];
-    let readiness = collect_readiness(compose_file, None, &services, messages)?;
+    let project = resolve_compose_project(compose_file, None, messages)?;
+    let readiness = collect_readiness(compose_file, &project, None, &services, messages)?;
     ensure_all_healthy(&readiness, messages)?;
     Ok(())
 }
@@ -1833,14 +1892,20 @@ pub(crate) struct ContainerReadiness {
 
 pub(crate) fn collect_readiness(
     compose_file: &Path,
+    project: &str,
     profile: Option<&str>,
     services: &[String],
     messages: &Messages,
 ) -> Result<Vec<ContainerReadiness>> {
     let mut readiness = Vec::with_capacity(services.len());
     for service in services {
-        let container_id =
-            docker_compose_output(compose_file, profile, &["ps", "-q", service], messages)?;
+        let container_id = docker_compose_output(
+            compose_file,
+            project,
+            profile,
+            &["ps", "-q", service],
+            messages,
+        )?;
         let container_id = container_id.trim().to_string();
         if container_id.is_empty() {
             anyhow::bail!(messages.error_service_no_container(service));
@@ -1956,18 +2021,28 @@ fn is_image_archive(path: &Path) -> bool {
     name.to_ascii_lowercase().ends_with(".tar.gz")
 }
 
-pub(crate) fn run_docker(args: &[&str], context: &str, messages: &Messages) -> Result<()> {
+pub(crate) fn run_docker<S: AsRef<OsStr>>(
+    args: &[S],
+    context: &str,
+    messages: &Messages,
+) -> Result<()> {
     run_docker_with_env(args, &[], context, messages)
 }
 
-pub(crate) fn run_docker_with_env(
-    args: &[&str],
+/// Runs `docker` with `args`.
+///
+/// Generic over the argument type so a `docker compose` vector built by
+/// [`crate::commands::compose_project::compose_args`] (`Vec<String>`) and
+/// a plain `docker` argument array (`[&str; N]`) both pass without an
+/// intermediate collect.
+pub(crate) fn run_docker_with_env<S: AsRef<OsStr>>(
+    args: &[S],
     env: &[(&str, &str)],
     context: &str,
     messages: &Messages,
 ) -> Result<()> {
     let mut cmd = ProcessCommand::new("docker");
-    cmd.args(args);
+    cmd.args(args.iter().map(AsRef::as_ref));
     for (key, value) in env {
         cmd.env(key, value);
     }
@@ -1980,19 +2055,30 @@ pub(crate) fn run_docker_with_env(
     Ok(())
 }
 
+/// Runs a read-only `docker compose` invocation and returns its stdout.
+///
+/// This is how the readiness probe reaches Docker (`collect_readiness`
+/// runs `ps -q <service>` per service), so routing it through the shared
+/// constructor is what scopes `status`, `ca restart`, `infra up`,
+/// `infra install` and `monitoring status` to the resolved project.
+/// Without it they would report on whichever project Compose defaults to
+/// rather than the one they were pointed at.
+///
+/// `project` is passed in rather than resolved here so a caller that
+/// already knows it — `infra install`, whose `--instance-name` outranks
+/// everything the resolver would consult — probes the same project it
+/// just brought the stack up under.
 pub(crate) fn docker_compose_output(
     compose_file: &Path,
+    project: &str,
     profile: Option<&str>,
     args: &[&str],
     messages: &Messages,
 ) -> Result<String> {
     let compose_str = compose_file.to_string_lossy();
+    let scoped_args = compose_args(project, &[compose_str.as_ref()], profile, args);
     let mut cmd = ProcessCommand::new("docker");
-    cmd.args(["compose", "-f", compose_str.as_ref()]);
-    if let Some(profile) = profile {
-        cmd.args(["--profile", profile]);
-    }
-    cmd.args(args);
+    cmd.args(&scoped_args);
     let output = cmd
         .output()
         .with_context(|| messages.error_command_run_failed("docker compose"))?;
@@ -2020,6 +2106,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::commands::compose_project::DOCKER_COMPOSE_SUBCOMMAND;
     use crate::i18n::test_messages;
 
     const COMPOSE_WITH_STEPCA: &str = "services:\n  openbao:\n    image: openbao/openbao\n  \
@@ -2138,13 +2225,15 @@ mod tests {
     #[test]
     fn build_compose_up_args_defaults_to_build() {
         let svc_refs = ["openbao", "postgres"];
-        let args = build_compose_up_args("docker-compose.yml", false, &svc_refs);
+        let args = build_compose_up_args("insight", "docker-compose.yml", false, &svc_refs);
         assert_eq!(
             args,
             vec![
-                "compose",
+                DOCKER_COMPOSE_SUBCOMMAND,
                 "-f",
                 "docker-compose.yml",
+                "-p",
+                "insight",
                 "up",
                 "--build",
                 "-d",
@@ -2157,13 +2246,15 @@ mod tests {
     #[test]
     fn build_compose_up_args_no_build_selects_no_build_flag() {
         let svc_refs = ["openbao", "postgres"];
-        let args = build_compose_up_args("docker-compose.deploy.yml", true, &svc_refs);
+        let args = build_compose_up_args("insight", "docker-compose.deploy.yml", true, &svc_refs);
         assert_eq!(
             args,
             vec![
-                "compose",
+                DOCKER_COMPOSE_SUBCOMMAND,
                 "-f",
                 "docker-compose.deploy.yml",
+                "-p",
+                "insight",
                 "up",
                 "--no-build",
                 "--pull",
@@ -2173,7 +2264,7 @@ mod tests {
                 "postgres",
             ]
         );
-        assert!(!args.contains(&"--build"));
+        assert!(!args.iter().any(|arg| arg == "--build"));
     }
 
     #[test]
@@ -2377,6 +2468,7 @@ mod tests {
     fn install_args(compose_file: PathBuf) -> InfraInstallArgs {
         InfraInstallArgs {
             compose_file: crate::cli::args::ComposeFileArgs { compose_file },
+            instance_name: None,
             services: default_infra_services(),
             image_archive_dir: None,
             restart_policy: "always".to_string(),
@@ -2397,6 +2489,35 @@ mod tests {
             stepca_host_port: None,
             http01_admin_host_port: None,
             no_build: false,
+        }
+    }
+
+    /// An invalid identity must be rejected before any side effect, so
+    /// a mistyped `--instance-name` leaves no `.env` behind for the next
+    /// run to pick up.
+    #[test]
+    fn install_rejects_an_invalid_instance_name_before_writing_anything() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempdir().unwrap();
+        let compose_path = dir.path().join("docker-compose.yml");
+        std::fs::write(&compose_path, COMPOSE_WITHOUT_STEPCA).unwrap();
+
+        for invalid in ["Insight", "in sight", "-insight", "", &"a".repeat(40)] {
+            let mut args = install_args(compose_path.clone());
+            args.instance_name = Some(invalid.to_string());
+            let err = run_infra_install(&args, &messages).unwrap_err().to_string();
+            assert!(
+                err.contains("39"),
+                "{invalid:?} error must name the limit: {err}"
+            );
+            assert!(
+                !dir.path().join(".env").exists(),
+                "{invalid:?} must not leave an .env behind"
+            );
+            assert!(
+                !dir.path().join("secrets").exists(),
+                "{invalid:?} must not create the install directories"
+            );
         }
     }
 
@@ -2571,7 +2692,7 @@ mod tests {
             (STEPCA_HOST_PORT_ENV, "19000".to_string()),
             (HTTP01_ADMIN_HOST_PORT_ENV, "18080".to_string()),
         ];
-        write_install_dotenv(&env_path, "1000:1000", &entries, &messages).unwrap();
+        write_install_dotenv(&env_path, "1000:1000", "bootroot", &entries, &messages).unwrap();
         let contents = std::fs::read_to_string(&env_path).unwrap();
         assert!(
             contents.contains("OPENBAO_HOST_PORT=18200"),
@@ -2606,7 +2727,7 @@ mod tests {
             (STEPCA_HOST_PORT_ENV, "19000".to_string()),
             (HTTP01_ADMIN_HOST_PORT_ENV, "18080".to_string()),
         ];
-        write_install_dotenv(&env_path, "1000:1000", &entries, &messages).unwrap();
+        write_install_dotenv(&env_path, "1000:1000", "bootroot", &entries, &messages).unwrap();
         let contents = std::fs::read_to_string(&env_path).unwrap();
         for expected in [
             "POSTGRES_HOST_PORT=15433",
@@ -2629,12 +2750,74 @@ mod tests {
         let messages = crate::i18n::test_messages();
         let dir = tempfile::tempdir().unwrap();
         let env_path = dir.path().join(".env");
-        write_install_dotenv(&env_path, "1000:1000", &[], &messages).unwrap();
+        write_install_dotenv(&env_path, "1000:1000", "bootroot", &[], &messages).unwrap();
         let contents = std::fs::read_to_string(&env_path).unwrap();
         assert!(
             !contents.contains("OPENBAO_HOST_PORT"),
             "unset flags must not be written, got: {contents}"
         );
+    }
+
+    /// The identity has to land on the fresh-file path of
+    /// `write_install_dotenv`, next to the generated `PostgreSQL`
+    /// credentials — that is the `.env` every later command reads the
+    /// project back from.
+    #[test]
+    fn install_dotenv_records_the_instance_on_a_fresh_env() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        write_install_dotenv(&env_path, "1000:1000", "insight", &[], &messages).unwrap();
+        let contents = std::fs::read_to_string(&env_path).unwrap();
+        assert!(
+            contents.contains("BOOTROOT_INSTANCE=insight"),
+            "fresh .env must record the identity, got: {contents}"
+        );
+    }
+
+    /// The existing-file path upserts instead of appending, so repeated
+    /// installs cannot accumulate duplicate `BOOTROOT_INSTANCE` lines —
+    /// and the operator-authored keys plus the previously generated
+    /// `PostgreSQL` password survive.
+    #[test]
+    fn install_dotenv_upserts_the_instance_into_an_existing_env() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        std::fs::write(
+            &env_path,
+            "POSTGRES_PASSWORD=keepme\nBOOTROOT_INSTANCE=insight\nOPERATOR_KEY=untouched\n",
+        )
+        .unwrap();
+        write_install_dotenv(&env_path, "1000:1000", "security", &[], &messages).unwrap();
+        let contents = std::fs::read_to_string(&env_path).unwrap();
+        assert_eq!(
+            contents
+                .lines()
+                .filter(|line| line.starts_with("BOOTROOT_INSTANCE="))
+                .count(),
+            1,
+            "the identity must be upserted, not duplicated, got: {contents}"
+        );
+        assert!(contents.contains("BOOTROOT_INSTANCE=security"));
+        assert!(
+            contents.contains("POSTGRES_PASSWORD=keepme")
+                && contents.contains("OPERATOR_KEY=untouched"),
+            "unrelated keys must survive, got: {contents}"
+        );
+    }
+
+    /// Repeated installs must converge, not accumulate.
+    #[test]
+    fn install_dotenv_instance_write_is_idempotent() {
+        let messages = crate::i18n::test_messages();
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        write_install_dotenv(&env_path, "1000:1000", "insight", &[], &messages).unwrap();
+        let first = std::fs::read_to_string(&env_path).unwrap();
+        write_install_dotenv(&env_path, "1000:1000", "insight", &[], &messages).unwrap();
+        let second = std::fs::read_to_string(&env_path).unwrap();
+        assert_eq!(first, second);
     }
 
     /// Closes #731: a resolved `OpenBao` host port reaches a pre-existing
@@ -4835,6 +5018,7 @@ tls_key_path = \"/app/bootroot-http01/tls/server.key\"
             compose_file: ComposeFileArgs {
                 compose_file: compose_path,
             },
+            instance_name: None,
             services: vec!["openbao".to_string()],
             image_archive_dir: None,
             restart_policy: "always".to_string(),

--- a/src/commands/init/constants.rs
+++ b/src/commands/init/constants.rs
@@ -150,3 +150,86 @@ pub(crate) mod openbao_constants {
     pub(crate) const PATH_AGENT_EAB: &str = "bootroot/agent/eab";
     pub(crate) const PATH_CA_TRUST: &str = "bootroot/ca";
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{OPENBAO_AGENT_RESPONDER_CONTAINER_NAME, OPENBAO_AGENT_STEPCA_CONTAINER_NAME};
+    use crate::commands::compose_project::{
+        DEFAULT_INSTANCE_NAME, DNS_LABEL_LIMIT, LONGEST_CONTAINER_NAME_SUFFIX,
+        MAX_INSTANCE_NAME_LEN,
+    };
+
+    /// Reads the `container_name:` values the tree declares today.
+    ///
+    /// Precedent: `shipped_compose_files_pass_the_localhost_binding_guardrail`
+    /// in `commands/guardrails.rs` reaches the checked-in compose files
+    /// the same way.
+    fn declared_container_names() -> Vec<String> {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut names = Vec::new();
+        for file in ["docker-compose.yml", "docker-compose.deploy.yml"] {
+            let contents =
+                std::fs::read_to_string(root.join(file)).expect("compose file must be readable");
+            for line in contents.lines() {
+                if let Some(value) = line.trim().strip_prefix("container_name:") {
+                    names.push(value.trim().to_string());
+                }
+            }
+        }
+        // The two sidecars are pinned by the generated OpenBao agent
+        // override rather than by a checked-in compose file, so they have
+        // to be added by hand — and one of them is the longest name.
+        names.push(OPENBAO_AGENT_STEPCA_CONTAINER_NAME.to_string());
+        names.push(OPENBAO_AGENT_RESPONDER_CONTAINER_NAME.to_string());
+        names
+    }
+
+    /// The 39-character instance-name limit is derived from the container
+    /// names this tree declares: each becomes `<instance><suffix>`, which
+    /// serves as a DNS name on the compose network and as a certificate
+    /// SAN, so it must fit a 63-octet DNS label.  Adding a longer
+    /// container name later must fail here rather than silently making
+    /// the limit wrong.
+    #[test]
+    fn instance_name_limit_leaves_room_for_every_container_name_suffix() {
+        let names = declared_container_names();
+        assert!(
+            names.len() >= 9,
+            "expected the seven compose services plus two sidecars, got {names:?}"
+        );
+        let mut longest = 0;
+        for name in &names {
+            let suffix = name.strip_prefix(DEFAULT_INSTANCE_NAME).unwrap_or_else(|| {
+                panic!("container name `{name}` does not start with `{DEFAULT_INSTANCE_NAME}`")
+            });
+            longest = longest.max(suffix.len());
+        }
+        assert_eq!(
+            longest,
+            LONGEST_CONTAINER_NAME_SUFFIX.len(),
+            "the longest declared suffix no longer matches \
+             `LONGEST_CONTAINER_NAME_SUFFIX`; update it and the derived limit"
+        );
+        assert!(
+            MAX_INSTANCE_NAME_LEN + longest <= DNS_LABEL_LIMIT,
+            "{MAX_INSTANCE_NAME_LEN} + the longest suffix ({longest}) exceeds \
+             the {DNS_LABEL_LIMIT}-octet DNS label limit"
+        );
+    }
+
+    /// `commands/rotate.rs` re-declares the two sidecar container names
+    /// instead of importing them.  The derivation above reads the
+    /// originals, so the duplicates have to stay equal to them or the
+    /// limit would be derived from names `rotate` does not use.
+    #[test]
+    fn rotate_sidecar_container_names_match_the_originals() {
+        assert_eq!(
+            crate::commands::rotate::OPENBAO_AGENT_STEPCA_CONTAINER,
+            OPENBAO_AGENT_STEPCA_CONTAINER_NAME
+        );
+        assert_eq!(
+            crate::commands::rotate::OPENBAO_AGENT_RESPONDER_CONTAINER,
+            OPENBAO_AGENT_RESPONDER_CONTAINER_NAME
+        );
+    }
+}

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -24,6 +24,9 @@ pub(crate) use orchestrator::run_init;
 pub(crate) use prompts::prompt_yes_no;
 
 use super::types::EabCredentials;
+use crate::commands::compose_project::{
+    DEFAULT_INSTANCE_NAME, compose_args, resolve_compose_project,
+};
 use crate::i18n::Messages;
 
 pub(super) struct InitBootstrap {
@@ -136,10 +139,12 @@ impl InitRollback {
             // forward path can fail before that (no unseal key source is
             // available), and tearing down a container this run never
             // touched would knock a healthy deployment offline.
-            let args = rollback_openbao_docker_args(compose_file);
-            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let args = rollback_openbao_docker_args(
+                &rollback_project(compose_file, messages),
+                compose_file,
+            );
             if let Err(err) = crate::commands::infra::run_docker(
-                &arg_refs,
+                &args,
                 "docker compose up -d openbao (rollback)",
                 messages,
             ) {
@@ -156,10 +161,13 @@ impl InitRollback {
         if let Some(override_path) = &self.openbao_agent_compose_override
             && let Some(compose_file) = &self.compose_file
         {
-            let args = rollback_openbao_agent_docker_args(compose_file, override_path);
-            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let args = rollback_openbao_agent_docker_args(
+                &rollback_project(compose_file, messages),
+                compose_file,
+                override_path,
+            );
             if let Err(err) = crate::commands::infra::run_docker(
-                &arg_refs,
+                &args,
                 "docker compose rm infra agents (rollback)",
                 messages,
             ) {
@@ -200,10 +208,13 @@ impl InitRollback {
                 .as_ref()
                 .filter(|f| f.original.is_some())
                 .and(self.responder_compose_override.as_deref());
-            let args = rollback_responder_docker_args(compose_file, config_override);
-            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let args = rollback_responder_docker_args(
+                &rollback_project(compose_file, messages),
+                compose_file,
+                config_override,
+            );
             if let Err(err) = crate::commands::infra::run_docker(
-                &arg_refs,
+                &args,
                 "docker compose up -d responder (rollback)",
                 messages,
             ) {
@@ -271,22 +282,32 @@ impl InitRollback {
     }
 }
 
+/// Resolves the Compose project for a rollback invocation.
+///
+/// Rollback is best-effort and reports through `eprintln!` rather than
+/// `Result`, so an unreadable `.env` falls back to the default identity
+/// instead of aborting the teardown half-way: leaving the containers up
+/// would be worse than acting on the default project, which is the one
+/// an install without `--instance-name` created.
+fn rollback_project(compose_file: &std::path::Path, messages: &Messages) -> String {
+    resolve_compose_project(compose_file, None, messages)
+        .unwrap_or_else(|_| DEFAULT_INSTANCE_NAME.to_string())
+}
+
 /// Builds the Docker Compose arguments for undoing the TLS override
 /// during rollback.
 ///
-/// Returns `["compose", "-f", <compose_file>, "up", "-d", "openbao"]`
-/// so that the container is recreated from the base compose config
+/// Returns a `compose -f <compose_file> -p <project> up -d openbao`
+/// vector so that the container is recreated from the base compose config
 /// (without the non-loopback override), ensuring the external port
 /// mapping is removed.
-fn rollback_openbao_docker_args(compose_file: &std::path::Path) -> Vec<String> {
-    vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().into_owned(),
-        "up".to_string(),
-        "-d".to_string(),
-        "openbao".to_string(),
-    ]
+fn rollback_openbao_docker_args(project: &str, compose_file: &std::path::Path) -> Vec<String> {
+    compose_args(
+        project,
+        &[&compose_file.to_string_lossy()],
+        None,
+        &["up", "-d", "openbao"],
+    )
 }
 
 /// Builds the Docker Compose arguments for undoing the responder TLS
@@ -296,47 +317,55 @@ fn rollback_openbao_docker_args(compose_file: &std::path::Path) -> Vec<String> {
 /// its volume mount, but omits the exposed port override so the
 /// container reverts to loopback-only binding.
 fn rollback_responder_docker_args(
+    project: &str,
     compose_file: &std::path::Path,
     config_override: Option<&std::path::Path>,
 ) -> Vec<String> {
-    let mut args = vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().into_owned(),
-    ];
-    if let Some(override_path) = config_override {
-        args.push("-f".to_string());
-        args.push(override_path.to_string_lossy().into_owned());
+    let compose_str = compose_file.to_string_lossy();
+    let override_str = config_override.map(|path| path.to_string_lossy().into_owned());
+    let mut files: Vec<&str> = vec![&compose_str];
+    if let Some(ref override_str) = override_str {
+        files.push(override_str);
     }
-    args.push("up".to_string());
-    args.push("-d".to_string());
-    args.push(crate::commands::constants::RESPONDER_SERVICE_NAME.to_string());
-    args
+    compose_args(
+        project,
+        &files,
+        None,
+        &[
+            "up",
+            "-d",
+            crate::commands::constants::RESPONDER_SERVICE_NAME,
+        ],
+    )
 }
 
 /// Builds the Docker Compose arguments for tearing down the infra
 /// `OpenBao` agents during rollback.
 ///
-/// Returns `["compose", "-f", <compose>, "-f", <override>, "rm", "-s",
-/// "-f", <stepca>, <responder>]` so the two agent containers are
+/// Returns a `compose -f <compose> -f <override> -p <project> rm -s -f
+/// <stepca> <responder>` vector so the two agent containers are
 /// stopped and removed.  They were started with a TLS `VAULT_ADDR`/
 /// `ca_cert` that a rolled-back plaintext `OpenBao` cannot serve.
 fn rollback_openbao_agent_docker_args(
+    project: &str,
     compose_file: &std::path::Path,
     override_path: &std::path::Path,
 ) -> Vec<String> {
-    vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().into_owned(),
-        "-f".to_string(),
-        override_path.to_string_lossy().into_owned(),
-        "rm".to_string(),
-        "-s".to_string(),
-        "-f".to_string(),
-        super::constants::OPENBAO_AGENT_STEPCA_SERVICE.to_string(),
-        super::constants::OPENBAO_AGENT_RESPONDER_SERVICE.to_string(),
-    ]
+    compose_args(
+        project,
+        &[
+            &compose_file.to_string_lossy(),
+            &override_path.to_string_lossy(),
+        ],
+        None,
+        &[
+            "rm",
+            "-s",
+            "-f",
+            super::constants::OPENBAO_AGENT_STEPCA_SERVICE,
+            super::constants::OPENBAO_AGENT_RESPONDER_SERVICE,
+        ],
+    )
 }
 
 fn rollback_file(file: &RollbackFile, messages: &Messages) -> Result<()> {
@@ -571,7 +600,7 @@ mod rollback_tests {
         use std::path::PathBuf;
 
         let compose = PathBuf::from("docker-compose.yml");
-        let args = super::rollback_openbao_docker_args(&compose);
+        let args = super::rollback_openbao_docker_args("bootroot", &compose);
 
         assert!(
             args.contains(&"up".to_string()) && args.contains(&"-d".to_string()),
@@ -618,7 +647,7 @@ mod rollback_tests {
             .as_ref()
             .filter(|f| f.original.is_some())
             .and(rollback.responder_compose_override.as_deref());
-        let args = super::rollback_responder_docker_args(&compose, config_override);
+        let args = super::rollback_responder_docker_args("bootroot", &compose, config_override);
 
         assert!(
             !args.iter().any(|a| a.ends_with("override.yml")),
@@ -651,7 +680,7 @@ mod rollback_tests {
             .as_ref()
             .filter(|f| f.original.is_some())
             .and(rollback.responder_compose_override.as_deref());
-        let args = super::rollback_responder_docker_args(&compose, config_override);
+        let args = super::rollback_responder_docker_args("bootroot", &compose, config_override);
 
         assert!(
             args.iter().any(|a| a.ends_with("override.yml")),
@@ -669,9 +698,18 @@ mod rollback_tests {
 
         let compose = PathBuf::from("docker-compose.yml");
         let override_path = PathBuf::from("secrets/openbao/agent.override.yml");
-        let args = super::rollback_openbao_agent_docker_args(&compose, &override_path);
+        let args = super::rollback_openbao_agent_docker_args("bootroot", &compose, &override_path);
 
-        assert_eq!(args.first().map(String::as_str), Some("compose"));
+        assert_eq!(
+            args.first().map(String::as_str),
+            Some(crate::commands::compose_project::DOCKER_COMPOSE_SUBCOMMAND)
+        );
+        // Every rollback vector must carry the project scoping too,
+        // otherwise the teardown would hit Compose's default project.
+        assert!(
+            args.iter().any(|a| a == "-p") && args.iter().any(|a| a == "bootroot"),
+            "rollback must stay scoped to the resolved project: {args:?}"
+        );
         assert!(
             args.contains(&"rm".to_string())
                 && args.contains(&"-s".to_string())

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -31,6 +31,7 @@ use super::ca_certs::{compute_ca_bundle_pem, compute_ca_fingerprints};
 use super::prompts::{confirm_overwrite, prompt_text, prompt_unseal_keys};
 use super::{InitBootstrap, InitRollback, InitSecrets};
 use crate::cli::args::InitArgs;
+use crate::commands::compose_project::{compose_args, resolve_compose_project};
 use crate::commands::constants::CA_TRUST_KEY;
 use crate::commands::infra::run_docker;
 use crate::commands::openbao_unseal::read_unseal_keys_from_file;
@@ -901,6 +902,7 @@ pub(super) fn apply_openbao_agent_compose_override(
     override_path: &Path,
     messages: &Messages,
 ) -> Result<()> {
+    let project = resolve_compose_project(compose_file, None, messages)?;
     let compose_str = compose_file.to_string_lossy();
     let override_str = override_path.to_string_lossy();
     // `--no-deps` is load-bearing: the agent override does not include
@@ -914,18 +916,18 @@ pub(super) fn apply_openbao_agent_compose_override(
     // trip: infra-up starts openbao with the preserved exposed
     // override, and the agent compose-up here recreates it back to
     // loopback unless we tell compose to ignore the dependency.
-    let args = [
-        "compose",
-        "-f",
-        &*compose_str,
-        "-f",
-        &*override_str,
-        "up",
-        "-d",
-        "--no-deps",
-        OPENBAO_AGENT_STEPCA_SERVICE,
-        OPENBAO_AGENT_RESPONDER_SERVICE,
-    ];
+    let args = compose_args(
+        &project,
+        &[&compose_str, &override_str],
+        None,
+        &[
+            "up",
+            "-d",
+            "--no-deps",
+            OPENBAO_AGENT_STEPCA_SERVICE,
+            OPENBAO_AGENT_RESPONDER_SERVICE,
+        ],
+    );
     run_docker(&args, "docker compose openbao agent override", messages)?;
     Ok(())
 }

--- a/src/commands/init/steps/openbao_transition.rs
+++ b/src/commands/init/steps/openbao_transition.rs
@@ -24,6 +24,7 @@ use anyhow::{Context, Result};
 use bootroot::openbao::OpenBaoClient;
 
 use super::prompts::prompt_unseal_keys;
+use crate::commands::compose_project::{compose_args, resolve_compose_project};
 use crate::commands::infra::{
     build_openbao_client, run_docker, wait_for_openbao_api_reachable_within,
 };
@@ -172,18 +173,20 @@ fn read_prepared_keys(path: &Path, messages: &Messages) -> Result<PreparedUnseal
 /// this very invocation is the one adding the `openbao-exposed`
 /// override.  Both files stay on the command line so the published bind
 /// address is unchanged by the recreate.
-fn openbao_recreate_docker_args(compose_file: &Path, override_path: &Path) -> Vec<String> {
-    vec![
-        "compose".to_string(),
-        "-f".to_string(),
-        compose_file.to_string_lossy().into_owned(),
-        "-f".to_string(),
-        override_path.to_string_lossy().into_owned(),
-        "up".to_string(),
-        "-d".to_string(),
-        "--force-recreate".to_string(),
-        OPENBAO_SERVICE_NAME.to_string(),
-    ]
+fn openbao_recreate_docker_args(
+    project: &str,
+    compose_file: &Path,
+    override_path: &Path,
+) -> Vec<String> {
+    compose_args(
+        project,
+        &[
+            &compose_file.to_string_lossy(),
+            &override_path.to_string_lossy(),
+        ],
+        None,
+        &["up", "-d", "--force-recreate", OPENBAO_SERVICE_NAME],
+    )
 }
 
 /// The plaintext → TLS transition of the `OpenBao` listener.
@@ -241,9 +244,9 @@ impl<'a> OpenBaoTlsTransition<'a> {
 
         println!("{}", messages.init_openbao_tls_recreate());
         *recreated = true;
-        let args = openbao_recreate_docker_args(self.compose_file, self.override_path);
-        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        run_docker(&arg_refs, "docker compose up -d openbao (tls)", messages)?;
+        let project = resolve_compose_project(self.compose_file, None, messages)?;
+        let args = openbao_recreate_docker_args(&project, self.compose_file, self.override_path);
+        run_docker(&args, "docker compose up -d openbao (tls)", messages)?;
 
         let client = self.probe_tls(messages).await?;
         ensure_unsealed(&client, prepared, messages).await
@@ -365,7 +368,7 @@ mod tests {
     fn recreate_args_do_not_depend_on_a_compose_delta() {
         let compose = PathBuf::from("docker-compose.yml");
         let override_path = PathBuf::from("secrets/openbao/docker-compose.openbao-exposed.yml");
-        let args = openbao_recreate_docker_args(&compose, &override_path);
+        let args = openbao_recreate_docker_args("bootroot", &compose, &override_path);
 
         assert!(
             args.contains(&"--force-recreate".to_string()),

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -42,6 +42,7 @@ use super::stepca_setup::{
 use crate::cli::args::{InitArgs, InitFeature};
 use crate::cli::output::{print_init_plan, print_init_summary};
 use crate::commands::compose_file::compose_file_dir;
+use crate::commands::compose_project::{compose_args, resolve_compose_project};
 use crate::commands::constants::RESPONDER_SERVICE_NAME;
 use crate::commands::guardrails::{
     client_url_from_bind_addr, ensure_all_services_localhost_binding, validate_http01_admin_tls,
@@ -430,11 +431,26 @@ async fn run_init_inner(
         confirm_overwrite(prompt.message(messages), messages)?;
     }
 
+    let compose_dir = crate::commands::compose_file::compose_file_dir(&args.compose.compose_file);
+    let compose_dir = compose_dir.as_path();
+
+    // `init` has no identity flag: the project comes from the `.env`
+    // `infra install` left beside the compose file (or an exported
+    // `COMPOSE_PROJECT_NAME`), so it acts on the stack it was pointed at.
+    //
+    // Resolved before `.env` is loaded into the process environment, so
+    // that `init` resolves from exactly what `status` and `clean` see.
+    // Several sub-steps below re-resolve the project after that load —
+    // the agent-sidecar and responder overrides, the `OpenBao` TLS
+    // recreate, the DB-password rotation and rollback — so they must all
+    // reach the same answer. `load_dotenv_into_env` skips
+    // `COMPOSE_PROJECT_NAME` for exactly that reason; see its doc
+    // comment.
+    let project = resolve_compose_project(&args.compose.compose_file, None, messages)?;
+
     // Load .env into the process environment so that
     // `build_admin_dsn_from_env()` and `build_dsn_from_env()` can discover
     // the temporary POSTGRES_PASSWORD written by `infra install`.
-    let compose_dir = crate::commands::compose_file::compose_file_dir(&args.compose.compose_file);
-    let compose_dir = compose_dir.as_path();
     crate::commands::dotenv::load_dotenv_into_env(&compose_dir.join(".env"), messages)?;
 
     let (db_dsn, db_dsn_normalization, admin_dsn_for_kv) =
@@ -508,7 +524,7 @@ async fn run_init_inner(
     let will_init_stepca = !secrets_dir.join("config").join("ca.json").exists();
     if will_init_stepca {
         let compose_str = args.compose.compose_file.to_string_lossy();
-        let stop_args = ["compose", "-f", &*compose_str, "stop", "step-ca"];
+        let stop_args = compose_args(&project, &[&compose_str], None, &["stop", "step-ca"]);
         let _ = run_docker(&stop_args, "docker compose stop step-ca", messages);
     }
     // step-ca's own serving certificate must carry the address
@@ -597,7 +613,7 @@ async fn run_init_inner(
         // an installed system.  Gating on the change keeps a repeat
         // `init` with the same recorded intent restart-free.
         let compose_str = args.compose.compose_file.to_string_lossy();
-        let restart_args = ["compose", "-f", &*compose_str, "restart", "step-ca"];
+        let restart_args = compose_args(&project, &[&compose_str], None, &["restart", "step-ca"]);
         let _ = run_docker(&restart_args, "docker compose restart step-ca", messages);
     }
     // Apply the step-ca exposed override when a bind intent is stored.
@@ -619,17 +635,12 @@ async fn run_init_inner(
     {
         let compose_str = args.compose.compose_file.to_string_lossy();
         let override_str = stepca_override.to_string_lossy();
-        let up_args = [
-            "compose",
-            "-f",
-            &*compose_str,
-            "-f",
-            &*override_str,
-            "up",
-            "-d",
-            "--no-deps",
-            "step-ca",
-        ];
+        let up_args = compose_args(
+            &project,
+            &[&compose_str, &override_str],
+            None,
+            &["up", "-d", "--no-deps", "step-ca"],
+        );
         run_docker(&up_args, "docker compose up -d step-ca (exposed)", messages)?;
     }
     let compose_has_responder = compose_has_responder(&args.compose.compose_file, messages)?;
@@ -733,19 +744,12 @@ async fn run_init_inner(
             // non-loopback host-port publish.  Reinit-recovery's
             // second init pass would then lose access to the bind URL
             // mid-flow.
-            let up_args = [
-                "compose",
-                "-f",
-                &*compose_str,
-                "-f",
-                &*config_override_str,
-                "-f",
-                &*exposed_override_str,
-                "up",
-                "-d",
-                "--no-deps",
-                RESPONDER_SERVICE_NAME,
-            ];
+            let up_args = compose_args(
+                &project,
+                &[&compose_str, &config_override_str, &exposed_override_str],
+                None,
+                &["up", "-d", "--no-deps", RESPONDER_SERVICE_NAME],
+            );
             run_docker(
                 &up_args,
                 "docker compose up -d responder (tls + exposed)",
@@ -1226,8 +1230,9 @@ async fn maybe_rotate_env_db_password(
     )?;
 
     // Restart step-ca to pick up the new DSN from the patched ca.json.
+    let project = resolve_compose_project(compose_file, None, messages)?;
     let compose_str = compose_file.to_string_lossy();
-    let restart_args = ["compose", "-f", &*compose_str, "restart", "step-ca"];
+    let restart_args = compose_args(&project, &[&compose_str], None, &["restart", "step-ca"]);
     let _ = run_docker(&restart_args, "docker compose restart step-ca", messages);
 
     Ok(Some(new_dsn))

--- a/src/commands/init/steps/responder_setup.rs
+++ b/src/commands/init/steps/responder_setup.rs
@@ -15,6 +15,7 @@ use super::super::paths::{ResponderPaths, compose_has_responder};
 use super::super::types::ResponderCheck;
 use super::InitSecrets;
 use crate::cli::args::{InitArgs, InitSkipPhase};
+use crate::commands::compose_project::{compose_args, resolve_compose_project};
 use crate::commands::constants::RESPONDER_SERVICE_NAME;
 use crate::commands::infra::run_docker;
 use crate::i18n::Messages;
@@ -169,6 +170,7 @@ pub(super) fn apply_responder_compose_override(
     override_path: &Path,
     messages: &Messages,
 ) -> Result<()> {
+    let project = resolve_compose_project(compose_file, None, messages)?;
     let compose_str = compose_file.to_string_lossy();
     let override_str = override_path.to_string_lossy();
     // `--no-deps` mirrors `apply_openbao_agent_compose_override`: the
@@ -178,17 +180,12 @@ pub(super) fn apply_responder_compose_override(
     // host-port publish.  Subsequent KV calls against the bind URL
     // would then fail with `Connection refused`.  See the comment on
     // that helper for the reinit-recovery scenario that exercises this.
-    let args = [
-        "compose",
-        "-f",
-        &*compose_str,
-        "-f",
-        &*override_str,
-        "up",
-        "-d",
-        "--no-deps",
-        RESPONDER_SERVICE_NAME,
-    ];
+    let args = compose_args(
+        &project,
+        &[&compose_str, &override_str],
+        None,
+        &["up", "-d", "--no-deps", RESPONDER_SERVICE_NAME],
+    );
     run_docker(&args, "docker compose responder override", messages)?;
     Ok(())
 }

--- a/src/commands/monitoring.rs
+++ b/src/commands/monitoring.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command as ProcessCommand;
 
@@ -7,6 +8,7 @@ use serde_json::Value;
 use crate::cli::args::{
     MonitoringDownArgs, MonitoringProfile, MonitoringStatusArgs, MonitoringUpArgs,
 };
+use crate::commands::compose_project::{compose_args, resolve_compose_project};
 use crate::commands::infra::{
     ContainerReadiness, collect_container_failures, collect_readiness, docker_compose_output,
     docker_output, run_docker,
@@ -15,8 +17,10 @@ use crate::i18n::Messages;
 
 pub(crate) fn run_monitoring_up(args: &MonitoringUpArgs, messages: &Messages) -> Result<()> {
     let services = monitoring_services(args.profile);
+    let project = resolve_compose_project(&args.compose_file.compose_file, None, messages)?;
     if monitoring_already_running(
         &args.compose_file.compose_file,
+        &project,
         args.profile,
         &services,
         messages,
@@ -27,16 +31,9 @@ pub(crate) fn run_monitoring_up(args: &MonitoringUpArgs, messages: &Messages) ->
     let compose_str = args.compose_file.compose_file.to_string_lossy();
     let profile_str = args.profile.to_string();
     let svc_refs: Vec<&str> = services.iter().map(String::as_str).collect();
-    let mut up_args: Vec<&str> = vec![
-        "compose",
-        "-f",
-        &compose_str,
-        "--profile",
-        &profile_str,
-        "up",
-        "-d",
-    ];
-    up_args.extend(&svc_refs);
+    let mut up_tail: Vec<&str> = vec!["up", "-d"];
+    up_tail.extend(&svc_refs);
+    let up_args = compose_args(&project, &[&compose_str], Some(&profile_str), &up_tail);
     run_docker_with_env(
         &up_args,
         "docker compose up",
@@ -46,6 +43,7 @@ pub(crate) fn run_monitoring_up(args: &MonitoringUpArgs, messages: &Messages) ->
 
     let readiness = collect_readiness(
         &args.compose_file.compose_file,
+        &project,
         Some(&profile_str),
         &services,
         messages,
@@ -61,7 +59,8 @@ pub(crate) fn run_monitoring_status(
     args: &MonitoringStatusArgs,
     messages: &Messages,
 ) -> Result<()> {
-    let profiles = detect_running_profiles(&args.compose_file.compose_file, messages)?;
+    let project = resolve_compose_project(&args.compose_file.compose_file, None, messages)?;
+    let profiles = detect_running_profiles(&args.compose_file.compose_file, &project, messages)?;
     if profiles.is_empty() {
         anyhow::bail!(messages.monitoring_status_no_services());
     }
@@ -74,6 +73,7 @@ pub(crate) fn run_monitoring_status(
         let profile_str = profile.to_string();
         let readiness = collect_readiness(
             &args.compose_file.compose_file,
+            &project,
             Some(&profile_str),
             &services,
             messages,
@@ -123,7 +123,8 @@ pub(crate) fn run_monitoring_status(
 }
 
 pub(crate) fn run_monitoring_down(args: &MonitoringDownArgs, messages: &Messages) -> Result<()> {
-    let profiles = detect_running_profiles(&args.compose_file.compose_file, messages)?;
+    let project = resolve_compose_project(&args.compose_file.compose_file, None, messages)?;
+    let profiles = detect_running_profiles(&args.compose_file.compose_file, &project, messages)?;
     if profiles.is_empty() {
         anyhow::bail!(messages.monitoring_status_no_services());
     }
@@ -135,6 +136,7 @@ pub(crate) fn run_monitoring_down(args: &MonitoringDownArgs, messages: &Messages
             let profile_str = profile.to_string();
             let grafana_container_id = docker_compose_output(
                 &args.compose_file.compose_file,
+                &project,
                 Some(&profile_str),
                 &["ps", "-q", grafana_service],
                 messages,
@@ -159,27 +161,14 @@ pub(crate) fn run_monitoring_down(args: &MonitoringDownArgs, messages: &Messages
         let profile_str = profile.to_string();
         let svc_refs: Vec<&str> = services.iter().map(String::as_str).collect();
 
-        let mut stop_args: Vec<&str> = vec![
-            "compose",
-            "-f",
-            &compose_str,
-            "--profile",
-            &profile_str,
-            "stop",
-        ];
-        stop_args.extend(&svc_refs);
+        let mut stop_tail: Vec<&str> = vec!["stop"];
+        stop_tail.extend(&svc_refs);
+        let stop_args = compose_args(&project, &[&compose_str], Some(&profile_str), &stop_tail);
         run_docker(&stop_args, "docker compose stop", messages)?;
 
-        let mut rm_args: Vec<&str> = vec![
-            "compose",
-            "-f",
-            &compose_str,
-            "--profile",
-            &profile_str,
-            "rm",
-            "-f",
-        ];
-        rm_args.extend(&svc_refs);
+        let mut rm_tail: Vec<&str> = vec!["rm", "-f"];
+        rm_tail.extend(&svc_refs);
+        let rm_args = compose_args(&project, &[&compose_str], Some(&profile_str), &rm_tail);
         run_docker(&rm_args, "docker compose rm", messages)?;
     }
 
@@ -215,12 +204,14 @@ fn profile_grafana_service(profile: MonitoringProfile) -> &'static str {
 
 fn detect_running_profiles(
     compose_file: &Path,
+    project: &str,
     messages: &Messages,
 ) -> Result<Vec<MonitoringProfile>> {
     detect_running_profiles_with(|profile, service| {
         let profile_str = profile.to_string();
         let container_id = docker_compose_output(
             compose_file,
+            project,
             Some(&profile_str),
             &["ps", "-q", service],
             messages,
@@ -286,6 +277,7 @@ fn ensure_all_healthy(readiness: &[ContainerReadiness], messages: &Messages) -> 
 
 fn monitoring_already_running(
     compose_file: &Path,
+    project: &str,
     profile: MonitoringProfile,
     services: &[String],
     messages: &Messages,
@@ -294,6 +286,7 @@ fn monitoring_already_running(
     for service in services {
         let container_id = docker_compose_output(
             compose_file,
+            project,
             Some(&profile_str),
             &["ps", "-q", service],
             messages,
@@ -390,14 +383,18 @@ fn grafana_data_volume_name(container_id: &str, messages: &Messages) -> Result<O
     Ok(None)
 }
 
-fn run_docker_with_env(
-    args: &[&str],
+/// Runs `docker` with only `GRAFANA_ADMIN_PASSWORD` added to the child
+/// environment.  Generic over the argument type so the `Vec<String>`
+/// that `compose_project::compose_args` produces passes without an
+/// intermediate collect.
+fn run_docker_with_env<S: AsRef<OsStr>>(
+    args: &[S],
     context: &str,
     messages: &Messages,
     grafana_admin_password: Option<&str>,
 ) -> Result<()> {
     let mut command = ProcessCommand::new("docker");
-    command.args(args);
+    command.args(args.iter().map(AsRef::as_ref));
     if let Some(password) = grafana_admin_password {
         command.env("GRAFANA_ADMIN_PASSWORD", password);
     }

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -11,9 +11,10 @@ use crate::cli::args::{
 };
 use crate::commands::clean::{
     COMPOSE_PROJECT_LABEL, COMPOSE_SERVICE_LABEL, container_exists_via_docker,
-    inspect_label_via_docker, remove_openbao_container_and_volumes, resolve_compose_project,
+    inspect_label_via_docker, remove_openbao_container_and_volumes,
 };
 use crate::commands::compose_file::compose_file_dir;
+use crate::commands::compose_project::resolve_compose_project_for_dir;
 use crate::commands::guardrails::client_url_from_bind_addr;
 use crate::commands::infra::run_infra_up;
 use crate::commands::init::{OPENBAO_CONTAINER_NAME, compose_has_openbao, prompt_yes_no, run_init};
@@ -319,7 +320,8 @@ fn verify_compose_managed_openbao(
         // from a source independent of the container (env override or
         // compose-dir basename).  Otherwise a mismatched container
         // would never trip the check.
-        let expected_project = resolve_expected_compose_project_excluding_container(compose_dir)?;
+        let expected_project =
+            resolve_expected_compose_project_excluding_container(compose_dir, messages)?;
         let container_project = inspect(OPENBAO_CONTAINER_NAME, COMPOSE_PROJECT_LABEL)?
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -351,25 +353,22 @@ fn verify_compose_managed_openbao(
         // only when the compose project can be derived from the work
         // directory; an unresolvable project surfaces here as an
         // actionable error rather than letting reinit proceed.
-        let _ = resolve_expected_compose_project_excluding_container(compose_dir)?;
+        let _ = resolve_expected_compose_project_excluding_container(compose_dir, messages)?;
     }
     Ok(())
 }
 
-/// Derives the expected compose project from the environment override
-/// or the compose-dir basename, ignoring any label that may exist on
-/// the `bootroot-openbao` container.  This is used as the
+/// Derives the expected compose project from the shared resolver — the
 /// "what should be" side of the mismatch check.
-fn resolve_expected_compose_project_excluding_container(compose_dir: &Path) -> Result<String> {
-    if let Ok(env_value) = std::env::var("COMPOSE_PROJECT_NAME")
-        && !env_value.is_empty()
-    {
-        return Ok(env_value);
-    }
-    // Reuse the basename-normalisation half of `resolve_compose_project`
-    // by passing an `inspect` that never returns a label, forcing the
-    // fallback path.
-    resolve_compose_project(compose_dir, &|_, _| Ok(None))
+///
+/// The resolver deliberately never consults the container's own
+/// `com.docker.compose.project` label, so reading that label as the
+/// "what is" side stays a real comparison rather than a tautology.
+fn resolve_expected_compose_project_excluding_container(
+    compose_dir: &Path,
+    messages: &Messages,
+) -> Result<String> {
+    resolve_compose_project_for_dir(compose_dir, None, messages)
 }
 
 /// Subset of `StateFile` fields preserved across a reinit.  Mirrors the
@@ -1017,26 +1016,17 @@ mod tests {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
-    use std::sync::{LazyLock, Mutex, MutexGuard};
 
     use anyhow::Result;
     use tempfile::tempdir;
 
     use super::*;
+    // One crate-wide lock: the resolver these tests exercise is also
+    // driven from `clean` and `compose_project`, and a per-module mutex
+    // would let two modules mutate `COMPOSE_PROJECT_NAME` concurrently.
+    use crate::commands::compose_project::test_env::{ComposeProjectEnv, env_lock};
     use crate::i18n::test_messages;
     use crate::state::{InfraCertEntry, ReloadStrategy, StateFile};
-
-    /// Serialises tests in this module that mutate process-wide
-    /// environment variables (e.g. `COMPOSE_PROJECT_NAME`).  Rust's
-    /// default test runner spawns multiple threads in the same process,
-    /// so concurrent `env::set_var` calls would otherwise race and the
-    /// project-mismatch test could flake under load.  Mirrors the
-    /// `ENV_LOCK` pattern used in `commands/rotate.rs::test_support`.
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        ENV_LOCK.lock().expect("test env lock must not be poisoned")
-    }
 
     fn state_with_intent() -> StateFile {
         let mut infra_certs = BTreeMap::new();
@@ -1325,9 +1315,7 @@ mod tests {
         // The lock guards process-wide env mutation against parallel
         // tests in this module that also touch `COMPOSE_PROJECT_NAME`.
         let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        // SAFETY: env access is serialised by `env_lock` above.
-        unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
+        let _env = ComposeProjectEnv::set(None);
         let err = verify_compose_managed_openbao(
             &compose_file,
             &work,
@@ -1336,11 +1324,86 @@ mod tests {
             &messages,
         )
         .unwrap_err();
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        }
         assert!(err.to_string().contains("project"), "got: {err}");
+    }
+
+    /// The mismatch refusal must survive folding the expected-project
+    /// derivation onto the shared resolver.  Both `.env` states matter:
+    /// with a recorded identity the resolver returns it, without one it
+    /// returns the fixed default — and in either case a container whose
+    /// project label disagrees still aborts.
+    #[test]
+    fn verify_compose_managed_openbao_rejects_project_mismatch_with_and_without_dotenv() {
+        let messages = test_messages();
+        let container_exists = |_: &str| -> Result<bool> { Ok(true) };
+        let inspect = |_: &str, label: &str| -> Result<Option<String>> {
+            if label == COMPOSE_PROJECT_LABEL {
+                Ok(Some("someone-elses-project".to_string()))
+            } else if label == COMPOSE_SERVICE_LABEL {
+                Ok(Some(OPENBAO_COMPOSE_SERVICE.to_string()))
+            } else {
+                Ok(None)
+            }
+        };
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+
+        for recorded in [None, Some("insight")] {
+            let dir = tempdir().unwrap();
+            let work = dir.path().join("stack");
+            fs::create_dir_all(&work).unwrap();
+            let compose_file = work.join("docker-compose.yml");
+            fs::write(&compose_file, "services:\n  openbao:\n    image: openbao\n").unwrap();
+            if let Some(instance) = recorded {
+                fs::write(work.join(".env"), format!("BOOTROOT_INSTANCE={instance}\n")).unwrap();
+            }
+            let err = verify_compose_managed_openbao(
+                &compose_file,
+                &work,
+                &container_exists,
+                &inspect,
+                &messages,
+            )
+            .unwrap_err();
+            assert!(
+                err.to_string().contains("someone-elses-project"),
+                "recorded={recorded:?}, got: {err}"
+            );
+        }
+    }
+
+    /// The other half of the same fold: a container whose project label
+    /// matches the recorded identity is accepted, so the check is a real
+    /// comparison and not a blanket refusal.
+    #[test]
+    fn verify_compose_managed_openbao_accepts_container_matching_the_recorded_instance() {
+        let messages = test_messages();
+        let container_exists = |_: &str| -> Result<bool> { Ok(true) };
+        let inspect = |_: &str, label: &str| -> Result<Option<String>> {
+            if label == COMPOSE_PROJECT_LABEL {
+                Ok(Some("insight".to_string()))
+            } else if label == COMPOSE_SERVICE_LABEL {
+                Ok(Some(OPENBAO_COMPOSE_SERVICE.to_string()))
+            } else {
+                Ok(None)
+            }
+        };
+        let _guard = env_lock();
+        let _env = ComposeProjectEnv::set(None);
+        let dir = tempdir().unwrap();
+        let work = dir.path().join("stack");
+        fs::create_dir_all(&work).unwrap();
+        let compose_file = work.join("docker-compose.yml");
+        fs::write(&compose_file, "services:\n  openbao:\n    image: openbao\n").unwrap();
+        fs::write(work.join(".env"), "BOOTROOT_INSTANCE=insight\n").unwrap();
+        verify_compose_managed_openbao(
+            &compose_file,
+            &work,
+            &container_exists,
+            &inspect,
+            &messages,
+        )
+        .expect("a container in the recorded instance's project must be accepted");
     }
 
     #[test]
@@ -1419,9 +1482,7 @@ mod tests {
             }
         };
         let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        // SAFETY: env access is serialised by `env_lock` above.
-        unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
+        let _env = ComposeProjectEnv::set(None);
         let result = verify_compose_managed_openbao(
             &compose_file,
             &work,
@@ -1429,10 +1490,6 @@ mod tests {
             &inspect,
             &messages,
         );
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        }
         let err = result.unwrap_err();
         assert!(
             err.to_string().contains(COMPOSE_SERVICE_LABEL),
@@ -1462,21 +1519,15 @@ mod tests {
             }
         };
         let _guard = env_lock();
-        let prior = std::env::var_os("COMPOSE_PROJECT_NAME");
-        // SAFETY: env access is serialised by `env_lock` above.
-        unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
-        let result = verify_compose_managed_openbao(
+        let _env = ComposeProjectEnv::set(None);
+        verify_compose_managed_openbao(
             &compose_file,
             &work,
             &container_exists,
             &inspect,
             &messages,
-        );
-        if let Some(prior) = prior {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        }
-        result.expect("should accept existing container with matching compose labels");
+        )
+        .expect("should accept existing container with matching compose labels");
     }
 
     /// Regression for #611: when `--compose-file` is the default
@@ -1490,9 +1541,7 @@ mod tests {
     #[test]
     fn verify_compose_managed_openbao_accepts_default_relative_compose_file() {
         let _guard = env_lock();
-        let prior_env = std::env::var_os("COMPOSE_PROJECT_NAME");
-        // SAFETY: env access is serialised by `env_lock` above.
-        unsafe { std::env::remove_var("COMPOSE_PROJECT_NAME") };
+        let _env = ComposeProjectEnv::set(None);
 
         let dir = tempdir().unwrap();
         fs::write(
@@ -1517,10 +1566,6 @@ mod tests {
         );
 
         std::env::set_current_dir(&original_cwd).unwrap();
-        if let Some(prior) = prior_env {
-            // SAFETY: still inside the env_lock guard.
-            unsafe { std::env::set_var("COMPOSE_PROJECT_NAME", prior) };
-        }
 
         result.expect("default relative --compose-file must not break the scope check");
     }

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -6,6 +6,7 @@ use bootroot::fs_util;
 
 use super::RENDERED_FILE_POLL_INTERVAL;
 use crate::cli::prompt::Prompt;
+use crate::commands::compose_project::{compose_args, resolve_compose_project};
 use crate::commands::infra::run_docker;
 use crate::i18n::Messages;
 use crate::state::ServiceEntry;
@@ -94,8 +95,14 @@ pub(super) fn restart_compose_service(
     service: &str,
     messages: &Messages,
 ) -> Result<()> {
-    let compose_file = compose_file.to_string_lossy();
-    let args = ["compose", "-f", compose_file.as_ref(), "restart", service];
+    let project = resolve_compose_project(compose_file, None, messages)?;
+    let compose_str = compose_file.to_string_lossy();
+    let args = compose_args(
+        &project,
+        &[compose_str.as_ref()],
+        None,
+        &["restart", service],
+    );
     run_docker(&args, "docker compose restart", messages)
 }
 
@@ -104,16 +111,14 @@ pub(super) fn reload_compose_service(
     service: &str,
     messages: &Messages,
 ) -> Result<()> {
-    let compose_file = compose_file.to_string_lossy();
-    let args = [
-        "compose",
-        "-f",
-        compose_file.as_ref(),
-        "kill",
-        "-s",
-        "HUP",
-        service,
-    ];
+    let project = resolve_compose_project(compose_file, None, messages)?;
+    let compose_str = compose_file.to_string_lossy();
+    let args = compose_args(
+        &project,
+        &[compose_str.as_ref()],
+        None,
+        &["kill", "-s", "HUP", service],
+    );
     run_docker(&args, "docker compose kill", messages)
 }
 

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -15,6 +15,7 @@ use crate::cli::output::{
     ServiceAddAppliedPaths, ServiceAddPlan, ServiceAddRemoteBootstrap, ServiceAddSummaryOptions,
     print_service_add_plan, print_service_add_summary, print_service_info_summary,
 };
+use crate::commands::compose_project::resolve_compose_project_for_dir;
 use crate::commands::constants::DEFAULT_SECRET_ID_WRAP_TTL;
 use crate::commands::dns_alias::register_dns_alias;
 use crate::commands::init::validate_secret_id_ttl;
@@ -536,7 +537,11 @@ async fn run_service_add_apply(
         rollback.disarm();
     }
 
-    register_dns_alias(state, messages)?;
+    // `service add` takes no compose file, so the project comes from the
+    // `.env` in the process working directory — the same place these
+    // commands already resolve `state.json` from.
+    let project = resolve_compose_project_for_dir(Path::new("."), None, messages)?;
+    register_dns_alias(state, &project, messages)?;
 
     print_service_add_apply_summary(
         &entry,

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::cli::args::ServiceRemoveArgs;
 use crate::cli::prompt::Prompt;
+use crate::commands::compose_project::resolve_compose_project_for_dir;
 use crate::commands::constants::SERVICE_KV_BASE;
 use crate::commands::dns_alias::reconcile_dns_aliases;
 use crate::commands::openbao_auth::{authenticate_openbao_client, resolve_runtime_auth};
@@ -172,11 +173,14 @@ pub(crate) async fn run_service_remove(
     // the service and can retry the alias refresh instead of failing with
     // `error_service_not_found`. The alias refresh is part of
     // deregistration, not a post-persist afterthought.
+    // As in `service add`: no compose file argument, so the project comes
+    // from the `.env` in the process working directory.
+    let project = resolve_compose_project_for_dir(Path::new("."), None, messages)?;
     finalize_removal(
         &mut state,
         &state_path,
         &args.service_name,
-        |post_removal| reconcile_dns_aliases(post_removal, messages),
+        |post_removal| reconcile_dns_aliases(post_removal, &project, messages),
         messages,
     )?;
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -7,6 +7,7 @@ use time::format_description::well_known::Rfc3339;
 
 use crate::cli::args::StatusArgs;
 use crate::commands::compose_file::compose_file_dir;
+use crate::commands::compose_project::resolve_compose_project;
 use crate::commands::infra::{
     ContainerReadiness, collect_container_failures, collect_readiness, default_infra_services,
 };
@@ -21,7 +22,9 @@ use crate::state::StateFile;
 
 pub(crate) async fn run_status(args: &StatusArgs, messages: &Messages) -> Result<()> {
     let services = default_infra_services();
-    let readiness = collect_readiness(&args.compose.compose_file, None, &services, messages)?;
+    let compose_file = &args.compose.compose_file;
+    let project = resolve_compose_project(compose_file, None, messages)?;
+    let readiness = collect_readiness(compose_file, &project, None, &services, messages)?;
     let infra_failures = collect_container_failures(&readiness);
 
     let state_path = StateFile::default_path();

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -435,6 +435,8 @@ pub(crate) struct Strings {
     pub(crate) dns_alias_connect_recovered: &'static str,
     pub(crate) dns_alias_rollback_failed: &'static str,
     pub(crate) dns_alias_network_not_found: &'static str,
+    pub(crate) dns_alias_responder_ambiguous: &'static str,
+    pub(crate) error_instance_name_invalid: &'static str,
     pub(crate) error_service_update_failed: &'static str,
     pub(crate) error_service_update_no_flags: &'static str,
     pub(crate) service_update_summary: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -424,6 +424,8 @@ pub(super) static STRINGS: Strings = Strings {
     dns_alias_connect_recovered: "WARNING: DNS alias registration failed but network connectivity was restored. Run `bootroot infra up` to apply aliases later. ({error})",
     dns_alias_rollback_failed: "CRITICAL: rollback also failed — bootroot-http01 is detached from network {network}. Reconnect manually: docker network connect {network} bootroot-http01 ({error})",
     dns_alias_network_not_found: "No Docker network found for container {value}",
+    dns_alias_responder_ambiguous: "{count} HTTP-01 responder containers match compose project `{project}`; refusing to pick one arbitrarily. Remove the stale container, or reinstall the other instance with a distinct `--instance-name`.",
+    error_instance_name_invalid: "Invalid --instance-name `{name}`: use lowercase ASCII letters, digits and `-`, starting with a letter or digit, at most {max} characters",
     error_service_update_failed: "bootroot service update failed",
     error_service_update_no_flags: "No update flags specified; pass --secret-id-ttl, --secret-id-wrap-ttl, --no-wrap, --rn-cidrs, --cert-group, --reload-style, or --post-renew-command",
     service_update_summary: "bootroot service update: summary",

--- a/src/i18n/infra.rs
+++ b/src/i18n/infra.rs
@@ -259,4 +259,18 @@ impl Messages {
             &[("value", container_id)],
         )
     }
+
+    pub(crate) fn dns_alias_responder_ambiguous(&self, count: usize, project: &str) -> String {
+        format_template(
+            self.strings().dns_alias_responder_ambiguous,
+            &[("count", &count.to_string()), ("project", project)],
+        )
+    }
+
+    pub(crate) fn error_instance_name_invalid(&self, name: &str, max: usize) -> String {
+        format_template(
+            self.strings().error_instance_name_invalid,
+            &[("name", name), ("max", &max.to_string())],
+        )
+    }
 }

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -424,6 +424,8 @@ pub(super) static STRINGS: Strings = Strings {
     dns_alias_connect_recovered: "경고: DNS 별칭 등록에 실패했지만 네트워크 연결이 복원되었습니다. 나중에 `bootroot infra up`을 실행하여 별칭을 적용하세요. ({error})",
     dns_alias_rollback_failed: "심각: 롤백도 실패 — bootroot-http01이 네트워크 {network}에서 분리됨. 수동 복구: docker network connect {network} bootroot-http01 ({error})",
     dns_alias_network_not_found: "컨테이너 {value}에 대한 Docker 네트워크를 찾을 수 없습니다",
+    dns_alias_responder_ambiguous: "compose 프로젝트 `{project}`에 일치하는 HTTP-01 응답기 컨테이너가 {count}개입니다. 임의로 선택하지 않습니다. 오래된 컨테이너를 제거하거나, 다른 인스턴스를 별도의 `--instance-name`으로 다시 설치하세요.",
+    error_instance_name_invalid: "잘못된 --instance-name `{name}`: 소문자 ASCII 문자, 숫자, `-`만 사용할 수 있으며 문자 또는 숫자로 시작하고 최대 {max}자여야 합니다",
     error_service_update_failed: "bootroot service update 실패",
     error_service_update_no_flags: "업데이트 플래그가 지정되지 않았습니다; --secret-id-ttl, --secret-id-wrap-ttl, --no-wrap, --rn-cidrs, --cert-group, --reload-style, 또는 --post-renew-command를 전달하세요",
     service_update_summary: "bootroot service update: 요약",

--- a/tests/bootroot_cli.rs
+++ b/tests/bootroot_cli.rs
@@ -129,6 +129,384 @@ fn test_status_command_message() {
     assert!(stdout.contains("status"));
 }
 
+/// Closes #745: `status` reaches Docker only through
+/// `docker compose ps -q`, so the project recorded in the `.env` beside
+/// the compose file is what decides whose containers it reports on. The
+/// fake docker records its argv so the `-p <instance>` scoping is
+/// asserted directly rather than inferred from the summary text.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_status_scopes_compose_to_the_recorded_instance() {
+    use std::env;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use anyhow::Context;
+    use support::{ROOT_TOKEN, stub_openbao};
+    use tempfile::tempdir;
+    use wiremock::MockServer;
+
+    let temp_dir = tempdir().expect("create temp dir");
+    let compose_file = temp_dir.path().join("docker-compose.yml");
+    fs::write(&compose_file, "services: {}")
+        .context("write compose file")
+        .unwrap();
+    // The identity `infra install --instance-name insight` would record.
+    fs::write(temp_dir.path().join(".env"), "BOOTROOT_INSTANCE=insight\n")
+        .context("write .env")
+        .unwrap();
+
+    let bin_dir = temp_dir.path().join("bin");
+    fs::create_dir_all(&bin_dir)
+        .context("create bin dir")
+        .unwrap();
+    let argv_log = temp_dir.path().join("docker-argv.log");
+    let fake_docker = format!(
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"{log}"
+
+if [ "${{1:-}}" = "compose" ]; then
+  printf "cid-openbao"
+  exit 0
+fi
+
+if [ "${{1:-}}" = "inspect" ]; then
+  printf "running|healthy"
+  exit 0
+fi
+
+exit 0
+"#,
+        log = argv_log.display()
+    );
+    let docker_path = bin_dir.join("docker");
+    fs::write(&docker_path, fake_docker)
+        .context("write fake docker")
+        .unwrap();
+    fs::set_permissions(&docker_path, fs::Permissions::from_mode(0o700))
+        .context("chmod fake docker")
+        .unwrap();
+
+    let server = MockServer::start().await;
+    stub_openbao(&server).await;
+    write_state_with_service(temp_dir.path()).expect("write state");
+
+    let path = env::var("PATH").unwrap_or_default();
+    let combined_path = format!("{}:{}", bin_dir.display(), path);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_bootroot"))
+        .current_dir(temp_dir.path())
+        .args([
+            "status",
+            "--compose-file",
+            compose_file.to_string_lossy().as_ref(),
+            "--openbao-url",
+            &server.uri(),
+            "--root-token",
+            ROOT_TOKEN,
+        ])
+        .env("PATH", combined_path)
+        // An unset override is what makes the recorded identity decide.
+        .env_remove("COMPOSE_PROJECT_NAME")
+        .output()
+        .expect("run status");
+
+    assert!(output.status.success());
+    let argv = fs::read_to_string(&argv_log).expect("fake docker must have been invoked");
+    let compose_lines: Vec<&str> = argv
+        .lines()
+        .filter(|line| line.starts_with("compose "))
+        .collect();
+    assert!(
+        !compose_lines.is_empty(),
+        "status must drive `docker compose`, got: {argv}"
+    );
+    for line in &compose_lines {
+        assert!(
+            line.contains("-p insight"),
+            "every compose invocation must be scoped to the recorded instance: {line}"
+        );
+    }
+}
+
+/// Test-only fixture for driving `infra install` against a fake `docker`.
+///
+/// The unit tests cover the identity's halves separately — validation,
+/// the `.env` upsert, the resolver's precedence, the argument
+/// constructor.  What only an end-to-end run pins is that
+/// `run_infra_install` wires them together in the right order: the
+/// recorded identity is resolved before the `.env` write and ignores
+/// `COMPOSE_PROJECT_NAME`, while the project the stack is brought up
+/// under is resolved after it and honours the override.
+#[cfg(unix)]
+struct InstallHarness {
+    dir: tempfile::TempDir,
+    compose_file: std::path::PathBuf,
+    bin_dir: std::path::PathBuf,
+    argv_log: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl InstallHarness {
+    fn new() -> Self {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let compose_file = dir.path().join("docker-compose.yml");
+        // No `ports:` at all, so the localhost-binding guardrail passes
+        // and only the resolved `--openbao-host-port` is pre-bound.
+        fs::write(&compose_file, "services:\n  openbao:\n    image: openbao\n")
+            .expect("write compose file");
+
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir_all(&bin_dir).expect("create bin dir");
+        let argv_log = dir.path().join("docker-argv.log");
+        let fake_docker = format!(
+            r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"{log}"
+
+if [ "${{1:-}}" = "compose" ]; then
+  printf "cid-openbao"
+  exit 0
+fi
+
+if [ "${{1:-}}" = "inspect" ]; then
+  printf "running|healthy"
+  exit 0
+fi
+
+exit 0
+"#,
+            log = argv_log.display()
+        );
+        let docker_path = bin_dir.join("docker");
+        fs::write(&docker_path, fake_docker).expect("write fake docker");
+        fs::set_permissions(&docker_path, fs::Permissions::from_mode(0o700))
+            .expect("chmod fake docker");
+
+        Self {
+            dir,
+            compose_file,
+            bin_dir,
+            argv_log,
+        }
+    }
+
+    /// Picks a port that is free right now, so the install's host-port
+    /// pre-bind does not collide with whatever the developer happens to
+    /// be running.
+    fn free_port() -> u16 {
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port for probing");
+        listener
+            .local_addr()
+            .expect("probe socket must have an address")
+            .port()
+    }
+
+    fn install(&self, instance_name: Option<&str>, compose_project_name: Option<&str>) -> String {
+        let path = std::env::var("PATH").unwrap_or_default();
+        let mut command = Command::new(env!("CARGO_BIN_EXE_bootroot"));
+        command
+            .current_dir(self.dir.path())
+            .args([
+                "infra",
+                "install",
+                "--compose-file",
+                self.compose_file.to_string_lossy().as_ref(),
+                "--services",
+                "openbao",
+                "--openbao-host-port",
+                &Self::free_port().to_string(),
+            ])
+            .env("PATH", format!("{}:{}", self.bin_dir.display(), path));
+        if let Some(instance_name) = instance_name {
+            command.args(["--instance-name", instance_name]);
+        }
+        match compose_project_name {
+            Some(value) => command.env("COMPOSE_PROJECT_NAME", value),
+            None => command.env_remove("COMPOSE_PROJECT_NAME"),
+        };
+
+        let output = command.output().expect("run infra install");
+        assert!(
+            output.status.success(),
+            "infra install failed: {}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        std::fs::read_to_string(&self.argv_log).expect("fake docker must have been invoked")
+    }
+
+    fn dotenv(&self) -> String {
+        std::fs::read_to_string(self.dir.path().join(".env")).expect("install must write .env")
+    }
+
+    /// Asserts every `docker compose` invocation the run made carried
+    /// `-p <project>`.  A single hand-built vector would show up here as
+    /// a compose line without the flag.
+    fn assert_every_compose_scoped_to(argv: &str, project: &str) {
+        let compose_lines: Vec<&str> = argv
+            .lines()
+            .filter(|line| line.starts_with("compose "))
+            .collect();
+        assert!(
+            !compose_lines.is_empty(),
+            "infra install must drive `docker compose`, got: {argv}"
+        );
+        for line in &compose_lines {
+            assert!(
+                line.contains(&format!("-p {project} ")),
+                "every compose invocation must carry `-p {project}`: {line}"
+            );
+        }
+    }
+}
+
+/// Closes #745: `infra install --instance-name insight` brings the stack
+/// up under project `insight` and records the identity in the `.env`
+/// beside the compose file.
+#[cfg(unix)]
+#[test]
+fn test_infra_install_scopes_compose_to_the_declared_instance() {
+    let harness = InstallHarness::new();
+    let argv = harness.install(Some("insight"), None);
+    InstallHarness::assert_every_compose_scoped_to(&argv, "insight");
+    assert!(
+        harness.dotenv().contains("BOOTROOT_INSTANCE=insight"),
+        "the declared identity must be recorded, got: {}",
+        harness.dotenv()
+    );
+}
+
+/// Closes #745: with no flag and no override, the project is the fixed
+/// literal `bootroot` — not the compose directory's basename, which
+/// here is a random `tempdir` name.
+#[cfg(unix)]
+#[test]
+fn test_infra_install_defaults_to_the_fixed_project() {
+    let harness = InstallHarness::new();
+    let argv = harness.install(None, None);
+    InstallHarness::assert_every_compose_scoped_to(&argv, "bootroot");
+    assert!(harness.dotenv().contains("BOOTROOT_INSTANCE=bootroot"));
+}
+
+/// Closes #745: an exported `COMPOSE_PROJECT_NAME` selects the project
+/// for the invocation — verbatim, and without being validated against
+/// the 39-character instance-name rule — but is never recorded, so the
+/// `.env` still carries the identity the install would have had without
+/// it.
+#[cfg(unix)]
+#[test]
+fn test_infra_install_honours_compose_project_name_without_recording_it() {
+    const HARNESS_PROJECT: &str = "bootroot-e2e-ci-openbao-tls-no-delta-1234567";
+    assert!(HARNESS_PROJECT.len() > 39, "must exceed the instance limit");
+
+    let harness = InstallHarness::new();
+    let argv = harness.install(None, Some(HARNESS_PROJECT));
+    InstallHarness::assert_every_compose_scoped_to(&argv, HARNESS_PROJECT);
+    assert!(
+        harness.dotenv().contains("BOOTROOT_INSTANCE=bootroot"),
+        "the override must not become the identity, got: {}",
+        harness.dotenv()
+    );
+}
+
+/// Closes #745: `--instance-name` outranks an exported
+/// `COMPOSE_PROJECT_NAME`, and a re-run without the flag keeps the
+/// recorded identity rather than resetting it to the default — while the
+/// generated `PostgreSQL` password survives the upsert.
+#[cfg(unix)]
+#[test]
+fn test_infra_install_rerun_preserves_the_recorded_instance() {
+    let harness = InstallHarness::new();
+    let argv = harness.install(Some("insight"), Some("throwaway-project"));
+    InstallHarness::assert_every_compose_scoped_to(&argv, "insight");
+
+    let first_dotenv = harness.dotenv();
+    let password = first_dotenv
+        .lines()
+        .find(|line| line.starts_with("POSTGRES_PASSWORD="))
+        .expect("the first install must generate a PostgreSQL password")
+        .to_string();
+
+    let argv = harness.install(None, None);
+    InstallHarness::assert_every_compose_scoped_to(&argv, "insight");
+
+    let second_dotenv = harness.dotenv();
+    assert_eq!(
+        second_dotenv
+            .lines()
+            .filter(|line| line.starts_with("BOOTROOT_INSTANCE="))
+            .count(),
+        1,
+        "the identity must be upserted, not duplicated: {second_dotenv}"
+    );
+    assert!(second_dotenv.contains("BOOTROOT_INSTANCE=insight"));
+    assert!(
+        second_dotenv.contains(&password),
+        "the generated password must survive the re-run: {second_dotenv}"
+    );
+}
+
+/// Closes #745: an invalid `--instance-name` is rejected with an error
+/// naming the character set and the limit, and nothing is written.
+#[cfg(unix)]
+#[test]
+fn test_infra_install_rejects_invalid_instance_names() {
+    let long_name = "a".repeat(40);
+    for invalid in ["Insight", "in sight", "-insight", "", long_name.as_str()] {
+        let harness = InstallHarness::new();
+        let path = std::env::var("PATH").unwrap_or_default();
+        let output = Command::new(env!("CARGO_BIN_EXE_bootroot"))
+            .current_dir(harness.dir.path())
+            .args([
+                "infra",
+                "install",
+                "--compose-file",
+                harness.compose_file.to_string_lossy().as_ref(),
+                "--services",
+                "openbao",
+                "--instance-name",
+                invalid,
+            ])
+            .env("PATH", format!("{}:{}", harness.bin_dir.display(), path))
+            .env_remove("COMPOSE_PROJECT_NAME")
+            .output()
+            .expect("run infra install");
+
+        assert!(!output.status.success(), "{invalid:?} must be rejected");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("39"),
+            "{invalid:?} error must name the limit: {stderr}"
+        );
+        assert!(
+            !harness.dir.path().join(".env").exists(),
+            "{invalid:?} must not leave an .env behind"
+        );
+    }
+}
+
+/// A 39-character name is the boundary the limit is derived from, so it
+/// must be accepted end to end rather than only by the validator.
+#[cfg(unix)]
+#[test]
+fn test_infra_install_accepts_the_maximum_length_instance_name() {
+    let name = "a".repeat(39);
+    let harness = InstallHarness::new();
+    let argv = harness.install(Some(&name), None);
+    InstallHarness::assert_every_compose_scoped_to(&argv, &name);
+    assert!(
+        harness
+            .dotenv()
+            .contains(&format!("BOOTROOT_INSTANCE={name}"))
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn test_status_command_summary() {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -42,14 +42,35 @@ pub(crate) fn write_fake_docker_with_status(
     status: &str,
     health: &str,
 ) -> Result<PathBuf> {
+    // The `ps -q <service>` match walks the argument list instead of
+    // indexing fixed positions: bootroot emits compose-level flags
+    // (`-f`, `--profile`, `-p <project>`) ahead of the subcommand, and
+    // how many there are is not fixed.
     let script = format!(
         r#"#!/bin/sh
 set -eu
 
-if [ "${{1:-}}" = "compose" ] && [ "${{2:-}}" = "-f" ] && [ "${{4:-}}" = "ps" ] && [ "${{5:-}}" = "-q" ]; then
-  service="${{6:-}}"
-  printf "cid-%s" "$service"
-  exit 0
+if [ "${{1:-}}" = "compose" ]; then
+  saw_ps=0
+  saw_q=0
+  service=""
+  for arg in "$@"; do
+    if [ "$saw_q" = "1" ] && [ -z "$service" ]; then
+      service="$arg"
+      continue
+    fi
+    if [ "$arg" = "ps" ]; then
+      saw_ps=1
+      continue
+    fi
+    if [ "$saw_ps" = "1" ] && [ "$arg" = "-q" ]; then
+      saw_q=1
+    fi
+  done
+  if [ "$saw_q" = "1" ] && [ -n "$service" ]; then
+    printf "cid-%s" "$service"
+    exit 0
+  fi
 fi
 
 if [ "${{1:-}}" = "inspect" ]; then


### PR DESCRIPTION
## Summary

Two bootroot installs on one host landed in the same Docker Compose project, so the second silently adopted the first's volumes and containers. Neither compose file sets a top-level `name:` and no invocation passed `-p`, so both installs took whatever project Compose derives from the compose directory's basename — conventionally `bootroot` for both.

This gives an install an explicit identity and threads it through every `docker compose` invocation.

- **`infra install --instance-name <name>`** — the whole identity, on `infra install` and no other command. Validated (lowercase ASCII letters, digits and `-`, starting with a letter or digit, at most 39 characters — derived so `<name>-openbao-agent-responder` fits a 63-octet DNS label), and recorded as `BOOTROOT_INSTANCE` in the compose directory's `.env` through both paths of `write_install_dotenv`. Not recorded in `state.json`, whose default path resolves against the process working directory rather than the compose directory.
- **One resolver, one order** (`src/commands/compose_project.rs`): `--instance-name`, then `COMPOSE_PROJECT_NAME` from the invoking environment, then `BOOTROOT_INSTANCE` from the `.env` beside the compose file, then the literal `bootroot`. The default is a fixed literal rather than the directory basename, so the identity is a property of the install and not of where it sits. Every other compose-driving command resolves from the compose file it was handed, with no flag of its own and regardless of the working directory.
- **`COMPOSE_PROJECT_NAME` keeps working** as Compose's own per-invocation override: used verbatim, never validated against the instance-name rules (the harness's project names exceed 39 characters), never recorded. `load_dotenv_into_env` now skips that key, so a `.env`-authored value cannot become an override for the second half of an `init` run and split it across two compose networks.
- **One constructor for all 25 invocation sites** — `compose_args` is what emits `-p`, at the compose-flag position after `-f`/`--profile`. Routing `infra::docker_compose_output` through it is what scopes the readiness probe behind `status`, `ca restart`, `infra up` and `monitoring status`. A test fails when a compose vector is built anywhere else.
- **`clean` and `reinit`** drop their container-label and basename derivations onto the shared resolver; `normalise_compose_project_name` goes away with its test. `reinit` still reads the live container's `com.docker.compose.project` label as the "what is" side of its mismatch check, so that check stays a real comparison.
- **`dns_alias`** filters the responder lookup on `com.docker.compose.project` as well as the service label, and errors instead of taking the first match when more than one still matches.
- **Scripts and CI** that drive `docker compose` alongside bootroot now pin `-p "${COMPOSE_PROJECT_NAME:-bootroot}"`, matching what the resolver returns — otherwise a bare `docker compose` in a git worktree or a differently-named CI workspace would diverge from bootroot's explicit `-p`. `deploy-no-build-smoke.sh` is the sharpest case: its argv assertion pins the whole `compose -f … -p … up --no-build --pull never` vector, so it now asserts the `-p` position too, and its own teardown has to name the same project or it would leave the smoke's stack standing in front of the job's next `infra install`.

Container names stay literal (out of scope, per the issue), so a second co-located install with a *distinct* identity now fails loudly with Docker's container-name-already-in-use error instead of cannibalising the first. Two installs that both take the default identity still share one project, by design.

Both new operator-facing strings are in `src/i18n/en.rs` and `src/i18n/ko.rs`; `docs/en/cli.md`, `docs/ko/cli.md` and both `installation.md` files document the flag, the default, the override and the co-location requirement.

Closes #745

## Test plan

- [x] Unit tests for the name validator: character set, leading-character rule, empty input, and both length boundaries (39 accepted, 40 rejected), with the error asserted to name the charset and the limit in both locales
- [x] A unit test deriving the 39-character limit from the `container_name:` values in both checked-in compose files plus the two sidecar constants, asserting longest suffix + limit ≤ 63, and a companion assertion pinning the `rotate.rs` sidecar duplicates to the originals
- [x] Resolver precedence tests: flag over `COMPOSE_PROJECT_NAME`, env over `.env`, `.env` over the default, empty env treated as unset, fixed default regardless of directory name, and a 45-character harness project accepted unvalidated
- [x] A resolver test using a fixture with a different `.env` in each of two directories, proving it reads the one beside the given compose file
- [x] Constructor tests placing `-p` at the compose-flag position for a vector from each of the three process runners, including the `docker_compose_output` readiness-probe vector and the `--profile`-carrying monitoring vector
- [x] Tests that the recorded identity ignores `COMPOSE_PROJECT_NAME` (fresh install under an override records `bootroot`) and preserves the existing value without the flag
- [x] `.env` upsert tests on both the fresh-file and existing-file paths of `write_install_dotenv`, idempotent across repeated installs, unrelated keys and the generated PostgreSQL password preserved
- [x] Reworked `clean` resolver tests for the new precedence, including both dot-relative-compose-dir cases; `resolve_compose_project_errors_when_basename_normalises_to_empty` removed deliberately as unreachable
- [x] Regression test that `reinit`'s mismatch refusal survives the fold, both with and without an `.env` present
- [x] Responder-lookup tests: the project-label filter is present, a single match returns, no match reads as not-running, an ambiguous match errors
- [x] A test that fails when a `docker compose` argument vector is built outside the shared constructor, plus a test that the guard itself fires on a hand-built vector
- [x] CLI-level tests: `infra install` scopes Compose to the declared instance, defaults to the fixed project, preserves the recorded instance on re-run, honours `COMPOSE_PROJECT_NAME` without recording it, accepts a 39-character name, rejects invalid ones; `status` scopes to the recorded instance
- [x] `cargo test --bin bootroot` — 928 passed
- [x] `cargo test --test bootroot_cli` — 16 passed
- [x] `cargo fmt --check`, `cargo clippy --all-targets` clean, `cargo doc` with `-D warnings`, `markdownlint-cli2`, `mkdocs build --strict` — via `scripts/preflight/ci/check.sh`, plus `scripts/validate-deploy-compose.sh`
- [x] `test-docker-e2e-matrix` — all eight scenarios green on CI for this branch, with the harness's exported `COMPOSE_PROJECT_NAME` still isolating them
- [x] `run-extended` from `e2e-extended.yml` — dispatched against this branch and green ([run 30433234849](https://github.com/aicers/bootroot/actions/runs/30433234849))
- [x] `scripts/preflight/extra/agent-scenarios.sh happy` — green locally (oneshot, daemon renewal, multi-profile, topology A, topology B) against a fully initialised stack. This is the one preflight CI never runs, and it auto-detected the remapped published step-ca port rather than assuming 9000.

### Docker-backed verification against a real daemon

- [x] `infra install --instance-name insight` creates containers all labelled `com.docker.compose.project=insight` and volumes `insight_openbao-data` / `insight_postgres-data` / `insight_openbao-audit`, and records `BOOTROOT_INSTANCE=insight` in the compose directory's `.env`
- [x] `infra install` with no flag, no recorded instance and no `COMPOSE_PROJECT_NAME`, run from a directory named `alpha`, lands in project `bootroot` (volumes `bootroot_openbao-data`, …) — the fixed literal, not the basename
- [x] With a default-instance stack running, a second `infra install` from a different directory with `--instance-name insight` creates its own `insight_default` network and `insight_*` volumes and then fails with the Docker daemon's `Conflict. The container name "/bootroot-http01" is already in use by container "bfc589a5e6fe…"`, naming the first instance's container. The first instance's four containers are byte-identical afterwards — same IDs, same creation timestamps — so neither recreated nor removed. This is the intended loud failure.
- [x] Re-running `infra install` without the flag over that `.env` kept `BOOTROOT_INSTANCE=insight`, and the previously generated `POSTGRES_PASSWORD` and all four host-port keys survived
- [x] `bootroot clean` against the default-instance stack removed only the `bootroot_*` volumes; all three `insight_*` volumes survived
- [x] `bootroot status`, run from an unrelated working directory with no flag of its own: pointed at the compose file whose `.env` records `insight` it reports `insight`'s running containers; pointed at one with no recorded instance it reports `Service has no running container: openbao`; with `COMPOSE_PROJECT_NAME=insight` exported it selects `insight` again
- [x] Invalid `--instance-name` values — `Insight`, `in sight`, `-insight`, empty, and 40 characters — are each rejected with the error naming the allowed character set and the 39-character limit, and no `.env` is written. A 39-character name is accepted and recorded.
- [x] A fresh install under `COMPOSE_PROJECT_NAME=bootroot-e2e-ci-openbao-tls-no-delta-1234567` (44 characters, well past the instance-name limit) created the stack under that project verbatim and recorded `BOOTROOT_INSTANCE=bootroot`
- [x] `-p` placement confirmed live through a `docker` argv shim: `compose -f docker-compose.deploy.yml -p bootroot up --no-build --pull never -d openbao postgres step-ca bootroot-http01`, plus `compose -f … -p bootroot ps -q <service>` for each readiness probe — so `docker_compose_output` is scoped too, and `deploy-no-build-smoke.sh`'s assertions (including the new `-p` argv position and the scoped teardown) pass when reproduced verbatim on remapped ports
- [x] A full `infra install` + `init` cycle completes end to end under the new resolver: all four services running, OpenBao unsealed, and `clean` tears the project down leaving no containers or volumes behind

### Not run

- [ ] `scripts/preflight/run-all.sh` in full — **not runnable on this host.** `test-core.sh`, `e2e-matrix.sh`, `e2e-extended.sh`, `cli-scenarios.sh` and `deploy-no-build-smoke.sh` all install on the default published ports 8200/9000/8080/5433, which unrelated OrbStack Linux VMs hold here, and they hardcode those defaults with no override. CI covers `test-core` (Unit & CLI Smoke) and `e2e-matrix` (all eight scenarios) on this branch, `run-extended` was dispatched and is green, `agent-scenarios.sh happy` ran locally, and `deploy-no-build-smoke.sh`'s assertions were reproduced on remapped ports. `cli-scenarios.sh` hardcodes `localhost:8080` / `localhost:9000` and still needs a clean host.
