### PR TITLE
Stop baseline and smoke inheriting a stale .env

### DIFF
--- a/scripts/impl/run-baseline.sh
+++ b/scripts/impl/run-baseline.sh
@@ -7,12 +7,26 @@ cd "$ROOT_DIR"
 
 # shellcheck source=lib/leftovers.sh
 . "$SCRIPT_DIR/lib/leftovers.sh"
+# shellcheck source=lib/ports.sh
+. "$SCRIPT_DIR/lib/ports.sh"
 
 # docker-compose.yml interpolates the entire file regardless of which
 # services are targeted or which profiles are active, so required vars
 # referenced by gated services (e.g. grafana) must still be defined.
 export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-step-pass}"
 export GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
+
+# This harness installs at the default identity, and declares it rather
+# than reading it out of `$ROOT_DIR/.env`.  Nothing here runs `infra
+# install`, so that file is whatever the last harness that did left
+# behind — since the lifecycle harnesses became run-scoped, a previous
+# run's derived instance.  Inheriting it would name this run's
+# containers after a run that is over, and point the leftover checks at
+# names this run never creates.  Exporting is what makes the recorded
+# value unreachable: Compose prefers a process-environment variable over
+# `.env`, where unsetting one would let `.env` supply it.
+RUN_INSTANCE="$BOOTROOT_DEFAULT_INSTANCE_NAME"
+export BOOTROOT_INSTANCE="$RUN_INSTANCE"
 
 DEFAULT_SCENARIO_FILE="$ROOT_DIR/tests/e2e/docker_harness/scenarios/scenario-a-single-node-mixed.json"
 SCENARIO_FILE="${SCENARIO_FILE:-$DEFAULT_SCENARIO_FILE}"
@@ -75,6 +89,23 @@ ensure_prerequisites() {
   command -v curl >/dev/null 2>&1 || fail_with_context "curl is required"
   [ -x "$BOOTROOT_BIN" ] || fail_with_context "bootroot binary not executable: $BOOTROOT_BIN"
   [ -x "$BOOTROOT_REMOTE_BIN" ] || fail_with_context "bootroot-remote binary not executable: $BOOTROOT_REMOTE_BIN"
+}
+
+# Picks this run's four published ports, for the same reason the
+# instance name is declared above and with one addition: `.env` records
+# the four ephemeral ports a previous lifecycle run chose, and one of
+# them may well have been taken since — a bind failure on a port this
+# harness never asked for.  Picking also leaves the compose file's
+# defaults as the one place they are written down.
+allocate_run_ports() {
+  pick_free_port
+  export POSTGRES_HOST_PORT="$PICKED_PORT"
+  pick_free_port
+  export OPENBAO_HOST_PORT="$PICKED_PORT"
+  pick_free_port
+  export STEPCA_HOST_PORT="$PICKED_PORT"
+  pick_free_port
+  export HTTP01_ADMIN_HOST_PORT="$PICKED_PORT"
 }
 
 compose_up() {
@@ -378,7 +409,7 @@ cleanup() {
       echo "run-baseline: teardown failed; see ${RUNNER_LOG}" >&2
       cleanup_status=1
     fi
-    report_leftover_containers "$COMPOSE_FILE" "run-baseline cleanup" || cleanup_status=1
+    report_leftover_containers "$COMPOSE_FILE" "run-baseline cleanup" "$RUN_INSTANCE" || cleanup_status=1
   fi
   exit_with_cleanup_status "$status" "$cleanup_status"
 }
@@ -391,13 +422,14 @@ main() {
   trap cleanup EXIT
 
   ensure_prerequisites
+  allocate_run_ports
   # The assertion comes first, before the teardown and before anything
   # else that could remove a container.  A `down -v` at this project
   # would take a real install on this host with it, volumes and all, and
   # leave the check reading a daemon it had just cleaned — and a killed
   # run's leftovers, which the check exists to report, are
   # indistinguishable from that install to everything but an operator.
-  assert_no_leftover_containers "$COMPOSE_FILE" "run-baseline startup"
+  assert_no_leftover_containers "$COMPOSE_FILE" "run-baseline startup" "$RUN_INSTANCE"
   # Past the assertion nothing here is anyone else's, so the stack
   # becomes this run's to remove.  Nothing used to tear it down at the
   # start of a run at all, so a previous run killed before its own

--- a/scripts/impl/run-harness-smoke.sh
+++ b/scripts/impl/run-harness-smoke.sh
@@ -7,12 +7,26 @@ cd "$ROOT_DIR"
 
 # shellcheck source=lib/leftovers.sh
 . "$SCRIPT_DIR/lib/leftovers.sh"
+# shellcheck source=lib/ports.sh
+. "$SCRIPT_DIR/lib/ports.sh"
 
 # docker-compose.yml interpolates the entire file regardless of which
 # services are targeted or which profiles are active, so required vars
 # referenced by gated services (e.g. grafana) must still be defined.
 export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-step-pass}"
 export GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
+
+# This harness installs at the default identity, and declares it rather
+# than reading it out of `$ROOT_DIR/.env`.  Nothing here runs `infra
+# install`, so that file is whatever the last harness that did left
+# behind — since the lifecycle harnesses became run-scoped, a previous
+# run's derived instance.  Inheriting it would name this run's
+# containers after a run that is over, and point the leftover checks at
+# names this run never creates.  Exporting is what makes the recorded
+# value unreachable: Compose prefers a process-environment variable over
+# `.env`, where unsetting one would let `.env` supply it.
+RUN_INSTANCE="$BOOTROOT_DEFAULT_INSTANCE_NAME"
+export BOOTROOT_INSTANCE="$RUN_INSTANCE"
 
 SCENARIO_ID="${SCENARIO_ID:-docker-harness-smoke}"
 PROJECT_NAME="${PROJECT_NAME:-bootroot-e2e-smoke-$$}"
@@ -78,6 +92,23 @@ ensure_bins() {
     printf "curl is required for mock OpenBao health checks\n" >&2
     exit 1
   fi
+}
+
+# Picks this run's four published ports, for the same reason the
+# instance name is declared above and with one addition: `.env` records
+# the four ephemeral ports a previous lifecycle run chose, and one of
+# them may well have been taken since — a bind failure on a port this
+# harness never asked for.  Picking also leaves the compose file's
+# defaults as the one place they are written down.
+allocate_run_ports() {
+  pick_free_port
+  export POSTGRES_HOST_PORT="$PICKED_PORT"
+  pick_free_port
+  export OPENBAO_HOST_PORT="$PICKED_PORT"
+  pick_free_port
+  export STEPCA_HOST_PORT="$PICKED_PORT"
+  pick_free_port
+  export HTTP01_ADMIN_HOST_PORT="$PICKED_PORT"
 }
 
 compose_up() {
@@ -155,7 +186,7 @@ cleanup() {
       echo "run-harness-smoke: teardown failed; see ${RUNNER_LOG}" >&2
       cleanup_status=1
     fi
-    report_leftover_containers "$COMPOSE_FILE" "run-harness-smoke cleanup" || cleanup_status=1
+    report_leftover_containers "$COMPOSE_FILE" "run-harness-smoke cleanup" "$RUN_INSTANCE" || cleanup_status=1
   fi
   exit_with_cleanup_status "$status" "$cleanup_status"
 }
@@ -310,6 +341,7 @@ run_verify() {
 main() {
   ensure_compose
   ensure_bins
+  allocate_run_ports
   mkdir -p "$ARTIFACT_DIR"
   : >"$RUNNER_LOG"
   : >"$PHASE_LOG"
@@ -322,7 +354,7 @@ main() {
   # leave the check reading a daemon it had just cleaned — and a killed
   # run's leftovers, which the check exists to report, are
   # indistinguishable from that install to everything but an operator.
-  assert_no_leftover_containers "$COMPOSE_FILE" "run-harness-smoke startup"
+  assert_no_leftover_containers "$COMPOSE_FILE" "run-harness-smoke startup" "$RUN_INSTANCE"
   # Past the assertion nothing here is anyone else's, so the stack
   # becomes this run's to remove.  Nothing used to tear it down at the
   # start of a run at all, so a previous run killed before its own


### PR DESCRIPTION
Closes #858.

## What changes

`run-baseline.sh` and `run-harness-smoke.sh` are the only two harnesses that neither delete nor overwrite `$ROOT_DIR/.env` before bringing their stack up. They never run `infra install` at all — they call `docker compose up -d` straight against the repository's compose file — so every `${BOOTROOT_INSTANCE:-bootroot}` and `${*_HOST_PORT:-…}` in it is interpolated from whatever that file holds.

Since #846 it holds a *previous lifecycle run's* identity: an install records the instance it was given, and the lifecycle scripts now give it a derived one plus four freshly picked ephemeral ports. `AGENTS.md` requires `scripts/preflight/run-all.sh` before pushing, and that reaches both scripts through `ci/e2e-extended.sh` → `run-extended-suite.sh`, so the trigger is running the mandated preflight twice in one worktree.

Three changes, in those two scripts and nowhere else:

- **The identity is declared, not read.** Both export `BOOTROOT_INSTANCE` as `BOOTROOT_DEFAULT_INSTANCE_NAME`, which `lib/leftovers.sh` already defines and both scripts already source. Exporting is what makes the recorded value unreachable — Compose prefers a process-environment variable over `.env`, where unsetting one would let `.env` supply it.
- **The four published ports are picked.** Both now source `lib/ports.sh` — extracted by #854 and already reused by `run-two-instance-isolation.sh` — and allocate a free port for each of `POSTGRES_HOST_PORT`, `OPENBAO_HOST_PORT`, `STEPCA_HOST_PORT` and `HTTP01_ADMIN_HOST_PORT` before the startup assertion. This drops the inherited ports without writing the compose file's defaults down in a second place, and lets two of these harnesses publish at once.
- **The leftover checks are told which identity to look at.** The same name is passed as the third argument to `assert_no_leftover_containers` and `report_leftover_containers`. Without it the checks stay wrong in the other direction: `resolve_recorded_instance_name` reads the `.env` *file*, so it would resolve the residue while Compose used the default, and the run would assert on container names it was never going to create.

Both scripts stay default-identity harnesses, exactly as `DEFAULT_IDENTITY_SCRIPTS` in `scripts/validate-e2e-leftover-check.sh` and the taxonomy in `lib/leftovers.sh` have them. Giving them run-scoped instances of their own was considered and rejected in the issue: their containers would then carry an identity no later run reproduces, so a run killed before its teardown would leave containers nothing ever collects — what #845 exists to catch, reintroduced — and avoiding that would mean writing run markers and joining the sweep, which is a change to `lib/run-scope.sh`'s declared-namespace table and to the 24 assertions in `scripts/validate-e2e-run-scope.sh`.

## Verification

Docker 29.7.2 on macOS 15.5, with a `.env` fixture recording a foreign instance and four foreign ports:

```
BOOTROOT_INSTANCE=e2e-local-stale99999
POSTGRES_HOST_PORT=52342  OPENBAO_HOST_PORT=52343
STEPCA_HOST_PORT=52344    HTTP01_ADMIN_HOST_PORT=52345
```

`docker compose config` with no environment override — what these two harnesses do today:

```
bootroot-http01  e2e-local-stale99999-http01     ports=['52345']
openbao          e2e-local-stale99999-openbao    ports=['52343']
postgres         e2e-local-stale99999-postgres   ports=['52342']
step-ca          e2e-local-stale99999-ca         ports=['52344']
```

and with this branch's exports applied, against the same `.env`:

```
picked: pg=62479 bao=62480 ca=62481 http01=62482
bootroot-http01  bootroot-http01                 ports=['62482']
openbao          bootroot-openbao                ports=['62480']
postgres         bootroot-postgres               ports=['62479']
step-ca          bootroot-ca                     ports=['62481']
```

The third change is what the last two lines of the fixture run show, and why it is not optional:

```
resolve_recorded_instance_name(.env only):     e2e-local-stale99999
resolve_recorded_instance_name(explicit arg):  bootroot
```

Without the explicit argument the checks would look for `e2e-local-stale99999-*` while the run created `bootroot-*`.

`scripts/validate-e2e-leftover-check.sh` and `scripts/validate-e2e-run-scope.sh` both pass — the first is what holds every default-identity harness to its startup assertion, its end-of-run report and its teardown wiring, so it is the one that would fail if these call sites had drifted. `shellcheck -x` reports exactly what it reported before the change, plus one `SC1091` per new `source` line, the same info-level note the existing `lib/leftovers.sh` line produces; it is not a CI step.

The fixture `.env` was removed afterwards, and no file outside the two scripts is touched.

## Not verified here

A full `run-extended-suite.sh` twice in one worktree was not run: it needs the extended Docker matrix end to end, and CI's `E2E Extended` workflow is what exercises that. The mechanism it would demonstrate — that neither harness reads the recorded instance or the recorded ports — is what the fixture run above shows directly.

## Test plan

- [x] With a `.env` recording a foreign instance and four foreign ports, both harnesses' Compose configuration resolves `bootroot-*` container names and freshly picked ports
- [x] The startup and cleanup leftover checks resolve the same identity Compose used, rather than the one `.env` records
- [x] Neither script writes, deletes or rewrites `$ROOT_DIR/.env`
- [x] `scripts/validate-e2e-leftover-check.sh` passes
- [x] `scripts/validate-e2e-run-scope.sh` passes
- [x] No other harness, and no file under `src/`, is changed
- [x] No `CHANGELOG.md` entry — test-harness only, and a user of the last release cannot observe it
- [ ] Two consecutive `run-extended-suite.sh` runs in one worktree both pass — see *Not verified here*
- [ ] Full CI passes
