### PR TITLE
Require an openssl with x509 -ext in E2E (#844)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Validate Compose Instance Names
         run: ./scripts/validate-compose-instance-names.sh
 
+      - name: Validate E2E OpenSSL Compatibility
+        run: ./scripts/validate-e2e-openssl-compat.sh
+
       - name: Install cargo-audit
         run: cargo install cargo-audit || true
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -570,6 +570,7 @@ Or run individual scripts:
 | `./scripts/preflight/ci/check.sh` | `ci.yml` Quality Check |
 | `./scripts/validate-deploy-compose.sh` | `ci.yml` Validate Deploy Compose |
 | `./scripts/validate-compose-instance-names.sh` | `ci.yml` Validate Compose Instance Names |
+| `./scripts/validate-e2e-openssl-compat.sh` | `ci.yml` Validate E2E OpenSSL Compatibility |
 | `./scripts/preflight/ci/deploy-no-build-smoke.sh` | `ci.yml` Deploy Compose No-Build Smoke |
 | `./scripts/preflight/ci/test-core.sh` | `ci.yml` Unit & CLI Smoke |
 | `./scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` Docker E2E Matrix |

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -596,7 +596,7 @@ When local `sudo -n` is unavailable:
 Use this only as a local constraint workaround. CI still executes
 `hosts` variants.
 
-The harnesses also assume two host tools, and each check fails in its
+The harnesses also assume three host tools, and each check fails in its
 prerequisite block rather than mid-run:
 
 - The bind-host guard in `run-reinit-recovery.sh`, `run-stepca-san.sh`,
@@ -610,6 +610,15 @@ prerequisite block rather than mid-run:
 - `run-remote-lifecycle.sh` reads the remote agent's TOML config with
   `tomllib`, so its `python3` must be 3.11 or newer. The prerequisite
   block imports it before any container starts.
+- The `openssl` the harness finds on `PATH` must support `x509 -ext`,
+  which `run-stepca-san.sh` reads step-ca's `subjectAltName` with. The
+  option arrived in OpenSSL 1.1.1, and LibreSSL 3.3.6 — what macOS
+  ships as `/usr/bin/openssl` — does not have it. The check probes for
+  the option rather than for the implementation's name and names the
+  binary it found; the fix is to put a directory holding a capable
+  `openssl` first on `PATH`. All six scripts that check for `openssl`
+  check this, not only the one that calls `-ext`, because the matrix
+  runs every step against one host.
 
 ## Init automation input/output rules
 

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -555,6 +555,7 @@ CI 워크플로 동등 스크립트(`scripts/preflight/ci/`):
 | `scripts/preflight/ci/check.sh` | `ci.yml` → Quality Check |
 | `scripts/validate-deploy-compose.sh` | `ci.yml` → Validate Deploy Compose |
 | `scripts/validate-compose-instance-names.sh` | `ci.yml` → Validate Compose Instance Names |
+| `scripts/validate-e2e-openssl-compat.sh` | `ci.yml` → Validate E2E OpenSSL Compatibility |
 | `scripts/preflight/ci/deploy-no-build-smoke.sh` | `ci.yml` → Deploy Compose No-Build Smoke |
 | `scripts/preflight/ci/test-core.sh` | `ci.yml` → test-core |
 | `scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` → test-docker-e2e-matrix |

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -586,7 +586,7 @@ scripts/preflight/run-all.sh
 
 이는 로컬 제약 우회용입니다. CI에서는 `hosts` 케이스도 실행됩니다.
 
-하네스는 호스트 도구 두 가지를 전제하며, 각 검사는 실행 도중이 아니라
+하네스는 호스트 도구 세 가지를 전제하며, 각 검사는 실행 도중이 아니라
 사전 조건 블록에서 실패합니다.
 
 - `run-reinit-recovery.sh`, `run-stepca-san.sh`,
@@ -601,6 +601,16 @@ scripts/preflight/run-all.sh
 - `run-remote-lifecycle.sh`는 원격 에이전트의 TOML 설정을 `tomllib`으로
   읽으므로 `python3`이 3.11 이상이어야 합니다. 사전 조건 블록에서
   컨테이너를 띄우기 전에 import를 확인합니다.
+- `PATH`에서 찾은 `openssl`은 `x509 -ext`를 지원해야 합니다.
+  `run-stepca-san.sh`가 step-ca의 `subjectAltName`을 이 옵션으로 읽기
+  때문입니다. 이 옵션은 OpenSSL 1.1.1에서 추가되었고, macOS가
+  `/usr/bin/openssl`로 제공하는 LibreSSL 3.3.6에는 없습니다. 검사는
+  구현체 이름이 아니라 옵션 지원 여부를 확인하며 찾은 실행 파일 경로를
+  함께 알립니다. 해결 방법은 해당 옵션을 지원하는 `openssl`이 있는
+  디렉터리를 `PATH` 앞에 두는 것입니다. `-ext`를 실제로 호출하는
+  스크립트는 하나뿐이지만 `openssl`을 검사하는 여섯 스크립트가 모두 이
+  검사를 수행합니다. 매트릭스의 모든 단계가 같은 호스트에서 실행되기
+  때문입니다.
 
 ## init 자동화 입출력 규칙
 

--- a/scripts/impl/run-ca-key-rotation-recovery.sh
+++ b/scripts/impl/run-ca-key-rotation-recovery.sh
@@ -124,11 +124,34 @@ on_error() {
 # Infrastructure helpers
 # ---------------------------------------------------------------------------
 
+# Finding *an* `openssl` on PATH is not enough. macOS ships LibreSSL as
+# /usr/bin/openssl, and LibreSSL 3.3.6 has no `x509 -ext` — an OpenSSL
+# 1.1.1 addition, and how the harness reads a certificate's
+# subjectAltName. Probe for that option rather than for the string
+# `OpenSSL` in `openssl version`: the harness needs the capability, not
+# a particular implementation, and a build that grows the option should
+# pass. Every matrix script checks this even where it makes no `-ext`
+# call, because the ten steps run against one host: a host that cannot
+# serve the SAN step cannot serve the matrix, and learning that at that
+# step costs every step before it.
+ensure_openssl() {
+  local openssl_bin x509_help
+  openssl_bin="$(command -v openssl 2>/dev/null || true)"
+  [ -n "$openssl_bin" ] || fail "openssl is required"
+  # `x509 -help` exits non-zero on some builds (LibreSSL 3.3.6 does), so
+  # capture the text and let the match alone decide.  A here-string, not
+  # a pipe: `grep -q` exits on the first match, and under `pipefail` the
+  # writer's SIGPIPE would then fail the very check that just passed.
+  x509_help="$(openssl x509 -help 2>&1 || true)"
+  grep -qE '^[[:space:]]*-ext([[:space:]]|$)' <<<"$x509_help" || fail \
+    "openssl at ${openssl_bin} does not support 'x509 -ext', which this harness needs to read a certificate's subjectAltName; put a directory holding an openssl that supports it first on PATH"
+}
+
 ensure_prerequisites() {
   command -v docker >/dev/null 2>&1 || fail "docker is required"
   docker compose version >/dev/null 2>&1 || fail "docker compose is required"
   command -v jq >/dev/null 2>&1 || fail "jq is required"
-  command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+  ensure_openssl
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
   [ -x "$BOOTROOT_REMOTE_BIN" ] || fail "bootroot-remote binary not executable: $BOOTROOT_REMOTE_BIN"
 }
@@ -313,18 +336,48 @@ snapshot_cert_meta() {
   openssl x509 -in "$cert_path" -noout -serial -startdate -enddate -fingerprint -sha256 >"$meta_file"
 }
 
+cert_meta_file() {
+  local service="$1" label="$2"
+  printf '%s\n' "$CERT_META_DIR/${service}-${label}.txt"
+}
+
+# `x509 -fingerprint` does not agree with itself on the digest's case —
+# OpenSSL 3.6.3 prints `sha256 Fingerprint=` here and `SHA2-256(stdin)= `
+# from `dgst -sha256`, and LibreSSL prints `SHA256 Fingerprint=`. Compare
+# the field case-insensitively instead of anchoring on one spelling.
+# Matching the whole field still pins the digest, so a second fingerprint
+# line added to `snapshot_cert_meta` later cannot satisfy this read. The
+# hex holds no `=`, so `$2` is the entire value.
 fingerprint_of() {
   local service="$1" label="$2"
-  awk -F= '/^sha256 Fingerprint=/{print $2}' "$CERT_META_DIR/${service}-${label}.txt"
+  local meta_file
+  meta_file="$(cert_meta_file "$service" "$label")"
+  awk -F= 'tolower($1) == "sha256 fingerprint" { print $2 }' "$meta_file"
+}
+
+# An unwritten snapshot and a snapshot this read cannot parse are
+# different problems: the first points at the phase that should have
+# written it, the second at the format the read expects. Reporting both
+# as "Missing fingerprint" sent the reader hunting for a file that was
+# there all along.
+assert_cert_meta_readable() {
+  local service="$1" label="$2"
+  local meta_file
+  meta_file="$(cert_meta_file "$service" "$label")"
+  [ -f "$meta_file" ] \
+    || fail "Missing cert-meta file for $service/$label: $meta_file"
+  if [ -z "$(fingerprint_of "$service" "$label")" ]; then
+    fail "No SHA-256 fingerprint parsed from $meta_file for $service/$label; it holds: $(tr '\n' ' ' <"$meta_file")"
+  fi
 }
 
 assert_fingerprint_changed() {
   local service="$1" before_label="$2" after_label="$3"
   local before_fp after_fp
+  assert_cert_meta_readable "$service" "$before_label"
+  assert_cert_meta_readable "$service" "$after_label"
   before_fp="$(fingerprint_of "$service" "$before_label")"
   after_fp="$(fingerprint_of "$service" "$after_label")"
-  [ -n "$before_fp" ] || fail "Missing fingerprint for $service/$before_label"
-  [ -n "$after_fp" ] || fail "Missing fingerprint for $service/$after_label"
   if [ "$before_fp" = "$after_fp" ]; then
     fail "Fingerprint did not change for $service ($before_label -> $after_label)"
   fi

--- a/scripts/impl/run-local-lifecycle.sh
+++ b/scripts/impl/run-local-lifecycle.sh
@@ -123,11 +123,34 @@ run_sudo() {
   sudo -n "$@"
 }
 
+# Finding *an* `openssl` on PATH is not enough. macOS ships LibreSSL as
+# /usr/bin/openssl, and LibreSSL 3.3.6 has no `x509 -ext` — an OpenSSL
+# 1.1.1 addition, and how the harness reads a certificate's
+# subjectAltName. Probe for that option rather than for the string
+# `OpenSSL` in `openssl version`: the harness needs the capability, not
+# a particular implementation, and a build that grows the option should
+# pass. Every matrix script checks this even where it makes no `-ext`
+# call, because the ten steps run against one host: a host that cannot
+# serve the SAN step cannot serve the matrix, and learning that at that
+# step costs every step before it.
+ensure_openssl() {
+  local openssl_bin x509_help
+  openssl_bin="$(command -v openssl 2>/dev/null || true)"
+  [ -n "$openssl_bin" ] || fail "openssl is required"
+  # `x509 -help` exits non-zero on some builds (LibreSSL 3.3.6 does), so
+  # capture the text and let the match alone decide.  A here-string, not
+  # a pipe: `grep -q` exits on the first match, and under `pipefail` the
+  # writer's SIGPIPE would then fail the very check that just passed.
+  x509_help="$(openssl x509 -help 2>&1 || true)"
+  grep -qE '^[[:space:]]*-ext([[:space:]]|$)' <<<"$x509_help" || fail \
+    "openssl at ${openssl_bin} does not support 'x509 -ext', which this harness needs to read a certificate's subjectAltName; put a directory holding an openssl that supports it first on PATH"
+}
+
 ensure_prerequisites() {
   command -v docker >/dev/null 2>&1 || fail "docker is required"
   docker compose version >/dev/null 2>&1 || fail "docker compose is required"
   command -v jq >/dev/null 2>&1 || fail "jq is required"
-  command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+  ensure_openssl
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
   [ -x "$BOOTROOT_REMOTE_BIN" ] || fail "bootroot-remote binary not executable: $BOOTROOT_REMOTE_BIN"
 }
@@ -558,11 +581,25 @@ snapshot_cert_meta() {
   openssl x509 -in "$cert_path" -noout -serial -startdate -enddate -fingerprint -sha256 >"$meta_file"
 }
 
+cert_meta_file() {
+  local service="$1"
+  local label="$2"
+  printf '%s\n' "$CERT_META_DIR/${service}-${label}.txt"
+}
+
+# `x509 -fingerprint` does not agree with itself on the digest's case —
+# OpenSSL 3.6.3 prints `sha256 Fingerprint=` here and `SHA2-256(stdin)= `
+# from `dgst -sha256`, and LibreSSL prints `SHA256 Fingerprint=`. Compare
+# the field case-insensitively instead of anchoring on one spelling.
+# Matching the whole field still pins the digest, so a second fingerprint
+# line added to `snapshot_cert_meta` later cannot satisfy this read. The
+# hex holds no `=`, so `$2` is the entire value.
 fingerprint_of() {
   local service="$1"
   local label="$2"
-  local meta_file="$CERT_META_DIR/${service}-${label}.txt"
-  awk -F= '/^sha256 Fingerprint=/{print $2}' "$meta_file"
+  local meta_file
+  meta_file="$(cert_meta_file "$service" "$label")"
+  awk -F= 'tolower($1) == "sha256 fingerprint" { print $2 }' "$meta_file"
 }
 
 run_verify_pair() {
@@ -725,15 +762,32 @@ wait_for_responder_hmac_propagation() {
   fail "bootroot-agent fast-poll did not propagate the rotated responder HMAC into $config within $((RESPONDER_HMAC_PROPAGATION_ATTEMPTS * RESPONDER_HMAC_PROPAGATION_DELAY_SECS))s"
 }
 
+# An unwritten snapshot and a snapshot this read cannot parse are
+# different problems: the first points at the phase that should have
+# written it, the second at the format the read expects. Reporting both
+# as "Missing fingerprint" sent the reader hunting for a file that was
+# there all along.
+assert_cert_meta_readable() {
+  local service="$1"
+  local label="$2"
+  local meta_file
+  meta_file="$(cert_meta_file "$service" "$label")"
+  [ -f "$meta_file" ] \
+    || fail "Missing cert-meta file for $service/$label: $meta_file"
+  if [ -z "$(fingerprint_of "$service" "$label")" ]; then
+    fail "No SHA-256 fingerprint parsed from $meta_file for $service/$label; it holds: $(tr '\n' ' ' <"$meta_file")"
+  fi
+}
+
 assert_fingerprint_changed() {
   local service="$1"
   local before_label="$2"
   local after_label="$3"
   local before_fp after_fp
+  assert_cert_meta_readable "$service" "$before_label"
+  assert_cert_meta_readable "$service" "$after_label"
   before_fp="$(fingerprint_of "$service" "$before_label")"
   after_fp="$(fingerprint_of "$service" "$after_label")"
-  [ -n "$before_fp" ] || fail "Missing fingerprint for $service/$before_label"
-  [ -n "$after_fp" ] || fail "Missing fingerprint for $service/$after_label"
   if [ "$before_fp" = "$after_fp" ]; then
     fail "Fingerprint did not change for $service ($before_label -> $after_label)"
   fi

--- a/scripts/impl/run-openbao-tls-reown.sh
+++ b/scripts/impl/run-openbao-tls-reown.sh
@@ -165,12 +165,35 @@ run_sudo() {
   sudo -n "$@"
 }
 
+# Finding *an* `openssl` on PATH is not enough. macOS ships LibreSSL as
+# /usr/bin/openssl, and LibreSSL 3.3.6 has no `x509 -ext` — an OpenSSL
+# 1.1.1 addition, and how the harness reads a certificate's
+# subjectAltName. Probe for that option rather than for the string
+# `OpenSSL` in `openssl version`: the harness needs the capability, not
+# a particular implementation, and a build that grows the option should
+# pass. Every matrix script checks this even where it makes no `-ext`
+# call, because the ten steps run against one host: a host that cannot
+# serve the SAN step cannot serve the matrix, and learning that at that
+# step costs every step before it.
+ensure_openssl() {
+  local openssl_bin x509_help
+  openssl_bin="$(command -v openssl 2>/dev/null || true)"
+  [ -n "$openssl_bin" ] || fail "openssl is required"
+  # `x509 -help` exits non-zero on some builds (LibreSSL 3.3.6 does), so
+  # capture the text and let the match alone decide.  A here-string, not
+  # a pipe: `grep -q` exits on the first match, and under `pipefail` the
+  # writer's SIGPIPE would then fail the very check that just passed.
+  x509_help="$(openssl x509 -help 2>&1 || true)"
+  grep -qE '^[[:space:]]*-ext([[:space:]]|$)' <<<"$x509_help" || fail \
+    "openssl at ${openssl_bin} does not support 'x509 -ext', which this harness needs to read a certificate's subjectAltName; put a directory holding an openssl that supports it first on PATH"
+}
+
 ensure_prerequisites() {
   command -v docker >/dev/null 2>&1 || fail "docker is required"
   docker compose version >/dev/null 2>&1 || fail "docker compose is required"
   command -v jq >/dev/null 2>&1 || fail "jq is required"
   command -v curl >/dev/null 2>&1 || fail "curl is required"
-  command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+  ensure_openssl
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
   # Re-owning the secrets tree to a foreign uid needs CAP_CHOWN, and the
   # rotation then has to run as root because it is no longer the owner

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -141,11 +141,34 @@ run_bootroot() {
   ( cd "$WORKSPACE_DIR" && "$BOOTROOT_BIN" "$@" )
 }
 
+# Finding *an* `openssl` on PATH is not enough. macOS ships LibreSSL as
+# /usr/bin/openssl, and LibreSSL 3.3.6 has no `x509 -ext` — an OpenSSL
+# 1.1.1 addition, and how the harness reads a certificate's
+# subjectAltName. Probe for that option rather than for the string
+# `OpenSSL` in `openssl version`: the harness needs the capability, not
+# a particular implementation, and a build that grows the option should
+# pass. Every matrix script checks this even where it makes no `-ext`
+# call, because the ten steps run against one host: a host that cannot
+# serve the SAN step cannot serve the matrix, and learning that at that
+# step costs every step before it.
+ensure_openssl() {
+  local openssl_bin x509_help
+  openssl_bin="$(command -v openssl 2>/dev/null || true)"
+  [ -n "$openssl_bin" ] || fail "openssl is required"
+  # `x509 -help` exits non-zero on some builds (LibreSSL 3.3.6 does), so
+  # capture the text and let the match alone decide.  A here-string, not
+  # a pipe: `grep -q` exits on the first match, and under `pipefail` the
+  # writer's SIGPIPE would then fail the very check that just passed.
+  x509_help="$(openssl x509 -help 2>&1 || true)"
+  grep -qE '^[[:space:]]*-ext([[:space:]]|$)' <<<"$x509_help" || fail \
+    "openssl at ${openssl_bin} does not support 'x509 -ext', which this harness needs to read a certificate's subjectAltName; put a directory holding an openssl that supports it first on PATH"
+}
+
 ensure_prerequisites() {
   command -v docker >/dev/null 2>&1 || fail "docker is required"
   docker compose version >/dev/null 2>&1 || fail "docker compose is required"
   command -v jq >/dev/null 2>&1 || fail "jq is required"
-  command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+  ensure_openssl
   command -v curl >/dev/null 2>&1 || fail "curl is required"
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
 }

--- a/scripts/impl/run-remote-lifecycle.sh
+++ b/scripts/impl/run-remote-lifecycle.sh
@@ -118,6 +118,29 @@ run_bootroot_control() {
   )
 }
 
+# Finding *an* `openssl` on PATH is not enough. macOS ships LibreSSL as
+# /usr/bin/openssl, and LibreSSL 3.3.6 has no `x509 -ext` — an OpenSSL
+# 1.1.1 addition, and how the harness reads a certificate's
+# subjectAltName. Probe for that option rather than for the string
+# `OpenSSL` in `openssl version`: the harness needs the capability, not
+# a particular implementation, and a build that grows the option should
+# pass. Every matrix script checks this even where it makes no `-ext`
+# call, because the ten steps run against one host: a host that cannot
+# serve the SAN step cannot serve the matrix, and learning that at that
+# step costs every step before it.
+ensure_openssl() {
+  local openssl_bin x509_help
+  openssl_bin="$(command -v openssl 2>/dev/null || true)"
+  [ -n "$openssl_bin" ] || fail "openssl is required"
+  # `x509 -help` exits non-zero on some builds (LibreSSL 3.3.6 does), so
+  # capture the text and let the match alone decide.  A here-string, not
+  # a pipe: `grep -q` exits on the first match, and under `pipefail` the
+  # writer's SIGPIPE would then fail the very check that just passed.
+  x509_help="$(openssl x509 -help 2>&1 || true)"
+  grep -qE '^[[:space:]]*-ext([[:space:]]|$)' <<<"$x509_help" || fail \
+    "openssl at ${openssl_bin} does not support 'x509 -ext', which this harness needs to read a certificate's subjectAltName; put a directory holding an openssl that supports it first on PATH"
+}
+
 ensure_prerequisites() {
   command -v docker >/dev/null 2>&1 || fail "docker is required"
   docker compose version >/dev/null 2>&1 || fail "docker compose is required"
@@ -129,7 +152,7 @@ ensure_prerequisites() {
   # than at the first import several phases in.
   python3 -c 'import tomllib' >/dev/null 2>&1 \
     || fail "python3 with tomllib (3.11+) is required"
-  command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+  ensure_openssl
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
   [ -x "$BOOTROOT_REMOTE_BIN" ] || fail "bootroot-remote binary not executable: $BOOTROOT_REMOTE_BIN"
   [ -x "$BOOTROOT_AGENT_BIN" ] || fail "bootroot-agent binary not executable: $BOOTROOT_AGENT_BIN"
@@ -476,11 +499,42 @@ snapshot_cert_meta() {
   openssl x509 -in "$cert_path" -noout -serial -startdate -enddate -fingerprint -sha256 >"$meta_file"
 }
 
+cert_meta_file() {
+  local service="$1"
+  local label="$2"
+  printf '%s\n' "$CERT_META_DIR/${service}-${label}.txt"
+}
+
+# `x509 -fingerprint` does not agree with itself on the digest's case —
+# OpenSSL 3.6.3 prints `sha256 Fingerprint=` here and `SHA2-256(stdin)= `
+# from `dgst -sha256`, and LibreSSL prints `SHA256 Fingerprint=`. Compare
+# the field case-insensitively instead of anchoring on one spelling.
+# Matching the whole field still pins the digest, so a second fingerprint
+# line added to `snapshot_cert_meta` later cannot satisfy this read. The
+# hex holds no `=`, so `$2` is the entire value.
 fingerprint_of() {
   local service="$1"
   local label="$2"
-  local meta_file="$CERT_META_DIR/${service}-${label}.txt"
-  awk -F= '/^sha256 Fingerprint=/{print $2}' "$meta_file"
+  local meta_file
+  meta_file="$(cert_meta_file "$service" "$label")"
+  awk -F= 'tolower($1) == "sha256 fingerprint" { print $2 }' "$meta_file"
+}
+
+# An unwritten snapshot and a snapshot this read cannot parse are
+# different problems: the first points at the phase that should have
+# written it, the second at the format the read expects. Reporting both
+# as "Missing fingerprint" sent the reader hunting for a file that was
+# there all along.
+assert_cert_meta_readable() {
+  local service="$1"
+  local label="$2"
+  local meta_file
+  meta_file="$(cert_meta_file "$service" "$label")"
+  [ -f "$meta_file" ] \
+    || fail "Missing cert-meta file for ${service}/${label}: ${meta_file}"
+  if [ -z "$(fingerprint_of "$service" "$label")" ]; then
+    fail "No SHA-256 fingerprint parsed from ${meta_file} for ${service}/${label}; it holds: $(tr '\n' ' ' <"$meta_file")"
+  fi
 }
 
 assert_fingerprint_changed() {
@@ -488,10 +542,10 @@ assert_fingerprint_changed() {
   local before_label="$2"
   local after_label="$3"
   local before_fp after_fp
+  assert_cert_meta_readable "$service" "$before_label"
+  assert_cert_meta_readable "$service" "$after_label"
   before_fp="$(fingerprint_of "$service" "$before_label")"
   after_fp="$(fingerprint_of "$service" "$after_label")"
-  [ -n "$before_fp" ] || fail "Missing fingerprint for ${service}/${before_label}"
-  [ -n "$after_fp" ] || fail "Missing fingerprint for ${service}/${after_label}"
   [ "$before_fp" != "$after_fp" ] || fail "Fingerprint did not change for ${service} (${before_label} -> ${after_label})"
 }
 

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -150,11 +150,31 @@ run_bootroot() {
   ( cd "$WORKSPACE_DIR" && "$BOOTROOT_BIN" "$@" )
 }
 
+# Finding *an* `openssl` on PATH is not enough. macOS ships LibreSSL as
+# /usr/bin/openssl, and LibreSSL 3.3.6 has no `x509 -ext` — an OpenSSL
+# 1.1.1 addition, and how `assert_stepca_ip_san` below reads step-ca's
+# subjectAltName. Probe for that option rather than for the string
+# `OpenSSL` in `openssl version`: the harness needs the capability, not
+# a particular implementation, and a build that grows the option should
+# pass.
+ensure_openssl() {
+  local openssl_bin x509_help
+  openssl_bin="$(command -v openssl 2>/dev/null || true)"
+  [ -n "$openssl_bin" ] || fail "openssl is required"
+  # `x509 -help` exits non-zero on some builds (LibreSSL 3.3.6 does), so
+  # capture the text and let the match alone decide.  A here-string, not
+  # a pipe: `grep -q` exits on the first match, and under `pipefail` the
+  # writer's SIGPIPE would then fail the very check that just passed.
+  x509_help="$(openssl x509 -help 2>&1 || true)"
+  grep -qE '^[[:space:]]*-ext([[:space:]]|$)' <<<"$x509_help" || fail \
+    "openssl at ${openssl_bin} does not support 'x509 -ext', which this harness needs to read a certificate's subjectAltName; put a directory holding an openssl that supports it first on PATH"
+}
+
 ensure_prerequisites() {
   command -v docker >/dev/null 2>&1 || fail "docker is required"
   docker compose version >/dev/null 2>&1 || fail "docker compose is required"
   command -v jq >/dev/null 2>&1 || fail "jq is required"
-  command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+  ensure_openssl
   command -v curl >/dev/null 2>&1 || fail "curl is required"
   [ -x "$BOOTROOT_BIN" ] || fail "bootroot binary not executable: $BOOTROOT_BIN"
 }

--- a/scripts/preflight/run-all.sh
+++ b/scripts/preflight/run-all.sh
@@ -14,6 +14,9 @@ echo "--- validate-deploy-compose.sh ---"
 echo "--- validate-compose-instance-names.sh ---"
 "$SCRIPT_DIR/../validate-compose-instance-names.sh"
 
+echo "--- validate-e2e-openssl-compat.sh ---"
+"$SCRIPT_DIR/../validate-e2e-openssl-compat.sh"
+
 echo "--- ci/deploy-no-build-smoke.sh ---"
 "$SCRIPT_DIR/ci/deploy-no-build-smoke.sh"
 

--- a/scripts/validate-e2e-openssl-compat.sh
+++ b/scripts/validate-e2e-openssl-compat.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+#
+# Validates the two openssl-compatibility properties the E2E harness
+# relies on, without Docker and without a second openssl on the host.
+#
+# Neither property is observable from CI. The runners carry an OpenSSL
+# that has `x509 -ext` and spells the digest `sha256 Fingerprint=`, so a
+# probe that stopped rejecting anything, or a read that went back to
+# anchoring on one spelling, would leave the whole matrix green and
+# break only on a host that ships LibreSSL as `openssl` — which is what
+# macOS does. The checks below drive the harness's own functions against
+# stub binaries and fixture files so a regression fails here instead.
+#
+# The functions are extracted from the harness scripts rather than
+# copied, so this validates the shipped code. Sourcing whole scripts is
+# what it avoids: they derive paths from `BASH_SOURCE` and pull in
+# `lib/audit-log.sh`, none of which these functions need.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+IMPL_DIR="$ROOT_DIR/scripts/impl"
+LABEL="validate-e2e-openssl-compat"
+
+# All six scripts that check for `openssl` gate on `x509 -ext`, not only
+# `run-stepca-san.sh`, which is the sole caller: the matrix runs every
+# step against one host, so a host that cannot serve the SAN step cannot
+# serve the matrix. Pinning the set here is what keeps a later change
+# from quietly narrowing it back to the one script that calls the option.
+GATED_SCRIPTS=(
+  run-ca-key-rotation-recovery.sh
+  run-local-lifecycle.sh
+  run-openbao-tls-reown.sh
+  run-reinit-recovery.sh
+  run-remote-lifecycle.sh
+  run-stepca-san.sh
+)
+
+# The scripts that read a SHA-256 fingerprint back out of a cert-meta
+# snapshot they wrote earlier in the same run.
+FINGERPRINT_SCRIPTS=(
+  run-ca-key-rotation-recovery.sh
+  run-local-lifecycle.sh
+  run-remote-lifecycle.sh
+)
+
+# An OpenSSL 3.x `x509 -help`, trimmed to the lines that matter: `-ext`
+# alongside the two options whose names start with it, so a probe that
+# matched a prefix rather than the whole option would pass here and fail
+# the LibreSSL case below.
+HELP_CAPABLE=' -help                      Display this summary
+ -ext val                   Restrict which X.509 extensions to print and/or copy
+ -extfile infile            Config file with X509V3 extensions to add
+ -extensions val            Section of extfile to use - default: unnamed section'
+
+# LibreSSL 3.3.6's `x509 -help`: `-extfile` and `-extensions` are there,
+# `-ext` is not.
+HELP_WITHOUT_EXT=' -clrext            Clear all extensions
+ -extensions section
+                    Section from config file with X509V3 extensions to add
+ -extfile file      Configuration file with X509V3 extensions to add
+ -fingerprint       Print the certificate fingerprint'
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+failures=0
+
+ok() {
+  printf '[%s]   ok   %s\n' "$LABEL" "$1"
+}
+
+bad() {
+  printf '[%s]   FAIL %s\n' "$LABEL" "$1" >&2
+  failures=$((failures + 1))
+}
+
+expect_eq() {
+  local what="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    ok "$what"
+  else
+    bad "$what: expected [$want], got [$got]"
+  fi
+}
+
+expect_contains() {
+  local what="$1" haystack="$2" needle="$3"
+  case "$haystack" in
+    *"$needle"*) ok "$what" ;;
+    *) bad "$what: [$haystack] does not contain [$needle]" ;;
+  esac
+}
+
+expect_lacks() {
+  local what="$1" haystack="$2" needle="$3"
+  case "$haystack" in
+    *"$needle"*) bad "$what: [$haystack] should not contain [$needle]" ;;
+    *) ok "$what" ;;
+  esac
+}
+
+# Writes a sourceable file holding the named functions as they appear in
+# the harness script, plus the two things they close over: a `fail` that
+# prints and exits, and `CERT_META_DIR`. A function that does not extract
+# is a hard error rather than an empty suite that reports success.
+build_subject() {
+  local script="$1" cert_meta_dir="$2" first_fn="$3"
+  shift 2
+  # Keyed by the first function too: one script is a subject of both
+  # suites below, and they want different function sets.
+  local subject="$TMP_DIR/subject-$script-$first_fn.sh"
+  {
+    printf 'CERT_META_DIR=%q\n' "$cert_meta_dir"
+    printf 'fail() { printf "%%s\\n" "$1" >&2; exit 1; }\n'
+  } >"$subject"
+
+  local fn body
+  for fn in "$@"; do
+    body="$(sed -n "/^${fn}() {/,/^}/p" "$IMPL_DIR/$script")"
+    if [ -z "$body" ]; then
+      printf '[%s] %s does not define %s()\n' "$LABEL" "$script" "$fn" >&2
+      exit 1
+    fi
+    printf '%s\n' "$body" >>"$subject"
+  done
+  printf '%s\n' "$subject"
+}
+
+# Runs one call against an extracted subject and prints its combined
+# output. The caller asserts on that text, so a `fail` inside the subject
+# must not take this script down with it.
+call_subject() {
+  local subject="$1" call="$2"
+  bash -c '. "$1"; eval "$2"' _ "$subject" "$call" 2>&1 || true
+}
+
+# A stub `openssl` that answers `x509 -help` with the given text and
+# exit status. The status varies because some builds exit non-zero from
+# `-help`, which is why the harness reads the text and lets the match
+# alone decide.
+#
+# `cat` is spelled absolutely: the stub runs under a PATH holding only
+# itself and the toolbox, so a bare `cat` would resolve to nothing and
+# every stub would answer with silence — which reads as "no -ext" and
+# would pass the rejection cases for the wrong reason.
+CAT_BIN="$(command -v cat)"
+
+make_openssl_stub() {
+  local dir="$1" exit_code="$2" help_text="$3"
+  mkdir -p "$dir"
+  printf '%s\n' "$help_text" >"$dir/help.txt"
+  printf '#!/bin/sh\n%q %q\nexit %s\n' "$CAT_BIN" "$dir/help.txt" "$exit_code" >"$dir/openssl"
+  chmod +x "$dir/openssl"
+}
+
+# ---------------------------------------------------------------------------
+# The prerequisite probe
+# ---------------------------------------------------------------------------
+
+# `ensure_openssl` needs `grep` on PATH and nothing else, so the absent
+# case can hand it a PATH that holds no `openssl` at all.
+TOOLBOX="$TMP_DIR/toolbox"
+mkdir -p "$TOOLBOX"
+ln -s "$(command -v grep)" "$TOOLBOX/grep"
+
+run_ensure_openssl() {
+  local subject="$1" path="$2"
+  PATH="$path" "$BASH" -c '. "$1"; ensure_openssl && printf "ACCEPTED\n"' _ "$subject" 2>&1 || true
+}
+
+check_prerequisite_probe() {
+  local script="$1"
+  printf '[%s] %s: openssl prerequisite\n' "$LABEL" "$script"
+  local subject
+  subject="$(build_subject "$script" "$TMP_DIR/unused" ensure_openssl)"
+
+  local capable="$TMP_DIR/bin-capable-$script"
+  local capable_noisy="$TMP_DIR/bin-capable-noisy-$script"
+  local libre="$TMP_DIR/bin-libre-$script"
+  local mute="$TMP_DIR/bin-mute-$script"
+  make_openssl_stub "$capable" 0 "$HELP_CAPABLE"
+  make_openssl_stub "$capable_noisy" 1 "$HELP_CAPABLE"
+  make_openssl_stub "$libre" 0 "$HELP_WITHOUT_EXT"
+  make_openssl_stub "$mute" 1 ""
+
+  expect_contains "accepts an openssl with x509 -ext" \
+    "$(run_ensure_openssl "$subject" "$capable:$TOOLBOX")" ACCEPTED
+
+  # The `|| true` around the probe exists for exactly this: a build that
+  # prints the option but exits non-zero from `-help` still has it.
+  expect_contains "accepts it even when -help exits non-zero" \
+    "$(run_ensure_openssl "$subject" "$capable_noisy:$TOOLBOX")" ACCEPTED
+
+  local rejected
+  rejected="$(run_ensure_openssl "$subject" "$libre:$TOOLBOX")"
+  expect_lacks "rejects an openssl without x509 -ext" "$rejected" ACCEPTED
+  expect_contains "rejection names the binary it found" "$rejected" "$libre/openssl"
+  expect_contains "rejection names the missing option" "$rejected" "x509 -ext"
+  expect_contains "rejection names the PATH fix" "$rejected" "first on PATH"
+  # On the hosts this triggers on, a capable openssl is usually already
+  # installed and merely later on PATH, and which command would install
+  # one is not something the harness can know. Word-bounded, so the
+  # `port` in "does not support" is not read as MacPorts.
+  if printf '%s' "$rejected" | grep -qwE 'brew|apt|apt-get|yum|dnf|pacman|macports|choco|nix|install'; then
+    bad "rejection recommends installing something: [$rejected]"
+  else
+    ok "rejection recommends no package manager"
+  fi
+
+  expect_lacks "rejects an openssl whose -help says nothing" \
+    "$(run_ensure_openssl "$subject" "$mute:$TOOLBOX")" ACCEPTED
+
+  # No openssl at all keeps the original message: the binary is what is
+  # missing, not a capability of one.
+  local absent
+  absent="$(run_ensure_openssl "$subject" "$TOOLBOX")"
+  expect_lacks "rejects a PATH with no openssl" "$absent" ACCEPTED
+  expect_contains "absent openssl reports the binary, not the option" \
+    "$absent" "openssl is required"
+}
+
+# ---------------------------------------------------------------------------
+# The fingerprint read
+# ---------------------------------------------------------------------------
+
+HEX_A='90:1F:CA:37:5A:0B:CE:11:2D:88:4F:6E:23:91:70:AC'
+HEX_B='4C:7D:E9:02:B8:61:34:AA:5F:10:9D:73:C6:28:E4:51'
+
+check_fingerprint_read() {
+  local script="$1"
+  printf '[%s] %s: cert-meta fingerprint read\n' "$LABEL" "$script"
+  local meta="$TMP_DIR/cert-meta-$script"
+  mkdir -p "$meta"
+
+  # `x509 -fingerprint -sha256` under OpenSSL and under LibreSSL. Every
+  # other line of the snapshot is byte-identical; only the digest name's
+  # case differs.
+  printf 'serial=0A\nnotBefore=x\nnotAfter=y\nsha256 Fingerprint=%s\n' "$HEX_A" >"$meta/svc-openssl.txt"
+  printf 'serial=0A\nnotBefore=x\nnotAfter=y\nSHA256 Fingerprint=%s\n' "$HEX_A" >"$meta/svc-libressl.txt"
+  printf 'serial=0B\nnotBefore=x\nnotAfter=y\nsha256 Fingerprint=%s\n' "$HEX_B" >"$meta/svc-rotated.txt"
+  printf 'serial=0A\nnotBefore=x\nnotAfter=y\n' >"$meta/svc-nofingerprint.txt"
+  # Matching the whole field rather than a prefix is what keeps another
+  # digest from satisfying the read.
+  printf 'sha512 Fingerprint=DE:AD:BE:EF\n' >"$meta/svc-otherdigest.txt"
+
+  local subject
+  subject="$(build_subject "$script" "$meta" \
+    cert_meta_file fingerprint_of assert_cert_meta_readable assert_fingerprint_changed)"
+
+  expect_eq "reads OpenSSL's spelling" \
+    "$(call_subject "$subject" 'fingerprint_of svc openssl')" "$HEX_A"
+  expect_eq "reads LibreSSL's spelling" \
+    "$(call_subject "$subject" 'fingerprint_of svc libressl')" "$HEX_A"
+  expect_eq "ignores a different digest" \
+    "$(call_subject "$subject" 'fingerprint_of svc otherdigest')" ""
+
+  expect_contains "an absent snapshot names the path" \
+    "$(call_subject "$subject" 'assert_cert_meta_readable svc missing')" \
+    "$meta/svc-missing.txt"
+
+  local unparsable
+  unparsable="$(call_subject "$subject" 'assert_cert_meta_readable svc nofingerprint')"
+  expect_contains "an unparsable snapshot reads differently from an absent one" \
+    "$unparsable" "No SHA-256 fingerprint parsed"
+  expect_lacks "an unparsable snapshot is not reported as missing" \
+    "$unparsable" "Missing cert-meta file"
+  expect_contains "an unparsable snapshot quotes what it holds" \
+    "$unparsable" 'serial=0A notBefore=x notAfter=y'
+
+  expect_contains "a readable snapshot passes" \
+    "$(call_subject "$subject" 'assert_cert_meta_readable svc openssl && printf READABLE\\n')" \
+    READABLE
+
+  # The comparison has to survive the two snapshots being written by
+  # different spellings, which is what happens across an upgrade of the
+  # host's openssl mid-matrix.
+  expect_contains "an unchanged fingerprint still fails the assertion" \
+    "$(call_subject "$subject" 'assert_fingerprint_changed svc openssl libressl')" \
+    "Fingerprint did not change"
+  expect_contains "a real rotation passes across spellings" \
+    "$(call_subject "$subject" 'assert_fingerprint_changed svc libressl rotated && printf CHANGED\\n')" \
+    CHANGED
+
+  expect_contains "the comparison surfaces an absent snapshot" \
+    "$(call_subject "$subject" 'assert_fingerprint_changed svc openssl missing')" \
+    "Missing cert-meta file"
+  expect_contains "the comparison surfaces an unparsable snapshot" \
+    "$(call_subject "$subject" 'assert_fingerprint_changed svc openssl nofingerprint')" \
+    "No SHA-256 fingerprint parsed"
+}
+
+# ---------------------------------------------------------------------------
+# Structural assertions
+# ---------------------------------------------------------------------------
+
+check_gating_is_not_narrowed() {
+  printf '[%s] every script that checks for openssl checks for the option\n' "$LABEL"
+
+  local discovered
+  discovered="$(cd "$IMPL_DIR" && { grep -lE '^ensure_openssl\(\) \{' ./*.sh || true; } | sed 's|^\./||' | sort | tr '\n' ' ')"
+  local expected
+  expected="$(printf '%s\n' "${GATED_SCRIPTS[@]}" | sort | tr '\n' ' ')"
+  expect_eq "the gated set is exactly the six scripts that check for openssl" \
+    "$discovered" "$expected"
+
+  local script
+  for script in "${GATED_SCRIPTS[@]}"; do
+    if grep -qE '^[[:space:]]*ensure_openssl$' "$IMPL_DIR/$script"; then
+      ok "$script calls ensure_openssl from its prerequisite block"
+    else
+      bad "$script defines ensure_openssl but never calls it"
+    fi
+  done
+
+  # The check this replaced passed on a LibreSSL host and let the run
+  # proceed to die minutes later. Nothing under scripts/impl should be
+  # spelling it that way again.
+  local stragglers
+  stragglers="$(grep -rlF 'command -v openssl >/dev/null' "$IMPL_DIR" || true)"
+  if [ -n "$stragglers" ]; then
+    bad "these still check only that some openssl exists: $(printf '%s' "$stragglers" | tr '\n' ' ')"
+  else
+    ok "no script is left checking only that some openssl exists"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+
+for script in "${GATED_SCRIPTS[@]}"; do
+  check_prerequisite_probe "$script"
+done
+
+for script in "${FINGERPRINT_SCRIPTS[@]}"; do
+  check_fingerprint_read "$script"
+done
+
+check_gating_is_not_narrowed
+
+if [ "$failures" -ne 0 ]; then
+  printf '[%s] %d check(s) failed\n' "$LABEL" "$failures" >&2
+  exit 1
+fi
+
+printf '[%s] all checks passed\n' "$LABEL"


### PR DESCRIPTION
Makes the E2E harness's `openssl` requirement explicit, makes the fingerprint read survive either spelling of the digest name, and pins both properties with a validator so CI can observe them.

Closes #844

## What changed

**The six prerequisite checks now probe for `x509 -ext`.** `run-local-lifecycle.sh`, `run-remote-lifecycle.sh`, `run-ca-key-rotation-recovery.sh`, `run-reinit-recovery.sh`, `run-stepca-san.sh` and `run-openbao-tls-reown.sh` each grew an `ensure_openssl` called from `ensure_prerequisites`, replacing the bare `command -v openssl` check. It captures `openssl x509 -help` and looks for the option, so a host whose first `openssl` cannot serve the SAN assertion is told so before Docker is touched:

```
openssl at /usr/bin/openssl does not support 'x509 -ext', which this harness needs to read a certificate's subjectAltName; put a directory holding an openssl that supports it first on PATH
```

It names the binary found, the missing option, and the `PATH` fix, and no package manager — on the hosts where this triggers, a capable `openssl` is usually already installed and merely later on `PATH`. It probes the capability rather than matching `OpenSSL` in `openssl version`, so a LibreSSL release that grows `-ext` passes. All six check it, not just the one caller, because the matrix runs every step against one host.

Two details worth flagging: `x509 -help` exits non-zero on LibreSSL 3.3.6, so the exit status is discarded and only the match decides; and the match is made with a here-string rather than a pipe, because `grep -q` exits on the first match and under `pipefail` the writer's SIGPIPE would fail a check that had just passed.

**The three fingerprint reads accept either spelling.** `awk -F= 'tolower($1) == "sha256 fingerprint" { print $2 }'` replaces the lowercase-anchored regex in `run-local-lifecycle.sh`, `run-remote-lifecycle.sh` and `run-ca-key-rotation-recovery.sh`. Matching the whole field still pins the digest, so a second fingerprint line added to `snapshot_cert_meta` later cannot satisfy the read. Each script also grew a `cert_meta_file` helper so the path is spelled once.

**`assert_fingerprint_changed` distinguishes the two ways the read comes up empty**, via a new `assert_cert_meta_readable`: an absent meta file names the path it looked for, and a file that parsed nothing quotes what the file holds, so the next format change names itself.

**A validator keeps all of it observable from CI.** Neither property is visible on a runner that already has a capable `openssl` and already spells the digest lowercase — a probe that stopped rejecting anything, or a read that went back to anchoring on one spelling, would leave the whole matrix green and break only on the kind of host the issue was reported from. `scripts/validate-e2e-openssl-compat.sh` extracts the harness's own functions out of the shipped scripts (rather than copying them) and drives them against stub `openssl` binaries and fixture snapshots: both digest spellings, a snapshot with no fingerprint line, an absent snapshot, an accepting stub, a rejecting stub, and a stub whose `-help` exits non-zero. It also asserts the gated set is exactly those six scripts, so a later change cannot quietly narrow the decision back to the single `-ext` caller. It needs no Docker and no second `openssl`, so it runs in the `check` job beside the other validators and in `scripts/preflight/run-all.sh`.

**Docs.** `docs/{en,ko}/e2e-ci.md` listed the two host tools the prerequisite blocks enforce; the `openssl` capability is now a third bullet, and the new validator is in the CI-equivalence table.

## Test plan

- [x] With `/usr/bin/openssl` (LibreSSL 3.3.6) first on `PATH`, `scripts/impl/run-local-lifecycle.sh` fails inside `ensure_prerequisites`, before any container starts, with the new message — instead of running for minutes and dying at `verify-after-responder-hmac`
- [x] All six gated scripts reject that binary the same way; with Homebrew's OpenSSL 3.6.3 first on `PATH`, `ensure_openssl` returns 0
- [x] `fingerprint_of` returns the hex from a cert-meta fixture spelled `sha256 Fingerprint=` and from one spelled `SHA256 Fingerprint=`, in all three scripts
- [x] A fixture with no fingerprint line yields the new "No SHA-256 fingerprint parsed from ..." error, and an absent file yields "Missing cert-meta file for ..." — the two are no longer reported alike
- [x] `./scripts/validate-e2e-openssl-compat.sh` passes
- [x] `./scripts/preflight/ci/check.sh` passes (`cargo fmt`/`clippy`/`doc`, ruff, biome, markdownlint, `mkdocs build --strict`, `cargo audit` with only the pre-existing allowed warning)
- [x] `bash -n` and `shellcheck` on the six scripts and the validator: no new findings
- [x] No `CHANGELOG.md` entry — this is test-harness only
- [ ] `scripts/preflight/ci/e2e-matrix.sh --skip-hosts` reaches at least step 8 — **not runnable on this host.** Re-confirmed during verification: step 1’s `infra install` aborts in its published-port preflight with `host port 127.0.0.1:8200 is already in use (Address already in use (os error 48)) (listener: pid 1255 (OrbStack Helper))`, before any container starts. The harness spells `8200`, `9000` and `8080` into its `--openbao-url`/step-ca/responder URLs literally, so `OPENBAO_HOST_PORT` cannot move the run off the conflict, and all three ports are held here. CI’s matrix exercises every touched path under a capable `openssl`.
- [x] Full CI green, including the local lifecycle completing unchanged under a capable `openssl` — all 18 required checks pass on `1e57e21`, including `Docker E2E (local-hosts)`/`(local-no-hosts)` and the whole ten-step matrix, plus a manually dispatched `E2E Extended` run on the same SHA

