### PR TITLE
Make the symlink decision a property of the destination (#847)

### DIFF
--- a/src/bin/bootroot-remote/agent_config.rs
+++ b/src/bin/bootroot-remote/agent_config.rs
@@ -209,20 +209,17 @@ pub(super) async fn apply_agent_config_updates(
         // against a stale responder HMAC or trust anchor with no signal
         // that a re-sync is needed.
         //
-        // A symlink at the destination is resolved first and the target
-        // is published, unlike the control plane's writers of the same
-        // file name. The rule there is that `service::local_config`
-        // creates `agent.toml` by rename, so a link at the path never
-        // survives the command that creates it and the later editors
-        // have nothing to preserve. On a bootstrap target this writer is
-        // the one that creates the file, and the write it replaces
-        // opened with `O_TRUNC`, which follows a final link — so an
-        // operator who pointed the destination at a config they keep
-        // elsewhere has a working installation today, and a bare rename
-        // would destroy the link, leave its target holding the previous
-        // profile, and report the item applied.
-        if let Err(err) = fs_util::atomic_write_through_symlink(
-            &args.agent_config_path,
+        // The destination is operator-named, unlike the control plane's
+        // writers of the same file name. The rule there is that
+        // `service::local_config` creates `agent.toml` by rename, so a
+        // link at the path never survives the command that creates it
+        // and the later editors have nothing to preserve. On a bootstrap
+        // target this writer is the one that creates the file, and the
+        // write it replaces opened with `O_TRUNC`, which follows a final
+        // link — so an operator who pointed the destination at a config
+        // they keep elsewhere has a working installation today.
+        if let Err(err) = fs_util::atomic_write(
+            fs_util::Destination::operator_named(&args.agent_config_path),
             with_profile.as_bytes(),
             fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
         )

--- a/src/bin/bootroot-remote/io.rs
+++ b/src/bin/bootroot-remote/io.rs
@@ -114,7 +114,7 @@ pub(super) async fn write_secret_file(path: &Path, contents: &str) -> Result<App
     // entry means re-running `service add` on the control plane, not
     // repeating the write here.
     fs_util::atomic_write(
-        path,
+        fs_util::Destination::bootroot_owned(path),
         next.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/cert_group.rs
+++ b/src/cert_group.rs
@@ -417,11 +417,15 @@ pub async fn write_key_file(path: &Path, key_pem: &str, policy: CertGroupPolicy)
 /// the key writer has done since #593 and what the certificate and the
 /// bundle now do beside it — the point of the conversion was to remove
 /// the asymmetry between them, not to relocate it into how a link is
-/// treated. The configuration writers take
-/// [`fs_util::atomic_write_through_symlink`] instead, for destinations
+/// treated. That is [`fs_util::Destination::bootroot_owned`]'s answer,
+/// which these three would take were they not calling the publisher
+/// directly for their [`StagedOwner::PolicyGroup`] ownership; the
+/// configuration writers take
+/// [`fs_util::Destination::operator_named`] instead, for destinations
 /// no rename writer has ever owned.
 ///
-/// [`fs_util::atomic_write_through_symlink`]: crate::fs_util::atomic_write_through_symlink
+/// [`fs_util::Destination::bootroot_owned`]: crate::fs_util::Destination::bootroot_owned
+/// [`fs_util::Destination::operator_named`]: crate::fs_util::Destination::operator_named
 ///
 /// [`fs_util::publish_staged_blocking`]: crate::fs_util::publish_staged_blocking
 /// [`fs_util::atomic_write_blocking`]: crate::fs_util::atomic_write_blocking

--- a/src/commands/ca.rs
+++ b/src/commands/ca.rs
@@ -159,8 +159,8 @@ fn patch_ca_json_ctmpl(
 /// the previous document in place and costs the next render or a re-run
 /// of `bootroot ca update`, not an unrecoverable state.
 fn publish_ca_json(path: &Path, contents: &str, messages: &Messages) -> Result<()> {
-    fs_util::atomic_replace_through_symlink_blocking(
-        path,
+    fs_util::atomic_replace_blocking(
+        fs_util::Destination::operator_named(path),
         contents.as_bytes(),
         fs_util::StagedMode::PreserveOrUmask,
     )

--- a/src/commands/dotenv.rs
+++ b/src/commands/dotenv.rs
@@ -48,10 +48,10 @@ fn strip_quotes(value: &str) -> String {
 /// Writes a `.env` file from key-value pairs.
 ///
 /// Published by rename through
-/// [`fs_util::atomic_write_through_symlink_blocking`]. Two readers make
-/// a torn `.env` costly: `docker compose` interpolates it on every
-/// invocation, and bootroot itself reads it back to recover the instance
-/// name and the assigned host ports.
+/// [`fs_util::atomic_write_blocking`]. Two readers make a torn `.env`
+/// costly: `docker compose` interpolates it on every invocation, and
+/// bootroot itself reads it back to recover the instance name and the
+/// assigned host ports.
 ///
 /// It takes the directory flush for that second reader. The ports and
 /// the instance id here are the only record of which containers this
@@ -59,12 +59,11 @@ fn strip_quotes(value: &str) -> String {
 /// fresh ones and unable to find the stack it already started, which no
 /// re-run of `init` repairs.
 ///
-/// A symlinked `.env` is resolved before staging. Compose's own
-/// convention is to keep one `.env` beside the compose file, so pointing
-/// it at a shared file is a thing operators do, and the truncating write
-/// this replaced updated that shared file; a bare rename would replace
-/// the link and leave every other consumer of the target reading stale
-/// ports.
+/// The destination is [`fs_util::Destination::operator_named`]:
+/// compose's own convention is to keep one `.env` beside the compose
+/// file, so pointing it at a shared file is a thing operators do, and
+/// replacing the link would leave every other consumer of the target
+/// reading stale ports.
 pub(crate) fn write_dotenv(
     path: &Path,
     entries: &[(&str, &str)],
@@ -77,8 +76,12 @@ pub(crate) fn write_dotenv(
         content.push_str(value);
         content.push('\n');
     }
-    fs_util::atomic_write_through_symlink_blocking(path, content.as_bytes(), DOTENV_PUBLISH_MODE)
-        .with_context(|| messages.error_write_file_failed(&path.display().to_string()))?;
+    fs_util::atomic_write_blocking(
+        fs_util::Destination::operator_named(path),
+        content.as_bytes(),
+        DOTENV_PUBLISH_MODE,
+    )
+    .with_context(|| messages.error_write_file_failed(&path.display().to_string()))?;
     Ok(())
 }
 
@@ -165,8 +168,9 @@ pub(crate) fn load_dotenv_into_env(path: &Path, messages: &Messages) -> Result<(
 
 /// Updates a single key in an existing `.env` file, preserving other entries.
 ///
-/// Publishes by rename, through a symlinked `.env`, and flushes — the
-/// same three decisions as [`write_dotenv`], for the same two readers.
+/// Publishes by rename at an operator-named destination, and flushes —
+/// the same three decisions as [`write_dotenv`], for the same two
+/// readers.
 /// This is the hotter of the pair — a rotated `POSTGRES_PASSWORD` lands
 /// here while compose may be interpolating the file — so the torn read
 /// it closes is the one a running stack is most likely to hit.
@@ -204,8 +208,12 @@ pub(crate) fn update_dotenv_key(
         output.push_str(new_value);
         output.push('\n');
     }
-    fs_util::atomic_write_through_symlink_blocking(path, output.as_bytes(), DOTENV_PUBLISH_MODE)
-        .with_context(|| messages.error_write_file_failed(&path.display().to_string()))?;
+    fs_util::atomic_write_blocking(
+        fs_util::Destination::operator_named(path),
+        output.as_bytes(),
+        DOTENV_PUBLISH_MODE,
+    )
+    .with_context(|| messages.error_write_file_failed(&path.display().to_string()))?;
     Ok(())
 }
 

--- a/src/commands/guardrails.rs
+++ b/src/commands/guardrails.rs
@@ -357,8 +357,8 @@ pub(crate) fn reject_http01_admin_advertise_addr_for_specific_bind(
 /// override alone and gives a fresh one what the umask would have given
 /// the truncating write this replaced.
 fn publish_compose_override(path: &Path, content: &str, messages: &Messages) -> Result<()> {
-    fs_util::atomic_replace_through_symlink_blocking(
-        path,
+    fs_util::atomic_replace_blocking(
+        fs_util::Destination::operator_named(path),
         content.as_bytes(),
         fs_util::StagedMode::PreserveOrUmask,
     )

--- a/src/commands/init/steps.rs
+++ b/src/commands/init/steps.rs
@@ -421,8 +421,8 @@ fn rollback_openbao_agent_invocation(
 /// umask exactly as the truncating write this replaced did.
 fn rollback_file(file: &RollbackFile, messages: &Messages) -> Result<()> {
     if let Some(contents) = &file.original {
-        fs_util::atomic_replace_through_symlink_blocking(
-            &file.path,
+        fs_util::atomic_replace_blocking(
+            fs_util::Destination::operator_named(&file.path),
             contents.as_bytes(),
             fs_util::StagedMode::PreserveOrUmask,
         )

--- a/src/commands/init/steps/http01_admin_tls.rs
+++ b/src/commands/init/steps/http01_admin_tls.rs
@@ -264,8 +264,8 @@ pub(crate) fn strip_responder_tls_config(secrets_dir: &Path, messages: &Messages
             } else {
                 filtered
             };
-            fs_util::atomic_replace_through_symlink_blocking(
-                path,
+            fs_util::atomic_replace_blocking(
+                fs_util::Destination::operator_named(path),
                 to_write.as_bytes(),
                 fs_util::StagedMode::PreserveOrCreate(fs_util::KEY_FILE_MODE),
             )

--- a/src/commands/init/steps/openbao_setup.rs
+++ b/src/commands/init/steps/openbao_setup.rs
@@ -794,8 +794,8 @@ async fn write_openbao_agent_files(
     // so a torn read is a container that will not come up, but the file
     // is regenerated in full from `state.json` and the template paths on
     // the next `init`.
-    fs_util::atomic_replace_through_symlink(
-        &stepca_agent_config,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&stepca_agent_config),
         stepca_config.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -803,8 +803,8 @@ async fn write_openbao_agent_files(
     .with_context(|| {
         messages.error_write_file_failed(&stepca_agent_config.display().to_string())
     })?;
-    fs_util::atomic_replace_through_symlink(
-        &responder_agent_config,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&responder_agent_config),
         responder_config.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -909,8 +909,8 @@ services:
     // Published by rename, not flushed, at the destination's mode or
     // the umask's answer on a create — the compose-override decisions
     // `crate::commands::guardrails` records.
-    fs_util::atomic_replace_through_symlink(
-        &override_path,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&override_path),
         contents.as_bytes(),
         fs_util::StagedMode::PreserveOrUmask,
     )
@@ -925,7 +925,7 @@ services:
 /// See the call site for why both decisions go this way.
 async fn write_agent_credential(path: &Path, value: &str, messages: &Messages) -> Result<()> {
     fs_util::atomic_write(
-        path,
+        fs_util::Destination::bootroot_owned(path),
         value.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/init/steps/openbao_tls.rs
+++ b/src/commands/init/steps/openbao_tls.rs
@@ -260,8 +260,8 @@ fn set_openbao_readable_permissions(cert_path: &Path, key_path: &Path) -> Result
 /// the process umask would have given the truncating write this
 /// replaced.
 fn publish_openbao_hcl(path: &Path, content: &str, messages: &Messages) -> Result<()> {
-    fs_util::atomic_replace_through_symlink_blocking(
-        path,
+    fs_util::atomic_replace_blocking(
+        fs_util::Destination::operator_named(path),
         content.as_bytes(),
         fs_util::StagedMode::PreserveOrUmask,
     )

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -301,11 +301,10 @@ async fn diagnose_partial_init(
 /// credentials that cannot be re-derived, so it is worth the disk round
 /// trip that makes the published name survive a power loss.
 ///
-/// A symlinked destination is resolved first
-/// ([`fs_util::resolve_symlink_destination`]), so the rename lands on
-/// the link's target the way the truncating write's `O_TRUNC` did.
-/// Renaming over the link instead would leave the operator without
-/// their link and the target holding the previous run's credentials.
+/// The destination is [`fs_util::Destination::operator_named`], and the
+/// link it may be is resolved by hand here rather than left to the
+/// publish: [`tighten_existing_secret_file`] has to narrow the file the
+/// rename will land on, which is the link's target and not the link.
 async fn write_init_summary_json(path: &Path, summary: &InitSummary) -> Result<()> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -317,8 +316,14 @@ async fn write_init_summary_json(path: &Path, summary: &InitSummary) -> Result<(
     tokio::task::spawn_blocking(move || -> Result<()> {
         let dest = fs_util::resolve_symlink_destination(&path_buf)?;
         tighten_existing_secret_file(&dest)?;
+        // `dest` is already the resolved target, so the constructor
+        // finds nothing left to follow. It is still the one that names
+        // this destination's side of the symlink axis. Handing it the
+        // unresolved path instead would resolve a second time, on its
+        // own, and the tighten above and the publish could then land on
+        // different files.
         fs_util::atomic_write_blocking(
-            &dest,
+            fs_util::Destination::operator_named(&dest),
             payload.as_bytes(),
             fs_util::StagedMode::Policy(SECRET_OUTPUT_FILE_MODE),
         )
@@ -376,10 +381,11 @@ fn tighten_existing_secret_file(path: &Path) -> Result<()> {
 /// means losing the only copy of a credential `reinit` will not mint
 /// again, which is worth a disk round trip on a once-per-init write.
 ///
-/// A symlinked destination is resolved first, as it is for the summary
-/// JSON — `validate_root_token_output_path` accepts a link to a regular
-/// file on purpose, so the token has to reach the file that preflight
-/// judged and not replace the link that named it.
+/// The destination is [`fs_util::Destination::operator_named`], resolved
+/// by hand as it is for the summary JSON —
+/// `validate_root_token_output_path` accepts a link to a regular file on
+/// purpose, so the token has to reach the file that preflight judged and
+/// not replace the link that named it.
 async fn write_root_token_file(path: &Path, token: &str) -> Result<()> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -391,8 +397,10 @@ async fn write_root_token_file(path: &Path, token: &str) -> Result<()> {
     tokio::task::spawn_blocking(move || -> Result<()> {
         let dest = fs_util::resolve_symlink_destination(&path_buf)?;
         tighten_existing_secret_file(&dest)?;
+        // Already resolved, for the reason `write_init_summary_json`
+        // records.
         fs_util::atomic_write_blocking(
-            &dest,
+            fs_util::Destination::operator_named(&dest),
             token.as_bytes(),
             fs_util::StagedMode::Policy(SECRET_OUTPUT_FILE_MODE),
         )
@@ -1350,8 +1358,8 @@ async fn maybe_rotate_env_db_password(
     if let Ok(mut doc) = serde_json::from_str::<serde_json::Value>(&ca_json_contents) {
         doc["db"]["dataSource"] = serde_json::Value::String(new_dsn.clone());
         if let Ok(updated) = serde_json::to_string_pretty(&doc) {
-            let _ = fs_util::atomic_replace_through_symlink(
-                &ca_json_path,
+            let _ = fs_util::atomic_replace(
+                fs_util::Destination::operator_named(&ca_json_path),
                 updated.as_bytes(),
                 fs_util::StagedMode::PreserveOrUmask,
             )

--- a/src/commands/init/steps/responder_setup.rs
+++ b/src/commands/init/steps/responder_setup.rs
@@ -49,8 +49,8 @@ pub(super) async fn write_responder_files(
     // directory entry costs that re-run.
     let template_path = templates_dir.join(RESPONDER_TEMPLATE_NAME);
     let template = build_responder_template(kv_mount, tls_enabled);
-    fs_util::atomic_replace_through_symlink(
-        &template_path,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&template_path),
         template.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -59,8 +59,8 @@ pub(super) async fn write_responder_files(
 
     let config_path = responder_dir.join(RESPONDER_CONFIG_NAME);
     let config = build_responder_config(hmac, tls_enabled);
-    fs_util::atomic_replace_through_symlink(
-        &config_path,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&config_path),
         config.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -181,8 +181,8 @@ services:
     // the same reader: `docker compose` parses this file on every
     // invocation, and it is regenerated from `state.json` by the `init`
     // step that writes it.
-    fs_util::atomic_replace_through_symlink(
-        &override_path,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&override_path),
         contents.as_bytes(),
         fs_util::StagedMode::PreserveOrUmask,
     )

--- a/src/commands/init/steps/stepca_setup.rs
+++ b/src/commands/init/steps/stepca_setup.rs
@@ -63,8 +63,8 @@ pub(super) async fn write_stepca_templates(
     // container — but the templates are themselves regenerated in full
     // by this function on the next `init`, so losing a directory entry
     // to a crash costs that re-run and nothing more.
-    fs_util::atomic_replace_through_symlink(
-        &password_template_path,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&password_template_path),
         password_template.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -86,8 +86,8 @@ pub(super) async fn write_stepca_templates(
         messages,
     )?;
     let ca_json_template_path = templates_dir.join(STEPCA_CA_JSON_TEMPLATE_NAME);
-    fs_util::atomic_replace_through_symlink(
-        &ca_json_template_path,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(&ca_json_template_path),
         ca_json_template.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -122,8 +122,8 @@ pub(super) async fn write_stepca_templates(
 /// reads it before writing, so the mode is always the destination's own
 /// and [`fs_util::StagedMode::PreserveOrUmask`]'s create arm never runs.
 async fn publish_ca_json(path: &Path, contents: &str, messages: &Messages) -> Result<()> {
-    fs_util::atomic_replace_through_symlink(
-        path,
+    fs_util::atomic_replace(
+        fs_util::Destination::operator_named(path),
         contents.as_bytes(),
         fs_util::StagedMode::PreserveOrUmask,
     )
@@ -426,7 +426,7 @@ pub(super) async fn write_password_file_with_backup(
     // directory entry after step-ca has been handed it leaves keys
     // nobody can open, which no re-run of `init` reconstructs.
     fs_util::atomic_write(
-        &password_path,
+        fs_util::Destination::bootroot_owned(&password_path),
         password.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/openbao_unseal.rs
+++ b/src/commands/openbao_unseal.rs
@@ -25,10 +25,8 @@ pub(crate) async fn save_unseal_keys(
     fs_util::ensure_secrets_dir(&dir).await?;
     let path = dir.join(UNSEAL_KEYS_FILENAME);
     let contents = keys.join("\n") + "\n";
-    // This bootroot-owned secrets-tree path publishes at its given name,
-    // replacing a final symlink rather than redirecting the key bytes.
     fs_util::atomic_write(
-        &path,
+        fs_util::Destination::bootroot_owned(&path),
         contents.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/rotate/approle.rs
+++ b/src/commands/rotate/approle.rs
@@ -521,7 +521,7 @@ async fn ensure_infra_role_id_file(
     // cannot log in. The early return above means this writes only on a
     // backfill, so the round trip is not on any repeated path.
     fs_util::atomic_write(
-        &role_id_path,
+        fs_util::Destination::bootroot_owned(&role_id_path),
         role_id.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -725,7 +725,7 @@ async fn ensure_role_id_file(
         // `role_id_path.exists()` means this only ever creates.
         fs_util::ensure_secrets_dir(service_dir).await?;
         fs_util::atomic_write(
-            &role_id_path,
+            fs_util::Destination::bootroot_owned(&role_id_path),
             role_id.as_bytes(),
             fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
         )

--- a/src/commands/rotate/helpers.rs
+++ b/src/commands/rotate/helpers.rs
@@ -69,7 +69,7 @@ pub(super) async fn write_secret_file(
         fs_util::ensure_secrets_dir(parent).await?;
     }
     fs_util::atomic_write(
-        path,
+        fs_util::Destination::bootroot_owned(path),
         contents.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -101,7 +101,7 @@ pub(super) async fn write_secret_id_atomic(
     }
     fs_util::ensure_secrets_dir(parent).await?;
     fs_util::atomic_write(
-        path,
+        fs_util::Destination::bootroot_owned(path),
         value.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/rotate/openbao_recovery.rs
+++ b/src/commands/rotate/openbao_recovery.rs
@@ -229,13 +229,12 @@ async fn write_openbao_recovery_output(
     // the time this runs; a crash that loses the directory entry is not
     // a rewrite, it is an unrecoverable barrier.
     //
-    // A symlinked destination is resolved first, as `init`'s two output
-    // files resolve theirs: `--output` names a path the operator chose,
-    // the truncating write this replaced delivered through a link there,
-    // and renaming over the link would leave the keys in a directory
-    // nobody picked while the target kept the superseded ones.
-    fs_util::atomic_write_through_symlink(
-        path,
+    // The destination is operator-named, as `init`'s two output files
+    // are: `--output` names a path the operator chose, and renaming over
+    // a link there would leave the keys in a directory nobody picked
+    // while the target kept the superseded ones.
+    fs_util::atomic_write(
+        fs_util::Destination::operator_named(path),
         payload.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1145,16 +1145,14 @@ fn rerender_local_managed_profile(entry: &ServiceEntry) -> Result<()> {
     // agent goes on reading the previous file and renewing against the
     // old `cert_group_gid`.
     //
-    // The rename lands on this path, not through a symlink at it —
-    // `atomic_write_blocking`, not the `_through_symlink` spelling the
-    // configuration writers take. `service::local_config` has published
-    // `agent.toml` by rename since #613, so a link an operator puts here
-    // is already replaced by the `service add` that creates the file;
-    // resolving it in the writer that only *edits* the file would make
-    // the two disagree about the same path rather than preserve anything
-    // that survives a `service add`.
+    // `service::local_config` has published `agent.toml` by rename since
+    // #613, so a link an operator puts here is already replaced by the
+    // `service add` that creates the file; resolving it in the writer
+    // that only *edits* the file would make the two disagree about the
+    // same path rather than preserve anything that survives a
+    // `service add`.
     fs_util::atomic_write_blocking(
-        agent_config_path,
+        fs_util::Destination::bootroot_owned(agent_config_path),
         next.as_bytes(),
         fs_util::StagedMode::PreserveOrCreate(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/service/approle.rs
+++ b/src/commands/service/approle.rs
@@ -163,7 +163,7 @@ async fn write_service_credential_file(
         let parent = path.parent().unwrap_or(Path::new("."));
         fs_util::ensure_secrets_dir(parent).await?;
         fs_util::atomic_write(
-            path,
+            fs_util::Destination::bootroot_owned(path),
             contents.as_bytes(),
             fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
         )

--- a/src/commands/service/local_config.rs
+++ b/src/commands/service/local_config.rs
@@ -166,7 +166,7 @@ pub(super) async fn apply_local_service_configs(
     // config" and exhausting the retry budget against a transient
     // partial file.
     fs_util::atomic_write(
-        &resolved.agent_config,
+        fs_util::Destination::bootroot_owned(&resolved.agent_config),
         next.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/service/remote_bootstrap.rs
+++ b/src/commands/service/remote_bootstrap.rs
@@ -280,7 +280,7 @@ async fn write_remote_bootstrap_artifact_file(
     // either, so `service add --remote` has to be re-run against a
     // freshly issued one.
     fs_util::atomic_write(
-        &artifact_path,
+        fs_util::Destination::bootroot_owned(&artifact_path),
         payload.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -441,11 +441,11 @@ fn strip_managed_profile(path: &Path, service_name: &str) -> Result<bool> {
     // and the agent may be re-reading it as this runs. It takes the
     // directory flush — losing the strip leaves the agent renewing a
     // profile the operator removed, and nothing rewrites the file again
-    // on its own. A symlink at the path is not resolved either, for the
-    // reason recorded there: `agent.toml`'s creating writer has renamed
-    // over the name since #613.
+    // on its own. The destination is bootroot-owned for the reason
+    // recorded there: `agent.toml`'s creating writer has renamed over
+    // the name since #613.
     fs_util::atomic_write_blocking(
-        path,
+        fs_util::Destination::bootroot_owned(path),
         next.as_bytes(),
         fs_util::StagedMode::PreserveOrCreate(fs_util::KEY_FILE_MODE),
     )

--- a/src/commands/trust.rs
+++ b/src/commands/trust.rs
@@ -164,7 +164,7 @@ pub(crate) async fn update_rotation_state_async(
 /// rename and the directory flush all live in `atomic_write_blocking`.
 fn update_rotation_state_file(path: &Path, json: &str, write_failed: &str) -> Result<()> {
     fs_util::atomic_write_blocking(
-        path,
+        fs_util::Destination::bootroot_owned(path),
         json.as_bytes(),
         fs_util::StagedMode::Policy(ROTATION_STATE_MODE),
     )

--- a/src/eab.rs
+++ b/src/eab.rs
@@ -117,11 +117,13 @@ async fn write_key_file(path: &Path, contents: &str) -> anyhow::Result<bool> {
         // Republishing replaces the link instead of repairing its target's
         // mode, even when the target already holds identical bytes.
     }
-    // This credential publishes at its given name, replacing a final symlink
-    // rather than redirecting the credential bytes.
-    fs_util::atomic_write(path, next.as_bytes(), StagedMode::Policy(KEY_FILE_MODE))
-        .await
-        .with_context(|| format!("Failed to write EAB file: {}", path.display()))?;
+    fs_util::atomic_write(
+        fs_util::Destination::bootroot_owned(path),
+        next.as_bytes(),
+        StagedMode::Policy(KEY_FILE_MODE),
+    )
+    .await
+    .with_context(|| format!("Failed to write EAB file: {}", path.display()))?;
     Ok(true)
 }
 

--- a/src/fast_poll.rs
+++ b/src/fast_poll.rs
@@ -212,7 +212,7 @@ impl FastPollState {
         let body =
             serde_json::to_string_pretty(self).context("Failed to serialize fast-poll state")?;
         fs_util::atomic_write(
-            path,
+            fs_util::Destination::bootroot_owned(path),
             body.as_bytes(),
             fs_util::StagedMode::Policy(STATE_FILE_MODE),
         )
@@ -1195,7 +1195,7 @@ async fn apply_trust_to_disk(
     let updated = toml_util::upsert_section_keys(&current, "trust", &trust_updates)
         .context("Failed to upsert [trust] section into agent config")?;
     fs_util::atomic_write(
-        config_path,
+        fs_util::Destination::bootroot_owned(config_path),
         updated.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -1220,7 +1220,7 @@ async fn apply_responder_hmac_to_disk(config_path: &Path, hmac: &str) -> Result<
     let updated = toml_util::upsert_section_keys(&current, ACME_SECTION, &hmac_updates)
         .context("Failed to upsert [acme] responder HMAC into agent config")?;
     fs_util::atomic_write(
-        config_path,
+        fs_util::Destination::bootroot_owned(config_path),
         updated.as_bytes(),
         fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
     )
@@ -1330,7 +1330,7 @@ where
         let body = format!("{secret_id}\n");
         Box::pin(async move {
             fs_util::atomic_write(
-                &secret_id_path,
+                fs_util::Destination::bootroot_owned(&secret_id_path),
                 body.as_bytes(),
                 fs_util::StagedMode::Policy(fs_util::KEY_FILE_MODE),
             )

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -487,12 +487,12 @@ enum SymlinkPolicy {
 }
 
 impl<'a> Destination<'a> {
-    /// A destination the operator named: a path from a CLI flag or a
-    /// config value, or a file bootroot renders into its own tree that
-    /// an operator may have pointed elsewhere. A symlink at the final
-    /// path component is resolved and the bytes are delivered to its
-    /// target, leaving the link standing — what the truncating write
-    /// these publishes replaced used to do.
+    /// Creates a destination the operator named: a path from a CLI flag
+    /// or a config value, or a file bootroot renders into its own tree
+    /// that an operator may have pointed elsewhere. A symlink at the
+    /// final path component is resolved and the bytes are delivered to
+    /// its target, leaving the link standing — what the truncating
+    /// write these publishes replaced used to do.
     ///
     /// This is what the configuration bootroot generates takes (`.env`,
     /// `ca.json` and its template, `openbao.hcl`, the compose overrides,
@@ -515,10 +515,10 @@ impl<'a> Destination<'a> {
         }
     }
 
-    /// A destination bootroot derived from a layout it owns: the
-    /// secrets tree, or a path it hands a reader itself. The publish
-    /// renames over the name, so a symlink found there is replaced by
-    /// the published file.
+    /// Creates a destination bootroot derived from a layout it owns:
+    /// the secrets tree, or a path it hands a reader itself. The
+    /// publish renames over the name, so a symlink found there is
+    /// replaced by the published file.
     ///
     /// Two classes take it:
     ///

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io::Write as _;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Component, Path, PathBuf};
@@ -61,19 +62,18 @@ fn parent_dir(path: &Path) -> PathBuf {
 ///
 /// A truncating write opens the path with `O_TRUNC`, which follows the
 /// final symlink, so a destination pointed at a link has always
-/// delivered its bytes to the link's target. [`atomic_write`] and
-/// [`atomic_write_blocking`] `rename` over the name they are given
-/// instead, which replaces the link itself: the operator's link is
-/// gone and the target is left holding whatever was written last.
+/// delivered its bytes to the link's target. A staged publish `rename`s
+/// over the name it is given instead, which replaces the link itself:
+/// the operator's link is gone and the target is left holding whatever
+/// was written last.
 ///
-/// Writers reach this through
-/// [`atomic_write_through_symlink`]/[`atomic_replace_through_symlink`]
-/// and their blocking halves, which document what takes that spelling
-/// and what deliberately keeps the bare rename. It is called directly
-/// only where the resolved path itself is needed — `bootroot reinit`'s
-/// two output preflights, which judge the target's mode before the
-/// destructive step, and the two writers behind them, which narrow that
-/// same target before writing a credential over it.
+/// Writers reach this through [`Destination::operator_named`], which
+/// documents which destinations resolve a link and which publish at the
+/// name. It is called directly only where the resolved path itself is
+/// needed — `bootroot reinit`'s two output preflights, which judge the
+/// target's mode before the destructive step, and the two writers behind
+/// them, which narrow that same target before writing a credential over
+/// it.
 ///
 /// Not a security check. It follows whatever the link points at, so a
 /// caller whose destination an untrusted user can plant must reject
@@ -439,7 +439,135 @@ async fn write_owned_impl(path: &Path, contents: &[u8], mode: u32, publish: Publ
     .context("Owned credential write task panicked")?
 }
 
-/// Writes `contents` to `path` atomically by staging it in a sibling
+/// A path a staged publish is aimed at, together with where that path
+/// came from — which is what decides whether a symlink at its final
+/// component is followed or replaced.
+///
+/// A truncating write opened the destination with `O_TRUNC`, which
+/// follows a link at the final component and delivers the bytes to its
+/// target. A staged publish renames over the name it is given instead,
+/// which replaces the link: the operator's arrangement is gone, and
+/// whatever it pointed at is left holding the previous contents while
+/// the write reports success. Both answers are wanted in this crate, and
+/// which one a file wants is not a property of the writer that happens
+/// to be publishing it. It is a property of where the path came from, so
+/// it is stated once, here, by the constructor that names that origin:
+///
+/// - [`Destination::operator_named`] — a path from a CLI flag, a config
+///   value, or a file the operator arranges in bootroot's tree. Resolves
+///   a final symlink and publishes at the target.
+/// - [`Destination::bootroot_owned`] — a path bootroot derived from the
+///   secrets tree or another layout it controls. Publishes at the name.
+///
+/// There is a third answer, and this type deliberately does not express
+/// it. The override credential writers —
+/// [`create_owned_credential_noclobber`], [`write_owned_file_replace`]
+/// and [`atomic_rewrite_owned_no_symlink`] — publish a service's
+/// `role_id`, `secret_id` and `eab.json` into an operator-provisioned,
+/// agent-owned directory, and refuse a link at the destination outright
+/// rather than resolving it or renaming over it, because the
+/// lower-privileged user who owns that directory can plant one. They
+/// stage independently and take their ownership from the parent
+/// directory, and folding them behind a constructor here would make one
+/// of the two callers wrong.
+#[derive(Clone, Copy)]
+pub struct Destination<'a> {
+    path: &'a Path,
+    symlink: SymlinkPolicy,
+}
+
+/// What a staged publish does about a symlink at the destination's final
+/// path component — [`Destination`]'s decision, spelled out.
+#[derive(Clone, Copy)]
+enum SymlinkPolicy {
+    /// Resolve the link and publish at its target, as `O_TRUNC` did.
+    Resolve,
+    /// Publish at the name, replacing a link found there.
+    PublishAtName,
+}
+
+impl<'a> Destination<'a> {
+    /// A destination the operator named: a path from a CLI flag or a
+    /// config value, or a file bootroot renders into its own tree that
+    /// an operator may have pointed elsewhere. A symlink at the final
+    /// path component is resolved and the bytes are delivered to its
+    /// target, leaving the link standing — what the truncating write
+    /// these publishes replaced used to do.
+    ///
+    /// This is what the configuration bootroot generates takes (`.env`,
+    /// `ca.json` and its template, `openbao.hcl`, the compose overrides,
+    /// the responder and `OpenBao` Agent configs, `state.json`), along
+    /// with the output paths named on the command line (`init`'s two,
+    /// `rotate openbao-recovery --output`, and `bootroot-remote
+    /// bootstrap`'s `agent.toml` destination — that command is what
+    /// creates the file on a target host, so a link there is one the
+    /// operator put in place and the truncating write followed).
+    ///
+    /// Not a security check: the link is followed wherever it points,
+    /// so a destination an untrusted user can plant is not this
+    /// constructor's case (see [`resolve_symlink_destination`], and
+    /// [`atomic_rewrite_owned_no_symlink`], which refuses one instead).
+    #[must_use]
+    pub fn operator_named(path: &'a Path) -> Self {
+        Self {
+            path,
+            symlink: SymlinkPolicy::Resolve,
+        }
+    }
+
+    /// A destination bootroot derived from a layout it owns: the
+    /// secrets tree, or a path it hands a reader itself. The publish
+    /// renames over the name, so a symlink found there is replaced by
+    /// the published file.
+    ///
+    /// Two classes take it:
+    ///
+    /// - **Credentials at a path bootroot chose**, inside the secrets
+    ///   tree. A link there is a redirection vector rather than an
+    ///   operator convenience, and the reader reads the path bootroot
+    ///   handed it — which the rename leaves holding the current secret
+    ///   — so following one buys nothing and costs the guarantee.
+    /// - **Files another writer already publishes by rename**, namely
+    ///   the control node's `agent.toml` (since #613) and the issued
+    ///   cert and key (since #593). A link at those paths does not
+    ///   survive the writer that creates the file, so resolving it in
+    ///   the writers that *edit* the file would make the two disagree
+    ///   rather than preserve anything.
+    ///
+    /// The replacement is decided, not silent: `publish_staged_blocking`
+    /// names the link and its former target at `warn` once the rename
+    /// has actually replaced it.
+    #[must_use]
+    pub fn bootroot_owned(path: &'a Path) -> Self {
+        Self {
+            path,
+            symlink: SymlinkPolicy::PublishAtName,
+        }
+    }
+
+    /// The path and the policy, with the path owned so both can cross
+    /// into a `spawn_blocking` closure and be re-borrowed as a
+    /// [`Destination`] on the other side. The one copy either half of an
+    /// async publish makes of the destination.
+    fn to_owned_parts(self) -> (PathBuf, SymlinkPolicy) {
+        (self.path.to_path_buf(), self.symlink)
+    }
+
+    /// The path the staged temporary is renamed onto: the destination's
+    /// own name, or — under [`SymlinkPolicy::Resolve`] — the file a
+    /// symlink there points at.
+    ///
+    /// Borrowed on the publish-at-name side, so the answer costs an
+    /// allocation only where a link actually has to be resolved.
+    fn publish_path(self) -> Result<Cow<'a, Path>> {
+        match self.symlink {
+            SymlinkPolicy::PublishAtName => Ok(Cow::Borrowed(self.path)),
+            SymlinkPolicy::Resolve => Ok(Cow::Owned(resolve_symlink_destination(self.path)?)),
+        }
+    }
+}
+
+/// Writes `contents` to `dest` atomically by staging it in a sibling
 /// temp file and `rename(2)`ing into place.
 ///
 /// `bootroot-agent`'s daemon loop re-reads `agent.toml` on every ACME
@@ -454,12 +582,16 @@ async fn write_owned_impl(path: &Path, contents: &[u8], mode: u32, publish: Publ
 ///
 /// The mode [`StagedMode`] resolves to is on the staged file before the
 /// rename so the on-disk mode never changes after the file appears at
-/// `path`. When `path` already exists, the existing uid/gid is also
-/// re-applied to the staged file before the rename so the caller does
-/// not silently re-own the destination to the writer's effective
-/// uid/gid (e.g. a `service add` run by root replacing an
+/// the destination. When the destination already exists, the existing
+/// uid/gid is also re-applied to the staged file before the rename so
+/// the caller does not silently re-own the destination to the writer's
+/// effective uid/gid (e.g. a `service add` run by root replacing an
 /// agent-readable file with a root-owned `0600` file the long-running
 /// agent process can no longer read).
+///
+/// Whether a symlink at the destination is resolved or replaced is
+/// [`Destination`]'s decision, taken by the constructor the caller
+/// names, not this function's.
 ///
 /// The containing directory is flushed after the rename
 /// ([`sync_parent_dir`]). This is the shared path for
@@ -470,15 +602,26 @@ async fn write_owned_impl(path: &Path, contents: &[u8], mode: u32, publish: Publ
 /// # Errors
 /// Returns an error if the temp file cannot be created, written,
 /// permissioned, chowned (when ownership preservation is needed),
-/// renamed, or if the containing directory cannot be flushed.
-pub async fn atomic_write(path: &Path, contents: &[u8], mode: StagedMode) -> Result<()> {
+/// renamed, if the containing directory cannot be flushed, or if an
+/// [`Destination::operator_named`] destination's symlink chain cannot be
+/// resolved (a cycle, or an unreadable link).
+pub async fn atomic_write(dest: Destination<'_>, contents: &[u8], mode: StagedMode) -> Result<()> {
     // Owned once, to move into the blocking task. The blocking half
     // borrows, so this is the only copy either path makes.
-    let dest = path.to_path_buf();
+    let (path, symlink) = dest.to_owned_parts();
     let payload = contents.to_vec();
-    tokio::task::spawn_blocking(move || atomic_write_blocking(&dest, &payload, mode))
-        .await
-        .context("Atomic write task panicked")?
+    tokio::task::spawn_blocking(move || {
+        atomic_write_blocking(
+            Destination {
+                path: &path,
+                symlink,
+            },
+            &payload,
+            mode,
+        )
+    })
+    .await
+    .context("Atomic write task panicked")?
 }
 
 /// The blocking half of [`atomic_write`], for callers that are not async.
@@ -496,9 +639,13 @@ pub async fn atomic_write(path: &Path, contents: &[u8], mode: StagedMode) -> Res
 ///
 /// # Errors
 /// Returns an error under the same conditions as [`atomic_write`].
-pub fn atomic_write_blocking(path: &Path, contents: &[u8], mode: StagedMode) -> Result<()> {
+pub fn atomic_write_blocking(
+    dest: Destination<'_>,
+    contents: &[u8],
+    mode: StagedMode,
+) -> Result<()> {
     publish_staged_blocking(
-        path,
+        &dest.publish_path()?,
         contents,
         mode,
         StagedOwner::Destination,
@@ -506,7 +653,7 @@ pub fn atomic_write_blocking(path: &Path, contents: &[u8], mode: StagedMode) -> 
     )
 }
 
-/// Publishes `contents` at `path` by rename, **without** flushing the
+/// Publishes `contents` at `dest` by rename, **without** flushing the
 /// containing directory.
 ///
 /// [`atomic_write`]'s guarantee against a torn read, without its
@@ -525,14 +672,27 @@ pub fn atomic_write_blocking(path: &Path, contents: &[u8], mode: StagedMode) -> 
 /// # Errors
 /// Returns an error under the same conditions as [`atomic_write`],
 /// except that no directory flush is attempted.
-pub async fn atomic_replace(path: &Path, contents: &[u8], mode: StagedMode) -> Result<()> {
+pub async fn atomic_replace(
+    dest: Destination<'_>,
+    contents: &[u8],
+    mode: StagedMode,
+) -> Result<()> {
     // Owned once, to move into the blocking task, exactly as
     // `atomic_write` does.
-    let dest = path.to_path_buf();
+    let (path, symlink) = dest.to_owned_parts();
     let payload = contents.to_vec();
-    tokio::task::spawn_blocking(move || atomic_replace_blocking(&dest, &payload, mode))
-        .await
-        .context("Atomic replace task panicked")?
+    tokio::task::spawn_blocking(move || {
+        atomic_replace_blocking(
+            Destination {
+                path: &path,
+                symlink,
+            },
+            &payload,
+            mode,
+        )
+    })
+    .await
+    .context("Atomic replace task panicked")?
 }
 
 /// The blocking half of [`atomic_replace`], for callers that are not
@@ -544,123 +704,18 @@ pub async fn atomic_replace(path: &Path, contents: &[u8], mode: StagedMode) -> R
 ///
 /// # Errors
 /// Returns an error under the same conditions as [`atomic_replace`].
-pub fn atomic_replace_blocking(path: &Path, contents: &[u8], mode: StagedMode) -> Result<()> {
+pub fn atomic_replace_blocking(
+    dest: Destination<'_>,
+    contents: &[u8],
+    mode: StagedMode,
+) -> Result<()> {
     publish_staged_blocking(
-        path,
+        &dest.publish_path()?,
         contents,
         mode,
         StagedOwner::Destination,
         StagedDurability::RenameOnly,
     )
-}
-
-/// [`atomic_write`], resolving a symlink at the final path component
-/// first.
-///
-/// The truncating write this pair of functions replaces opened the
-/// destination with `O_TRUNC`, which follows that link and delivers the
-/// bytes to its target. A bare rename replaces the link instead: the
-/// operator's link is gone, and whatever it pointed at is left holding
-/// the previous contents while the write reports success. Resolving
-/// first keeps the file the operator arranged to be written the file
-/// that is written.
-///
-/// This is the spelling for a destination an operator arranges: the
-/// configuration bootroot renders into its own tree and an operator may
-/// have pointed elsewhere (`.env`, `ca.json` and its template,
-/// `openbao.hcl`, the compose overrides, the responder and `OpenBao`
-/// Agent configs, `state.json`), and the output paths they name on the
-/// command line (`init`'s two, `rotate openbao-recovery --output`,
-/// `bootroot-remote bootstrap`'s `agent.toml` destination — that
-/// command is what creates the file on a target host, so a link there
-/// is one the operator put in place and the truncating write followed).
-///
-/// Two classes deliberately keep [`atomic_write`]'s bare rename:
-///
-/// - **Credentials at a path bootroot chose**, inside the secrets tree.
-///   A link there is a redirection vector rather than an operator
-///   convenience, and the reader reads the path bootroot handed it —
-///   which the rename leaves holding the current secret — so following
-///   one buys nothing and costs the guarantee. The override credential
-///   paths, whose directory an unprivileged user owns, go further and
-///   refuse a link outright ([`atomic_rewrite_owned_no_symlink`]).
-/// - **Files another writer already publishes by rename**, namely the
-///   control node's `agent.toml` (since #613) and the issued cert and
-///   key (since #593). A link at those paths does not survive the
-///   writer that creates the file, so resolving it in the writers that
-///   *edit* the file would make the two disagree rather than preserve
-///   anything.
-///
-/// Not a security check: see [`resolve_symlink_destination`].
-///
-/// # Errors
-/// Returns an error under the same conditions as [`atomic_write`], or
-/// if the destination's symlink chain cannot be resolved (a cycle, or
-/// an unreadable link).
-pub async fn atomic_write_through_symlink(
-    path: &Path,
-    contents: &[u8],
-    mode: StagedMode,
-) -> Result<()> {
-    let dest = path.to_path_buf();
-    let payload = contents.to_vec();
-    tokio::task::spawn_blocking(move || {
-        atomic_write_through_symlink_blocking(&dest, &payload, mode)
-    })
-    .await
-    .context("Atomic write task panicked")?
-}
-
-/// The blocking half of [`atomic_write_through_symlink`], for callers
-/// that are not async.
-///
-/// # Errors
-/// Returns an error under the same conditions as
-/// [`atomic_write_through_symlink`].
-pub fn atomic_write_through_symlink_blocking(
-    path: &Path,
-    contents: &[u8],
-    mode: StagedMode,
-) -> Result<()> {
-    atomic_write_blocking(&resolve_symlink_destination(path)?, contents, mode)
-}
-
-/// [`atomic_replace`], resolving a symlink at the final path component
-/// first.
-///
-/// The same compatibility decision [`atomic_write_through_symlink`]
-/// documents — see there for which destinations take it and which keep
-/// the bare rename — without the directory flush.
-///
-/// # Errors
-/// Returns an error under the same conditions as [`atomic_replace`], or
-/// if the destination's symlink chain cannot be resolved.
-pub async fn atomic_replace_through_symlink(
-    path: &Path,
-    contents: &[u8],
-    mode: StagedMode,
-) -> Result<()> {
-    let dest = path.to_path_buf();
-    let payload = contents.to_vec();
-    tokio::task::spawn_blocking(move || {
-        atomic_replace_through_symlink_blocking(&dest, &payload, mode)
-    })
-    .await
-    .context("Atomic replace task panicked")?
-}
-
-/// The blocking half of [`atomic_replace_through_symlink`], for callers
-/// that are not async.
-///
-/// # Errors
-/// Returns an error under the same conditions as
-/// [`atomic_replace_through_symlink`].
-pub fn atomic_replace_through_symlink_blocking(
-    path: &Path,
-    contents: &[u8],
-    mode: StagedMode,
-) -> Result<()> {
-    atomic_replace_blocking(&resolve_symlink_destination(path)?, contents, mode)
 }
 
 /// Where the mode of the inode a staged publish renames into place
@@ -815,9 +870,9 @@ pub enum StagedDurability {
 /// so a publish that fails at the rename leaves the link standing and
 /// says nothing about having replaced it.
 ///
-/// The `_through_symlink` wrappers resolve the destination before they
-/// publish, so the path they hand the core is the link's target and
-/// never a link itself. They are exempt by construction rather than by
+/// [`Destination::operator_named`] resolves the destination before the
+/// publish, so the path its callers hand the core is the link's target
+/// and never a link itself. It is exempt by construction rather than by
 /// a flag.
 ///
 /// Reads the destination with `symlink_metadata`, which does not follow
@@ -881,9 +936,12 @@ fn chown_preserve_context(uid: u32, gid: u32, path: &Path) -> String {
 /// Callers reach it through one of the four wrappers rather than
 /// directly: [`atomic_write`]/[`atomic_write_blocking`] for a file read
 /// back to resume, [`atomic_replace`]/[`atomic_replace_blocking`] for
-/// one that can be regenerated. `crate::cert_group` is the exception,
-/// calling in with [`StagedOwner::PolicyGroup`] for the three files the
-/// `--cert-group` policy owns.
+/// one that can be regenerated. Those four take a [`Destination`] and
+/// have already answered the symlink question by the time they call in
+/// here, so the `path` below is a name to rename onto and never a link
+/// to resolve. `crate::cert_group` is the exception, calling in with
+/// [`StagedOwner::PolicyGroup`] for the three files the `--cert-group`
+/// policy owns.
 ///
 /// The staged file is created at `0600` and reaches its final mode only
 /// while it is still at its temporary name, so a wider mode is never
@@ -924,8 +982,9 @@ fn chown_preserve_context(uid: u32, gid: u32, path: &Path) -> String {
 ///
 /// A destination that is a symlink is renamed over rather than followed,
 /// which destroys the operator's link. That is the decided behaviour
-/// here — the wrappers that resolve first are the `_through_symlink`
-/// pair — but it is not left silent: the destination is read with
+/// here — a caller wanting the link resolved says so with
+/// [`Destination::operator_named`], which resolves before reaching this
+/// far — but it is not left silent: the destination is read with
 /// `symlink_metadata` while the link is still there, and once the
 /// rename has replaced it the link and the file it pointed at are
 /// reported at `warn`.
@@ -1572,17 +1631,25 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("agent.toml");
 
-        super::atomic_write(&path, b"first", StagedMode::Policy(KEY_FILE_MODE))
-            .await
-            .unwrap();
+        super::atomic_write(
+            Destination::bootroot_owned(&path),
+            b"first",
+            StagedMode::Policy(KEY_FILE_MODE),
+        )
+        .await
+        .unwrap();
         let contents = fs::read_to_string(&path).await.unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(contents, "first");
         assert_eq!(mode, KEY_FILE_MODE);
 
-        super::atomic_write(&path, b"second", StagedMode::Policy(KEY_FILE_MODE))
-            .await
-            .unwrap();
+        super::atomic_write(
+            Destination::bootroot_owned(&path),
+            b"second",
+            StagedMode::Policy(KEY_FILE_MODE),
+        )
+        .await
+        .unwrap();
         let contents = fs::read_to_string(&path).await.unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(contents, "second");
@@ -1602,9 +1669,13 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("compose.override.yml");
 
-        super::atomic_replace(&path, b"first", StagedMode::Policy(0o644))
-            .await
-            .unwrap();
+        super::atomic_replace(
+            Destination::bootroot_owned(&path),
+            b"first",
+            StagedMode::Policy(0o644),
+        )
+        .await
+        .unwrap();
         assert_eq!(fs::read_to_string(&path).await.unwrap(), "first");
         let first_ino = std::fs::metadata(&path).unwrap().ino();
         assert_eq!(
@@ -1612,9 +1683,13 @@ mod tests {
             0o644
         );
 
-        super::atomic_replace(&path, b"second", StagedMode::Policy(0o644))
-            .await
-            .unwrap();
+        super::atomic_replace(
+            Destination::bootroot_owned(&path),
+            b"second",
+            StagedMode::Policy(0o644),
+        )
+        .await
+        .unwrap();
         assert_eq!(fs::read_to_string(&path).await.unwrap(), "second");
         assert_ne!(
             std::fs::metadata(&path).unwrap().ino(),
@@ -1633,30 +1708,47 @@ mod tests {
         );
     }
 
-    /// The two spellings differ in exactly one observable way, and this
-    /// pins both halves of it: given a symlinked destination, the
-    /// `_through_symlink` wrappers deliver to the target and leave the
-    /// link standing — what `O_TRUNC` did — while the bare wrappers
-    /// replace the link with the published file, which is what the
-    /// `agent.toml` and cert/key writers want.
+    /// The two constructors differ in exactly one observable way, and
+    /// this pins both halves of it at the primitive, over the same
+    /// seeded arrangement: `operator_named` delivers to a live link's
+    /// target and leaves the link standing — what `O_TRUNC` did — while
+    /// `bootroot_owned` replaces the link at that same path with the
+    /// published file, which is what the `agent.toml` and cert/key
+    /// writers want.
+    ///
+    /// Runs through both durability spellings, since the symlink axis is
+    /// the destination's property and must not depend on which of the
+    /// two is publishing.
     #[tokio::test]
-    async fn through_symlink_wrappers_deliver_to_the_target_the_bare_ones_replace() {
+    async fn operator_named_delivers_to_the_target_and_bootroot_owned_replaces_the_link() {
         let dir = tempdir().unwrap();
-
-        for (name, published) in [("write.env", false), ("replace.env", true)] {
+        let seed = |name: &str| {
             let target = dir.path().join(format!("target-{name}"));
             let link = dir.path().join(name);
             std::fs::write(&target, b"seed").unwrap();
             std::os::unix::fs::symlink(&target, &link).unwrap();
+            (target, link)
+        };
 
-            if published {
-                super::atomic_replace_through_symlink(&link, b"fresh", StagedMode::Policy(0o644))
-                    .await
-                    .unwrap();
+        for (name, flushes) in [("write.env", true), ("replace.env", false)] {
+            let (target, link) = seed(name);
+
+            if flushes {
+                super::atomic_write(
+                    Destination::operator_named(&link),
+                    b"fresh",
+                    StagedMode::Policy(0o644),
+                )
+                .await
+                .unwrap();
             } else {
-                super::atomic_write_through_symlink(&link, b"fresh", StagedMode::Policy(0o644))
-                    .await
-                    .unwrap();
+                super::atomic_replace(
+                    Destination::operator_named(&link),
+                    b"fresh",
+                    StagedMode::Policy(0o644),
+                )
+                .await
+                .unwrap();
             }
 
             assert!(
@@ -1674,42 +1766,60 @@ mod tests {
             );
         }
 
-        let target = dir.path().join("target-bare");
-        let link = dir.path().join("bare");
-        std::fs::write(&target, b"seed").unwrap();
-        std::os::unix::fs::symlink(&target, &link).unwrap();
+        for (name, flushes) in [("bare-write.env", true), ("bare-replace.env", false)] {
+            let (target, link) = seed(name);
 
-        super::atomic_write(&link, b"fresh", StagedMode::Policy(0o644))
-            .await
-            .unwrap();
+            if flushes {
+                super::atomic_write(
+                    Destination::bootroot_owned(&link),
+                    b"fresh",
+                    StagedMode::Policy(0o644),
+                )
+                .await
+                .unwrap();
+            } else {
+                super::atomic_replace(
+                    Destination::bootroot_owned(&link),
+                    b"fresh",
+                    StagedMode::Policy(0o644),
+                )
+                .await
+                .unwrap();
+            }
 
-        assert!(
-            !std::fs::symlink_metadata(&link)
-                .unwrap()
-                .file_type()
-                .is_symlink(),
-            "the bare spelling publishes at the name, replacing the link"
-        );
-        assert_eq!(std::fs::read_to_string(&link).unwrap(), "fresh");
-        assert_eq!(
-            std::fs::read_to_string(&target).unwrap(),
-            "seed",
-            "and leaves the target alone"
-        );
+            assert!(
+                !std::fs::symlink_metadata(&link)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink(),
+                "{name}: `bootroot_owned` publishes at the name, replacing the link"
+            );
+            assert_eq!(std::fs::read_to_string(&link).unwrap(), "fresh");
+            assert_eq!(
+                std::fs::read_to_string(&target).unwrap(),
+                "seed",
+                "{name}: and leaves the target alone"
+            );
+        }
     }
 
-    /// A dangling link is followed to where it points, so a first write
-    /// through one creates the target rather than replacing the link —
-    /// the `O_CREAT` half of the behaviour being preserved.
+    /// A dangling link is followed to where it points, so a first
+    /// `operator_named` write through one creates the target rather than
+    /// replacing the link — the `O_CREAT` half of the behaviour being
+    /// preserved.
     #[test]
-    fn through_symlink_wrappers_create_a_dangling_links_target() {
+    fn operator_named_creates_a_dangling_links_target() {
         let dir = tempdir().unwrap();
         let target = dir.path().join("absent.yml");
         let link = dir.path().join("override.yml");
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
-        super::atomic_replace_through_symlink_blocking(&link, b"fresh", StagedMode::Policy(0o644))
-            .unwrap();
+        super::atomic_replace_blocking(
+            Destination::operator_named(&link),
+            b"fresh",
+            StagedMode::Policy(0o644),
+        )
+        .unwrap();
 
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "fresh");
         assert!(
@@ -1752,9 +1862,9 @@ mod tests {
         );
     }
 
-    /// The `_through_symlink` wrappers are exempt from that warning by
-    /// construction rather than by a flag: what they hand the core is
-    /// the resolved target, and a resolved target is never a link.
+    /// [`Destination::operator_named`] is exempt from that warning by
+    /// construction rather than by a flag: what it hands the core is the
+    /// resolved target, and a resolved target is never a link.
     #[test]
     fn a_resolved_destination_is_never_a_replaced_symlink() {
         let dir = tempdir().unwrap();
@@ -1771,7 +1881,7 @@ mod tests {
             assert_eq!(
                 replaced_symlink_target(&resolved),
                 None,
-                "the path a `_through_symlink` wrapper publishes to must not warn"
+                "the path an `operator_named` publish lands on must not warn"
             );
         }
     }
@@ -1809,10 +1919,10 @@ mod tests {
     }
 
     /// The observable half of the helper tests above, through the two
-    /// spellings an operator actually reaches: a bare publish over a
-    /// seeded link says so once and names both ends of it, and the
-    /// `_through_symlink` publish over the same arrangement says
-    /// nothing, because it never hands the core a link.
+    /// constructors an operator actually reaches: a `bootroot_owned`
+    /// publish over a seeded link says so once and names both ends of
+    /// it, and an `operator_named` publish over the same arrangement
+    /// says nothing, because it never hands the core a link.
     #[test]
     fn a_bare_publish_over_a_link_warns_once_and_a_resolved_one_stays_quiet() {
         let dir = tempdir().unwrap();
@@ -1826,7 +1936,12 @@ mod tests {
 
         let (bare_target, bare_link) = seed("bare.env");
         let logged = logs_from(|| {
-            atomic_write_blocking(&bare_link, b"fresh", StagedMode::Policy(0o644)).unwrap();
+            atomic_write_blocking(
+                Destination::bootroot_owned(&bare_link),
+                b"fresh",
+                StagedMode::Policy(0o644),
+            )
+            .unwrap();
         });
 
         assert_eq!(
@@ -1846,8 +1961,8 @@ mod tests {
 
         let (resolved_target, resolved_link) = seed("resolved.env");
         let quiet = logs_from(|| {
-            atomic_write_through_symlink_blocking(
-                &resolved_link,
+            atomic_write_blocking(
+                Destination::operator_named(&resolved_link),
                 b"fresh",
                 StagedMode::Policy(0o644),
             )
@@ -1886,7 +2001,7 @@ mod tests {
     /// the truncating write's `ELOOP` did rather than replacing one of
     /// the links with the file.
     #[test]
-    fn through_symlink_wrappers_refuse_a_symlink_cycle() {
+    fn operator_named_refuses_a_symlink_cycle() {
         let dir = tempdir().unwrap();
         let a = dir.path().join("a.env");
         let b = dir.path().join("b.env");
@@ -1894,12 +2009,20 @@ mod tests {
         std::os::unix::fs::symlink(&a, &b).unwrap();
 
         assert!(
-            super::atomic_write_through_symlink_blocking(&a, b"x", StagedMode::Policy(0o644))
-                .is_err()
+            super::atomic_write_blocking(
+                Destination::operator_named(&a),
+                b"x",
+                StagedMode::Policy(0o644)
+            )
+            .is_err()
         );
         assert!(
-            super::atomic_replace_through_symlink_blocking(&a, b"x", StagedMode::Policy(0o644))
-                .is_err()
+            super::atomic_replace_blocking(
+                Destination::operator_named(&a),
+                b"x",
+                StagedMode::Policy(0o644)
+            )
+            .is_err()
         );
         assert!(
             std::fs::symlink_metadata(&a)
@@ -2048,18 +2171,26 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("agent.toml");
 
-        super::atomic_write(&path, b"first", StagedMode::Policy(KEY_FILE_MODE))
-            .await
-            .unwrap();
+        super::atomic_write(
+            Destination::bootroot_owned(&path),
+            b"first",
+            StagedMode::Policy(KEY_FILE_MODE),
+        )
+        .await
+        .unwrap();
         std::os::unix::fs::chown(&path, None, Some(gid))
             .expect("test process must be able to chgrp to a supplementary gid");
         let pre_meta = std::fs::metadata(&path).unwrap();
         assert_eq!(pre_meta.gid(), gid, "seed gid must take effect");
         let pre_uid = pre_meta.uid();
 
-        super::atomic_write(&path, b"second", StagedMode::Policy(KEY_FILE_MODE))
-            .await
-            .unwrap();
+        super::atomic_write(
+            Destination::bootroot_owned(&path),
+            b"second",
+            StagedMode::Policy(KEY_FILE_MODE),
+        )
+        .await
+        .unwrap();
 
         let post_meta = std::fs::metadata(&path).unwrap();
         assert_eq!(
@@ -2090,9 +2221,13 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("agent.toml");
 
-        super::atomic_write(&path, b"payload", StagedMode::Policy(KEY_FILE_MODE))
-            .await
-            .unwrap();
+        super::atomic_write(
+            Destination::bootroot_owned(&path),
+            b"payload",
+            StagedMode::Policy(KEY_FILE_MODE),
+        )
+        .await
+        .unwrap();
 
         let mut entries = Vec::new();
         let mut rd = fs::read_dir(dir.path()).await.unwrap();
@@ -2173,7 +2308,11 @@ mod tests {
             return;
         }
 
-        let result = atomic_write_blocking(&path, b"payload", StagedMode::Policy(KEY_FILE_MODE));
+        let result = atomic_write_blocking(
+            Destination::bootroot_owned(&path),
+            b"payload",
+            StagedMode::Policy(KEY_FILE_MODE),
+        );
         restore_directory_reads(&published);
 
         let err = result.unwrap_err();

--- a/src/state.rs
+++ b/src/state.rs
@@ -194,8 +194,9 @@ impl StateFile {
     }
 
     /// The blocking core both entry points share: publish the bytes by
-    /// rename, through a symlinked destination, at whichever mode the
-    /// environment would have given the write this replaced.
+    /// rename at an [`fs_util::Destination::operator_named`]
+    /// destination, at whichever mode the environment would have given
+    /// the write this replaced.
     ///
     /// `state.json` has no mode policy — it is an inventory of
     /// services, paths and role ids, carrying no secret, since the
@@ -206,8 +207,8 @@ impl StateFile {
     /// under the process umask. A host that had been getting a `0600`
     /// state file from a restrictive umask goes on getting one.
     fn publish(path: &Path, contents: &str) -> Result<()> {
-        fs_util::atomic_write_through_symlink_blocking(
-            path,
+        fs_util::atomic_write_blocking(
+            fs_util::Destination::operator_named(path),
             contents.as_bytes(),
             fs_util::StagedMode::PreserveOrUmask,
         )


### PR DESCRIPTION
## Summary

Publishing by rename forced a symlink decision at every writer in the crate, and #841 made that decision correctly per file — but expressed it as four public spellings over one publisher, chosen by hand at 41 call sites. Every spelling compiles, every spelling publishes by rename, every spelling returns `Result<()>`, so nothing separated a correct choice from a wrong one until an operator found a link they arranged replaced by a regular file, or a credential written through a link they did not arrange.

This makes the answer a property of the destination instead:

- `fs_util::Destination::operator_named(path)` — a path from a CLI flag, a config value, or a file the operator arranges in bootroot's tree. Resolves a final symlink and publishes at the target.
- `fs_util::Destination::bootroot_owned(path)` — a path bootroot derived from the secrets tree or another layout it controls. Publishes at the name.

`atomic_write`, `atomic_replace` and their blocking halves now take a `Destination` and read the symlink policy off it; the four `_through_symlink` wrappers are gone. The durability axis is untouched — `atomic_write` still flushes the containing directory, `atomic_replace` still does not, and every site keeps the one it had. The `Destination` rustdoc states the rule that decides between the constructors and names the override credential writers (`create_owned_credential_noclobber`, `write_owned_file_replace`, `atomic_rewrite_owned_no_symlink`) as the third answer this type deliberately does not express, since they refuse a link outright and folding them in would make one of their two callers wrong. `resolve_symlink_destination` stays public and stays where it is, for `reinit`'s two output preflights.

All 41 production call sites are migrated, each on the same side of the symlink axis as before: 22 `operator_named` and 19 `bootroot_owned`. The 22 are the 20 former `_through_symlink` sites plus `init`'s summary-JSON and root-token writers, which resolve the link by hand before publishing so `tighten_existing_secret_file` can narrow the file the rename lands on — those destinations are `--summary-json` and `--root-token-output`, so `operator_named` names the right side and finds nothing left to follow. Where a site's comment explained its symlink answer, it now carries only the part the constructor name does not.

Test coverage follows the same move: the primitive-level tests that exercised the wrapper pair now exercise the constructors, asserting that `operator_named` delivers to a live link's target and leaves the link standing while `bootroot_owned` replaces the link at the same seeded path. The per-site symlink tests #841 added are unchanged — they pin the per-file answers this must not change.

No file changes which side it is on, no observable behaviour changes, and no destination was "fixed" along the way.

### Observation, no change made

The migration makes one asymmetry legible for the first time: the control node's `agent.toml` editor takes `bootroot_owned` (`src/commands/service.rs`), while `bootroot-remote bootstrap`'s writer of a file by the same name takes `operator_named` (`src/bin/bootroot-remote/agent_config.rs`). This is #841's decision and it is deliberate on both sides — on the control node `service::local_config` has created `agent.toml` by rename since #613, so a link there never survives the command that creates the file and the later editors have nothing to preserve; on a bootstrap target that writer *is* the creating writer, and the `O_TRUNC` write it replaced followed a final link, so an operator who pointed the destination elsewhere has a working installation today. Both comments now say so. Recorded here only because the two constructor names sit side by side in a way the four spellings did not, and a reader may notice it before reading either comment.

Closes #847

## Test plan

- [x] `cargo fmt -- --config group_imports=StdExternalCrate` leaves no diff
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` clean
- [x] `cargo test` green, with no test changed except where a call site's signature moved
- [x] `scripts/preflight/ci/check.sh` end to end
- [x] `git grep -n 'atomic_write\|atomic_replace' src/`, filtered to non-test code, shows no call passing a bare `&Path`
- [x] No `_through_symlink` spelling remains anywhere in the crate
- [x] Every one of the 41 production sites verified against `origin/main` to be on the same side of the symlink axis as before
- [ ] `scripts/preflight/ci/e2e-matrix.sh` — partially runnable here. The two lifecycle scenarios that bind port 0 and pick free host ports (local no-hosts, remote no-hosts) run and pass locally. The `hosts` variants need `sudo -n`, which prompts for a password in this environment, and the rotation/recovery, reinit-recovery, step-ca SAN and two OpenBao TLS scenarios bind fixed loopback ports that an unrelated local OrbStack process already holds (`127.0.0.1:8080`, `127.0.0.1:8200`), so they abort at container start. All ten scenarios pass in CI's Docker E2E matrix.
- [x] Full CI green, including the Docker E2E matrix — 18/18 checks pass, including all ten Docker E2E scenarios

