### PR TITLE
Run the E2E run-scope validator in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,9 @@ jobs:
       - name: Validate E2E Leftover Check
         run: ./scripts/validate-e2e-leftover-check.sh
 
+      - name: Validate E2E Run Scope
+        run: ./scripts/validate-e2e-run-scope.sh
+
       - name: Install cargo-audit
         run: cargo install cargo-audit || true
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -278,8 +278,13 @@ world-writable directory is one a run's write would truncate wherever
 somebody else's link pointed.
 
 `scripts/validate-e2e-run-scope.sh` covers the derivation, the markers, the
-sweep and the `hosts` lock without Docker. It is a local check, run by
-`scripts/preflight/run-all.sh` and not by any CI workflow.
+sweep and the `hosts` lock without Docker, and runs in the `check` CI job. It
+needs nothing that job does not already have, and redirects its marker
+directory and its `hosts` lock into a temporary directory of its own, so it
+touches neither the runner's `/etc/hosts` nor anything another job holds.
+None of what it asserts is visible to the E2E matrix: each runner gets one
+run on an empty host, so a derivation that started colliding or a sweep that
+began reaching past its own runs would leave every arm green.
 
 ### Leftover containers fail a run before it starts
 
@@ -812,6 +817,7 @@ Or run individual scripts:
 | `./scripts/validate-compose-instance-names.sh` | `ci.yml` Validate Compose Instance Names |
 | `./scripts/validate-e2e-openssl-compat.sh` | `ci.yml` Validate E2E OpenSSL Compatibility |
 | `./scripts/validate-e2e-leftover-check.sh` | `ci.yml` Validate E2E Leftover Check |
+| `./scripts/validate-e2e-run-scope.sh` | `ci.yml` Validate E2E Run Scope |
 | `./scripts/preflight/ci/deploy-no-build-smoke.sh` | `ci.yml` Deploy Compose No-Build Smoke |
 | `./scripts/preflight/ci/test-core.sh` | `ci.yml` Unit & CLI Smoke |
 | `./scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` Docker E2E Matrix |
@@ -825,7 +831,6 @@ Local-only extras (not in any CI workflow):
 
 | Script | Description |
 | --- | --- |
-| `./scripts/validate-e2e-run-scope.sh` | Run-scope derivation, markers, sweep, `hosts` lock |
 | `./scripts/preflight/extra/agent-scenarios.sh` | Agent scenario tests |
 | `./scripts/preflight/extra/cli-scenarios.sh` | CLI scenario tests |
 

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -274,8 +274,13 @@ pid가 살아 있는 것은 건너뛰고, 죽은 것은 그 인스턴스의 컨�
 그것을 잘라 버리게 되는 경로이기 때문입니다.
 
 `scripts/validate-e2e-run-scope.sh`가 Docker 없이 이름 생성, 마커, 수거,
-`hosts` 잠금을 모두 확인합니다. 이 스크립트는 로컬 검사이며,
-`scripts/preflight/run-all.sh`가 실행하고 CI 워크플로에서는 실행되지 않습니다.
+`hosts` 잠금을 모두 확인하며, CI의 `check` 잡에서 실행됩니다. 그 잡이 이미
+갖춘 것 외에는 아무것도 필요하지 않고, 마커 디렉터리와 `hosts` 잠금을 자신이
+만든 임시 디렉터리로 돌려놓으므로 러너의 `/etc/hosts`도 다른 잡이 쥔 것도
+건드리지 않습니다. 이 스크립트가 확인하는 내용은 E2E 매트릭스에서는 보이지
+않습니다. 러너마다 빈 호스트에서 한 번씩만 실행하므로, 이름 생성이 충돌하기
+시작하거나 수거가 자기 실행 너머까지 손을 뻗기 시작해도 모든 갈래가 초록으로
+남습니다.
 
 ### 남은 컨테이너는 실행이 시작되기 전에 실패시킵니다
 
@@ -795,6 +800,7 @@ CI 워크플로 동등 스크립트(`scripts/preflight/ci/`):
 | `scripts/validate-compose-instance-names.sh` | `ci.yml` → Validate Compose Instance Names |
 | `scripts/validate-e2e-openssl-compat.sh` | `ci.yml` → Validate E2E OpenSSL Compatibility |
 | `scripts/validate-e2e-leftover-check.sh` | `ci.yml` → Validate E2E Leftover Check |
+| `scripts/validate-e2e-run-scope.sh` | `ci.yml` → Validate E2E Run Scope |
 | `scripts/preflight/ci/deploy-no-build-smoke.sh` | `ci.yml` → Deploy Compose No-Build Smoke |
 | `scripts/preflight/ci/test-core.sh` | `ci.yml` → test-core |
 | `scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` → test-docker-e2e-matrix |
@@ -808,7 +814,6 @@ CI 워크플로 동등 스크립트(`scripts/preflight/ci/`):
 
 | 스크립트 | 설명 |
 | --- | --- |
-| `scripts/validate-e2e-run-scope.sh` | 실행 범위 이름 생성, 마커, 수거, `hosts` 잠금 |
 | `scripts/preflight/extra/agent-scenarios.sh` | 에이전트 시나리오 |
 | `scripts/preflight/extra/cli-scenarios.sh` | CLI 시나리오 |
 


### PR DESCRIPTION
Adds `Validate E2E Run Scope` to the `check` job, after `Validate E2E Leftover Check` and before `Install cargo-audit`, and corrects the two documentation places that said the validator runs in no CI workflow.

`scripts/validate-e2e-run-scope.sh` was the per-run E2E identity's only guard, and nothing but `scripts/preflight/run-all.sh` invoked it — a control that depends on remembering. None of what it asserts is observable from the E2E matrix: each runner gets one run on an empty host, so a derivation that started colliding, a marker that stopped being written, or a sweep that began reaching past the runs it recorded would all leave every arm green.

The step adds no toolchain setup, no service and no cache. The validator redirects its marker directory and its hosts lock into its own `mktemp -d`, and stubs `docker` on `PATH`, so it cannot touch the runner's `/etc/hosts` or anything another job holds.

## Documentation

`docs/en/e2e-ci.md` and `docs/ko/e2e-ci.md` both stated the validator "is a local check ... not run by any CI workflow", and listed it under local-only extras. Those sentences are now false, so each was rewritten to say where it runs and what it needs, and the entry moved from the local-only table into the CI-equivalent one.

No `CHANGELOG.md` entry: CI and test-harness only, so a user of the last release cannot observe it. No Rust code changed and no E2E code path is touched, so the Docker preflight scripts were not run locally — CI's matrix covers them.

## Test plan

- [x] `./scripts/validate-e2e-run-scope.sh` exits 0 on this tree, reporting 45 `ok:` lines, in 3.2s measured on a non-root host — and the same on a detached worktree of `origin/main` (exit 0, 45 `ok:`, 3.4s), which is the clean checkout the issue asks about.
- [x] A break in the guarded behaviour turns the step red, checked on two separate guards and reverted after each, leaving `git status` clean.
    - Hosts lock default in `scripts/impl/lib/run-scope.sh` changed from `/etc/hosts` to a path of the harness's own: exit 1, `FAIL: the default hosts lock is '/tmp/broken-lock' rather than /etc/hosts; a lock at a path of the harness's own can be swapped for another inode between the check and the open, and one under $TMPDIR is not even machine-wide`.
    - Pid-liveness filter dropped from `hosts_lock_label` (`run_pid_is_alive "$pid" || return 0` removed): exit 1, `FAIL: the refusal named a dead run's label as the holder: ... (pid 4194305, a run that was killed)`.
- [x] The `check` job's step order is `... Validate E2E Leftover Check`, `Validate E2E Run Scope`, `Install cargo-audit`, `Run Security Audit`, and the step declares only `run:` — no toolchain setup, service or cache.
- [x] The four validators already in `check` are unchanged, and no job is added or reordered — the workflow diff is three added lines.
- [x] `./scripts/check-docs.sh` passes (`mkdocs build --strict` plus the theme assertions); `markdownlint-cli2` reports 0 issues and `biome ci --error-on-warnings .` is clean.
- [x] No `CHANGELOG.md` entry.
- [x] Full CI passes on this pull request — all 18 checks green. The new step took **2s** on the runner (`Validate E2E Run Scope`, 23:19:01 -> 23:19:03), less than the `Validate E2E Leftover Check` step above it.
- [x] The step runs and passes on a docs-only push. No single run can show this from here — the branch changes `.github/workflows/**`, which the change filter counts as code — so it was checked against two real runs instead of argued from the workflow alone. That the `check` job runs in full on a docs-only push is observed on [run 30968767229](https://github.com/aicers/bootroot/actions/runs/30968767229) (PR #791, which touched only two files under `docs/`): `Change Filter` resolved `docs_only=true`, `Unit & CLI Smoke` and every E2E matrix arm skipped, and `Quality Check` still ran to success with each of its validator steps green. That the new step passes inside that job is observed on this pull request's own run. The step cannot distinguish the two cases: it declares no `if:`, and it reads `scripts/impl/lib/run-scope.sh` and `src/commands/compose_project.rs` out of the full checkout rather than anything about the diff.

Closes #857

