### PR TITLE
Prove two co-located instances stay independent (#747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,10 @@ jobs:
             script: run-openbao-tls-reown.sh
             resolution: ""
             artifact: ci-openbao-tls-reown
+          - label: two-instance
+            script: run-two-instance-isolation.sh
+            resolution: ""
+            artifact: ci-two-instance
     steps:
       - uses: actions/checkout@v7
 
@@ -441,7 +445,7 @@ jobs:
         run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run E2E scenario (lifecycle)
-        if: matrix.scenario.label != 'rotation' && matrix.scenario.label != 'reinit-recovery' && matrix.scenario.label != 'stepca-san' && matrix.scenario.label != 'openbao-tls-no-delta' && matrix.scenario.label != 'openbao-tls-reown'
+        if: matrix.scenario.label != 'rotation' && matrix.scenario.label != 'reinit-recovery' && matrix.scenario.label != 'stepca-san' && matrix.scenario.label != 'openbao-tls-no-delta' && matrix.scenario.label != 'openbao-tls-reown' && matrix.scenario.label != 'two-instance'
         run: |
           ARTIFACT_DIR="$(pwd)/tmp/e2e/${{ matrix.scenario.artifact }}-${GITHUB_RUN_ID}"
           # Local arms run the daemon-only model: every service agent is
@@ -567,6 +571,33 @@ jobs:
             done
             [ -f "$ARTIFACT_DIR/openbao-tls-ownership.log" ] && cat "$ARTIFACT_DIR/openbao-tls-ownership.log" || true
             [ -f "$ARTIFACT_DIR/compose-logs.log" ] && tail -n 200 "$ARTIFACT_DIR/compose-logs.log" || true
+            exit 1
+          }
+
+      - name: Run E2E scenario (two-instance isolation)
+        if: matrix.scenario.label == 'two-instance'
+        # Deliberately no COMPOSE_PROJECT_NAME: this scenario resolves
+        # each instance's project from that instance's own `.env`, and a
+        # caller-supplied project would collapse both installs into one.
+        # The script derives its own run-scoped instance names from
+        # GITHUB_RUN_ID and picks free host ports itself.
+        run: |
+          ARTIFACT_DIR="$(pwd)/tmp/e2e/${{ matrix.scenario.artifact }}-${GITHUB_RUN_ID}"
+          ARTIFACT_DIR="$ARTIFACT_DIR" \
+          BOOTROOT_BIN="$(pwd)/target/debug/bootroot" \
+          ./scripts/impl/run-two-instance-isolation.sh || {
+            echo "two-instance failed"
+            [ -f "$ARTIFACT_DIR/phases.log" ] && cat "$ARTIFACT_DIR/phases.log" || true
+            [ -f "$ARTIFACT_DIR/run.log" ] && tail -n 200 "$ARTIFACT_DIR/run.log" || true
+            for f in "$ARTIFACT_DIR"/init-*.raw.log; do
+              [ -f "$f" ] && { echo "--- $(basename "$f") ---"; tail -n 120 "$f"; } || true
+            done
+            for f in "$ARTIFACT_DIR"/compose-logs-*.log; do
+              [ -f "$f" ] && { echo "--- $(basename "$f") ---"; tail -n 120 "$f"; } || true
+            done
+            for f in "$ARTIFACT_DIR"/snapshots/*.diff; do
+              [ -f "$f" ] && { echo "--- $(basename "$f") ---"; cat "$f"; } || true
+            done
             exit 1
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -930,8 +930,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- `scripts/impl/run-two-instance-isolation.sh`, a real-daemon Docker E2E
-  scenario that installs, initialises and verifies two bootroot
+- `scripts/impl/run-two-instance-isolation.sh` (driven by
+  `tests/docker_e2e_two_instance_isolation.rs`), a real-daemon Docker
+  E2E scenario that installs, initialises and verifies two bootroot
   instances on one host and proves they stay independent. The existing
   instance-identity coverage drives a fake `docker` on `PATH` and
   asserts on its argv, which is the wrong level of abstraction for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -930,6 +930,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `scripts/impl/run-two-instance-isolation.sh`, a real-daemon Docker E2E
+  scenario that installs, initialises and verifies two bootroot
+  instances on one host and proves they stay independent. The existing
+  instance-identity coverage drives a fake `docker` on `PATH` and
+  asserts on its argv, which is the wrong level of abstraction for a
+  defect that only manifests with two live Compose projects on one
+  daemon. The script installs into two compose directories that share a
+  basename under different parents — the layout Compose would otherwise
+  derive one default project name from — and asserts, individually, that
+  A's container IDs and volumes survive B's install and teardown
+  (`docker volume inspect` metadata plus a per-run sentinel written into
+  each volume, because a recreated volume reappears under the same
+  name), that the two instances' container names, volume names and
+  `com.docker.compose.project` labels are disjoint, that each instance's
+  published OpenBao port belongs to its own `<instance>-openbao`, and
+  that `service add` on one instance rewires only that instance's
+  HTTP-01 responder aliases — the one cross-instance path that would not
+  announce itself as a Docker name conflict, since both responders carry
+  the same compose service label by design. It sanitises inherited
+  `COMPOSE_PROJECT_NAME` / `BOOTROOT_INSTANCE` and then asserts each
+  resolved project, so an ambient value can neither break the run nor
+  silently reduce it to a single-instance test. Instance names are
+  run-scoped and every teardown and leftover check is driven off those
+  exact names, so the script is safe on a host that already has a
+  default `bootroot` install. Wired into
+  `scripts/preflight/ci/e2e-matrix.sh` and the `test-docker-e2e-matrix`
+  CI job. (Closes #747)
 - `bootroot infra install --instance-name <name>` gives an install an
   explicit identity and threads it through every `docker compose`
   invocation as `-p <name>`, so two installs on one host stop sharing a

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -71,6 +71,8 @@ PR-critical Docker test set validates:
 - step-ca certificate SANs
 - OpenBao TLS transition with no compose delta
 - OpenBao TLS re-issuance after `secrets/` is re-owned
+- two co-located instances stay independent (install, containers, volumes,
+  published ports and HTTP-01 responder DNS aliases)
 
 Primary scripts:
 
@@ -81,6 +83,16 @@ Primary scripts:
 - `scripts/impl/run-stepca-san.sh`
 - `scripts/impl/run-openbao-tls-no-delta.sh`
 - `scripts/impl/run-openbao-tls-reown.sh`
+- `scripts/impl/run-two-instance-isolation.sh`
+
+`run-two-instance-isolation.sh` is the one matrix scenario that is **not**
+handed a `COMPOSE_PROJECT_NAME`: it installs two instances into two compose
+directories that share a basename and must resolve each instance's Compose
+project from that instance's own `.env`, so a caller-supplied project name
+would collapse both into one. It derives run-scoped `--instance-name` values
+and picks free host ports itself, and every teardown and leftover check is
+scoped to those exact names — it is safe to run on a host that already has a
+default `bootroot` install.
 
 Extended workflow validates:
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -9,7 +9,7 @@ PR-critical CI (`.github/workflows/ci.yml`) runs:
 
 - `test-core`: unit/integration smoke path
 - `test-docker-e2e-matrix`: Docker E2E test set for end-to-end flow +
-  rotation/recovery (8 scenarios run in parallel via matrix strategy)
+  rotation/recovery (10 scenarios run in parallel via matrix strategy)
 
 Extended E2E (`.github/workflows/e2e-extended.yml`) runs separately:
 

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -235,6 +235,56 @@ is a set of defaults, not a requirement, and two bootroot instances can share a
 host: the shipped compose files derive their container names from the recorded
 `--instance-name`, so the second instance needs no compose file of its own.
 
+### Co-Locating a Second Instance
+
+"No compose file of its own" means no *hand-modified* compose file — not that
+two installs can share one directory. Each instance needs its own compose
+directory holding a copy of the shipped compose file, because everything that
+makes an install distinct lives beside it:
+
+- `.env`, and with it the recorded `BOOTROOT_INSTANCE` that names the Compose
+  project and every container, plus that instance's `POSTGRES_PASSWORD` and its
+  `*_HOST_PORT` entries;
+- `secrets/`, the CA material, rendered config and AppRole credentials that
+  step-ca and the OpenBao Agent sidecars bind-mount;
+- the generated overrides (`secrets/openbao/`, `secrets/responder/`) that
+  `bootroot infra install` and `bootroot init` write.
+
+The compose file also resolves `./openbao`, `./secrets` and
+`./responder.toml.compose` relative to its own directory, so a second directory
+needs `openbao/openbao.hcl` and `responder.toml.compose` alongside the compose
+file. Two installs pointed at one directory would share all of the above and
+land in the same Compose project — the failure this identity exists to prevent.
+
+A minimal second instance therefore looks like:
+
+```bash
+mkdir -p /srv/insight/openbao
+cp docker-compose.yml /srv/insight/
+cp openbao/openbao.hcl /srv/insight/openbao/
+cp responder.toml.compose /srv/insight/
+cd /srv/insight
+bootroot infra install --instance-name insight \
+  --postgres-host-port 5434 --openbao-host-port 8201 \
+  --stepca-host-port 9001 --http01-admin-host-port 8081
+bootroot init --secrets-dir secrets --responder-url http://127.0.0.1:8081
+```
+
+Run every command for an instance from that instance's own directory.
+`bootroot` resolves `state.json` against the process working directory — the
+bare relative path `state.json`, with no `--state-file` override on
+`bootroot service add` — so the working directory decides which state file is
+written, which Compose project is rewired, and which OpenBao is contacted: the
+URL comes from that directory's `state.json`. Running `bootroot service add`
+from the wrong directory registers the service against the wrong instance.
+
+Finally, an exported `COMPOSE_PROJECT_NAME` outranks the recorded
+`BOOTROOT_INSTANCE` (see
+[Instance identity and the Compose project](cli.md#instance-identity-and-the-compose-project)
+for the full order). Leaving one set in a shell silently targets that project
+instead of the instance whose directory you are standing in; unset it before
+working with co-located instances.
+
 `bootroot init`, `bootroot status` and `bootroot reinit` pick up a non-default
 OpenBao host port automatically whenever `--openbao-url` is left at its default.
 step-ca and HTTP-01 client URLs are not derived from their host ports: pass

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -256,6 +256,15 @@ needs `openbao/openbao.hcl` and `responder.toml.compose` alongside the compose
 file. Two installs pointed at one directory would share all of the above and
 land in the same Compose project — the failure this identity exists to prevent.
 
+What the second directory does *not* get is a build context. `bootroot-http01`
+in `docker-compose.yml` declares `build.context: .` with
+`docker/http01-responder/Dockerfile`, which copies the whole source tree, and
+`bootroot infra install` defaults to `docker compose up --build`. Outside a
+checkout that build has nothing to read, so install the second instance with
+`--no-build` and let it reuse the images the first install already produced:
+`--no-build` implies `--pull never`, and the first install both built
+`bootroot-http01-responder:latest` and pulled the third-party images.
+
 A minimal second instance therefore looks like:
 
 ```bash
@@ -264,7 +273,7 @@ cp docker-compose.yml /srv/insight/
 cp openbao/openbao.hcl /srv/insight/openbao/
 cp responder.toml.compose /srv/insight/
 cd /srv/insight
-bootroot infra install --instance-name insight \
+bootroot infra install --instance-name insight --no-build \
   --postgres-host-port 5434 --openbao-host-port 8201 \
   --stepca-host-port 9001 --http01-admin-host-port 8081
 bootroot init --secrets-dir secrets --responder-url http://127.0.0.1:8081

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -21,6 +21,43 @@ The most common cause is mixing flags across binaries.
 
 ## `bootroot infra up` / `bootroot init` failures
 
+### A second install reports "orphan containers for this project"
+
+Symptoms:
+
+- `bootroot infra install` on a host that already runs bootroot prints
+  Compose's "Found orphan containers ... for this project" warning, naming
+  the *first* install's containers (typically its OpenBao Agent sidecars)
+- an existing `bootroot-*` container is recreated by the second install, and
+  the first instance's OpenBao comes back sealed, empty, or complaining about
+  its storage
+
+Cause: both installs resolved to the **same Compose project**, so Compose
+treats the first instance's containers and volumes as belonging to the second.
+There are two ways to get there:
+
+- both installs share one compose directory, so both read the same `.env` and
+  the same recorded `BOOTROOT_INSTANCE`;
+- a `COMPOSE_PROJECT_NAME` is exported in the shell. It outranks the recorded
+  `BOOTROOT_INSTANCE`, so both installs land in that one project no matter what
+  each `.env` says.
+
+Fix:
+
+- give each install a distinct `bootroot infra install --instance-name <name>`
+  and its own compose directory (its own `.env`, `secrets/`, and generated
+  overrides). See
+  [Co-Locating a Second Instance](installation.md#co-locating-a-second-instance).
+- `unset COMPOSE_PROJECT_NAME` before running anything against either install.
+- Confirm the result: `docker inspect --format
+  '{{index .Config.Labels "com.docker.compose.project"}}' <name>-openbao`
+  must print that instance's own name, and the two installs' container names,
+  volume names and project labels must not overlap.
+
+Do not try to recover by running `docker compose down` without `-p`: it would
+target whatever project Compose infers from the directory name, which is the
+same mistake in the other direction.
+
 ### OpenBao failures
 
 - Check whether OpenBao is still `sealed` and unseal if needed

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -69,6 +69,8 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 - step-ca 인증서 SAN
 - compose 델타 없는 OpenBao TLS 전환
 - `secrets/` 소유자 변경 이후 OpenBao TLS 인증서 재발급
+- 같은 호스트의 두 인스턴스가 서로 독립적으로 유지되는지(설치,
+  컨테이너, 볼륨, 게시 포트, HTTP-01 리스폰더 DNS 별칭)
 
 주요 스크립트:
 
@@ -79,6 +81,16 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 - `scripts/impl/run-stepca-san.sh`
 - `scripts/impl/run-openbao-tls-no-delta.sh`
 - `scripts/impl/run-openbao-tls-reown.sh`
+- `scripts/impl/run-two-instance-isolation.sh`
+
+`run-two-instance-isolation.sh`는 매트릭스 시나리오 가운데 유일하게
+`COMPOSE_PROJECT_NAME`을 전달받지 **않는** 시나리오입니다. basename이
+같은 두 compose 디렉터리에 두 인스턴스를 설치하고 각 인스턴스의 Compose
+프로젝트를 그 인스턴스 자신의 `.env`에서 해석해야 하므로, 호출자가
+프로젝트 이름을 넘기면 두 인스턴스가 하나로 합쳐집니다. 실행마다
+고유한 `--instance-name` 값을 스스로 만들고 비어 있는 호스트 포트도
+직접 고르며, 모든 정리와 잔여물 확인이 그 이름들로만 한정되므로 기본
+`bootroot` 설치본이 이미 있는 호스트에서도 안전하게 실행할 수 있습니다.
 
 확장 워크플로는 다음을 검증합니다.
 

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -9,7 +9,7 @@ PR 필수 CI(`.github/workflows/ci.yml`)는 다음을 실행합니다.
 
 - `test-core`: 단위/통합 스모크 경로
 - `test-docker-e2e-matrix`: 전체 흐름 + 회전/복구 Docker E2E 조합 검증
-  (8개 시나리오가 matrix 전략으로 병렬 실행)
+  (10개 시나리오가 matrix 전략으로 병렬 실행)
 
 확장 E2E(`.github/workflows/e2e-extended.yml`)는 별도 실행됩니다.
 

--- a/docs/ko/installation.md
+++ b/docs/ko/installation.md
@@ -263,6 +263,16 @@ compose 파일은 `./openbao`, `./secrets`,
 향하게 하면 위 항목을 모두 공유하고 같은 Compose 프로젝트에 놓이게
 되는데, 이는 인스턴스 정체성이 막으려는 바로 그 장애입니다.
 
+반면 두 번째 디렉터리에 없는 것은 빌드 컨텍스트입니다.
+`docker-compose.yml`의 `bootroot-http01`은 소스 트리 전체를 복사하는
+`docker/http01-responder/Dockerfile`을 `build.context: .`로 선언하고,
+`bootroot infra install`은 기본적으로 `docker compose up --build`를
+실행합니다. 체크아웃 밖에서는 이 빌드가 읽을 것이 없으므로 두 번째
+인스턴스는 `--no-build`로 설치해 첫 번째 설치가 이미 만들어 둔 이미지를
+재사용하세요. `--no-build`는 `--pull never`를 함의하는데, 첫 번째 설치가
+`bootroot-http01-responder:latest`를 빌드하고 서드파티 이미지도 이미
+받아 두었으므로 조건이 충족됩니다.
+
 최소한의 두 번째 인스턴스 구성은 다음과 같습니다.
 
 ```bash
@@ -271,7 +281,7 @@ cp docker-compose.yml /srv/insight/
 cp openbao/openbao.hcl /srv/insight/openbao/
 cp responder.toml.compose /srv/insight/
 cd /srv/insight
-bootroot infra install --instance-name insight \
+bootroot infra install --instance-name insight --no-build \
   --postgres-host-port 5434 --openbao-host-port 8201 \
   --stepca-host-port 9001 --http01-admin-host-port 8081
 bootroot init --secrets-dir secrets --responder-url http://127.0.0.1:8081

--- a/docs/ko/installation.md
+++ b/docs/ko/installation.md
@@ -240,6 +240,58 @@ bootroot 인스턴스가 한 호스트를 공유할 수 있습니다. 배포되�
 파일이 기록된 `--instance-name`에서 컨테이너 이름을 유도하므로 두 번째
 인스턴스에 별도의 compose 파일은 필요하지 않습니다.
 
+### 두 번째 인스턴스를 같은 호스트에 배치하기
+
+"별도의 compose 파일이 필요하지 않다"는 것은 *직접 수정한* compose
+파일이 필요 없다는 뜻이며, 두 설치본이 하나의 디렉터리를 공유해도
+된다는 뜻이 아닙니다. 각 인스턴스는 배포된 compose 파일 사본을 담은
+자체 compose 디렉터리가 필요합니다. 설치본을 구분 짓는 요소가 모두
+compose 파일 옆에 놓이기 때문입니다.
+
+- `.env`. Compose 프로젝트와 모든 컨테이너 이름을 결정하는
+  `BOOTROOT_INSTANCE`, 해당 인스턴스의 `POSTGRES_PASSWORD`,
+  `*_HOST_PORT` 항목이 여기에 기록됩니다.
+- `secrets/`. step-ca와 OpenBao Agent 사이드카가 bind-mount하는 CA
+  자재, 렌더링된 설정, AppRole 자격 증명이 들어 있습니다.
+- `bootroot infra install`과 `bootroot init`이 생성하는 오버라이드
+  (`secrets/openbao/`, `secrets/responder/`).
+
+compose 파일은 `./openbao`, `./secrets`,
+`./responder.toml.compose`를 자신의 디렉터리 기준으로 해석하므로 두 번째
+디렉터리에는 compose 파일과 함께 `openbao/openbao.hcl`과
+`responder.toml.compose`도 있어야 합니다. 두 설치본을 한 디렉터리로
+향하게 하면 위 항목을 모두 공유하고 같은 Compose 프로젝트에 놓이게
+되는데, 이는 인스턴스 정체성이 막으려는 바로 그 장애입니다.
+
+최소한의 두 번째 인스턴스 구성은 다음과 같습니다.
+
+```bash
+mkdir -p /srv/insight/openbao
+cp docker-compose.yml /srv/insight/
+cp openbao/openbao.hcl /srv/insight/openbao/
+cp responder.toml.compose /srv/insight/
+cd /srv/insight
+bootroot infra install --instance-name insight \
+  --postgres-host-port 5434 --openbao-host-port 8201 \
+  --stepca-host-port 9001 --http01-admin-host-port 8081
+bootroot init --secrets-dir secrets --responder-url http://127.0.0.1:8081
+```
+
+각 인스턴스의 명령은 반드시 해당 인스턴스의 디렉터리에서 실행하세요.
+bootroot는 `state.json`을 프로세스 작업 디렉터리 기준으로 해석합니다
+(`state.json`이라는 상대 경로 그대로이며, `bootroot service add`에는
+`--state-file` 옵션이 없습니다). 따라서 작업 디렉터리가 어떤 상태
+파일에 기록할지, 어떤 Compose 프로젝트를 재구성할지, 어떤 OpenBao에
+접속할지를 모두 결정합니다. OpenBao URL도 그 디렉터리의 `state.json`에서
+가져오기 때문입니다. 잘못된 디렉터리에서 `bootroot service add`를
+실행하면 서비스가 다른 인스턴스에 등록됩니다.
+
+마지막으로, 내보낸 `COMPOSE_PROJECT_NAME`은 기록된
+`BOOTROOT_INSTANCE`보다 우선합니다(전체 우선순위는 [CLI](cli.md)의
+"인스턴스 정체성과 Compose 프로젝트" 절 참고). 셸에 값이 남아 있으면
+현재 서 있는 디렉터리의 인스턴스가 아니라 그 프로젝트를 조용히
+대상으로 삼으므로, 같은 호스트의 여러 인스턴스를 다루기 전에 해제하세요.
+
 `--openbao-url`을 기본값으로 두면 `bootroot init`, `bootroot status`,
 `bootroot reinit`이 기본값이 아닌 OpenBao 호스트 포트를 자동으로
 반영합니다. step-ca와 HTTP-01 클라이언트 URL은 호스트 포트에서

--- a/docs/ko/troubleshooting.md
+++ b/docs/ko/troubleshooting.md
@@ -21,6 +21,44 @@
 
 ## `bootroot infra up`/`bootroot init` 단계가 실패할 때
 
+### 두 번째 설치가 "orphan containers for this project"를 보고할 때
+
+증상:
+
+- 이미 bootroot가 동작 중인 호스트에서 `bootroot infra install`을 실행하면
+  Compose가 *첫 번째* 설치본의 컨테이너(대개 OpenBao Agent 사이드카)를
+  가리키며 "Found orphan containers ... for this project" 경고를 출력
+- 기존 `bootroot-*` 컨테이너가 두 번째 설치에 의해 재생성되고, 첫 번째
+  인스턴스의 OpenBao가 sealed 상태로 돌아오거나 비어 있거나 스토리지
+  오류를 냄
+
+원인: 두 설치본이 **같은 Compose 프로젝트**로 해석되어, Compose가 첫
+인스턴스의 컨테이너와 볼륨을 두 번째 설치본의 것으로 취급합니다. 경로는
+두 가지입니다.
+
+- 두 설치본이 하나의 compose 디렉터리를 공유해 같은 `.env`와 같은
+  `BOOTROOT_INSTANCE`를 읽는 경우
+- 셸에 `COMPOSE_PROJECT_NAME`이 내보내져 있는 경우. 이 값은 기록된
+  `BOOTROOT_INSTANCE`보다 우선하므로, 각 `.env`에 무엇이 적혀 있든 두
+  설치본이 모두 그 하나의 프로젝트에 놓입니다.
+
+해결:
+
+- 각 설치본에 서로 다른
+  `bootroot infra install --instance-name <name>`과 자체 compose
+  디렉터리(자체 `.env`, `secrets/`, 생성된 오버라이드)를 주세요.
+  [두 번째 인스턴스를 같은 호스트에 배치하기](installation.md#_3)를
+  참고하세요.
+- 두 설치본을 다루기 전에 `unset COMPOSE_PROJECT_NAME`을 실행하세요.
+- 결과 확인: `docker inspect --format
+  '{{index .Config.Labels "com.docker.compose.project"}}' <name>-openbao`가
+  해당 인스턴스 이름을 출력해야 하며, 두 설치본의 컨테이너 이름, 볼륨
+  이름, 프로젝트 라벨이 겹치지 않아야 합니다.
+
+`-p` 없이 `docker compose down`을 실행해 복구하려 하지 마세요. 디렉터리
+이름에서 유추한 프로젝트를 대상으로 삼게 되므로 같은 실수를 반대 방향으로
+반복하는 셈입니다.
+
 ### OpenBao 관련
 
 - OpenBao가 `sealed` 상태인지 확인하고, 필요 시 unseal 후 재시도

--- a/scripts/impl/run-two-instance-isolation.sh
+++ b/scripts/impl/run-two-instance-isolation.sh
@@ -262,15 +262,23 @@ s.close()')"
   fail "could not allocate a free host port after 200 attempts"
 }
 
+# Allocated per instance immediately before that instance's install.  The
+# bind-to-port-0 result is advisory — the port is free at that instant,
+# not reserved — so the shorter the gap between the pick and `infra
+# install`'s own bind, the smaller the chance an unrelated process claims
+# it in between.  Instance B installs minutes after instance A, which is
+# why the two allocations are not batched.  `PORTS_TAKEN` keeps the later
+# allocation clear of the ports the earlier instance already holds.
 allocate_ports() {
-  local var
-  for var in PORT_A_POSTGRES PORT_A_OPENBAO PORT_A_STEPCA PORT_A_HTTP01 \
-    PORT_B_POSTGRES PORT_B_OPENBAO PORT_B_STEPCA PORT_B_HTTP01; do
+  local side="$1" var suffix
+  for suffix in POSTGRES OPENBAO STEPCA HTTP01; do
+    var="PORT_${side}_${suffix}"
     pick_free_port
     printf -v "$var" '%s' "$PICKED_PORT"
   done
-  log "instance A ports: postgres=${PORT_A_POSTGRES} openbao=${PORT_A_OPENBAO} stepca=${PORT_A_STEPCA} http01=${PORT_A_HTTP01}"
-  log "instance B ports: postgres=${PORT_B_POSTGRES} openbao=${PORT_B_OPENBAO} stepca=${PORT_B_STEPCA} http01=${PORT_B_HTTP01}"
+  local pg="PORT_${side}_POSTGRES" bao="PORT_${side}_OPENBAO"
+  local ca="PORT_${side}_STEPCA" http01="PORT_${side}_HTTP01"
+  log "instance ${side} ports: postgres=${!pg} openbao=${!bao} stepca=${!ca} http01=${!http01}"
 }
 
 # ---------------------------------------------------------------------------
@@ -319,6 +327,11 @@ prepull_third_party_images() {
     docker compose -p "$INSTANCE_A" -f "$DIR_A/$COMPOSE_FILE_NAME" \
     pull openbao postgres step-ca >>"$RUN_LOG" 2>&1 ||
     fail "failed to pre-pull the third-party images"
+  # Resolved here, before the first install, so `remove_run_root`'s chown
+  # fallback can still reach an image when the run fails early — by the
+  # time cleanup runs, the containers it would otherwise be read off are
+  # gone.
+  resolve_helper_image
 }
 
 create_run_root() {
@@ -638,9 +651,22 @@ snapshot_volume_metadata() {
   [ -s "$out" ] || fail "no volumes found for project ${project}"
 }
 
+# Read off the compose file rather than off a running container: the same
+# image the run's own stack uses, but known from before the first install
+# and still known after the last container is gone, which is what the
+# cleanup chown fallback needs.  The two placeholder passwords only
+# satisfy the compose file's `:?` guards; `config` starts nothing.
 resolve_helper_image() {
   [ -n "$HELPER_IMAGE" ] && return 0
-  HELPER_IMAGE="$(docker inspect --format '{{.Config.Image}}' "${INSTANCE_A}-openbao" 2>/dev/null || true)"
+  HELPER_IMAGE="$(POSTGRES_PASSWORD=resolve-only GRAFANA_ADMIN_PASSWORD=resolve-only \
+    BOOTROOT_INSTANCE="$INSTANCE_A" \
+    docker compose -p "$INSTANCE_A" -f "$DIR_A/$COMPOSE_FILE_NAME" \
+    config --images openbao 2>/dev/null | head -n 1)" || true
+  # Falls back to a running container so a `config` that cannot render
+  # (or that `pipefail` trips on `head` closing the pipe) is recoverable
+  # rather than fatal.
+  [ -n "$HELPER_IMAGE" ] ||
+    HELPER_IMAGE="$(docker inspect --format '{{.Config.Image}}' "${INSTANCE_A}-openbao" 2>/dev/null || true)"
   [ -n "$HELPER_IMAGE" ] || fail "could not resolve an image for the sentinel containers"
 }
 
@@ -667,10 +693,8 @@ volume_sentinel_read() {
 
 seed_volume_sentinels() {
   local project="$1" out="$2" volume
-  # Resolved here, in the caller's own shell, so the cleanup chown
-  # fallback can still reach the image after the run's containers are
-  # gone; the read path resolves inside a command substitution and would
-  # only ever set it in a subshell.
+  # Resolved in the caller's own shell: the read path resolves inside a
+  # command substitution and would only ever set the global in a subshell.
   resolve_helper_image
   : >"$out"
   while IFS= read -r volume; do
@@ -955,8 +979,8 @@ main() {
   build_responder_image
   create_run_root
   prepull_third_party_images
-  allocate_ports
 
+  allocate_ports A
   install_instance "$INSTANCE_A" "$DIR_A" \
     "$PORT_A_POSTGRES" "$PORT_A_OPENBAO" "$PORT_A_STEPCA" "$PORT_A_HTTP01"
   init_instance "$INSTANCE_A" "$DIR_A" \
@@ -978,6 +1002,7 @@ main() {
   # dotfile must surface here rather than as a confusing later failure.
   wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-sentinels"
 
+  allocate_ports B
   install_instance "$INSTANCE_B" "$DIR_B" \
     "$PORT_B_POSTGRES" "$PORT_B_OPENBAO" "$PORT_B_STEPCA" "$PORT_B_HTTP01"
 
@@ -999,6 +1024,10 @@ main() {
   assert_instance_serving "$INSTANCE_B" "$PORT_B_OPENBAO" "$PORT_B_STEPCA" \
     "$PORT_B_HTTP01" "after-init"
   wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-b-init"
+  # Re-asserted with both instances up: this is the co-located state the
+  # criterion is about, and the check A got before B existed could not
+  # observe a cross-instance mix-up.
+  assert_openbao_publication "$INSTANCE_A" "$PORT_A_OPENBAO"
 
   assert_instances_disjoint
 

--- a/scripts/impl/run-two-instance-isolation.sh
+++ b/scripts/impl/run-two-instance-isolation.sh
@@ -1,0 +1,973 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docker-backed E2E harness proving that two bootroot installs on one
+# host stay independent (#747).
+#
+# Before the install identity existed, a second install on the same host
+# adopted the first install's containers: Compose reported the first
+# instance's OpenBao Agent sidecars as "orphan containers for this
+# project" and recreated its already-initialised OpenBao against the
+# wrong configuration, storage volume and unseal keys.  That regression
+# does not surface as a crash — it surfaces as another team's CA quietly
+# losing its state — so it needs two live Compose projects on one real
+# daemon, not a unit test of a naming function.
+#
+# The layout is deliberate: both compose directories share a basename
+# (`<run-root>/a/bootroot` and `<run-root>/b/bootroot`) under different
+# parents.  An identical basename is what Compose would otherwise derive
+# an identical default project name from, so this is the layout that
+# proves the explicit `-p` scoping — and not the directory name — is
+# what separates the two installs.
+#
+# What it asserts:
+#
+#   - instance A installs, initialises and reports healthy
+#   - instance B installs, initialises and reports healthy
+#   - A's containers survive B's install with byte-identical container
+#     IDs, and A's volumes survive with byte-identical `docker volume
+#     inspect` output *and* an unchanged per-run sentinel written into
+#     each volume
+#   - the two instances' container names, volume names and
+#     `com.docker.compose.project` labels are disjoint
+#   - the container publishing each instance's OpenBao host port is that
+#     instance's own `<instance-name>-openbao`, and it answers there
+#   - registering a service on one instance adds that service's alias to
+#     that instance's responder only, in both directions
+#   - tearing instance B down leaves A healthy and still serving
+#
+# Safety contract.  A developer running the preflight suite may well
+# have a real default-identity `bootroot` install on the same machine.
+# This script must be safe there: both instance names are derived from a
+# per-run token, every teardown and leftover check is driven off those
+# exact names and their `com.docker.compose.project` labels — never a
+# `bootroot-*` wildcard — and nothing outside the run's own `mktemp -d`
+# root is written or removed.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# ---------------------------------------------------------------------------
+# Ambient environment sanitisation
+# ---------------------------------------------------------------------------
+#
+# `COMPOSE_PROJECT_NAME` outranks the recorded `BOOTROOT_INSTANCE`, so a
+# value inherited from the invoking shell would make both instances
+# resolve to one project and quietly turn this into a single-instance run
+# that still passes several assertions.  Compose likewise prefers a
+# process-environment `BOOTROOT_INSTANCE` over the project directory's
+# `.env`, so an ambient value would misrender container names for this
+# script's own raw `docker compose` calls.  The host-port variables are
+# cleared for the same reason: they outrank each compose directory's
+# `.env`, and a shared inherited value would collapse both instances onto
+# one published port.
+#
+# Clearing them makes an inherited value harmless rather than fatal.  It
+# is deliberately only the first of two layers — `assert_resolved_project`
+# below asserts each instance's resolved project rather than assuming it,
+# which is what catches a sanitisation that is later broken or bypassed.
+unset COMPOSE_PROJECT_NAME BOOTROOT_INSTANCE
+unset POSTGRES_HOST_PORT OPENBAO_HOST_PORT STEPCA_HOST_PORT HTTP01_ADMIN_HOST_PORT
+unset POSTGRES_HOST POSTGRES_PORT POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB
+
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/docker-two-instance-$(date +%s)}"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+BOOTROOT_BIN="${BOOTROOT_BIN:-$ROOT_DIR/target/debug/bootroot}"
+
+PHASE_LOG="$ARTIFACT_DIR/phases.log"
+RUN_LOG="$ARTIFACT_DIR/run.log"
+SNAPSHOT_DIR="$ARTIFACT_DIR/snapshots"
+
+# Per-run token both instance names are derived from, so neither can
+# collide with a pre-existing install and both stay inside the
+# 39-character instance-name limit.
+RUN_TOKEN="${RUN_TOKEN:-${GITHUB_RUN_ID:-$(date +%s)$$}}"
+RUN_TOKEN="$(printf '%s' "$RUN_TOKEN" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')"
+INSTANCE_A="twoinst-a-${RUN_TOKEN}"
+INSTANCE_B="twoinst-b-${RUN_TOKEN}"
+# `MAX_INSTANCE_NAME_LEN` in src/commands/compose_project.rs: the
+# DNS-label budget left over after the longest container-name suffix.
+MAX_INSTANCE_NAME_LEN=39
+
+COMPOSE_FILE_NAME="docker-compose.deploy.yml"
+# Both directories share this basename under different parents — see the
+# header note on why that is the layout under test.
+COMPOSE_DIR_BASENAME="bootroot"
+
+# The `bootroot-http01` image the deploy compose file references.  The
+# tag is run-scoped so the build cannot overwrite an image a co-located
+# default install is running, and it is removed again on the way out.
+HTTP01_IMAGE="bootroot-http01-responder:two-instance-${RUN_TOKEN}"
+export BOOTROOT_HTTP01_IMAGE="$HTTP01_IMAGE"
+
+DOMAIN="trusted.domain"
+# `service add --instance-id` is a per-service replica identifier and is
+# unrelated to `infra install --instance-name`.  The values are chosen to
+# look nothing like the instance names so a mix-up is unmistakable in the
+# failure output.
+SERVICE_A="alpha-app"
+HOSTNAME_A="alpha-node-01"
+SERVICE_INSTANCE_ID_A="701"
+SERVICE_B="beta-app"
+HOSTNAME_B="beta-node-01"
+SERVICE_INSTANCE_ID_B="802"
+
+# Dotfile written at each volume's root as the content-continuity
+# observable.  `CreatedAt` has one-second granularity and so cannot by
+# itself distinguish a recreation that happens fast enough; the sentinel
+# is what proves the *contents* survived rather than just the metadata.
+SENTINEL_FILE=".bootroot-two-instance-sentinel"
+
+HEALTH_ATTEMPTS="${HEALTH_ATTEMPTS:-40}"
+HEALTH_DELAY_SECS="${HEALTH_DELAY_SECS:-3}"
+SERVE_ATTEMPTS="${SERVE_ATTEMPTS:-30}"
+SERVE_DELAY_SECS="${SERVE_DELAY_SECS:-2}"
+
+CURRENT_PHASE="startup"
+RUN_ROOT=""
+DIR_A=""
+DIR_B=""
+PORTS_TAKEN=""
+# Image used by the throwaway sentinel containers and by the cleanup
+# chown fallback.  Resolved from a running container of the run's own
+# stack so no extra image has to be present under `--no-build`.
+HELPER_IMAGE=""
+PYTHON_BIN=""
+
+PORT_A_POSTGRES=0
+PORT_A_OPENBAO=0
+PORT_A_STEPCA=0
+PORT_A_HTTP01=0
+PORT_B_POSTGRES=0
+PORT_B_OPENBAO=0
+PORT_B_STEPCA=0
+PORT_B_HTTP01=0
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+log_phase() {
+  local phase="$1"
+  CURRENT_PHASE="$phase"
+  local now
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"ts":"%s","phase":"%s"}\n' "$now" "$phase" >>"$PHASE_LOG"
+}
+
+log() {
+  printf '[two-instance][%s] %s\n' "$CURRENT_PHASE" "$1" | tee -a "$RUN_LOG"
+}
+
+# Reports one assertion individually so a failure names what broke — and
+# so a passing run reads as a checklist rather than as silence.
+pass() {
+  printf '[two-instance][%s] PASS %s\n' "$CURRENT_PHASE" "$1" | tee -a "$RUN_LOG"
+}
+
+fail() {
+  local message="$1"
+  printf '[fatal][%s] %s\n' "$CURRENT_PHASE" "$message" >>"$RUN_LOG" 2>/dev/null || true
+  echo "[two-instance][${CURRENT_PHASE}] FAIL $message" >&2
+  exit 1
+}
+
+on_error() {
+  local line="$1"
+  echo "[two-instance] failed at phase=${CURRENT_PHASE} line=${line}" >&2
+  echo "[two-instance] artifact dir: ${ARTIFACT_DIR}" >&2
+  if [ -f "$RUN_LOG" ]; then
+    echo "--- run.log (tail) ---" >&2
+    tail -n 120 "$RUN_LOG" >&2 || true
+  fi
+}
+
+assert_equal() {
+  local what="$1" expected="$2" actual="$3"
+  if [ "$expected" != "$actual" ]; then
+    fail "${what}: expected '${expected}', got '${actual}'"
+  fi
+  pass "$what"
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisites and host-port allocation
+# ---------------------------------------------------------------------------
+
+ensure_prerequisites() {
+  command -v docker >/dev/null 2>&1 || fail "docker is required"
+  docker compose version >/dev/null 2>&1 || fail "docker compose is required"
+  command -v jq >/dev/null 2>&1 || fail "jq is required"
+  command -v curl >/dev/null 2>&1 || fail "curl is required"
+  [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+  fi
+  [ -n "$RUN_TOKEN" ] || fail "RUN_TOKEN reduced to the empty string; supply a token of [a-z0-9]"
+  local name
+  for name in "$INSTANCE_A" "$INSTANCE_B"; do
+    if [ "${#name}" -gt "$MAX_INSTANCE_NAME_LEN" ]; then
+      fail "derived instance name '${name}' exceeds the ${MAX_INSTANCE_NAME_LEN}-character limit; shorten RUN_TOKEN"
+    fi
+  done
+}
+
+port_is_taken() {
+  local port="$1" taken
+  for taken in $PORTS_TAKEN; do
+    [ "$taken" = "$port" ] && return 0
+  done
+  return 1
+}
+
+# Picks a free host port on 127.0.0.1 into `PICKED_PORT`.
+#
+# Prefers the bind-to-port-0 allocation `free_port` in
+# tests/bootroot_cli.rs uses: the kernel hands back a port that was free
+# at that instant.  Without python3 the fallback probes a randomised
+# high range instead.  Either way the allocation is advisory — `infra
+# install` binds every published port up front and aborts with `host
+# port <addr> is already in use`, and surfacing that failure is the
+# contract here rather than adding a second timeout layer.  Neither
+# branch ever waits on an occupied port.
+#
+# The result travels through a global rather than stdout because the
+# already-handed-out list has to survive the call, and a command
+# substitution would keep it inside a subshell.
+PICKED_PORT=0
+pick_free_port() {
+  local attempt port
+  for attempt in $(seq 1 200); do
+    if [ -n "$PYTHON_BIN" ]; then
+      port="$("$PYTHON_BIN" -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()')"
+    else
+      port=$((20000 + RANDOM % 30000))
+      if bash -c ": >/dev/tcp/127.0.0.1/${port}" >/dev/null 2>&1; then
+        continue
+      fi
+    fi
+    if [ -n "$port" ] && ! port_is_taken "$port"; then
+      PORTS_TAKEN="$PORTS_TAKEN $port"
+      PICKED_PORT="$port"
+      return 0
+    fi
+  done
+  fail "could not allocate a free host port after 200 attempts"
+}
+
+allocate_ports() {
+  local var
+  for var in PORT_A_POSTGRES PORT_A_OPENBAO PORT_A_STEPCA PORT_A_HTTP01 \
+    PORT_B_POSTGRES PORT_B_OPENBAO PORT_B_STEPCA PORT_B_HTTP01; do
+    pick_free_port
+    printf -v "$var" '%s' "$PICKED_PORT"
+  done
+  log "instance A ports: postgres=${PORT_A_POSTGRES} openbao=${PORT_A_OPENBAO} stepca=${PORT_A_STEPCA} http01=${PORT_A_HTTP01}"
+  log "instance B ports: postgres=${PORT_B_POSTGRES} openbao=${PORT_B_OPENBAO} stepca=${PORT_B_STEPCA} http01=${PORT_B_HTTP01}"
+}
+
+# ---------------------------------------------------------------------------
+# Compose-directory materialisation
+# ---------------------------------------------------------------------------
+
+# `docker-compose.yml` declares `build.context: .` for `bootroot-http01`
+# with a Dockerfile that copies the whole project root and builds a Rust
+# binary, so a directory holding only a copy of it would not come up.
+# `docker-compose.deploy.yml` carries no build context at all — every
+# service references a prebuilt `image:` tag — which is why both
+# instances install from it with `--no-build` against an image built once
+# up front.  The only source-tree config it still resolves relative to
+# the compose directory is `openbao/openbao.hcl` and
+# `responder.toml.compose`; `infra install` creates `secrets/` and
+# `certs/` itself.
+materialise_compose_dir() {
+  local dir="$1"
+  mkdir -p "$dir/openbao"
+  cp "$ROOT_DIR/$COMPOSE_FILE_NAME" "$dir/$COMPOSE_FILE_NAME"
+  cp "$ROOT_DIR/openbao/openbao.hcl" "$dir/openbao/openbao.hcl"
+  cp "$ROOT_DIR/responder.toml.compose" "$dir/responder.toml.compose"
+}
+
+build_responder_image() {
+  log "building $HTTP01_IMAGE"
+  # Built with `docker build` rather than `docker compose build` so the
+  # repository's own `.env` and compose project are never read or
+  # touched: this script has to be safe on a host that already has a
+  # default `bootroot` install.
+  docker build -t "$HTTP01_IMAGE" \
+    -f "$ROOT_DIR/docker/http01-responder/Dockerfile" "$ROOT_DIR" \
+    >>"$RUN_LOG" 2>&1 || fail "failed to build $HTTP01_IMAGE"
+}
+
+# `--no-build` implies `--pull never`, so every third-party image has to
+# be on the host before either install runs.  Pulled through Compose so
+# the tags come from the compose file itself rather than from a second
+# copy of them here.  Scoped with `-p` like every other raw compose call
+# in this script, though `pull` creates no project resources.
+prepull_third_party_images() {
+  log "pre-pulling third-party images"
+  POSTGRES_PASSWORD=prepull-only \
+    GRAFANA_ADMIN_PASSWORD=prepull-only \
+    BOOTROOT_INSTANCE="$INSTANCE_A" \
+    docker compose -p "$INSTANCE_A" -f "$DIR_A/$COMPOSE_FILE_NAME" \
+    pull openbao postgres step-ca >>"$RUN_LOG" 2>&1 ||
+    fail "failed to pre-pull the third-party images"
+}
+
+create_run_root() {
+  RUN_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/bootroot-two-instance-XXXXXX")"
+  # One removal at cleanup that cannot miss a stray sibling directory.
+  DIR_A="$RUN_ROOT/a/$COMPOSE_DIR_BASENAME"
+  DIR_B="$RUN_ROOT/b/$COMPOSE_DIR_BASENAME"
+  materialise_compose_dir "$DIR_A"
+  materialise_compose_dir "$DIR_B"
+  log "run root: $RUN_ROOT"
+  assert_equal "both compose directories share a basename" \
+    "$(basename "$DIR_A")" "$(basename "$DIR_B")"
+}
+
+# ---------------------------------------------------------------------------
+# Per-instance command helpers
+# ---------------------------------------------------------------------------
+
+# Every bootroot command runs from that instance's own directory:
+# `service add` and `status` resolve `state.json` against the process
+# working directory and the Compose identity against `./.env`, so the
+# working directory is what decides which state file is written, which
+# Compose project is rewired, and which OpenBao is contacted.
+run_bootroot() {
+  local dir="$1"
+  shift
+  (cd "$dir" && BOOTROOT_LANG=en "$BOOTROOT_BIN" "$@")
+}
+
+# Raw compose invocations always carry `-p`: without it Compose would
+# infer the project from the directory basename, which both instances
+# share by design, and this script would inspect and tear down whatever
+# that produced.
+instance_compose() {
+  local project="$1" dir="$2"
+  shift 2
+  BOOTROOT_INSTANCE="$project" docker compose -p "$project" -f "$dir/$COMPOSE_FILE_NAME" "$@"
+}
+
+dotenv_value() {
+  local file="$1" key="$2"
+  [ -f "$file" ] || return 0
+  awk -F= -v k="$key" '$1 == k { sub(/^[^=]*=/, ""); print; exit }' "$file"
+}
+
+install_instance() {
+  local name="$1" dir="$2" pg="$3" bao="$4" ca="$5" http01="$6"
+  log_phase "install-${name}"
+  log "installing instance ${name} in ${dir}"
+  run_bootroot "$dir" infra install \
+    --compose-file "$dir/$COMPOSE_FILE_NAME" \
+    --instance-name "$name" \
+    --postgres-host-port "$pg" \
+    --openbao-host-port "$bao" \
+    --stepca-host-port "$ca" \
+    --http01-admin-host-port "$http01" \
+    --no-build \
+    >>"$RUN_LOG" 2>&1 || fail "infra install failed for instance ${name}"
+}
+
+init_instance() {
+  local name="$1" dir="$2" http01="$3"
+  log_phase "init-${name}"
+  log "initialising instance ${name}"
+  local raw_log="$ARTIFACT_DIR/init-${name}.raw.log"
+  # Non-interactive: every prompt has its own flag and stdin is closed.
+  # `--openbao-url` is left at its default so `init` derives the endpoint
+  # from this directory's own `.env` — the same derivation `status`
+  # applies, and the reason each instance talks to its own OpenBao.
+  if ! run_bootroot "$dir" init \
+    --compose-file "$dir/$COMPOSE_FILE_NAME" \
+    --secrets-dir "$dir/secrets" \
+    --summary-json "$ARTIFACT_DIR/init-summary-${name}.json" \
+    --enable auto-generate,show-secrets,db-provision \
+    --stepca-password "two-instance-${name}" \
+    --http-hmac "dev-hmac-${name}" \
+    --no-eab \
+    --save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
+    --confirm-db-provision \
+    --db-user "step" \
+    --db-name "stepca" \
+    --responder-url "http://127.0.0.1:${http01}" \
+    </dev/null >"$raw_log" 2>&1; then
+    {
+      echo "bootroot init failed for instance ${name} (raw tail):"
+      tail -n 200 "$raw_log" || true
+    } >>"$RUN_LOG"
+    fail "bootroot init failed for instance ${name}"
+  fi
+  sed 's/^\(root token: \).*/\1<redacted>/' "$raw_log" >"$ARTIFACT_DIR/init-${name}.log"
+}
+
+# `bootroot status` bails when any core container is missing or unhealthy
+# and when OpenBao is unreachable, so a zero exit is the health report.
+# It reads `state.json` from the working directory and derives the
+# OpenBao endpoint from that directory's `.env`, which is exactly the
+# per-instance resolution under test.
+wait_for_instance_healthy() {
+  local name="$1" dir="$2" label="$3"
+  local attempt out="$ARTIFACT_DIR/status-${name}-${label}.log"
+  for attempt in $(seq 1 "$HEALTH_ATTEMPTS"); do
+    if run_bootroot "$dir" status --compose-file "$dir/$COMPOSE_FILE_NAME" \
+      >"$out" 2>&1; then
+      pass "instance ${name} reports healthy (${label})"
+      return 0
+    fi
+    sleep "$HEALTH_DELAY_SECS"
+  done
+  {
+    echo "bootroot status never succeeded for instance ${name} (${label}); tail:"
+    tail -n 80 "$out" || true
+  } >>"$RUN_LOG"
+  fail "instance ${name} did not report healthy (${label})"
+}
+
+# ---------------------------------------------------------------------------
+# Identity, port-publication and disjointness assertions
+# ---------------------------------------------------------------------------
+
+# The second sanitisation layer.  The resolved Compose project is read
+# off the containers the install actually created, so a sanitisation that
+# is later broken, bypassed by a newly added command, or defeated by some
+# other mechanism shows up here instead of degrading the run to a silent
+# single-instance pass.
+assert_resolved_project() {
+  local name="$1" dir="$2"
+  local container="${name}-openbao"
+  local project
+  project="$(docker inspect \
+    --format '{{index .Config.Labels "com.docker.compose.project"}}' \
+    "$container" 2>/dev/null || true)"
+  assert_equal "instance ${name} resolved Compose project" "$name" "$project"
+  assert_equal "instance ${name} records BOOTROOT_INSTANCE in its own .env" \
+    "$name" "$(dotenv_value "$dir/.env" BOOTROOT_INSTANCE)"
+}
+
+# Returns the name of the container publishing 127.0.0.1:<port>.
+#
+# Read-only across every running container on the host: a co-located
+# default install is inspected, never touched.
+container_publishing_port() {
+  local port="$1" id name
+  for id in $(docker ps -q); do
+    if docker port "$id" 2>/dev/null | grep -q "127\.0\.0\.1:${port}\$"; then
+      name="$(docker inspect --format '{{.Name}}' "$id")"
+      printf '%s' "${name#/}"
+      return 0
+    fi
+  done
+}
+
+assert_openbao_publication() {
+  local name="$1" port="$2"
+  assert_equal "the container publishing instance ${name}'s OpenBao port ${port}" \
+    "${name}-openbao" "$(container_publishing_port "$port")"
+}
+
+assert_openbao_answers() {
+  local name="$1" port="$2" label="$3"
+  local attempt out="$ARTIFACT_DIR/seal-status-${name}-${label}.json"
+  for attempt in $(seq 1 "$SERVE_ATTEMPTS"); do
+    if curl -fsS -m 5 "http://127.0.0.1:${port}/v1/sys/seal-status" >"$out" 2>>"$RUN_LOG"; then
+      local sealed
+      sealed="$(jq -r '.sealed' "$out")"
+      if [ "$sealed" != "false" ]; then
+        fail "instance ${name}'s OpenBao on port ${port} is sealed (${label})"
+      fi
+      pass "instance ${name}'s OpenBao answers unsealed on port ${port} (${label})"
+      return 0
+    fi
+    sleep "$SERVE_DELAY_SECS"
+  done
+  fail "instance ${name}'s OpenBao did not answer on port ${port} (${label})"
+}
+
+# "Still serving" is more than "the containers are up": each published
+# endpoint has to answer on the instance's own port.
+assert_instance_serving() {
+  local name="$1" bao="$2" ca="$3" http01="$4" label="$5"
+  assert_openbao_answers "$name" "$bao" "$label"
+  local attempt
+  for attempt in $(seq 1 "$SERVE_ATTEMPTS"); do
+    if curl -kfsS -m 5 "https://127.0.0.1:${ca}/acme/acme/directory" >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$attempt" -eq "$SERVE_ATTEMPTS" ]; then
+      fail "instance ${name}'s step-ca ACME directory did not answer on port ${ca} (${label})"
+    fi
+    sleep "$SERVE_DELAY_SECS"
+  done
+  pass "instance ${name}'s step-ca ACME directory answers on port ${ca} (${label})"
+  for attempt in $(seq 1 "$SERVE_ATTEMPTS"); do
+    local code
+    code="$(curl -sS -m 5 -o /dev/null -w '%{http_code}' \
+      "http://127.0.0.1:${http01}/admin/http01" 2>/dev/null || true)"
+    if [ -n "$code" ] && [ "$code" != "000" ]; then
+      break
+    fi
+    if [ "$attempt" -eq "$SERVE_ATTEMPTS" ]; then
+      fail "instance ${name}'s HTTP-01 admin API did not answer on port ${http01} (${label})"
+    fi
+    sleep "$SERVE_DELAY_SECS"
+  done
+  pass "instance ${name}'s HTTP-01 admin API answers on port ${http01} (${label})"
+}
+
+instance_container_names() {
+  docker ps -a --filter "label=com.docker.compose.project=$1" --format '{{.Names}}' |
+    LC_ALL=C sort
+}
+
+instance_volume_names() {
+  docker volume ls -q --filter "label=com.docker.compose.project=$1" | LC_ALL=C sort
+}
+
+instance_project_labels() {
+  local id
+  for id in $(docker ps -aq --filter "label=com.docker.compose.project=$1"); do
+    docker inspect --format '{{index .Config.Labels "com.docker.compose.project"}}' "$id"
+  done | LC_ALL=C sort -u
+}
+
+assert_disjoint() {
+  local what="$1" left="$2" right="$3"
+  local overlap
+  overlap="$(LC_ALL=C comm -12 <(printf '%s\n' "$left") <(printf '%s\n' "$right") | grep -v '^$' || true)"
+  if [ -n "$overlap" ]; then
+    fail "${what} overlap between the two instances: $(printf '%s' "$overlap" | tr '\n' ' ')"
+  fi
+  pass "$what are disjoint"
+}
+
+assert_instances_disjoint() {
+  log_phase "assert-disjoint"
+  assert_disjoint "container names" \
+    "$(instance_container_names "$INSTANCE_A")" "$(instance_container_names "$INSTANCE_B")"
+  assert_disjoint "volume names" \
+    "$(instance_volume_names "$INSTANCE_A")" "$(instance_volume_names "$INSTANCE_B")"
+  assert_disjoint "com.docker.compose.project labels" \
+    "$(instance_project_labels "$INSTANCE_A")" "$(instance_project_labels "$INSTANCE_B")"
+  assert_equal "instance A carries exactly one project label" \
+    "$INSTANCE_A" "$(instance_project_labels "$INSTANCE_A" | tr '\n' ' ' | sed 's/ $//')"
+  assert_equal "instance B carries exactly one project label" \
+    "$INSTANCE_B" "$(instance_project_labels "$INSTANCE_B" | tr '\n' ' ' | sed 's/ $//')"
+}
+
+# ---------------------------------------------------------------------------
+# Container and volume continuity
+# ---------------------------------------------------------------------------
+
+# Container IDs, not names: an ID is byte-identical across the second
+# install only if the container was never recreated.
+snapshot_container_ids() {
+  local project="$1" out="$2" id
+  : >"$out"
+  for id in $(docker ps -aq --filter "label=com.docker.compose.project=$project"); do
+    docker inspect --format '{{.Name}} {{.Id}}' "$id"
+  done | LC_ALL=C sort >"$out"
+  [ -s "$out" ] || fail "no containers found for project ${project}"
+}
+
+# The full `docker volume inspect` document — `Name`, `Driver`, `Labels`,
+# `Mountpoint`, `Options`, `Scope` and `CreatedAt`.  A volume *name* is
+# not evidence of continuity: a volume Compose removed and recreated
+# comes back under the same project-derived name, so comparing names
+# alone would pass on exactly the regression this exists to catch.
+snapshot_volume_metadata() {
+  local project="$1" out="$2" volume
+  : >"$out"
+  while IFS= read -r volume; do
+    [ -n "$volume" ] || continue
+    docker volume inspect "$volume" >>"$out" ||
+      fail "failed to inspect volume ${volume} of project ${project}"
+  done < <(instance_volume_names "$project")
+  [ -s "$out" ] || fail "no volumes found for project ${project}"
+}
+
+resolve_helper_image() {
+  [ -n "$HELPER_IMAGE" ] && return 0
+  HELPER_IMAGE="$(docker inspect --format '{{.Config.Image}}' "${INSTANCE_A}-openbao" 2>/dev/null || true)"
+  [ -n "$HELPER_IMAGE" ] || fail "could not resolve an image for the sentinel containers"
+}
+
+# Writes/reads the sentinel through a throwaway container mounting the
+# volume, built from an image already present on the host (the pattern
+# `seed_root_owned_ca_keys` in run-local-lifecycle.sh follows), so the
+# sentinel needs no image pull under the `--no-build` constraint.  The
+# entrypoint is overridden rather than relied on so the helper works
+# whatever image it lands on.
+volume_sentinel_write() {
+  local volume="$1" value="$2"
+  resolve_helper_image
+  docker run --rm --user root --entrypoint sh -v "${volume}:/mnt" "$HELPER_IMAGE" \
+    -c "printf '%s' '${value}' > /mnt/${SENTINEL_FILE}" >>"$RUN_LOG" 2>&1 ||
+    fail "failed to write the sentinel into volume ${volume}"
+}
+
+volume_sentinel_read() {
+  local volume="$1"
+  resolve_helper_image
+  docker run --rm --user root --entrypoint sh -v "${volume}:/mnt" "$HELPER_IMAGE" \
+    -c "cat /mnt/${SENTINEL_FILE} 2>/dev/null || true" 2>/dev/null
+}
+
+seed_volume_sentinels() {
+  local project="$1" out="$2" volume
+  # Resolved here, in the caller's own shell, so the cleanup chown
+  # fallback can still reach the image after the run's containers are
+  # gone; the read path resolves inside a command substitution and would
+  # only ever set it in a subshell.
+  resolve_helper_image
+  : >"$out"
+  while IFS= read -r volume; do
+    [ -n "$volume" ] || continue
+    volume_sentinel_write "$volume" "${volume}:${RUN_TOKEN}"
+    printf '%s %s\n' "$volume" "${volume}:${RUN_TOKEN}" >>"$out"
+  done < <(instance_volume_names "$project")
+  [ -s "$out" ] || fail "no volumes found to seed for project ${project}"
+}
+
+assert_volume_sentinels() {
+  local project="$1" expected_file="$2" label="$3" volume expected actual
+  while read -r volume expected; do
+    [ -n "$volume" ] || continue
+    actual="$(volume_sentinel_read "$volume")"
+    if [ "$actual" != "$expected" ]; then
+      fail "volume ${volume} lost its sentinel ${label} (expected '${expected}', got '${actual}'); the volume was recreated"
+    fi
+  done <"$expected_file"
+  pass "every volume of project ${project} kept its sentinel ${label}"
+}
+
+assert_containers_unchanged() {
+  local project="$1" before="$2" label="$3"
+  local after="$SNAPSHOT_DIR/containers-${project}-${label}.txt"
+  snapshot_container_ids "$project" "$after"
+  if ! diff -u "$before" "$after" >"$SNAPSHOT_DIR/containers-${project}-${label}.diff" 2>&1; then
+    cat "$SNAPSHOT_DIR/containers-${project}-${label}.diff" >>"$RUN_LOG"
+    fail "project ${project}'s containers were recreated, removed or relabelled ${label} (see $SNAPSHOT_DIR)"
+  fi
+  pass "project ${project}'s container IDs are unchanged ${label}"
+}
+
+assert_volumes_unchanged() {
+  local project="$1" before="$2" sentinels="$3" label="$4"
+  local after="$SNAPSHOT_DIR/volumes-${project}-${label}.json"
+  snapshot_volume_metadata "$project" "$after"
+  if ! diff -u "$before" "$after" >"$SNAPSHOT_DIR/volumes-${project}-${label}.diff" 2>&1; then
+    cat "$SNAPSHOT_DIR/volumes-${project}-${label}.diff" >>"$RUN_LOG"
+    fail "project ${project}'s volume metadata changed ${label} (see $SNAPSHOT_DIR)"
+  fi
+  pass "project ${project}'s volume inspect output is byte-identical ${label}"
+  assert_volume_sentinels "$project" "$sentinels" "$label"
+}
+
+# ---------------------------------------------------------------------------
+# DNS-alias containment
+# ---------------------------------------------------------------------------
+
+# Both instances' responders carry the same
+# `com.docker.compose.service=bootroot-http01` label by design, so the
+# project filter is the only thing keeping them apart.  This is the
+# narrowed lookup `find_responder_container` in src/commands/dns_alias.rs
+# performs — deliberately *not* the un-narrowed service-label-only lookup
+# `verify_dns_aliases` in scripts/preflight/extra/cli-scenarios.sh uses,
+# which is correct for a single-instance script and wrong here.
+responder_container_id() {
+  local project="$1" ids count
+  ids="$(docker ps -q \
+    -f "label=com.docker.compose.service=bootroot-http01" \
+    -f "label=com.docker.compose.project=${project}")"
+  count="$(printf '%s\n' "$ids" | grep -c '[^[:space:]]' || true)"
+  if [ "$count" != "1" ]; then
+    fail "expected exactly one responder for project ${project}, found ${count}"
+  fi
+  printf '%s' "$ids"
+}
+
+# The engine adds the container's own short ID to the alias set; it is
+# filtered out so the comparison is over the aliases bootroot controls.
+responder_aliases() {
+  local cid="$1"
+  docker inspect \
+    --format '{{range $k, $v := .NetworkSettings.Networks}}{{range $v.Aliases}}{{.}} {{end}}{{end}}' \
+    "$cid" |
+    tr ' ' '\n' |
+    awk -v id="$cid" 'NF && index(id, $0) != 1' |
+    LC_ALL=C sort -u
+}
+
+snapshot_responder_aliases() {
+  local project="$1" label="$2"
+  responder_aliases "$(responder_container_id "$project")" \
+    >"$SNAPSHOT_DIR/aliases-${project}-${label}.txt"
+}
+
+register_service() {
+  local name="$1" dir="$2" service="$3" hostname="$4" instance_id="$5" \
+    stepca_port="$6" http01_port="$7"
+  local summary="$ARTIFACT_DIR/init-summary-${name}.json"
+  local role_id secret_id
+  role_id="$(jq -r '.approles[] | select(.label == "runtime_service_add") | .role_id // empty' "$summary")"
+  secret_id="$(jq -r '.approles[] | select(.label == "runtime_service_add") | .secret_id // empty' "$summary")"
+  [ -n "$role_id" ] || fail "failed to parse runtime_service_add role_id for instance ${name}"
+  [ -n "$secret_id" ] || fail "failed to parse runtime_service_add secret_id for instance ${name}"
+
+  # `service add` takes no compose-file argument at all: it resolves the
+  # identity with `ComposeIdentity::resolve_for_dir(Path::new("."), ...)`,
+  # loads `state.json` from the bare relative `state.json`, and reaches
+  # OpenBao at the `openbao_url` recorded there.  Running it from this
+  # instance's own directory is therefore what selects all three.
+  run_bootroot "$dir" service add \
+    --service-name "$service" \
+    --delivery-mode local-file \
+    --hostname "$hostname" \
+    --domain "$DOMAIN" \
+    --agent-config "$dir/agent-${service}.toml" \
+    --cert-path "$dir/certs/${service}.crt" \
+    --key-path "$dir/certs/${service}.key" \
+    --instance-id "$instance_id" \
+    --agent-server "https://127.0.0.1:${stepca_port}/acme/acme/directory" \
+    --agent-responder-url "http://127.0.0.1:${http01_port}" \
+    --auth-mode approle \
+    --approle-role-id "$role_id" \
+    --approle-secret-id "$secret_id" \
+    >>"$RUN_LOG" 2>&1 || fail "service add failed on instance ${name}"
+}
+
+# One rewiring, both responders observed.  The rewired instance must gain
+# exactly the new alias; the other instance's alias set must be
+# byte-identical to its pre-registration snapshot.  This is the one
+# cross-instance path that would not announce itself as a Docker name
+# conflict: the service label is identical across instances by design, so
+# rewiring the wrong responder would silently move another instance's
+# DNS aliases.
+assert_alias_containment() {
+  local rewired="$1" other="$2" alias_fqdn="$3" round="$4"
+  local before_rewired="$SNAPSHOT_DIR/aliases-${rewired}-before-${round}.txt"
+  local before_other="$SNAPSHOT_DIR/aliases-${other}-before-${round}.txt"
+  local after_rewired="$SNAPSHOT_DIR/aliases-${rewired}-after-${round}.txt"
+  local after_other="$SNAPSHOT_DIR/aliases-${other}-after-${round}.txt"
+
+  responder_aliases "$(responder_container_id "$rewired")" >"$after_rewired"
+  responder_aliases "$(responder_container_id "$other")" >"$after_other"
+
+  local gained
+  gained="$(LC_ALL=C comm -13 "$before_rewired" "$after_rewired" | grep -v '^$' || true)"
+  assert_equal "instance ${rewired}'s responder gained exactly the new alias (${round})" \
+    "$alias_fqdn" "$gained"
+
+  if ! diff -u "$before_other" "$after_other" >"$SNAPSHOT_DIR/aliases-${other}-${round}.diff" 2>&1; then
+    cat "$SNAPSHOT_DIR/aliases-${other}-${round}.diff" >>"$RUN_LOG"
+    fail "instance ${other}'s responder alias set changed while instance ${rewired} was rewired (${round})"
+  fi
+  pass "instance ${other}'s responder alias set is byte-identical (${round})"
+
+  if grep -qxF "$alias_fqdn" "$after_other"; then
+    fail "instance ${other}'s responder acquired instance ${rewired}'s alias ${alias_fqdn} (${round})"
+  fi
+  pass "instance ${other}'s responder did not acquire ${alias_fqdn} (${round})"
+}
+
+run_alias_containment() {
+  log_phase "dns-alias-containment"
+  local alias_a="${SERVICE_INSTANCE_ID_A}.${SERVICE_A}.${HOSTNAME_A}.${DOMAIN}"
+  local alias_b="${SERVICE_INSTANCE_ID_B}.${SERVICE_B}.${HOSTNAME_B}.${DOMAIN}"
+
+  snapshot_responder_aliases "$INSTANCE_A" "before-a-then-b"
+  snapshot_responder_aliases "$INSTANCE_B" "before-a-then-b"
+  register_service "$INSTANCE_A" "$DIR_A" "$SERVICE_A" "$HOSTNAME_A" \
+    "$SERVICE_INSTANCE_ID_A" "$PORT_A_STEPCA" "$PORT_A_HTTP01"
+  assert_alias_containment "$INSTANCE_A" "$INSTANCE_B" "$alias_a" "a-then-b"
+
+  snapshot_responder_aliases "$INSTANCE_A" "before-b-then-a"
+  snapshot_responder_aliases "$INSTANCE_B" "before-b-then-a"
+  register_service "$INSTANCE_B" "$DIR_B" "$SERVICE_B" "$HOSTNAME_B" \
+    "$SERVICE_INSTANCE_ID_B" "$PORT_B_STEPCA" "$PORT_B_HTTP01"
+  assert_alias_containment "$INSTANCE_B" "$INSTANCE_A" "$alias_b" "b-then-a"
+}
+
+# ---------------------------------------------------------------------------
+# Teardown and leftover checks
+# ---------------------------------------------------------------------------
+
+capture_artifacts() {
+  local project dir
+  for project in "$INSTANCE_A:$DIR_A" "$INSTANCE_B:$DIR_B"; do
+    dir="${project#*:}"
+    project="${project%%:*}"
+    [ -n "$dir" ] && [ -d "$dir" ] || continue
+    instance_compose "$project" "$dir" ps \
+      >"$ARTIFACT_DIR/compose-ps-${project}.log" 2>&1 || true
+    instance_compose "$project" "$dir" logs --no-color \
+      >"$ARTIFACT_DIR/compose-logs-${project}.log" 2>&1 || true
+  done
+}
+
+# Every teardown action is scoped to the run's own instance names and
+# their `com.docker.compose.project` labels — never a `bootroot-*`
+# wildcard — so a co-located default install is untouched.
+teardown_instance() {
+  local project="$1" dir="$2" id
+  if [ -n "$dir" ] && [ -f "$dir/$COMPOSE_FILE_NAME" ]; then
+    instance_compose "$project" "$dir" down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+  for id in $(docker ps -aq --filter "label=com.docker.compose.project=${project}" 2>/dev/null); do
+    docker rm -f "$id" >/dev/null 2>&1 || true
+  done
+  for id in $(docker volume ls -q --filter "label=com.docker.compose.project=${project}" 2>/dev/null); do
+    docker volume rm -f "$id" >/dev/null 2>&1 || true
+  done
+  for id in $(docker network ls -q --filter "label=com.docker.compose.project=${project}" 2>/dev/null); do
+    docker network rm "$id" >/dev/null 2>&1 || true
+  done
+}
+
+assert_no_leftovers() {
+  local project="$1" label="$2" leftovers
+  leftovers="$(docker ps -aq --filter "label=com.docker.compose.project=${project}" 2>/dev/null || true)"
+  [ -z "$leftovers" ] || fail "containers of project ${project} survived ${label}"
+  leftovers="$(docker volume ls -q --filter "label=com.docker.compose.project=${project}" 2>/dev/null || true)"
+  [ -z "$leftovers" ] || fail "volumes of project ${project} survived ${label}"
+  pass "no container or volume of project ${project} survived ${label}"
+}
+
+remove_run_root() {
+  [ -n "$RUN_ROOT" ] && [ -d "$RUN_ROOT" ] || return 0
+  if rm -rf "$RUN_ROOT" 2>/dev/null; then
+    return 0
+  fi
+  # A container may have left material under `secrets/` owned by another
+  # uid.  Re-own it through the same throwaway-container route the
+  # sentinels use rather than reaching for host privileges.
+  if [ -n "$HELPER_IMAGE" ]; then
+    docker run --rm --user root --entrypoint sh -v "${RUN_ROOT}:/mnt" "$HELPER_IMAGE" \
+      -c "chown -R $(id -u):$(id -g) /mnt" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$RUN_ROOT" 2>/dev/null || true
+  [ ! -d "$RUN_ROOT" ] || fail "failed to remove the run root ${RUN_ROOT}"
+}
+
+cleanup() {
+  local status=$?
+  log_phase "cleanup"
+  capture_artifacts
+  teardown_instance "$INSTANCE_A" "$DIR_A"
+  teardown_instance "$INSTANCE_B" "$DIR_B"
+  docker image rm -f "$HTTP01_IMAGE" >/dev/null 2>&1 || true
+  remove_run_root
+  local project leftovers
+  for project in "$INSTANCE_A" "$INSTANCE_B"; do
+    leftovers="$(docker ps -aq --filter "label=com.docker.compose.project=${project}" 2>/dev/null || true)"
+    leftovers="${leftovers}$(docker volume ls -q --filter "label=com.docker.compose.project=${project}" 2>/dev/null || true)"
+    if [ -n "$leftovers" ]; then
+      echo "[two-instance][cleanup] leftovers survived for project ${project}" >&2
+      status=1
+    fi
+  done
+  if [ -d "$RUN_ROOT" ]; then
+    echo "[two-instance][cleanup] run root survived: ${RUN_ROOT}" >&2
+    status=1
+  fi
+  exit "$status"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  mkdir -p "$ARTIFACT_DIR" "$SNAPSHOT_DIR"
+  : >"$PHASE_LOG"
+  : >"$RUN_LOG"
+  log_phase "startup"
+  trap cleanup EXIT
+  trap 'on_error $LINENO' ERR
+
+  ensure_prerequisites
+  log "instance A: ${INSTANCE_A}"
+  log "instance B: ${INSTANCE_B}"
+
+  log_phase "prepare"
+  build_responder_image
+  create_run_root
+  prepull_third_party_images
+  allocate_ports
+
+  install_instance "$INSTANCE_A" "$DIR_A" \
+    "$PORT_A_POSTGRES" "$PORT_A_OPENBAO" "$PORT_A_STEPCA" "$PORT_A_HTTP01"
+  init_instance "$INSTANCE_A" "$DIR_A" "$PORT_A_HTTP01"
+
+  log_phase "assert-a-installed"
+  wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-init"
+  assert_resolved_project "$INSTANCE_A" "$DIR_A"
+  assert_openbao_publication "$INSTANCE_A" "$PORT_A_OPENBAO"
+  assert_instance_serving "$INSTANCE_A" "$PORT_A_OPENBAO" "$PORT_A_STEPCA" \
+    "$PORT_A_HTTP01" "after-init"
+
+  log_phase "snapshot-a"
+  snapshot_container_ids "$INSTANCE_A" "$SNAPSHOT_DIR/containers-${INSTANCE_A}-baseline.txt"
+  snapshot_volume_metadata "$INSTANCE_A" "$SNAPSHOT_DIR/volumes-${INSTANCE_A}-baseline.json"
+  seed_volume_sentinels "$INSTANCE_A" "$SNAPSHOT_DIR/sentinels-${INSTANCE_A}.txt"
+  # The sentinels are written into live data roots, so re-assert health
+  # before treating them as a baseline: a service that rejected the
+  # dotfile must surface here rather than as a confusing later failure.
+  wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-sentinels"
+
+  install_instance "$INSTANCE_B" "$DIR_B" \
+    "$PORT_B_POSTGRES" "$PORT_B_OPENBAO" "$PORT_B_STEPCA" "$PORT_B_HTTP01"
+
+  log_phase "assert-a-survived-b-install"
+  assert_containers_unchanged "$INSTANCE_A" \
+    "$SNAPSHOT_DIR/containers-${INSTANCE_A}-baseline.txt" "after-b-install"
+  assert_volumes_unchanged "$INSTANCE_A" \
+    "$SNAPSHOT_DIR/volumes-${INSTANCE_A}-baseline.json" \
+    "$SNAPSHOT_DIR/sentinels-${INSTANCE_A}.txt" "after-b-install"
+  wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-b-install"
+
+  init_instance "$INSTANCE_B" "$DIR_B" "$PORT_B_HTTP01"
+
+  log_phase "assert-b-installed"
+  wait_for_instance_healthy "$INSTANCE_B" "$DIR_B" "after-init"
+  assert_resolved_project "$INSTANCE_B" "$DIR_B"
+  assert_openbao_publication "$INSTANCE_B" "$PORT_B_OPENBAO"
+  assert_instance_serving "$INSTANCE_B" "$PORT_B_OPENBAO" "$PORT_B_STEPCA" \
+    "$PORT_B_HTTP01" "after-init"
+  wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-b-init"
+
+  assert_instances_disjoint
+
+  run_alias_containment
+
+  log_phase "teardown-b"
+  teardown_instance "$INSTANCE_B" "$DIR_B"
+  assert_no_leftovers "$INSTANCE_B" "instance B teardown"
+
+  log_phase "assert-a-survived-b-teardown"
+  assert_containers_unchanged "$INSTANCE_A" \
+    "$SNAPSHOT_DIR/containers-${INSTANCE_A}-baseline.txt" "after-b-teardown"
+  assert_volumes_unchanged "$INSTANCE_A" \
+    "$SNAPSHOT_DIR/volumes-${INSTANCE_A}-baseline.json" \
+    "$SNAPSHOT_DIR/sentinels-${INSTANCE_A}.txt" "after-b-teardown"
+  wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-b-teardown"
+  assert_instance_serving "$INSTANCE_A" "$PORT_A_OPENBAO" "$PORT_A_STEPCA" \
+    "$PORT_A_HTTP01" "after-b-teardown"
+
+  log_phase "done"
+  log "two-instance isolation checks passed"
+}
+
+main "$@"

--- a/scripts/impl/run-two-instance-isolation.sh
+++ b/scripts/impl/run-two-instance-isolation.sh
@@ -123,6 +123,8 @@ HEALTH_ATTEMPTS="${HEALTH_ATTEMPTS:-40}"
 HEALTH_DELAY_SECS="${HEALTH_DELAY_SECS:-3}"
 SERVE_ATTEMPTS="${SERVE_ATTEMPTS:-30}"
 SERVE_DELAY_SECS="${SERVE_DELAY_SECS:-2}"
+INFRA_READY_ATTEMPTS="${INFRA_READY_ATTEMPTS:-60}"
+INFRA_READY_DELAY_SECS="${INFRA_READY_DELAY_SECS:-2}"
 
 CURRENT_PHASE="startup"
 RUN_ROOT=""
@@ -377,9 +379,48 @@ install_instance() {
     >>"$RUN_LOG" 2>&1 || fail "infra install failed for instance ${name}"
 }
 
+# `infra install` returns once every container reports `running`, which
+# is not the same as the servers inside them accepting connections.
+# `bootroot init` opens with a single-shot `OpenBao` health check and a
+# single-shot database connect — neither retries on `Connection refused`
+# — so the wait belongs here, as it does in every other `scripts/impl/`
+# script.  Both probes are scoped to this instance's own container and
+# its own published port.
+wait_for_openbao_listening() {
+  local name="$1" port="$2" attempt code
+  for attempt in $(seq 1 "$INFRA_READY_ATTEMPTS"); do
+    code="$(curl -kSs -o /dev/null -w '%{http_code}' -m 3 \
+      "http://127.0.0.1:${port}/v1/sys/seal-status" 2>/dev/null || true)"
+    if [ -n "$code" ] && [ "$code" != "000" ]; then
+      return 0
+    fi
+    sleep "$INFRA_READY_DELAY_SECS"
+  done
+  docker logs "${name}-openbao" >>"$RUN_LOG" 2>&1 || true
+  fail "instance ${name}'s OpenBao did not answer on port ${port} before init"
+}
+
+wait_for_postgres_admin() {
+  local name="$1" port="$2" attempt
+  for attempt in $(seq 1 "$INFRA_READY_ATTEMPTS"); do
+    # Probe over TCP as well: the initdb bootstrap server listens only on
+    # the Unix socket, so a socket-based `pg_isready` reports ready before
+    # the final server — the one init connects to — is up.
+    if docker exec "${name}-postgres" pg_isready -h 127.0.0.1 -U step -d postgres >/dev/null 2>&1 &&
+      bash -c ": >/dev/tcp/127.0.0.1/${port}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$INFRA_READY_DELAY_SECS"
+  done
+  docker logs "${name}-postgres" >>"$RUN_LOG" 2>&1 || true
+  fail "instance ${name}'s PostgreSQL did not accept connections on port ${port} before init"
+}
+
 init_instance() {
-  local name="$1" dir="$2" http01="$3"
+  local name="$1" dir="$2" pg="$3" bao="$4" http01="$5"
   log_phase "init-${name}"
+  wait_for_postgres_admin "$name" "$pg"
+  wait_for_openbao_listening "$name" "$bao"
   log "initialising instance ${name}"
   local raw_log="$ARTIFACT_DIR/init-${name}.raw.log"
   # Non-interactive: every prompt has its own flag and stdin is closed.
@@ -909,7 +950,8 @@ main() {
 
   install_instance "$INSTANCE_A" "$DIR_A" \
     "$PORT_A_POSTGRES" "$PORT_A_OPENBAO" "$PORT_A_STEPCA" "$PORT_A_HTTP01"
-  init_instance "$INSTANCE_A" "$DIR_A" "$PORT_A_HTTP01"
+  init_instance "$INSTANCE_A" "$DIR_A" \
+    "$PORT_A_POSTGRES" "$PORT_A_OPENBAO" "$PORT_A_HTTP01"
 
   log_phase "assert-a-installed"
   wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-init"
@@ -938,7 +980,8 @@ main() {
     "$SNAPSHOT_DIR/sentinels-${INSTANCE_A}.txt" "after-b-install"
   wait_for_instance_healthy "$INSTANCE_A" "$DIR_A" "after-b-install"
 
-  init_instance "$INSTANCE_B" "$DIR_B" "$PORT_B_HTTP01"
+  init_instance "$INSTANCE_B" "$DIR_B" \
+    "$PORT_B_POSTGRES" "$PORT_B_OPENBAO" "$PORT_B_HTTP01"
 
   log_phase "assert-b-installed"
   wait_for_instance_healthy "$INSTANCE_B" "$DIR_B" "after-init"

--- a/scripts/impl/run-two-instance-isolation.sh
+++ b/scripts/impl/run-two-instance-isolation.sh
@@ -727,7 +727,13 @@ assert_volumes_unchanged() {
 # performs — deliberately *not* the un-narrowed service-label-only lookup
 # `verify_dns_aliases` in scripts/preflight/extra/cli-scenarios.sh uses,
 # which is correct for a single-instance script and wrong here.
-responder_container_id() {
+#
+# The result travels through a global for the same reason `PICKED_PORT`
+# does: inside a command substitution `fail`'s `exit` would only leave the
+# subshell, so a missing or ambiguous responder would print its diagnosis
+# and then let the run carry on against an empty container id.
+RESPONDER_ID=""
+resolve_responder_container() {
   local project="$1" ids count
   ids="$(docker ps -q \
     -f "label=com.docker.compose.service=bootroot-http01" \
@@ -736,7 +742,7 @@ responder_container_id() {
   if [ "$count" != "1" ]; then
     fail "expected exactly one responder for project ${project}, found ${count}"
   fi
-  printf '%s' "$ids"
+  RESPONDER_ID="$ids"
 }
 
 # The engine adds the container's own short ID to the alias set; it is
@@ -753,7 +759,8 @@ responder_aliases() {
 
 snapshot_responder_aliases() {
   local project="$1" label="$2"
-  responder_aliases "$(responder_container_id "$project")" \
+  resolve_responder_container "$project"
+  responder_aliases "$RESPONDER_ID" \
     >"$SNAPSHOT_DIR/aliases-${project}-${label}.txt"
 }
 
@@ -803,8 +810,10 @@ assert_alias_containment() {
   local after_rewired="$SNAPSHOT_DIR/aliases-${rewired}-after-${round}.txt"
   local after_other="$SNAPSHOT_DIR/aliases-${other}-after-${round}.txt"
 
-  responder_aliases "$(responder_container_id "$rewired")" >"$after_rewired"
-  responder_aliases "$(responder_container_id "$other")" >"$after_other"
+  resolve_responder_container "$rewired"
+  responder_aliases "$RESPONDER_ID" >"$after_rewired"
+  resolve_responder_container "$other"
+  responder_aliases "$RESPONDER_ID" >"$after_other"
 
   local gained
   gained="$(LC_ALL=C comm -13 "$before_rewired" "$after_rewired" | grep -v '^$' || true)"

--- a/scripts/preflight/ci/e2e-matrix.sh
+++ b/scripts/preflight/ci/e2e-matrix.sh
@@ -23,6 +23,7 @@ Runs the same Docker E2E matrix steps used in CI:
 7) step-ca certificate SANs
 8) OpenBao TLS transition with no compose delta
 9) OpenBao TLS re-issuance after secrets/ is re-owned
+10) two co-located instances stay independent
 
 Options:
   --skip-hosts  Skip hosts steps (useful when sudo -n is unavailable locally)
@@ -185,6 +186,16 @@ SECRETS_DIR="$ROOT_DIR/secrets" \
 BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
 "$ROOT_DIR/scripts/impl/run-openbao-tls-reown.sh"
 
+# No COMPOSE_PROJECT_NAME here, unlike the scenarios above: this one has
+# to resolve each instance's project from that instance's own `.env`, and
+# a caller-supplied project name would collapse both instances into one.
+# The script derives its own run-scoped instance names and picks free
+# host ports itself, so it needs no port or secrets wiring either.
+echo "[ci-local-e2e] run two-instance isolation (issue #747)"
+ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-two-instance-${RUN_ID}" \
+BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
+"$ROOT_DIR/scripts/impl/run-two-instance-isolation.sh"
+
 echo "[ci-local-e2e] done"
 echo "[ci-local-e2e] artifacts:"
 echo "  - $ROOT_DIR/tmp/e2e/ci-local-no-hosts-${RUN_ID}"
@@ -196,3 +207,4 @@ echo "  - $ROOT_DIR/tmp/e2e/ci-reinit-recovery-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-stepca-san-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-openbao-tls-no-delta-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-openbao-tls-reown-${RUN_ID}"
+echo "  - $ROOT_DIR/tmp/e2e/ci-two-instance-${RUN_ID}"

--- a/tests/docker_e2e_two_instance_isolation.rs
+++ b/tests/docker_e2e_two_instance_isolation.rs
@@ -1,0 +1,86 @@
+#[cfg(unix)]
+mod support;
+
+#[cfg(unix)]
+mod unix_integration {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use anyhow::{Context, Result};
+
+    /// Closes #747: two bootroot installs on one host must stay
+    /// independent.
+    ///
+    /// Before the instance identity existed, a second install adopted the
+    /// first install's containers — Compose reported the first instance's
+    /// `OpenBao` Agent sidecars as orphans and recreated its already
+    /// initialised `OpenBao` against the wrong storage volume and unseal
+    /// keys.  A regression does not surface as a crash but as another
+    /// team's CA quietly losing its state, so it needs two live Compose
+    /// projects on one real daemon rather than the fake-`docker` argv
+    /// assertions in `tests/bootroot_cli.rs`.
+    ///
+    /// Marked `#[ignore]` so `cargo test` stays fast; CI invokes the
+    /// script directly via `scripts/preflight/ci/e2e-matrix.sh` (and the
+    /// `two-instance` arm of `test-docker-e2e-matrix`).
+    #[test]
+    #[ignore = "Requires local Docker and brings up two full bootroot stacks"]
+    fn docker_two_co_located_instances_stay_independent() -> Result<()> {
+        // The script sanitises the token to `[a-z0-9]` and both derived
+        // instance names must stay inside the 39-character limit, so keep
+        // the prefix short.
+        let scenario_id = super::support::docker_harness::unique_scenario_id("ti");
+        let artifact_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tmp")
+            .join("e2e")
+            .join(format!("docker-two-instance-{scenario_id}"));
+
+        // Deliberately no `COMPOSE_PROJECT_NAME`, unlike every other
+        // harness in this directory: this scenario has to resolve each
+        // instance's project from that instance's own `.env`, and a
+        // caller-supplied project name would collapse both installs into
+        // one and quietly reduce the run to a single-instance test.
+        let output = Command::new("bash")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .arg(super::support::docker_harness::two_instance_isolation_script_path())
+            .env("ARTIFACT_DIR", &artifact_dir)
+            .env("RUN_TOKEN", &scenario_id)
+            .env("BOOTROOT_BIN", env!("CARGO_BIN_EXE_bootroot"))
+            .output()
+            .with_context(|| "Failed to run two-instance isolation script")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("two-instance isolation script failed: {stderr}");
+        }
+
+        let phase_log = artifact_dir.join("phases.log");
+        assert!(phase_log.exists(), "missing phase log at {phase_log:?}");
+        let phases =
+            std::fs::read_to_string(&phase_log).with_context(|| "Failed to read phase log")?;
+        // `assert-a-survived-b-install` and `assert-a-survived-b-teardown`
+        // are the two continuity gates; `dns-alias-containment` is the one
+        // cross-instance path that would not announce itself as a Docker
+        // name conflict.  A run that skipped any of them would prove
+        // nothing about #747 even if every other assertion passed.
+        for phase in [
+            "prepare",
+            "assert-a-installed",
+            "snapshot-a",
+            "assert-a-survived-b-install",
+            "assert-b-installed",
+            "assert-disjoint",
+            "dns-alias-containment",
+            "teardown-b",
+            "assert-a-survived-b-teardown",
+            "done",
+        ] {
+            assert!(
+                phases.contains(&format!("\"phase\":\"{phase}\"")),
+                "missing phase {phase} in {phases}"
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/tests/support/docker_harness.rs
+++ b/tests/support/docker_harness.rs
@@ -72,6 +72,13 @@ pub(crate) fn openbao_tls_reown_script_path() -> PathBuf {
         .join("run-openbao-tls-reown.sh")
 }
 
+pub(crate) fn two_instance_isolation_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts")
+        .join("impl")
+        .join("run-two-instance-isolation.sh")
+}
+
 pub(crate) fn baseline_scenario_path(file_name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")


### PR DESCRIPTION
## Summary

Instance identity, the `-p <project>` scoping and the instance-derived container names all shipped, but nothing ever ran two installs against a real Docker daemon. The existing coverage in `tests/bootroot_cli.rs` drives a fake `docker` on `PATH` and asserts on its argv — the wrong level of abstraction for a defect that only manifests with two live Compose projects on one daemon, and one that surfaces not as a crash but as another team's CA quietly losing its state.

**`scripts/impl/run-two-instance-isolation.sh`** installs, initialises and verifies two bootroot instances on one host, reporting each assertion individually so a failure names what broke:

- Both compose directories share a **basename** under different parents (`<run-root>/a/bootroot`, `<run-root>/b/bootroot`) — the layout Compose would otherwise derive one default project name from, so the run proves the explicit `-p` and not the directory name is what separates the installs.
- **Continuity is read off observables a recreation cannot fake**: container IDs (byte-identical only if never recreated), the full `docker volume inspect` document (`Name`, `Driver`, `Labels`, `Mountpoint`, `Options`, `Scope`, `CreatedAt`), and a per-run sentinel dotfile written into each volume — because a volume Compose removed and recreated comes back under the same project-derived name, so a name comparison would pass on exactly the regression being guarded. All three of A's volumes accepted the sentinel; the script re-asserts A's health right after seeding so a service that ever rejects one fails there, named.
- **The DNS-alias containment check gets its own assertion**, because it is the one cross-instance path that would not announce itself as a Docker name conflict: both responders carry the same `com.docker.compose.service=bootroot-http01` label by design, so only the project filter keeps them apart. A single `service add` is snapshotted before/after on *both* responders and asserted in both directions (A-then-B, B-then-A).
- **Ambient project environment is sanitised and then the resolved project is asserted**, not assumed — so an inherited value can neither break the run nor silently reduce it to a single-instance test that still passes several assertions. `COMPOSE_PROJECT_NAME` and `BOOTROOT_INSTANCE` are cleared because they outrank each `.env`; the `*_HOST_PORT` and `POSTGRES_*` variables are cleared for the same reason, since a shared inherited value would collapse both instances onto one published port.
- **Safe beside a real default-identity install**: instance names are derived from a per-run token, and every teardown and leftover check is scoped to those exact names and their project labels — never a `bootroot-*` wildcard. Filesystem cleanup is one removal of the run's own `mktemp -d` root.
- Host ports are picked with the bind-to-port-0 pattern **immediately before each instance's own install** rather than all eight up front, since a bind-to-port-0 result is advisory and B installs minutes after A.
- The `--no-build` constraint is met via `docker-compose.deploy.yml` (no build context at all): the responder image is built once up front under a run-scoped tag passed through `BOOTROOT_HTTP01_IMAGE`, so the build cannot overwrite an image a co-located default install is running.

**Wiring**: `scripts/preflight/ci/e2e-matrix.sh` (which `run-all.sh` already invokes) and a `two-instance` scenario in `ci.yml`'s `test-docker-e2e-matrix`, with both its own run step and the addition to the lifecycle step's exclusion list. It deliberately passes **no** `COMPOSE_PROJECT_NAME`, unlike the surrounding scenarios, since a caller-supplied project would collapse both instances into one. `tests/docker_e2e_two_instance_isolation.rs` adds the `#[ignore]`d cargo entry point the other Docker E2E scripts carry, alongside its path helper in `tests/support/docker_harness.rs`.

**Docs**: `docs/{en,ko}/installation.md` gain a "Co-Locating a Second Instance" section — the per-instance compose-directory requirement and what lives beside the compose file, the extra files a second directory needs (`openbao/openbao.hcl`, `responder.toml.compose`), why a second instance installs with `--no-build` (the shipped `docker-compose.yml` declares a `build.context` that has nothing to read outside a checkout) with a worked example, the working-directory rule `state.json` follows from (and that it is what selects the OpenBao each instance talks to), and the precedence of an exported `COMPOSE_PROJECT_NAME`. `docs/{en,ko}/troubleshooting.md` gain the orphan-containers / container-recreated symptom this work came from; `docs/{en,ko}/e2e-ci.md` list the new script and its no-`COMPOSE_PROJECT_NAME` exception, and correct the matrix scenario count to ten. `CHANGELOG.md` gets an `Added` entry.

No production Rust source, shipped compose file or naming behaviour changed — the only Rust in this PR is the `#[ignore]`d test entry point and its harness path helper.

## Test plan

- [x] `scripts/impl/run-two-instance-isolation.sh` passes against a real Docker daemon.
- [ ] `scripts/preflight/ci/e2e-matrix.sh` passes with the new script included, and `scripts/preflight/run-all.sh` passes.
- [x] `scripts/preflight/ci/check.sh` passes (formatting, clippy, markdown lint, docs build).
- [x] The `test-docker-e2e-matrix` job's new `two-instance` arm passes in CI, and the lifecycle step does **not** also run for that label.
- [x] Negative control (development-only, not committed): reverting the compose files to literal `container_name: bootroot-*` values makes the script fail.
- [x] Negative control (development-only): dropping the `com.docker.compose.project` filter from `responder_lookup_args` makes the DNS-alias assertion fail — expected failure is `select_responder_container`'s ambiguity error, since `docker ps` does not guarantee match order.
- [x] Positive control: exporting a shared `COMPOSE_PROJECT_NAME` and a `BOOTROOT_INSTANCE` before invoking the script changes nothing — the sanitisation absorbs them and the run still passes.
- [x] Negative control (development-only): with that same ambient environment, removing the sanitisation makes the resolved-project assertion fail, proving it does real work rather than passing vacuously.
- [x] Negative control (development-only): forcing one of A's volumes to be removed and recreated between the two snapshots makes the volume-continuity assertion fail.
- [x] After a passing run **and** after a deliberately failed run, no container or volume carrying either run-scoped instance name survives, and the run's temporary root is gone.
- [x] Run at least once on a host that already has a default `bootroot` install up; that install is untouched and still healthy afterwards, and its `.env` is unmodified.
- [x] Rendered `docs/{en,ko}` installation, troubleshooting and e2e-ci pages stay in sync in content between English and Korean.

> The `e2e-matrix.sh` / `run-all.sh` box is the one left unchecked: this development host cannot run the
> full matrix. Every scenario other than the new one hard-codes the compose default host ports
> (8200/9000/8080/5433), and all four are held on this machine by unrelated long-running processes, so
> `infra install`'s port preflight aborts before those arms start. The new scenario picks free ports itself
> and was executed through exactly the invocation `e2e-matrix.sh` uses (`ARTIFACT_DIR` + `BOOTROOT_BIN`, no
> `COMPOSE_PROJECT_NAME`); the full matrix is green in CI.

Closes #747
