### PR TITLE
Stop re-creating the responder after service add (#829)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,18 +331,6 @@ jobs:
             --instance-id 001 \
             --root-token "$OPENBAO_ROOT_TOKEN"
 
-          # Re-create the responder with Docker DNS aliases so step-ca
-          # can resolve challenge hostnames via Docker's internal DNS.
-          # Include the responder compose override written by init so the
-          # rendered config (with the correct HMAC) is preserved.
-          RESPONDER_OVERRIDE="$BOOTROOT_SECRETS_DIR/responder/docker-compose.responder.override.yml"
-          docker compose \
-            -p "${COMPOSE_PROJECT_NAME:-bootroot}" \
-            -f docker-compose.yml \
-            -f "$RESPONDER_OVERRIDE" \
-            -f docker-compose.test.yml \
-            up -d bootroot-http01
-
           # Wait for step-ca to be healthy after the restart triggered
           # by init's DB password rotation.
           for i in {1..30}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,11 @@ jobs:
             sleep 1
           done
 
+          # TEMPORARY PROBE (issue #829 test plan item 2) — remove before merge.
+          echo "::group::responder network aliases"
+          docker inspect -f '{{json .NetworkSettings.Networks}}' bootroot-http01
+          echo "::endgroup::"
+
           export PATH="$(pwd)/target/debug:$PATH"
 
           cargo run --bin bootroot -- verify \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,11 +342,6 @@ jobs:
             sleep 1
           done
 
-          # TEMPORARY PROBE (issue #829 test plan item 2) — remove before merge.
-          echo "::group::responder network aliases"
-          docker inspect -f '{{json .NetworkSettings.Networks}}' bootroot-http01
-          echo "::endgroup::"
-
           export PATH="$(pwd)/target/debug:$PATH"
 
           cargo run --bin bootroot -- verify \


### PR DESCRIPTION
## Summary

Removes the `docker compose … up -d bootroot-http01` re-create from the `CLI Service Add + Verify (Smoke)` step in `.github/workflows/ci.yml`, along with its comment and the `RESPONDER_OVERRIDE` assignment.

The step sat *after* the three `service add` calls, which inverted what its comment described. `service add` already registers each service's HTTP-01 challenge hostname as a Docker network alias on the running responder (`service.rs` → `register_dns_alias` → `apply_dns_aliases`), so the re-create was not installing aliases — it was destroying the ones just registered and restoring an equivalent set from the hard-coded list in `docker-compose.test.yml`.

That left two sources of truth for one alias set, with the stale one winning. Changing a `--service-name`, `--hostname` or `--instance-id` in the workflow's `service add` calls would leave the overlay's literals to be installed over the correct names, surfacing as a `verify` failure with nothing pointing at the overlay.

The override the step included to preserve init's rendered config (and its HMAC) has nothing left to preserve: nothing between init and this point re-creates the responder, and `register_dns_alias` only disconnects and reconnects the container on its network.

Scope kept tight per the issue:

- `Wait for step-ca to be healthy` loop is untouched — it waits on init's DB password rotation restart, not on this re-create.
- `docker-compose.test.yml` is byte-identical; every script that layers it is unchanged.
- Nothing under `src/` changed. The diff is 12 deleted lines in one file.

Closes #829

## Test plan

- [x] `.github/workflows/ci.yml` contains no `up -d bootroot-http01` invocation and no reference to `RESPONDER_OVERRIDE` inside the `CLI Service Add + Verify (Smoke)` step
- [x] The `Wait for step-ca to be healthy` loop is still present and unchanged
- [x] `docker-compose.test.yml` is byte-identical to before, and every script that layers it still does
- [x] `Unit & CLI Smoke` passes on this PR, with all three `verify` calls succeeding — the assertion that the aliases `service add` registered survived to the point step-ca needed them
- [x] Temporarily add `docker inspect -f '{{json .NetworkSettings.Networks}}' bootroot-http01` before the `verify` calls and confirm the three `001.*.trusted.domain` aliases are present with no re-create having run; remove the probe line before merging
- [x] Docker E2E matrix jobs unaffected — they call `scripts/impl/run-*.sh`, which layer `docker-compose.test.yml` into their own `docker compose up` and do not go through this workflow step

