### PR TITLE
Enumerate local addresses before blaming the bind host (#827)

### DIFF
--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -591,6 +591,21 @@ When local `sudo -n` is unavailable:
 Use this only as a local constraint workaround. CI still executes
 `hosts` variants.
 
+The harnesses also assume two host tools, and each check fails in its
+prerequisite block rather than mid-run:
+
+- The bind-host guard in `run-reinit-recovery.sh`, `run-stepca-san.sh`,
+  `run-openbao-tls-no-delta.sh` and `run-openbao-tls-reown.sh` lists the
+  machine's IPv4 addresses with `ip` (iproute2), falling back to
+  `ifconfig`. A host with neither is told exactly that, because no value
+  of `OPENBAO_BIND_HOST` / `STEPCA_BIND_HOST` fixes a check that cannot
+  enumerate. Both default to `172.17.0.1`, the Docker bridge gateway on
+  Linux; elsewhere (Docker Desktop has no such interface) set them to an
+  address the host actually holds.
+- `run-remote-lifecycle.sh` reads the remote agent's TOML config with
+  `tomllib`, so its `python3` must be 3.11 or newer. The prerequisite
+  block imports it before any container starts.
+
 ## Init automation input/output rules
 
 Lifecycle scripts consume `bootroot init --summary-json` output for automation.

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -581,6 +581,22 @@ scripts/preflight/run-all.sh
 
 이는 로컬 제약 우회용입니다. CI에서는 `hosts` 케이스도 실행됩니다.
 
+하네스는 호스트 도구 두 가지를 전제하며, 각 검사는 실행 도중이 아니라
+사전 조건 블록에서 실패합니다.
+
+- `run-reinit-recovery.sh`, `run-stepca-san.sh`,
+  `run-openbao-tls-no-delta.sh`, `run-openbao-tls-reown.sh`의 bind host
+  가드는 `ip`(iproute2)로, 없으면 `ifconfig`로 로컬 IPv4 주소를
+  열거합니다. 둘 다 없는 호스트에는 그 사실을 그대로 알립니다.
+  열거 자체가 불가능한 검사는 `OPENBAO_BIND_HOST` /
+  `STEPCA_BIND_HOST`를 어떤 값으로 바꿔도 통과하지 않기 때문입니다.
+  두 변수의 기본값 `172.17.0.1`은 Linux의 Docker 브리지 게이트웨이이며,
+  그 인터페이스가 없는 환경(예: Docker Desktop)에서는 호스트가 실제로
+  가진 주소로 지정합니다.
+- `run-remote-lifecycle.sh`는 원격 에이전트의 TOML 설정을 `tomllib`으로
+  읽으므로 `python3`이 3.11 이상이어야 합니다. 사전 조건 블록에서
+  컨테이너를 띄우기 전에 import를 확인합니다.
+
 ## init 자동화 입출력 규칙
 
 라이프사이클 스크립트는 `bootroot init --summary-json` 출력으로 자동화를

--- a/scripts/impl/run-openbao-tls-no-delta.sh
+++ b/scripts/impl/run-openbao-tls-no-delta.sh
@@ -180,8 +180,12 @@ ensure_bind_host_available() {
     fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
   # -F: the bind host is data, not a pattern, so a value carrying regex
-  # metacharacters cannot match an address it is not.
-  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
+  # metacharacters cannot match an address it is not.  `--` for the same
+  # reason one argument earlier: the value arrives from the environment, and
+  # one beginning with a dash is an option to grep rather than the pattern.
+  # `-e127.0.0.1` would otherwise be read as a second pattern and match a
+  # host holding 127.0.0.1, which is not the address that was configured.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx -- "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-openbao-tls-no-delta.sh
+++ b/scripts/impl/run-openbao-tls-no-delta.sh
@@ -171,13 +171,17 @@ ensure_bind_host_available() {
   #
   # Not being able to enumerate at all is a different condition from the
   # address being absent, and it has a different fix: no value of the bind
-  # host variable helps a host that has neither `ip` nor `ifconfig`, so
-  # that case must not tell the operator to change the variable.
+  # host variable helps a host that cannot list its own addresses, so that
+  # case must not tell the operator to change the variable.  `pipefail`
+  # also routes a present-but-failing `ip` here, whose own stderr now
+  # reaches the operator, so the message covers both.
   local bind_host="$1" bind_var="$2" local_addrs
   if ! local_addrs="$(list_local_ipv4)"; then
-    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
-  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+  # -F: the bind host is data, not a pattern, so a value carrying regex
+  # metacharacters cannot match an address it is not.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-openbao-tls-no-delta.sh
+++ b/scripts/impl/run-openbao-tls-no-delta.sh
@@ -154,10 +154,31 @@ ensure_prerequisites() {
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
 }
 
+list_local_ipv4() {
+  if command -v ip >/dev/null 2>&1; then
+    ip -4 -o addr show | awk '{print $4}' | sed 's|/.*||'
+  elif command -v ifconfig >/dev/null 2>&1; then
+    ifconfig -a | awk '/inet /{print $2}' | sed 's/^addr://'
+  else
+    return 1
+  fi
+}
+
 ensure_bind_host_available() {
-  if ! ip -4 -o addr show 2>/dev/null | awk '{print $4}' | sed 's|/.*||' \
-      | grep -qx "$OPENBAO_BIND_HOST"; then
-    fail "non-loopback bind host $OPENBAO_BIND_HOST is not assigned to any local interface (set OPENBAO_BIND_HOST to an address that is)"
+  # Verify the configured non-loopback bind host actually exists on this
+  # machine; otherwise compose refuses to publish the port and the run
+  # fails for a reason that has nothing to do with what it exercises.
+  #
+  # Not being able to enumerate at all is a different condition from the
+  # address being absent, and it has a different fix: no value of the bind
+  # host variable helps a host that has neither `ip` nor `ifconfig`, so
+  # that case must not tell the operator to change the variable.
+  local bind_host="$1" bind_var="$2" local_addrs
+  if ! local_addrs="$(list_local_ipv4)"; then
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+  fi
+  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+    fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }
 
@@ -474,7 +495,7 @@ main() {
   trap 'on_error $LINENO' ERR
 
   ensure_prerequisites
-  ensure_bind_host_available
+  ensure_bind_host_available "$OPENBAO_BIND_HOST" OPENBAO_BIND_HOST
   compose_down
   snapshot_repo_openbao_config
 

--- a/scripts/impl/run-openbao-tls-reown.sh
+++ b/scripts/impl/run-openbao-tls-reown.sh
@@ -182,10 +182,31 @@ ensure_prerequisites() {
   fi
 }
 
+list_local_ipv4() {
+  if command -v ip >/dev/null 2>&1; then
+    ip -4 -o addr show | awk '{print $4}' | sed 's|/.*||'
+  elif command -v ifconfig >/dev/null 2>&1; then
+    ifconfig -a | awk '/inet /{print $2}' | sed 's/^addr://'
+  else
+    return 1
+  fi
+}
+
 ensure_bind_host_available() {
-  if ! ip -4 -o addr show 2>/dev/null | awk '{print $4}' | sed 's|/.*||' \
-      | grep -qx "$OPENBAO_BIND_HOST"; then
-    fail "non-loopback bind host $OPENBAO_BIND_HOST is not assigned to any local interface (set OPENBAO_BIND_HOST to an address that is)"
+  # Verify the configured non-loopback bind host actually exists on this
+  # machine; otherwise compose refuses to publish the port and the run
+  # fails for a reason that has nothing to do with what it exercises.
+  #
+  # Not being able to enumerate at all is a different condition from the
+  # address being absent, and it has a different fix: no value of the bind
+  # host variable helps a host that has neither `ip` nor `ifconfig`, so
+  # that case must not tell the operator to change the variable.
+  local bind_host="$1" bind_var="$2" local_addrs
+  if ! local_addrs="$(list_local_ipv4)"; then
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+  fi
+  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+    fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }
 
@@ -584,7 +605,7 @@ main() {
   trap 'on_error $LINENO' ERR
 
   ensure_prerequisites
-  ensure_bind_host_available
+  ensure_bind_host_available "$OPENBAO_BIND_HOST" OPENBAO_BIND_HOST
   compose_down
   snapshot_repo_openbao_config
 

--- a/scripts/impl/run-openbao-tls-reown.sh
+++ b/scripts/impl/run-openbao-tls-reown.sh
@@ -199,13 +199,17 @@ ensure_bind_host_available() {
   #
   # Not being able to enumerate at all is a different condition from the
   # address being absent, and it has a different fix: no value of the bind
-  # host variable helps a host that has neither `ip` nor `ifconfig`, so
-  # that case must not tell the operator to change the variable.
+  # host variable helps a host that cannot list its own addresses, so that
+  # case must not tell the operator to change the variable.  `pipefail`
+  # also routes a present-but-failing `ip` here, whose own stderr now
+  # reaches the operator, so the message covers both.
   local bind_host="$1" bind_var="$2" local_addrs
   if ! local_addrs="$(list_local_ipv4)"; then
-    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
-  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+  # -F: the bind host is data, not a pattern, so a value carrying regex
+  # metacharacters cannot match an address it is not.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-openbao-tls-reown.sh
+++ b/scripts/impl/run-openbao-tls-reown.sh
@@ -208,8 +208,12 @@ ensure_bind_host_available() {
     fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
   # -F: the bind host is data, not a pattern, so a value carrying regex
-  # metacharacters cannot match an address it is not.
-  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
+  # metacharacters cannot match an address it is not.  `--` for the same
+  # reason one argument earlier: the value arrives from the environment, and
+  # one beginning with a dash is an option to grep rather than the pattern.
+  # `-e127.0.0.1` would otherwise be read as a second pattern and match a
+  # host holding 127.0.0.1, which is not the address that was configured.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx -- "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -426,13 +426,17 @@ ensure_bind_host_available() {
   #
   # Not being able to enumerate at all is a different condition from the
   # address being absent, and it has a different fix: no value of the bind
-  # host variable helps a host that has neither `ip` nor `ifconfig`, so
-  # that case must not tell the operator to change the variable.
+  # host variable helps a host that cannot list its own addresses, so that
+  # case must not tell the operator to change the variable.  `pipefail`
+  # also routes a present-but-failing `ip` here, whose own stderr now
+  # reaches the operator, so the message covers both.
   local bind_host="$1" bind_var="$2" local_addrs
   if ! local_addrs="$(list_local_ipv4)"; then
-    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
-  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+  # -F: the bind host is data, not a pattern, so a value carrying regex
+  # metacharacters cannot match an address it is not.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -409,14 +409,31 @@ reset_workspace() {
   rm -f "$ROOT_DIR/.env"
 }
 
+list_local_ipv4() {
+  if command -v ip >/dev/null 2>&1; then
+    ip -4 -o addr show | awk '{print $4}' | sed 's|/.*||'
+  elif command -v ifconfig >/dev/null 2>&1; then
+    ifconfig -a | awk '/inet /{print $2}' | sed 's/^addr://'
+  else
+    return 1
+  fi
+}
+
 ensure_bind_host_available() {
-  # Verify the configured non-loopback bind host actually exists on
-  # this machine; otherwise compose will refuse to publish the port
-  # and reinit will look broken when the real cause is a missing
-  # docker0 interface.
-  if ! ip -4 -o addr show 2>/dev/null | awk '{print $4}' | sed 's|/.*||' \
-      | grep -qx "$OPENBAO_BIND_HOST"; then
-    fail "non-loopback bind host $OPENBAO_BIND_HOST is not assigned to any local interface (set OPENBAO_BIND_HOST to an address that is)"
+  # Verify the configured non-loopback bind host actually exists on this
+  # machine; otherwise compose refuses to publish the port and the run
+  # fails for a reason that has nothing to do with what it exercises.
+  #
+  # Not being able to enumerate at all is a different condition from the
+  # address being absent, and it has a different fix: no value of the bind
+  # host variable helps a host that has neither `ip` nor `ifconfig`, so
+  # that case must not tell the operator to change the variable.
+  local bind_host="$1" bind_var="$2" local_addrs
+  if ! local_addrs="$(list_local_ipv4)"; then
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+  fi
+  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+    fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }
 
@@ -628,7 +645,7 @@ main() {
   trap 'on_error $LINENO' ERR
 
   ensure_prerequisites
-  ensure_bind_host_available
+  ensure_bind_host_available "$OPENBAO_BIND_HOST" OPENBAO_BIND_HOST
   compose_down
   snapshot_repo_openbao_config
 

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -435,8 +435,12 @@ ensure_bind_host_available() {
     fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
   # -F: the bind host is data, not a pattern, so a value carrying regex
-  # metacharacters cannot match an address it is not.
-  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
+  # metacharacters cannot match an address it is not.  `--` for the same
+  # reason one argument earlier: the value arrives from the environment, and
+  # one beginning with a dash is an option to grep rather than the pattern.
+  # `-e127.0.0.1` would otherwise be read as a second pattern and match a
+  # host holding 127.0.0.1, which is not the address that was configured.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx -- "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -123,6 +123,12 @@ ensure_prerequisites() {
   docker compose version >/dev/null 2>&1 || fail "docker compose is required"
   command -v jq >/dev/null 2>&1 || fail "jq is required"
   command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+  # This harness parses the remote agent's TOML config with `tomllib`,
+  # which is standard library only from 3.11.  Check it here so an older
+  # interpreter stops the run before any container is started, rather
+  # than at the first import several phases in.
+  python3 -c 'import tomllib' >/dev/null 2>&1 \
+    || fail "python3 with tomllib (3.11+) is required"
   command -v openssl >/dev/null 2>&1 || fail "openssl is required"
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
   [ -x "$BOOTROOT_REMOTE_BIN" ] || fail "bootroot-remote binary not executable: $BOOTROOT_REMOTE_BIN"

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -185,8 +185,12 @@ ensure_bind_host_available() {
     fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
   # -F: the bind host is data, not a pattern, so a value carrying regex
-  # metacharacters cannot match an address it is not.
-  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
+  # metacharacters cannot match an address it is not.  `--` for the same
+  # reason one argument earlier: the value arrives from the environment, and
+  # one beginning with a dash is an option to grep rather than the pattern.
+  # `-e127.0.0.1` would otherwise be read as a second pattern and match a
+  # host holding 127.0.0.1, which is not the address that was configured.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx -- "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -176,13 +176,17 @@ ensure_bind_host_available() {
   #
   # Not being able to enumerate at all is a different condition from the
   # address being absent, and it has a different fix: no value of the bind
-  # host variable helps a host that has neither `ip` nor `ifconfig`, so
-  # that case must not tell the operator to change the variable.
+  # host variable helps a host that cannot list its own addresses, so that
+  # case must not tell the operator to change the variable.  `pipefail`
+  # also routes a present-but-failing `ip` here, whose own stderr now
+  # reaches the operator, so the message covers both.
   local bind_host="$1" bind_var="$2" local_addrs
   if ! local_addrs="$(list_local_ipv4)"; then
-    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working"
   fi
-  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+  # -F: the bind host is data, not a pattern, so a value carrying regex
+  # metacharacters cannot match an address it is not.
+  if ! printf '%s\n' "$local_addrs" | grep -qFx "$bind_host"; then
     fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -159,13 +159,31 @@ ensure_prerequisites() {
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
 }
 
+list_local_ipv4() {
+  if command -v ip >/dev/null 2>&1; then
+    ip -4 -o addr show | awk '{print $4}' | sed 's|/.*||'
+  elif command -v ifconfig >/dev/null 2>&1; then
+    ifconfig -a | awk '/inet /{print $2}' | sed 's/^addr://'
+  else
+    return 1
+  fi
+}
+
 ensure_bind_host_available() {
   # Verify the configured non-loopback bind host actually exists on this
-  # machine; otherwise compose refuses to publish the port and the SAN
-  # assertions fail for a reason that has nothing to do with #733.
-  if ! ip -4 -o addr show 2>/dev/null | awk '{print $4}' | sed 's|/.*||' \
-      | grep -qx "$STEPCA_BIND_HOST"; then
-    fail "non-loopback bind host $STEPCA_BIND_HOST is not assigned to any local interface (set STEPCA_BIND_HOST to an address that is)"
+  # machine; otherwise compose refuses to publish the port and the run
+  # fails for a reason that has nothing to do with what it exercises.
+  #
+  # Not being able to enumerate at all is a different condition from the
+  # address being absent, and it has a different fix: no value of the bind
+  # host variable helps a host that has neither `ip` nor `ifconfig`, so
+  # that case must not tell the operator to change the variable.
+  local bind_host="$1" bind_var="$2" local_addrs
+  if ! local_addrs="$(list_local_ipv4)"; then
+    fail "cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed"
+  fi
+  if ! printf '%s\n' "$local_addrs" | grep -qx "$bind_host"; then
+    fail "non-loopback bind host $bind_host is not assigned to any local interface (set $bind_var to an address that is)"
   fi
 }
 
@@ -567,7 +585,7 @@ main() {
   trap 'on_error $LINENO' ERR
 
   ensure_prerequisites
-  ensure_bind_host_available
+  ensure_bind_host_available "$STEPCA_BIND_HOST" STEPCA_BIND_HOST
 
   scenario_a_fresh_install_with_bind
   scenario_b_repair_initialized_ca


### PR DESCRIPTION
Two prerequisite checks in `scripts/impl/` did not check the thing they gated on. Both passed on a Linux CI runner and both misled anyone running the preflight suite elsewhere.

## Changes

**Bind-host guard** — `ensure_bind_host_available()` piped `ip -4 -o addr show 2>/dev/null` into `grep -qx`. Where `ip` is absent (macOS has only `ifconfig`), the redirect swallowed "command not found", the pipeline yielded nothing, and the guard failed with a message telling the operator to set `OPENBAO_BIND_HOST` to an assigned address — a fix no value could satisfy, since nothing was being enumerated.

Enumeration now goes through a `list_local_ipv4()` helper that picks `ip`, falls back to `ifconfig`, and returns non-zero when it has neither. The guard fails one way when enumeration fails, naming the absent tools and saying nothing about the bind host variable, and the other way — with today's wording — when the address is simply not in the list. The `2>/dev/null` is gone, so a present-but-failing `ip` reports its own stderr; the message says "installed and working" to cover both routes into that branch.

The guard now takes the bind host and the name of its variable as parameters, which is what lets the four copies be byte-identical: `run-stepca-san.sh` reads `STEPCA_BIND_HOST` where the other three read `OPENBAO_BIND_HOST`. Membership is tested with `grep -qFx -- "$bind_host"`: `-F` so a bind host arriving from the environment as `.*` cannot match an address the host does not hold, and `--` so one arriving as `-e127.0.0.1` is tested as the literal address it claims to be rather than being read as grep's own `-e` and its pattern.

`OPENBAO_BIND_HOST_DEFAULT` and `STEPCA_BIND_HOST_DEFAULT` stay at `172.17.0.1` as specified — correct for CI, and now a true and actionable failure elsewhere.

**`run-remote-lifecycle.sh`** — the prerequisite block checked `command -v python3` while line 697 imports `tomllib`, standard library only from 3.11. On a host with an older `python3` the run died several phases in, after the stack was up. The block now verifies the interpreter it found can import `tomllib`.

**Docs** — `docs/en/e2e-ci.md` and `docs/ko/e2e-ci.md` record both host requirements beside the existing `sudo -n` note.

Closes #827

## Test plan

- [x] With no `ip` and no `ifconfig` on `PATH`, the guard fails with `cannot enumerate local IPv4 addresses: neither ip (iproute2) nor ifconfig is installed and working`, and does not mention changing the bind host variable
- [x] With enumeration working and the bind host unassigned (`172.17.0.1` on macOS), the message is unchanged from today's
- [x] With enumeration working and the bind host assigned, the guard passes — the check is no stricter than before
- [x] A bind host of `.*` is rejected on a host that does not literally hold that address
- [x] A bind host beginning with a dash is rejected rather than consumed as an option: with `127.0.0.1` and `10.1.0.2` enumerated, `-e127.0.0.1`, `-e10.1.0.2`, `-x` and `--` all fail with the "not assigned to any local interface" message, where before `--` the two `-e` forms were accepted
- [x] `run-remote-lifecycle.sh` under Python 3.9 fails inside its prerequisite block, names 3.11, and starts no containers
- [x] `run-remote-lifecycle.sh` under Python 3.13 passes the prerequisite block and the run proceeds to completion as before
- [x] The four copies of `list_local_ipv4()` and `ensure_bind_host_available()` are byte-identical
- [x] `markdownlint-cli2` clean on the changed docs
- [x] On the `ip` path, driven with an iproute2 shim emitting real `ip -4 -o addr show` output, the guard's verdict matches the pre-change guard for every literal address tried; the only divergence is the intended one, where `.*`, `10.1.0.2.` and `[0-9].*` no longer match an address the host does not hold
- [x] `mkdocs build --strict` via `./scripts/check-docs.sh`, and both manual pages render the new host-requirements section


