### PR TITLE
Drive init from the E2E and preflight scripts with flags instead of piped prompt answers (#822)

### DIFF
--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -159,17 +159,24 @@ bootroot infra install --compose-file "$COMPOSE_FILE"
 # DB credentials are read from .env created by infra install.
 # POSTGRES_HOST and POSTGRES_PORT are set by the script so that
 # build_admin_dsn_from_env() connects via the host-mapped port.
-# The piped sequence must answer every prompt the run reaches: init
-# fails on EOF rather than answering an unanswered prompt itself.
-printf "y\ny\ny\n" | BOOTROOT_LANG=en bootroot init \
+# Every prompt is answered by its own flag and stdin is closed, so the
+# run depends on no piped answer sequence and on no leftover file:
+# an overwrite flag whose file is absent is a silent no-op. init fails
+# on EOF rather than answering an unanswered prompt itself.
+BOOTROOT_LANG=en bootroot init \
   --compose-file "$COMPOSE_FILE" \
   --secrets-dir "$SECRETS_DIR" \
   --summary-json "$INIT_SUMMARY_JSON" \
   --enable auto-generate,show-secrets,db-provision \
   --no-eab \
+  --save-unseal-keys \
+  --overwrite-password \
+  --overwrite-ca-json \
+  --overwrite-state \
+  --confirm-db-provision \
   --db-user "step" \
   --db-name "stepca" \
-  --responder-url "$RESPONDER_URL"
+  --responder-url "$RESPONDER_URL" </dev/null
 
 # 3) service-add
 # Each distinct local service gets its own agent config (one daemon
@@ -304,10 +311,14 @@ Actual commands (script excerpt):
 ```bash
 # control node: infra-install / init / service-add
 bootroot infra install --compose-file "$COMPOSE_FILE"
-printf "y\ny\nn\n" | BOOTROOT_LANG=en bootroot init \
+BOOTROOT_LANG=en bootroot init \
   --compose-file "$COMPOSE_FILE" --summary-json "$INIT_SUMMARY_JSON" \
-  --enable auto-generate,show-secrets --eab-kid "$INIT_EAB_KID" \
-  --eab-hmac "$INIT_EAB_HMAC"
+  --enable auto-generate,show-secrets,db-provision \
+  --no-eab --save-unseal-keys \
+  --overwrite-password --overwrite-ca-json --overwrite-state \
+  --confirm-db-provision \
+  --db-user "step" --db-name "stepca" \
+  --responder-url "$RESPONDER_URL" </dev/null
 bootroot service add --service-name edge-proxy \
   --delivery-mode remote-bootstrap --agent-config "$REMOTE_AGENT_CONFIG_PATH"
 bootroot service add --service-name web-app \

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -156,17 +156,24 @@ bootroot infra install --compose-file "$COMPOSE_FILE"
 # DB 자격 증명은 infra install이 생성한 .env에서 자동으로 읽힙니다.
 # POSTGRES_HOST와 POSTGRES_PORT는 스크립트에서 설정하여
 # host-mapped 포트를 통해 연결합니다.
-# 파이프로 넘기는 답변은 해당 실행이 도달하는 모든 프롬프트를 채워야
-# 합니다. init은 EOF를 답으로 읽지 않고 실행을 실패시킵니다.
-printf "y\ny\ny\n" | BOOTROOT_LANG=en bootroot init \
+# 모든 프롬프트를 각자의 전용 플래그로 답하고 stdin을 닫아서 실행하므로,
+# 파이프로 넘기는 답변 순서에도 남아 있는 파일에도 의존하지 않습니다.
+# 대상 파일이 없는 overwrite 플래그는 아무 일도 하지 않습니다. init은
+# EOF를 답으로 읽지 않고 실행을 실패시킵니다.
+BOOTROOT_LANG=en bootroot init \
   --compose-file "$COMPOSE_FILE" \
   --secrets-dir "$SECRETS_DIR" \
   --summary-json "$INIT_SUMMARY_JSON" \
   --enable auto-generate,show-secrets,db-provision \
   --no-eab \
+  --save-unseal-keys \
+  --overwrite-password \
+  --overwrite-ca-json \
+  --overwrite-state \
+  --confirm-db-provision \
   --db-user "step" \
   --db-name "stepca" \
-  --responder-url "$RESPONDER_URL"
+  --responder-url "$RESPONDER_URL" </dev/null
 
 # 3) service-add
 # 서로 다른 로컬 서비스는 각자 자신의 에이전트 설정을 사용합니다
@@ -295,10 +302,14 @@ sudo -n cp "$tmp_file" /etc/hosts
 ```bash
 # control node: infra-install / init / service-add
 bootroot infra install --compose-file "$COMPOSE_FILE"
-printf "y\ny\nn\n" | BOOTROOT_LANG=en bootroot init \
+BOOTROOT_LANG=en bootroot init \
   --compose-file "$COMPOSE_FILE" --summary-json "$INIT_SUMMARY_JSON" \
-  --enable auto-generate,show-secrets --eab-kid "$INIT_EAB_KID" \
-  --eab-hmac "$INIT_EAB_HMAC"
+  --enable auto-generate,show-secrets,db-provision \
+  --no-eab --save-unseal-keys \
+  --overwrite-password --overwrite-ca-json --overwrite-state \
+  --confirm-db-provision \
+  --db-user "step" --db-name "stepca" \
+  --responder-url "$RESPONDER_URL" </dev/null
 bootroot service add --service-name edge-proxy \
   --delivery-mode remote-bootstrap --agent-config "$REMOTE_AGENT_CONFIG_PATH"
 bootroot service add --service-name web-app \

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -556,7 +556,11 @@ run_bootstrap_chain() {
 
   log_phase "init"
   rm -f "$WORKSPACE_DIR/state.json"
-  if ! BOOTROOT_LANG=en printf "y\ny\ny\n" | run_bootroot init \
+  # Answer every prompt with its own flag and run with stdin closed, so
+  # the run neither depends on which of password.txt, ca.json and
+  # state.json the cleanup above happened to leave behind nor needs a
+  # TTY.  An overwrite flag whose file is absent is a silent no-op.
+  if ! BOOTROOT_LANG=en run_bootroot init \
     --compose-file "$COMPOSE_FILE" \
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$INIT_SUMMARY_JSON" \
@@ -565,9 +569,14 @@ run_bootstrap_chain() {
     --stepca-password "password" \
     --http-hmac "dev-hmac" \
     --no-eab \
+    --save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
+    --confirm-db-provision \
     --db-user "step" \
     --db-name "stepca" \
-    --responder-url "$RESPONDER_URL" >"$INIT_RAW_LOG" 2>&1; then
+    --responder-url "$RESPONDER_URL" </dev/null >"$INIT_RAW_LOG" 2>&1; then
     {
       echo "bootroot init failed (raw tail):"
       tail -n 160 "$INIT_RAW_LOG" || true

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -328,7 +328,11 @@ run_bootstrap_chain() {
 
   log_phase "init"
   rm -f "$WORKSPACE_DIR/state.json"
-  if ! BOOTROOT_LANG=en printf "y\ny\ny\n" | run_bootroot init \
+  # Answer every prompt with its own flag and run with stdin closed, so
+  # the run neither depends on which of password.txt, ca.json and
+  # state.json the cleanup above happened to leave behind nor needs a
+  # TTY.  An overwrite flag whose file is absent is a silent no-op.
+  if ! BOOTROOT_LANG=en run_bootroot init \
     --compose-file "$COMPOSE_FILE" \
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$INIT_SUMMARY_JSON" \
@@ -337,9 +341,14 @@ run_bootstrap_chain() {
     --stepca-password "password" \
     --http-hmac "dev-hmac" \
     --no-eab \
+    --save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
+    --confirm-db-provision \
     --db-user "step" \
     --db-name "stepca" \
-    --responder-url "$RESPONDER_URL" >"$INIT_RAW_LOG" 2>&1; then
+    --responder-url "$RESPONDER_URL" </dev/null >"$INIT_RAW_LOG" 2>&1; then
     {
       echo "bootroot init failed (raw tail):"
       tail -n 160 "$INIT_RAW_LOG" || true

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -438,12 +438,12 @@ run_bootstrap_init() {
 
   log_phase "bootstrap-init"
   # `infra install` writes state.json (to capture the openbao_bind_addr
-  # intent) before init runs, so init's overwrite-state prompt fires
-  # under default-yes-no semantics.  Pipe `y` answers to clear that
-  # prompt (and any future ca.json / password.txt overwrite prompts
-  # that may appear on rerun) so the bootstrap pass stays
-  # non-interactive.
-  if ! printf 'y\ny\ny\n' | BOOTROOT_LANG=en run_bootroot init \
+  # intent) before init runs, so init's overwrite-state prompt fires;
+  # ca.json and password.txt prompt too on a rerun, and `db-provision`
+  # adds its own confirmation.  Answer all four with their per-prompt
+  # flags and run with stdin closed, so the bootstrap pass stays
+  # non-interactive whatever the workspace was left holding.
+  if ! BOOTROOT_LANG=en run_bootroot init \
     --compose-file "$COMPOSE_FILE" \
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$INIT_SUMMARY_JSON" \
@@ -452,10 +452,14 @@ run_bootstrap_init() {
     --http-hmac "dev-hmac" \
     --no-eab \
     --save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
+    --confirm-db-provision \
     --db-user "step" \
     --db-name "stepca" \
     --responder-url "http://localhost:8080" \
-    --skip responder-check >"$INIT_RAW_LOG" 2>&1; then
+    --skip responder-check </dev/null >"$INIT_RAW_LOG" 2>&1; then
     {
       echo "bootroot init failed (raw tail):"
       tail -n 200 "$INIT_RAW_LOG" || true

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -281,7 +281,11 @@ run_bootstrap_chain() {
 
   log_phase "init"
   rm -f "$CONTROL_DIR/state.json"
-  if ! BOOTROOT_LANG=en printf "y\ny\ny\n" | run_bootroot_control init \
+  # Answer every prompt with its own flag and run with stdin closed, so
+  # the run neither depends on which of password.txt, ca.json and
+  # state.json the cleanup above happened to leave behind nor needs a
+  # TTY.  An overwrite flag whose file is absent is a silent no-op.
+  if ! BOOTROOT_LANG=en run_bootroot_control init \
     --compose-file "$COMPOSE_FILE" \
     --secrets-dir "$SECRETS_DIR" \
     --summary-json "$INIT_SUMMARY_JSON" \
@@ -289,10 +293,15 @@ run_bootstrap_chain() {
     --stepca-provisioner "acme" \
     --stepca-password "password" \
     --no-eab \
+    --save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
+    --confirm-db-provision \
     --http-hmac "dev-hmac" \
     --db-user "step" \
     --db-name "stepca" \
-    --responder-url "$RESPONDER_URL" >"$INIT_RAW_LOG" 2>&1; then
+    --responder-url "$RESPONDER_URL" </dev/null >"$INIT_RAW_LOG" 2>&1; then
     {
       echo "bootroot init failed (raw tail):"
       tail -n 160 "$INIT_RAW_LOG" || true

--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -25,16 +25,24 @@ cargo test --test monitoring_integration
 echo "[test-core] installing infrastructure"
 cargo run --bin bootroot -- infra install
 
-# --- Zero-config Init (answer n, no show-secrets) ---
-# Two answers, one per prompt this run reaches: decline EAB registration,
-# then decline saving the unseal keys.  The second `n` is what makes the
-# assertion below exercise the declined path deliberately — `init` fails
-# on EOF rather than reading an unanswered prompt as "no".
-echo "[test-core] zero-config init (answer n, no show-secrets)"
-printf "n\nn\n" | BOOTROOT_LANG=en cargo run --bin bootroot -- init \
+# --- Zero-config Init (decline saving the unseal keys, no show-secrets) ---
+# Every prompt but one is answered by its own flag, so the run cannot
+# depend on which of password.txt, ca.json and state.json a previous run
+# left behind.  The single piped `n` answers the save-unseal-keys
+# prompt, and it stays an answer on purpose: only the declined branch of
+# that prompt echoes the keys in cleartext, which is what the assertion
+# below reads.  `--no-save-unseal-keys` suppresses that echo, so it must
+# not replace this answer.  `init` fails on EOF rather than reading an
+# unanswered prompt as "no".
+echo "[test-core] zero-config init (decline saving the unseal keys, no show-secrets)"
+printf "n\n" | BOOTROOT_LANG=en cargo run --bin bootroot -- init \
   --enable auto-generate \
   --http-hmac "dev-hmac" \
   --secrets-dir "$BOOTROOT_SECRETS_DIR" \
+  --no-eab \
+  --overwrite-password \
+  --overwrite-ca-json \
+  --overwrite-state \
   --responder-url "http://localhost:8080" \
   --skip responder-check 2>&1 | tee zero-config-init.log
 
@@ -50,14 +58,21 @@ cargo run --bin bootroot -- clean -y
 cargo run --bin bootroot -- infra install
 
 # --- CLI Init ---
-# `clean -y` above removed password.txt, ca.json and state.json, so no
-# overwrite confirmation fires here: the two prompts this run reaches
-# are EAB registration and saving the unseal keys, both declined.
+# The overwrite prompts are answered by their own flags rather than by
+# relying on `clean -y` above having removed password.txt, ca.json and
+# state.json, and `--no-eab` answers the EAB prompt.  The piped `n`
+# answers the save-unseal-keys prompt: declining it needs no flag here
+# because `--no-save-unseal-keys` requires `--summary-json`, which this
+# smoke run does not write.
 echo "[test-core] CLI init (smoke)"
-printf "n\nn\n" | BOOTROOT_LANG=en cargo run --bin bootroot -- init \
+printf "n\n" | BOOTROOT_LANG=en cargo run --bin bootroot -- init \
   --enable auto-generate,show-secrets \
   --http-hmac "dev-hmac" \
   --secrets-dir "$BOOTROOT_SECRETS_DIR" \
+  --no-eab \
+  --overwrite-password \
+  --overwrite-ca-json \
+  --overwrite-state \
   --responder-url "http://localhost:8080" \
   --skip responder-check | tee cli-init.log
 

--- a/scripts/preflight/extra/cli-scenarios.sh
+++ b/scripts/preflight/extra/cli-scenarios.sh
@@ -85,19 +85,27 @@ run_init_scenario() {
 
   wait_for_postgres_admin
   log "Running bootroot init"
-  # One answer per prompt this run reaches.  `secrets/` and `state.json`
-  # were removed above, so no overwrite confirmation fires: `y` confirms
-  # the `db-provision` feature, then EAB registration and saving the
-  # unseal keys are both declined.  An answer short of the last prompt
-  # aborts the run — init fails on EOF rather than answering itself.
-  printf "y\nn\nn\n" | BOOTROOT_LANG=en cargo run --bin bootroot -- init \
+  # Answer every prompt with its own flag and run with stdin closed,
+  # rather than relying on the cleanup above having removed `secrets/`
+  # and `state.json` so that a piped answer sequence lines up: an
+  # overwrite flag whose file is absent is a silent no-op.
+  # `--no-save-unseal-keys` declines persistence and suppresses the
+  # cleartext echo, which nothing here asserts on; the keys stay
+  # available in the 0600 summary JSON this run already writes.
+  BOOTROOT_LANG=en cargo run --bin bootroot -- init \
     --enable auto-generate,show-secrets,db-provision \
     --summary-json "$INIT_SUMMARY_JSON" \
     --http-hmac "$responder_hmac" \
+    --no-eab \
+    --no-save-unseal-keys \
+    --overwrite-password \
+    --overwrite-ca-json \
+    --overwrite-state \
+    --confirm-db-provision \
     --db-user "step" \
     --db-name "stepca" \
     --responder-url "http://localhost:8080" \
-    --skip responder-check | tee "$ROOT_DIR/tmp/cli-init.log"
+    --skip responder-check </dev/null | tee "$ROOT_DIR/tmp/cli-init.log"
 
   if [ ! -f "$INIT_SUMMARY_JSON" ]; then
     fail "Init summary JSON not found: $INIT_SUMMARY_JSON"


### PR DESCRIPTION
## Summary

Every `bootroot init` invocation under `scripts/` was driven non-interactively by piping a fixed answer sequence into it. How many prompts a run actually reaches is state-dependent — an overwrite confirmation for each of `secrets/password.txt`, `secrets/config/ca.json` and `state.json` that exists on disk, plus a `db-provision` confirmation — so those sequences lined up only because a cleanup step earlier in the same script had left the right files absent. Since `init` fails on EOF rather than answering a prompt itself, that invisible coupling breaks the run the moment a cleanup step, a flag or the prompt set changes.

Each prompt that has a non-interactive flag is now supplied with that flag (`--overwrite-password`, `--overwrite-ca-json`, `--overwrite-state`, `--confirm-db-provision`, `--no-eab`, and `--save-unseal-keys` / `--no-save-unseal-keys`), and the invocations left with nothing to answer read from `/dev/null`. An overwrite flag whose file is absent is a silent no-op, so the same command works on a clean workspace and on a rerun.

Two piped answers remain, both in `scripts/preflight/ci/test-core.sh`, each commented with the prompt it answers. Only the *declined* branch of the save-unseal-keys prompt echoes the keys in cleartext, and that echo is exactly what the zero-config assertion reads; `--no-save-unseal-keys` suppresses it, and additionally requires a `--summary-json` neither smoke run writes.

The three `scripts/impl/` invocations that wrote `BOOTROOT_LANG=en` on the left of the pipe bound it to `printf`, leaving the `bootroot` run whose English output the script parses to take the caller's ambient locale. With the pipe gone, the prefix binds to the run it was written for.

The `bootroot init` excerpts in `docs/en/e2e-ci.md` and `docs/ko/e2e-ci.md` were updated to match the scripts they document; the remote excerpt had also drifted, still showing `--eab-kid` / `--eab-hmac` for a script that passes `--no-eab`.

No Rust changed: `init`'s EOF behaviour, the prompts it asks, and the flags it accepts are all untouched.

Closes #822

## Test plan

- [x] `scripts/preflight/ci/test-core.sh` completes, including its cleartext unseal-key assertion (`grep -q "unseal key" zero-config-init.log`)
- [x] `scripts/preflight/extra/cli-scenarios.sh` completes
- [x] `scripts/preflight/ci/e2e-matrix.sh` completes, covering the local, remote and reinit-recovery lifecycle scripts
- [x] `scripts/preflight/ci/e2e-extended.sh` completes, covering the extended suite that runs `scripts/impl/run-ca-key-rotation-recovery.sh`
- [x] The Docker E2E matrix jobs (`test-docker-e2e-matrix`) pass in CI on this PR
- [x] `run-extended` from `e2e-extended.yml` passes
- [x] `./scripts/check-docs.sh` passes (verified locally)
- [ ] Each script still runs standalone as well as through `scripts/preflight/run-all.sh`
- [x] No `init` invocation under `scripts/` depends on the on-disk state of `password.txt`, `ca.json` or `state.json` for its answer sequence to be long enough
- [x] Every remaining piped answer names the prompt it answers in a comment


