### PR TITLE
Remove orphans when test-core tears the stack down

### DIFF
--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -9,7 +9,12 @@ BOOTROOT_SECRETS_DIR="$ROOT_DIR/secrets"
 
 cleanup() {
   echo "[test-core] cleanup"
-  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" "${COMPOSE_FILES[@]}" down 2>/dev/null || true
+  # `--remove-orphans` because the OpenBao Agent sidecars are defined in
+  # the overlay `init` writes under `secrets/`, not in the two compose
+  # files above, so a plain `down` treats them as orphans and leaves them
+  # running.  `-v` is deliberately not passed: the named volumes are not
+  # what this teardown is failing to reach.
+  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" "${COMPOSE_FILES[@]}" down --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Adds `--remove-orphans` to the `cleanup` trap in `scripts/preflight/ci/test-core.sh`.

The trap passes `-f docker-compose.yml -f docker-compose.test.yml` to `docker compose down`, and neither file defines the OpenBao Agent sidecars — those come from the overlay `init` writes under `secrets/`. Compose therefore treated `bootroot-openbao-agent-stepca` and `bootroot-openbao-agent-responder` as orphans and left them running, so a run that printed `[test-core] cleanup` and exited 0 still left two containers attached to OpenBao, rendering templates for a stack that no longer existed.

`clean` already layers those overlays back on and passes `-v --remove-orphans` (`src/commands/clean.rs:66`), and every teardown under `scripts/impl/` passes the flag. This trap was the only one in the repository that did not.

`-v` is deliberately not added. The named volumes are not what the teardown was failing to reach, and destroying them on exit is a separate decision — issue #833 records that as out of scope.

## Verification

Run on macOS with a non-root CA container, from a clean state each time (no `secrets/`, no `.env`, no `bootroot-*` container or volume, the four host ports confirmed free).

The final run, on this branch rebased onto `05d4e02` and `4d33ce6`:

```
EXIT=0
--- leftover containers ---
(none)
```

with every stage passing through `PASS: Certificate files created` and `[test-core] done`. That covers both acceptance criteria: the script runs to completion and exits 0, and `docker ps -a --format '{{.Names}}' | grep bootroot` prints nothing afterwards.

Three earlier runs on this branch exited 1, and it is worth recording why rather than leaving it out. They failed at three different points — ACME validation for the third service, `infra install` on a host port not yet released, and `init`'s responder override — and the last two came back as `Error response from daemon: removal of container … is already in progress`. A control run of the same script on `main`, from the same clean state, failed the same way at `infra install`, which placed the cause outside this change. Restarting Docker Desktop cleared it, and the run above is from after that restart. Nothing in this diff runs before the `EXIT` trap fires.

All four runs, including the three that failed, left no containers behind — the trap does its work on the failure path too, which the previous behaviour did not.

## Not verified here

`scripts/preflight/run-all.sh` was not run to completion on this host: `ci/e2e-matrix.sh` cannot pass here, since `run-reinit-recovery.sh` and its siblings need a Docker bridge gateway address assigned to a local interface and the hosts-mode lifecycles need passwordless sudo. CI does not exercise this script at all — no workflow invokes `scripts/preflight/ci/test-core.sh` — so this change is covered by the run above and by review, not by a CI job.

Closes #833
