### PR TITLE
Delete test-core's unwritable /etc/hosts step (#826)

### DIFF
--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -138,15 +138,6 @@ cargo run --bin bootroot -- service add \
   --instance-id 001 \
   --root-token "$ROOT_TOKEN"
 
-RESPONDER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' bootroot-http01)"
-if [ -z "${RESPONDER_IP:-}" ]; then
-  echo "Failed to read responder container IP"
-  exit 1
-fi
-docker exec bootroot-ca sh -c "printf '%s %s\n' '$RESPONDER_IP' '001.edge-proxy.edge-node-01.trusted.domain' >> /etc/hosts"
-docker exec bootroot-ca sh -c "printf '%s %s\n' '$RESPONDER_IP' '001.web-app.web-01.trusted.domain' >> /etc/hosts"
-docker exec bootroot-ca sh -c "printf '%s %s\n' '$RESPONDER_IP' '001.bootroot-agent.bootroot-agent.trusted.domain' >> /etc/hosts"
-
 host="001.edge-proxy.edge-node-01.trusted.domain"
 for attempt in {1..15}; do
   if docker exec bootroot-ca bash -lc "timeout 2 bash -lc 'echo > /dev/tcp/${host}/80'" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Deletes the block in `scripts/preflight/ci/test-core.sh` that read the responder container's IP and appended three entries to `/etc/hosts` inside the step-ca container.

That write could never succeed. `docker-compose.yml` runs step-ca as `user: "${BOOTROOT_STEPCA_USER:-1000:1000}"`, and `/etc/hosts` in `smallstep/step-ca:0.30.2` is `root`-owned and not group- or world-writable, so the first `docker exec` failed with `sh: can't create /etc/hosts: Permission denied` and `set -euo pipefail` aborted the script there. Nothing caught it because no workflow invokes this script — it only ever ran locally, where it always died at this point.

The three names resolve without it. Each of the `service add` calls above the block registers `{instance_id}.{service_name}.{hostname}.{domain}` as a Docker network alias on `bootroot-http01` via `register_dns_alias`, and Docker's embedded DNS answers it for every container on the network, step-ca included. That path is also the more durable one: Docker regenerates `/etc/hosts` on container start, so a restart of the `restart: always` CA dropped the entries, and the entries pinned an address a responder restart can change — whereas `replay_dns_aliases` exists precisely to restore the alias set after a restart.

The reachability probe that follows is left untouched. With the writes gone it measures the aliases `service add` registered rather than the entries the script had just written itself, which is what it should have been checking all along.

No `docker exec -u root`, no compose invocation added, and `docker-compose.yml` / `docker-compose.test.yml` are byte-identical to before.

Closes #826

## Test plan

- [x] With `BOOTROOT_STEPCA_USER` unset (non-root CA container), from a clean state — no `secrets/`, no `.env`, no `bootroot-*` container — `scripts/preflight/ci/test-core.sh` runs to completion and exits 0, reporting `Responder HTTP-01 is reachable from step-ca` and `PASS: Certificate files created`
- [x] On the pre-change script the same run dies at the first `docker exec` with `sh: can't create /etc/hosts: Permission denied`
- [x] After the three `service add` calls, `docker inspect bootroot-http01` lists `001.edge-proxy.edge-node-01.trusted.domain`, `001.web-app.web-01.trusted.domain`, and `001.bootroot-agent.bootroot-agent.trusted.domain` among its network aliases
- [x] `docker exec bootroot-ca grep -c edge-proxy /etc/hosts` returns 0, confirming the alias path is what carries the resolution
- [x] The probe still has teeth: with the stack up, stop `bootroot-http01` and re-run the probe section — it reports `Responder HTTP-01 is not reachable from step-ca` and exits non-zero
- [x] No `/etc/hosts` write and no `docker inspect` of the responder IP remains in `scripts/preflight/ci/test-core.sh`
- [x] `docker-compose.yml` and `docker-compose.test.yml` are unchanged, and no compose invocation was added to the script

