### PR TITLE
Load settings from a file without touching the environment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
-use config::{Config, ConfigError, Environment, File};
+use config::builder::DefaultState;
+use config::{Config, ConfigBuilder, ConfigError, Environment, File};
 use serde::Deserialize;
 
 mod defaults;
@@ -252,21 +253,9 @@ impl Settings {
     /// # Errors
     /// Returns error if configuration parsing fails (e.g. file not found, invalid format).
     pub fn new(config_path: Option<PathBuf>) -> Result<Self, ConfigError> {
-        let mut s = Config::builder();
-
-        // 1. Set Defaults
-        s = defaults::apply_defaults(s)?;
-
-        // 2. Merge File (optional)
-        // If config_path is provided, use it. Otherwise look for "agent.toml"
-        let path = config_path.unwrap_or_else(|| PathBuf::from("agent.toml"));
-
-        // Add file source (required = false, so it doesn't panic if missing)
-        s = s.add_source(File::from(path).required(false));
-
         // 3. Environment Variables (double-underscore for nesting)
         // e.g. BOOTROOT_EMAIL, BOOTROOT_PATHS__CERT, BOOTROOT_DAEMON__RENEW_BEFORE
-        s = s.add_source(
+        let s = Self::file_builder(config_path)?.add_source(
             Environment::with_prefix("BOOTROOT")
                 .separator("__")
                 .try_parsing(true)
@@ -278,6 +267,39 @@ impl Settings {
 
         // 4. Build
         s.build()?.try_deserialize()
+    }
+
+    /// Creates a new `Settings` instance from `config_path` alone, without
+    /// the `BOOTROOT_*` environment overlay that [`Settings::new`] applies.
+    ///
+    /// Use this to assert on what a file actually contains. Reading through
+    /// `new` would let a `BOOTROOT_*` variable in the caller's environment
+    /// replace the value under test, and the only way to rule that out
+    /// there is to empty the environment first — which no process running a
+    /// tokio runtime, an HTTP client, or an env-filtered subscriber can do
+    /// soundly, since `set_var` requires that nothing else be reading.
+    ///
+    /// # Errors
+    /// Returns error if configuration parsing fails (e.g. file not found, invalid format).
+    pub fn from_file(config_path: Option<PathBuf>) -> Result<Self, ConfigError> {
+        Self::file_builder(config_path)?.build()?.try_deserialize()
+    }
+
+    /// Builds the defaults-plus-file layers both constructors share.
+    fn file_builder(
+        config_path: Option<PathBuf>,
+    ) -> Result<ConfigBuilder<DefaultState>, ConfigError> {
+        let mut s = Config::builder();
+
+        // 1. Set Defaults
+        s = defaults::apply_defaults(s)?;
+
+        // 2. Merge File (optional)
+        // If config_path is provided, use it. Otherwise look for "agent.toml"
+        let path = config_path.unwrap_or_else(|| PathBuf::from("agent.toml"));
+
+        // Add file source (required = false, so it doesn't panic if missing)
+        Ok(s.add_source(File::from(path).required(false)))
     }
 
     /// Merges CLI arguments into the settings, overriding values if present.

--- a/tests/e2e_multi_host_tls.rs
+++ b/tests/e2e_multi_host_tls.rs
@@ -127,13 +127,12 @@
 
 #![cfg(unix)]
 
-use std::ffi::OsString;
 use std::fs;
 use std::io::Read;
 use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use bootroot::acme::responder_client::{
@@ -807,49 +806,29 @@ async fn run_remote_bootstrap(
     cmd.output().await.expect("run bootroot-remote")
 }
 
-/// Shared mutex guarding temporary mutation of `BOOTROOT_*` environment
-/// variables across parallel test threads inside this binary.
-static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
 /// Loads [`Settings`] from the `agent.toml` file that `bootroot-remote
 /// bootstrap` wrote.  This is the production path the RN agent takes at
 /// `src/acme/flow.rs:156` — no test-synthesised trust material is injected;
 /// the CA bundle path and SHA-256 pins are exactly what bootstrap persisted
 /// from the TLS-protected `OpenBao` `/trust` read.
 ///
-/// `Settings::new` merges a `BOOTROOT_*` environment overlay on top of the
-/// file at `src/config.rs:210`, which would otherwise let developer or CI
-/// env vars (e.g. `BOOTROOT_TRUST__CA_BUNDLE_PATH`,
-/// `BOOTROOT_TRUST__TRUSTED_CA_SHA256`,
+/// Loaded through [`Settings::from_file`] rather than [`Settings::new`],
+/// which merges a `BOOTROOT_*` environment overlay on top of the file and
+/// would let a developer or CI variable (e.g.
+/// `BOOTROOT_TRUST__CA_BUNDLE_PATH`, `BOOTROOT_TRUST__TRUSTED_CA_SHA256`,
 /// `BOOTROOT_ACME__HTTP_RESPONDER_URL`) silently replace the values this
-/// test is trying to prove came from the TLS-protected `/trust` read.  The
-/// helper scrubs every `BOOTROOT_*` var under a shared [`ENV_LOCK`] while
-/// building `Settings`, then restores them, so the loaded `Settings`
-/// reflects the bootstrap-written `agent.toml` alone.
+/// test is trying to prove came from the TLS-protected `/trust` read. So
+/// the loaded `Settings` reflects the bootstrap-written `agent.toml`
+/// alone, and this test asserts the file is sufficient rather than
+/// arranging for the environment to be empty first.
 ///
 /// `http_responder_token_ttl_secs` is overridden to keep the admin
 /// registration well below the responder's `max_token_ttl_secs`; everything
 /// security-relevant (URL, HMAC, trust bundle path, pins) comes from the
 /// file on disk.
 fn load_settings_from_bootstrap_output(agent_config_path: &Path) -> Settings {
-    let _guard = ENV_LOCK.lock().expect("env lock not poisoned");
-    let saved: Vec<(OsString, OsString)> = std::env::vars_os()
-        .filter(|(k, _)| k.to_str().is_some_and(|key| key.starts_with("BOOTROOT_")))
-        .collect();
-    for (key, _) in &saved {
-        // SAFETY: Tests hold ENV_LOCK while mutating process environment.
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
-    let result = Settings::new(Some(agent_config_path.to_path_buf()));
-    for (key, value) in &saved {
-        // SAFETY: Tests hold ENV_LOCK while mutating process environment.
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-    let mut settings = result.expect("load agent.toml");
+    let mut settings =
+        Settings::from_file(Some(agent_config_path.to_path_buf())).expect("load agent.toml");
     settings.acme.http_responder_token_ttl_secs = TEST_TTL_SECS;
     settings
 }

--- a/tests/e2e_multi_host_tls_real_daemon.rs
+++ b/tests/e2e_multi_host_tls_real_daemon.rs
@@ -39,13 +39,11 @@
 
 #![cfg(unix)]
 
-use std::ffi::OsString;
 use std::fs;
 use std::io::Read;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use bootroot::acme::responder_client::{
@@ -722,27 +720,9 @@ async fn assert_cert_chain_valid_under_trust(trusted_pem: &str, port: u16) {
     let _ = response.status();
 }
 
-static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
 fn load_settings_from_bootstrap_output(agent_config_path: &Path) -> Settings {
-    let _guard = ENV_LOCK.lock().expect("env lock not poisoned");
-    let saved: Vec<(OsString, OsString)> = std::env::vars_os()
-        .filter(|(k, _)| k.to_str().is_some_and(|key| key.starts_with("BOOTROOT_")))
-        .collect();
-    for (key, _) in &saved {
-        // SAFETY: tests hold ENV_LOCK while mutating process environment.
-        unsafe {
-            std::env::remove_var(key);
-        }
-    }
-    let result = Settings::new(Some(agent_config_path.to_path_buf()));
-    for (key, value) in &saved {
-        // SAFETY: tests hold ENV_LOCK while mutating process environment.
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-    let mut settings = result.expect("load agent.toml");
+    let mut settings =
+        Settings::from_file(Some(agent_config_path.to_path_buf())).expect("load agent.toml");
     settings.acme.http_responder_token_ttl_secs = TEST_TTL_SECS;
     settings
 }


### PR DESCRIPTION
Closes #799.

Two E2E tests scrubbed every `BOOTROOT_*` variable out of the process environment, loaded `Settings`, then put them back, under a shared `ENV_LOCK`. The SAFETY comment said the lock made it sound:

```rust
// SAFETY: Tests hold ENV_LOCK while mutating process environment.
unsafe { std::env::remove_var(key); }
```

It does not. `set_var` is `unsafe` in edition 2024 because `setenv(3)` is not thread-safe — glibc reallocs the `environ` array and frees the old block while a concurrent `getenv` is walking it. The contract is that **no other thread in the process may be reading the environment**, not that writers are serialised among themselves. `ENV_LOCK` excludes only the code that takes it, and these two are E2E tests running a live tokio runtime, `reqwest`, and an env-filtered subscriber — every one of which reads the environment from threads holding nothing.

## Why they did it

`Settings::new` layers a `BOOTROOT_*` overlay on top of the file, so a stray `BOOTROOT_TRUST__CA_BUNDLE_PATH` in a developer or CI environment could silently replace the value under test. These tests exist to prove the trust material came from the TLS-protected `/trust` read and was persisted to `agent.toml`, so that substitution would hollow them out.

## The fix

`Settings::from_file` loads the file alone; `Settings::new` keeps its behaviour and both now share a `file_builder` helper for the defaults-plus-file layers. Both tests call `from_file`, and `ENV_LOCK`, the save-and-restore, and four `unsafe` blocks are gone.

It is also a better test than before: it proves the file is *sufficient*, rather than proving it after arranging for the environment to be empty.

## One thing that cannot be tested

`from_file`'s own property — that it ignores the overlay — cannot be asserted in-process without setting a `BOOTROOT_*` variable, which is the thing being removed. It rests on the constructor not adding the `Environment` source at all, which is visible at the definition rather than checked from outside. Testing it through a child process with `Command::env` would work but is disproportionate here.

## Not in scope

`src/commands/dotenv.rs:96` also calls `set_var`, and its SAFETY comment is sound — single-threaded init before any worker thread exists. Left alone.

The rest of the crate still mutates the environment in `#[cfg(test)]` modules across seven files. That is a separate, much larger change.

## Verified locally

- `cargo clippy --lib --tests --all-features -- -D warnings` clean
- `cargo test --lib` — 398 passed, 0 failed
- `cargo fmt` applied
- Neither test file contains `ENV_LOCK`, `unsafe`, `set_var`, or `remove_var`
