### PR TITLE
Update shared instruction blocks to 0.4.0

### DIFF
--- a/.agent-instructions.toml
+++ b/.agent-instructions.toml
@@ -2,5 +2,5 @@
 # it is on, and the shared blocks it has. Its drift check reads this file,
 # and its apply job rewrites it. Which blocks a repository should carry is
 # decided upstream in repos.json, not here.
-ref = "0.3.1"
+ref = "0.4.0"
 blocks = ["workflow", "agentcoop", "rust", "changelog"]


### PR DESCRIPTION
Synced from `aicers/agent-instructions` by `scripts/sync.sh`.

Blocks in this pull request: workflow agentcoop rust changelog

The marked blocks are generated. Change the wording upstream in
`aicers/agent-instructions` rather than editing it here — the drift check in CI
will fail if this repository's copy diverges.