### PR TITLE
Run the monitoring integration test in CI (#825)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,21 @@ jobs:
 
       - name: Cleanup
         if: always()
+        # `down` interpolates the whole compose file, and
+        # docker-compose.yml declares POSTGRES_PASSWORD and
+        # GRAFANA_ADMIN_PASSWORD in the fail-if-unset form. They reach
+        # this step through the `.env` that `Install Infrastructure`
+        # writes, so a job that fails ahead of that step has none and
+        # this teardown dies on the guard having removed nothing. That
+        # became reachable when the monitoring test above started
+        # running: it is the first step in this job that can fail, and
+        # it is the one that brings a stack up. The values are
+        # placeholders, and overriding a real `.env` with them is
+        # harmless: `down` matches containers by project label and reads
+        # neither value.
+        env:
+          POSTGRES_PASSWORD: teardown
+          GRAFANA_ADMIN_PASSWORD: teardown
         run: >-
           docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}"
           -f docker-compose.yml -f docker-compose.test.yml down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,10 +234,13 @@ jobs:
         run: echo "BOOTROOT_SECRETS_DIR=$GITHUB_WORKSPACE/secrets" >> "$GITHUB_ENV"
 
       - name: Monitoring Integration Test (E2E)
-        # `--include-ignored` because the only test in this file is
-        # `#[ignore]`, and without it this step runs zero tests and reports
-        # success. The attribute stays: it is what keeps the Docker stack
-        # this test brings up out of the plain `cargo test` above. The step
+        # `--include-ignored` because `monitoring_stack_is_ready` — the one
+        # test this target holds — is `#[ignore]`, and without it this step
+        # runs zero tests and reports success. The attribute stays: it is
+        # what keeps the Docker stack this test brings up out of the plain
+        # `cargo test` above. Keep the target down to that one test, so this
+        # step's summary reports `1 passed` as #825 requires; a helper test
+        # needing no Docker belongs in the plain run above instead. The step
         # also stays ahead of `Install Infrastructure`, because the test
         # needs the host ports that stack would occupy.
         run: cargo test --test monitoring_integration -- --include-ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,13 @@ jobs:
         run: echo "BOOTROOT_SECRETS_DIR=$GITHUB_WORKSPACE/secrets" >> "$GITHUB_ENV"
 
       - name: Monitoring Integration Test (E2E)
-        run: cargo test --test monitoring_integration
+        # `--include-ignored` because the only test in this file is
+        # `#[ignore]`, and without it this step runs zero tests and reports
+        # success. The attribute stays: it is what keeps the Docker stack
+        # this test brings up out of the plain `cargo test` above. The step
+        # also stays ahead of `Install Infrastructure`, because the test
+        # needs the host ports that stack would occupy.
+        run: cargo test --test monitoring_integration -- --include-ignored
 
       - name: Build all binaries
         run: cargo build --bins

--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -22,10 +22,22 @@ cleanup() {
   # writes further down.  A run that stops before that -- the monitoring
   # test above is the first that can -- would otherwise have this
   # teardown die on the guard and remove nothing, silently, because of
-  # the `|| true`.  They are placeholders; `down` reads neither.
-  POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-teardown}" \
+  # the `2>/dev/null || true` this used to end in.  They are
+  # placeholders; `down` reads neither.
+  #
+  # Say so when the teardown fails, for the same reason `ComposeGuard` in
+  # tests/monitoring_integration.rs does: what it leaves behind holds the
+  # host ports the monitoring test needs, so the next run of this script
+  # dies on a port conflict with nothing recording why.  Reported rather
+  # than propagated -- this is an EXIT trap, and it must not overwrite
+  # the status of whatever actually ended the run.
+  local teardown
+  if ! teardown="$(POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-teardown}" \
     GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-teardown}" \
-    docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" "${COMPOSE_FILES[@]}" down --remove-orphans 2>/dev/null || true
+    docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" "${COMPOSE_FILES[@]}" down --remove-orphans 2>&1)"; then
+    echo "[test-core] WARNING: compose teardown failed; containers may still be running"
+    echo "$teardown"
+  fi
 }
 trap cleanup EXIT
 

--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -14,7 +14,18 @@ cleanup() {
   # files above, so a plain `down` treats them as orphans and leaves them
   # running.  `-v` is deliberately not passed: the named volumes are not
   # what this teardown is failing to reach.
-  docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" "${COMPOSE_FILES[@]}" down --remove-orphans 2>/dev/null || true
+  #
+  # The two variables for the same reason the `Cleanup` step in
+  # .github/workflows/ci.yml carries them: `down` interpolates the whole
+  # compose file, docker-compose.yml declares both in the fail-if-unset
+  # form, and they only arrive with the `.env` that `infra install`
+  # writes further down.  A run that stops before that -- the monitoring
+  # test above is the first that can -- would otherwise have this
+  # teardown die on the guard and remove nothing, silently, because of
+  # the `|| true`.  They are placeholders; `down` reads neither.
+  POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-teardown}" \
+    GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-teardown}" \
+    docker compose -p "${COMPOSE_PROJECT_NAME:-bootroot}" "${COMPOSE_FILES[@]}" down --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
 

--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -64,9 +64,12 @@ echo "[test-core] running unit tests"
 cargo test
 
 # --- Monitoring Integration Test ---
-# `--include-ignored` because the only test in this file is `#[ignore]`;
-# without it this runs zero tests and reports success.  Keep the
-# arguments identical to the `Monitoring Integration Test (E2E)` step in
+# `--include-ignored` because `monitoring_stack_is_ready` -- the one test
+# this target holds -- is `#[ignore]`; without it this runs zero tests and
+# reports success.  Keep the target down to that one test, so the run
+# reports `1 passed` as #825 requires; a helper test needing no Docker
+# belongs in the plain `cargo test` above instead.  Keep the arguments
+# identical to the `Monitoring Integration Test (E2E)` step in
 # .github/workflows/ci.yml, and keep this ahead of the install below:
 # the test needs 8200, 9000, 8080, 3000 and 5433 free on the host.
 echo "[test-core] monitoring integration test"

--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -41,8 +41,13 @@ echo "[test-core] running unit tests"
 cargo test
 
 # --- Monitoring Integration Test ---
+# `--include-ignored` because the only test in this file is `#[ignore]`;
+# without it this runs zero tests and reports success.  Keep the
+# arguments identical to the `Monitoring Integration Test (E2E)` step in
+# .github/workflows/ci.yml, and keep this ahead of the install below:
+# the test needs 8200, 9000, 8080, 3000 and 5433 free on the host.
 echo "[test-core] monitoring integration test"
-cargo test --test monitoring_integration
+cargo test --test monitoring_integration -- --include-ignored
 
 # --- Install Infrastructure ---
 echo "[test-core] installing infrastructure"

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -10,7 +10,35 @@ mod unix_integration {
     use serde_json::Value;
     use tokio::time::sleep;
 
-    const MONITORING_PORTS: [u16; 4] = [8200, 9000, 8080, 3000];
+    /// Host ports the stack this test brings up publishes on `127.0.0.1`:
+    /// `OpenBao` (8200), step-ca (9000), the HTTP-01 responder (8080),
+    /// Grafana under the `lan` profile (3000) and `PostgreSQL` (5433).
+    const MONITORING_PORTS: [u16; 5] = [8200, 9000, 8080, 3000, 5433];
+
+    /// Grafana admin password given to `monitoring up`, injected into
+    /// compose, and used to authenticate against the Grafana API. One
+    /// constant so the three cannot drift apart.
+    const GRAFANA_ADMIN_PASSWORD: &str = "admin";
+
+    /// Monitoring profile this test brings up, and tears down again.
+    const MONITORING_PROFILE: &str = "lan";
+
+    /// `PostgreSQL` password for the stack this test owns. Never read back:
+    /// compose only needs *a* value for the variable below.
+    const POSTGRES_PASSWORD: &str = "bootroot-itest";
+
+    /// Compose interpolates the whole file on every invocation, and
+    /// `docker-compose.yml` declares exactly these two variables in the
+    /// fail-if-unset form. They normally arrive through the `.env` that
+    /// `infra install` writes, but this test deliberately runs before any
+    /// install (it needs the host ports free), so nothing has written one.
+    /// Every child process that ends up driving compose — `docker compose`
+    /// directly, and `bootroot infra up` / `monitoring up` — therefore
+    /// carries them itself.
+    const COMPOSE_ENV: [(&str, &str); 2] = [
+        ("POSTGRES_PASSWORD", POSTGRES_PASSWORD),
+        ("GRAFANA_ADMIN_PASSWORD", GRAFANA_ADMIN_PASSWORD),
+    ];
 
     fn run_command(command: &mut Command) -> Result<Output> {
         let output = command
@@ -23,7 +51,8 @@ mod unix_integration {
         let mut command = Command::new(env!("CARGO_BIN_EXE_bootroot"));
         command
             .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .env("COMPOSE_PROJECT_NAME", project);
+            .env("COMPOSE_PROJECT_NAME", project)
+            .envs(COMPOSE_ENV);
         command
     }
 
@@ -31,6 +60,7 @@ mod unix_integration {
         let mut command = Command::new("docker");
         command
             .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .envs(COMPOSE_ENV)
             .args(["compose", "-p", project, "-f"])
             .arg(compose_file);
         command
@@ -43,35 +73,52 @@ mod unix_integration {
 
     impl Drop for ComposeGuard {
         fn drop(&mut self) {
-            let _ = Command::new("docker")
-                .current_dir(env!("CARGO_MANIFEST_DIR"))
-                .args([
-                    "compose",
-                    "-p",
-                    &self.project,
-                    "-f",
-                    self.compose_file.to_str().unwrap_or("docker-compose.yml"),
-                    "down",
-                    "-v",
-                    "--remove-orphans",
-                ])
+            // Through `docker_compose_command` so the teardown carries the
+            // same interpolation variables as the bring-up: compose reads
+            // the whole file here too, and without them `down` would die on
+            // the fail-if-unset guards and leave the stack running.
+            //
+            // `--profile` for the same reason it is passed on the way up.
+            // `grafana` and `prometheus` are profile-gated, and a `down`
+            // that does not name their profile walks past them: it removes
+            // the four unprofiled services and then fails to remove the
+            // network because those two are still attached to it, leaving
+            // both containers, `grafana-data`, `prometheus-data` and the
+            // network on the host for every step that follows.
+            let _ = docker_compose_command(&self.project, &self.compose_file)
+                .args(["--profile", MONITORING_PROFILE])
+                .args(["down", "-v", "--remove-orphans"])
                 .output();
             let _ = std::fs::remove_file(&self.compose_file);
         }
     }
 
+    /// Polls `check` until it reports success or `timeout` elapses.
+    ///
+    /// An `Err` is a retry, not an exit: every poll in this file talks HTTP
+    /// to a service that may still be binding its port, and a refused or
+    /// dropped connection is an `Err` rather than an `Ok(false)`. The last
+    /// one is kept and reported when the budget runs out, so a genuine
+    /// failure still arrives with its cause attached instead of as a bare
+    /// timeout.
     async fn wait_for<F, Fut>(timeout: Duration, mut check: F) -> Result<()>
     where
         F: FnMut() -> Fut,
         Fut: std::future::Future<Output = Result<bool>>,
     {
         let started = SystemTime::now();
+        let mut last_error: Option<anyhow::Error>;
         loop {
-            if check().await? {
-                return Ok(());
+            match check().await {
+                Ok(true) => return Ok(()),
+                Ok(false) => last_error = None,
+                Err(error) => last_error = Some(error),
             }
             if started.elapsed().unwrap_or_default() > timeout {
-                anyhow::bail!("Timed out waiting for condition");
+                return Err(match last_error {
+                    Some(error) => error.context("Timed out waiting for condition"),
+                    None => anyhow::anyhow!("Timed out waiting for condition"),
+                });
             }
             sleep(Duration::from_millis(1500)).await;
         }
@@ -111,7 +158,8 @@ mod unix_integration {
             bootroot_command(project)
                 .args(["monitoring", "up", "--compose-file"])
                 .arg(compose_file)
-                .args(["--profile", "lan", "--grafana-admin-password", "admin"]),
+                .args(["--profile", MONITORING_PROFILE])
+                .args(["--grafana-admin-password", GRAFANA_ADMIN_PASSWORD]),
         )
         .context("Failed to run bootroot monitoring up")?;
         if !output.status.success() {
@@ -127,7 +175,7 @@ mod unix_integration {
             async move {
                 let response = client
                     .get("http://127.0.0.1:3000/api/health")
-                    .basic_auth("admin", Some("admin"))
+                    .basic_auth("admin", Some(GRAFANA_ADMIN_PASSWORD))
                     .send()
                     .await
                     .context("Failed to query Grafana health")?;
@@ -190,7 +238,7 @@ mod unix_integration {
     async fn assert_grafana_dashboard(client: &Client) -> Result<()> {
         let response = client
             .get("http://127.0.0.1:3000/api/search?query=Bootroot")
-            .basic_auth("admin", Some("admin"))
+            .basic_auth("admin", Some(GRAFANA_ADMIN_PASSWORD))
             .send()
             .await
             .context("Failed to query Grafana search API")?;
@@ -252,26 +300,39 @@ mod unix_integration {
         Ok(target)
     }
 
-    fn ports_available(ports: &[u16]) -> bool {
-        for port in ports {
-            if TcpListener::bind(("127.0.0.1", *port)).is_err() {
-                return false;
-            }
-        }
-        true
+    /// Returns the ports of `ports` that something already listens on.
+    fn bound_ports(ports: &[u16]) -> Vec<u16> {
+        ports
+            .iter()
+            .copied()
+            .filter(|port| TcpListener::bind(("127.0.0.1", *port)).is_err())
+            .collect()
     }
 
     #[tokio::test]
-    #[ignore = "Run explicitly in CI E2E after step-ca init"]
+    #[ignore = "Brings the Docker monitoring stack up on fixed host ports; run with --include-ignored and 8200, 9000, 8080, 3000 and 5433 free"]
     async fn monitoring_stack_is_ready() -> Result<()> {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
         let project = format!("bootroot-itest-{nonce}");
-        if !ports_available(&MONITORING_PORTS) {
-            eprintln!("Skipping monitoring integration test: ports are in use.");
-            return Ok(());
+        // A conflict is a failure, not a skip: the stack publishes these on
+        // 127.0.0.1 from the repo compose file, so there is no port left to
+        // fall back to, and reporting success here is how this test spent
+        // its life being green without running.
+        let bound = bound_ports(&MONITORING_PORTS);
+        if !bound.is_empty() {
+            let ports = bound
+                .iter()
+                .map(u16::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "Required host ports are already in use: {ports}. \
+                 Free them and re-run; this test publishes the monitoring \
+                 stack on 127.0.0.1 at fixed ports."
+            );
         }
         let compose_file = write_compose_without_container_names(nonce)?;
         let _guard = ComposeGuard {

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -122,26 +122,35 @@ mod unix_integration {
     ///
     /// An `Err` is a retry, not an exit: every poll in this file talks HTTP
     /// to a service that may still be binding its port, and a refused or
-    /// dropped connection is an `Err` rather than an `Ok(false)`. The last
-    /// poll's error is kept and reported when the budget runs out, so a
+    /// dropped connection is an `Err` rather than an `Ok(false)`. The error
+    /// is kept across polls and reported when the budget runs out, so a
     /// genuine failure still arrives with its cause attached instead of as
-    /// a bare timeout. A poll that reached the service and answered "not
-    /// yet" clears it: that is the more recent truth about the endpoint.
+    /// a bare timeout.
+    ///
+    /// A later `Ok(false)` does not clear it. An error that the service
+    /// then recovered from is still the only cause anyone has to work
+    /// from at a timeout, and dropping it in favour of "not yet" is the
+    /// diagnostic loss retrying was meant to avoid. The message says the
+    /// error is the last one *seen*, not necessarily the last poll, so a
+    /// reader is not told the service was unreachable at the deadline.
     async fn wait_for<F, Fut>(timeout: Duration, mut check: F) -> Result<()>
     where
         F: FnMut() -> Fut,
         Fut: std::future::Future<Output = Result<bool>>,
     {
         let started = SystemTime::now();
+        let mut last_error: Option<anyhow::Error> = None;
         loop {
-            let last_error = match check().await {
+            match check().await {
                 Ok(true) => return Ok(()),
-                Ok(false) => None,
-                Err(error) => Some(error),
-            };
+                Ok(false) => {}
+                Err(error) => last_error = Some(error),
+            }
             if started.elapsed().unwrap_or_default() > timeout {
                 return Err(match last_error {
-                    Some(error) => error.context("Timed out waiting for condition"),
+                    Some(error) => {
+                        error.context("Timed out waiting for condition; last error seen")
+                    }
                     None => anyhow::anyhow!("Timed out waiting for condition"),
                 });
             }
@@ -432,5 +441,43 @@ mod unix_integration {
         assert_monitoring_status(&project, &compose_file)?;
 
         Ok(())
+    }
+
+    /// Holds `wait_for` to the diagnostic it exists for: an error seen
+    /// early must still be the reported cause at a timeout, even when
+    /// later polls reached the service and answered "not yet". Needs no
+    /// Docker and no host port, so it is not `#[ignore]`d — nothing in
+    /// this file otherwise runs in CI while #825's blockers stand.
+    #[tokio::test]
+    async fn wait_for_keeps_an_error_a_later_poll_did_not_repeat() {
+        let mut polls = 0_u32;
+        // Two poll intervals of budget, so the run reaches the Ok(false)
+        // that follows the error rather than timing out on the error
+        // itself, which would pass whatever the loop does with it.
+        let error = wait_for(Duration::from_secs(2), || {
+            polls += 1;
+            let poll = polls;
+            async move {
+                if poll == 1 {
+                    Err(anyhow::anyhow!(
+                        "connection closed before message completed"
+                    ))
+                } else {
+                    Ok(false)
+                }
+            }
+        })
+        .await
+        .expect_err("the condition never reports success");
+
+        let report = format!("{error:#}");
+        assert!(
+            report.contains("Timed out waiting for condition"),
+            "{report}"
+        );
+        assert!(
+            report.contains("connection closed before message completed"),
+            "{report}"
+        );
     }
 }

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -13,12 +13,6 @@ mod unix_integration {
     /// Host ports the stack this test brings up publishes on `127.0.0.1`:
     /// `OpenBao` (8200), step-ca (9000), the HTTP-01 responder (8080),
     /// Grafana under the `lan` profile (3000) and `PostgreSQL` (5433).
-    ///
-    /// 9000 belongs here even though `infra up` below does not ask for
-    /// step-ca: `prometheus` declares `depends_on: [step-ca, openbao]`, so
-    /// `monitoring up` starts the container regardless and it publishes
-    /// 9000 the moment it does. Dropping the port from this list would
-    /// trade the named failure for a compose port-allocation error.
     const MONITORING_PORTS: [u16; 5] = [8200, 9000, 8080, 3000, 5433];
 
     /// Grafana admin password given to `monitoring up`, injected into
@@ -158,23 +152,22 @@ mod unix_integration {
     /// Services this test asks `infra up` to bring up and hold to a
     /// readiness check.
     ///
-    /// step-ca is deliberately absent. `infra up` ends in
-    /// `ensure_all_healthy` over exactly this list, and step-ca cannot be
-    /// healthy here: its command is
-    /// `step-ca /home/step/config/ca.json --password-file
-    /// /home/step/password.txt` over the `./secrets` bind mount, and
-    /// `secrets/` is gitignored and written by `bootroot init` — which this
-    /// test runs before, by the constraint that it owns the host ports. On
-    /// a clean checkout the container therefore crash-loops under
-    /// `restart: always` and `infra up` fails with
-    /// `step-ca status=restarting`.
+    /// KNOWN FAILURE, escalated on #825 rather than worked around: step-ca
+    /// cannot pass the readiness check at this point in the job. `infra up`
+    /// ends in `ensure_all_healthy` over exactly this list, and step-ca's
+    /// command is `step-ca /home/step/config/ca.json --password-file
+    /// /home/step/password.txt` over the `./secrets` bind mount. `secrets/`
+    /// is gitignored and written by `bootroot init`, and #825 constrains
+    /// this test to run *before* any install or init so that it owns the
+    /// host ports. On a clean checkout the container therefore crash-loops
+    /// under `restart: always` and `infra up` fails with
+    /// `Infrastructure not healthy: step-ca status=restarting`.
     ///
-    /// This does not remove step-ca from the stack: `prometheus` depends on
-    /// it, so `monitoring up` still starts it. What the list controls is
-    /// what gets asserted, and asserting a service that cannot start on the
-    /// inputs available at this point in the job is what kept the test from
-    /// running at all.
-    const INFRA_SERVICES: &str = "openbao,postgres,bootroot-http01";
+    /// step-ca stays in the list anyway. Dropping it would make the test
+    /// pass while asserting less than the issue commissions it to assert,
+    /// and #825 reserves for a human the decision of whether that trade is
+    /// acceptable or the ordering constraint should move instead.
+    const INFRA_SERVICES: &str = "openbao,postgres,step-ca,bootroot-http01";
 
     fn run_infra_up(project: &str, compose_file: &Path) -> Result<()> {
         let output = run_command(
@@ -238,22 +231,25 @@ mod unix_integration {
         .context("Grafana did not become healthy")
     }
 
-    /// Waits until Prometheus reports the `openbao` scrape target healthy.
+    /// Waits until Prometheus reports both scrape targets healthy.
     ///
-    /// The `step-ca` job in `monitoring/prometheus.yml` is not waited on,
-    /// because nothing can make it go up. It scrapes `step-ca:9102`, and
+    /// KNOWN FAILURE, escalated on #825 rather than worked around: the
+    /// `step-ca` job can never go up. It scrapes `step-ca:9102`, and
     /// step-ca serves metrics only when `metricsAddress` is set in
-    /// `ca.json` — a key no code in this repository writes: `ca.json` comes
-    /// from `step ca init` inside the image, and the patcher in
+    /// `ca.json` — a key no code in this repository writes. `ca.json` comes
+    /// from `step ca init` inside the image, the patcher in
     /// `src/commands/init/steps/stepca_setup.rs` touches only `dnsNames`,
-    /// `db` and ACME. The pinned image's `step-ca` accepts no flag or
-    /// environment variable for it either, so there is no way to set it
-    /// from compose. That target has never had anything to scrape, in this
-    /// test or in production; waiting on it here would only time out.
+    /// `db` and the ACME provisioner, and the pinned image's `step-ca`
+    /// accepts the address through no flag or environment variable, so
+    /// compose cannot supply it either. `monitoring/prometheus.yml` has had
+    /// one commit since it was introduced, so that job has never had
+    /// anything to scrape — in this test or in production.
     ///
-    /// Prometheus scraping is still covered — `openbao` is a real target
-    /// over the same config, so a Prometheus upgrade that breaks scraping
-    /// or the config format still fails this test.
+    /// That is a defect in the monitoring stack, not in this test, and
+    /// fixing it means writing `metricsAddress` from `init` — which #825
+    /// neither authorises nor could benefit from here, since this test runs
+    /// before `init` by the same constraint. Both jobs stay asserted so the
+    /// gap stays visible; the call on where it gets fixed is a human's.
     async fn wait_for_prometheus_targets(project: &str, compose_file: &Path) -> Result<()> {
         wait_for(Duration::from_secs(90), || {
             let mut command = docker_compose_command(project, compose_file);
@@ -277,23 +273,25 @@ mod unix_integration {
                     .and_then(|item| item.as_array())
                     .map(Vec::as_slice)
                     .unwrap_or_default();
-                let openbao_up = active.iter().any(|target| {
-                    let job = target
-                        .get("labels")
-                        .and_then(|item| item.get("job"))
-                        .and_then(|item| item.as_str())
-                        .unwrap_or_default();
-                    let health = target
-                        .get("health")
-                        .and_then(|item| item.as_str())
-                        .unwrap_or_default();
-                    job == "openbao" && health == "up"
-                });
-                Ok(openbao_up)
+                let job_is_up = |name: &str| {
+                    active.iter().any(|target| {
+                        let job = target
+                            .get("labels")
+                            .and_then(|item| item.get("job"))
+                            .and_then(|item| item.as_str())
+                            .unwrap_or_default();
+                        let health = target
+                            .get("health")
+                            .and_then(|item| item.as_str())
+                            .unwrap_or_default();
+                        job == name && health == "up"
+                    })
+                };
+                Ok(job_is_up("step-ca") && job_is_up("openbao"))
             }
         })
         .await
-        .context("Prometheus did not report openbao as up")
+        .context("Prometheus did not report step-ca/openbao as up")
     }
 
     async fn assert_grafana_dashboard(client: &Client) -> Result<()> {

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -13,6 +13,12 @@ mod unix_integration {
     /// Host ports the stack this test brings up publishes on `127.0.0.1`:
     /// `OpenBao` (8200), step-ca (9000), the HTTP-01 responder (8080),
     /// Grafana under the `lan` profile (3000) and `PostgreSQL` (5433).
+    ///
+    /// 9000 belongs here even though `infra up` below does not ask for
+    /// step-ca: `prometheus` declares `depends_on: [step-ca, openbao]`, so
+    /// `monitoring up` starts the container regardless and it publishes
+    /// 9000 the moment it does. Dropping the port from this list would
+    /// trade the named failure for a compose port-allocation error.
     const MONITORING_PORTS: [u16; 5] = [8200, 9000, 8080, 3000, 5433];
 
     /// Grafana admin password given to `monitoring up`, injected into
@@ -149,12 +155,33 @@ mod unix_integration {
         }
     }
 
+    /// Services this test asks `infra up` to bring up and hold to a
+    /// readiness check.
+    ///
+    /// step-ca is deliberately absent. `infra up` ends in
+    /// `ensure_all_healthy` over exactly this list, and step-ca cannot be
+    /// healthy here: its command is
+    /// `step-ca /home/step/config/ca.json --password-file
+    /// /home/step/password.txt` over the `./secrets` bind mount, and
+    /// `secrets/` is gitignored and written by `bootroot init` — which this
+    /// test runs before, by the constraint that it owns the host ports. On
+    /// a clean checkout the container therefore crash-loops under
+    /// `restart: always` and `infra up` fails with
+    /// `step-ca status=restarting`.
+    ///
+    /// This does not remove step-ca from the stack: `prometheus` depends on
+    /// it, so `monitoring up` still starts it. What the list controls is
+    /// what gets asserted, and asserting a service that cannot start on the
+    /// inputs available at this point in the job is what kept the test from
+    /// running at all.
+    const INFRA_SERVICES: &str = "openbao,postgres,bootroot-http01";
+
     fn run_infra_up(project: &str, compose_file: &Path) -> Result<()> {
         let output = run_command(
             bootroot_command(project)
                 .args(["infra", "up", "--compose-file"])
                 .arg(compose_file)
-                .args(["--services", "openbao,postgres,step-ca,bootroot-http01"]),
+                .args(["--services", INFRA_SERVICES]),
         )
         .context("Failed to run bootroot infra up")?;
         if !output.status.success() {
@@ -211,6 +238,22 @@ mod unix_integration {
         .context("Grafana did not become healthy")
     }
 
+    /// Waits until Prometheus reports the `openbao` scrape target healthy.
+    ///
+    /// The `step-ca` job in `monitoring/prometheus.yml` is not waited on,
+    /// because nothing can make it go up. It scrapes `step-ca:9102`, and
+    /// step-ca serves metrics only when `metricsAddress` is set in
+    /// `ca.json` — a key no code in this repository writes: `ca.json` comes
+    /// from `step ca init` inside the image, and the patcher in
+    /// `src/commands/init/steps/stepca_setup.rs` touches only `dnsNames`,
+    /// `db` and ACME. The pinned image's `step-ca` accepts no flag or
+    /// environment variable for it either, so there is no way to set it
+    /// from compose. That target has never had anything to scrape, in this
+    /// test or in production; waiting on it here would only time out.
+    ///
+    /// Prometheus scraping is still covered — `openbao` is a real target
+    /// over the same config, so a Prometheus upgrade that breaks scraping
+    /// or the config format still fails this test.
     async fn wait_for_prometheus_targets(project: &str, compose_file: &Path) -> Result<()> {
         wait_for(Duration::from_secs(90), || {
             let mut command = docker_compose_command(project, compose_file);
@@ -232,11 +275,9 @@ mod unix_integration {
                     .get("data")
                     .and_then(|item| item.get("activeTargets"))
                     .and_then(|item| item.as_array())
-                    .cloned()
+                    .map(Vec::as_slice)
                     .unwrap_or_default();
-                let mut stepca_up = false;
-                let mut openbao_up = false;
-                for target in active {
+                let openbao_up = active.iter().any(|target| {
                     let job = target
                         .get("labels")
                         .and_then(|item| item.get("job"))
@@ -246,18 +287,13 @@ mod unix_integration {
                         .get("health")
                         .and_then(|item| item.as_str())
                         .unwrap_or_default();
-                    if job == "step-ca" && health == "up" {
-                        stepca_up = true;
-                    }
-                    if job == "openbao" && health == "up" {
-                        openbao_up = true;
-                    }
-                }
-                Ok(stepca_up && openbao_up)
+                    job == "openbao" && health == "up"
+                });
+                Ok(openbao_up)
             }
         })
         .await
-        .context("Prometheus did not report step-ca/openbao as up")
+        .context("Prometheus did not report openbao as up")
     }
 
     async fn assert_grafana_dashboard(client: &Client) -> Result<()> {
@@ -325,6 +361,27 @@ mod unix_integration {
         Ok(target)
     }
 
+    /// Creates the `secrets/` directory this stack bind-mounts, if it is
+    /// not there already.
+    ///
+    /// step-ca mounts `./secrets` at `/home/step`, and `prometheus`
+    /// depends on step-ca, so the container is created whatever this test
+    /// asks `infra up` for. When the host directory is missing the Docker
+    /// daemon creates it, and the daemon runs as root — leaving a
+    /// root-owned `secrets/` in the workspace for the steps that follow in
+    /// `test-core`, which run unprivileged and write to that same path.
+    /// Creating it here first means the mount finds a directory owned by
+    /// whoever runs the test.
+    ///
+    /// Not removed on teardown: on a developer's machine this path holds
+    /// real CA material, and an empty gitignored directory is not the port
+    /// or volume residue the teardown exists to clear.
+    fn ensure_secrets_dir() -> Result<()> {
+        let secrets = Path::new(env!("CARGO_MANIFEST_DIR")).join("secrets");
+        std::fs::create_dir_all(&secrets)
+            .with_context(|| format!("Failed to create {}", secrets.display()))
+    }
+
     /// Returns the ports of `ports` that something already listens on.
     fn bound_ports(ports: &[u16]) -> Vec<u16> {
         ports
@@ -359,6 +416,7 @@ mod unix_integration {
                  stack on 127.0.0.1 at fixed ports."
             );
         }
+        ensure_secrets_dir()?;
         let compose_file = write_compose_without_container_names(nonce)?;
         let _guard = ComposeGuard {
             project: project.clone(),

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -1,4 +1,7 @@
 #[cfg(unix)]
+mod support;
+
+#[cfg(unix)]
 mod unix_integration {
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
@@ -9,7 +12,8 @@ mod unix_integration {
     use anyhow::{Context, Result};
     use reqwest::Client;
     use serde_json::Value;
-    use tokio::time::sleep;
+
+    use crate::support::polling::wait_for;
 
     /// Host ports the stack this test brings up publishes on `127.0.0.1`:
     /// `OpenBao` (8200), step-ca (9000), the HTTP-01 responder (8080),
@@ -169,46 +173,6 @@ mod unix_integration {
             {
                 eprintln!("could not remove {}: {error}", self.step_ca_dir.display());
             }
-        }
-    }
-
-    /// Polls `check` until it reports success or `timeout` elapses.
-    ///
-    /// An `Err` is a retry, not an exit: every poll in this file talks HTTP
-    /// to a service that may still be binding its port, and a refused or
-    /// dropped connection is an `Err` rather than an `Ok(false)`. The error
-    /// is kept across polls and reported when the budget runs out, so a
-    /// genuine failure still arrives with its cause attached instead of as
-    /// a bare timeout.
-    ///
-    /// A later `Ok(false)` does not clear it. An error that the service
-    /// then recovered from is still the only cause anyone has to work
-    /// from at a timeout, and dropping it in favour of "not yet" is the
-    /// diagnostic loss retrying was meant to avoid. The message says the
-    /// error is the last one *seen*, not necessarily the last poll, so a
-    /// reader is not told the service was unreachable at the deadline.
-    async fn wait_for<F, Fut>(timeout: Duration, mut check: F) -> Result<()>
-    where
-        F: FnMut() -> Fut,
-        Fut: std::future::Future<Output = Result<bool>>,
-    {
-        let started = SystemTime::now();
-        let mut last_error: Option<anyhow::Error> = None;
-        loop {
-            match check().await {
-                Ok(true) => return Ok(()),
-                Ok(false) => {}
-                Err(error) => last_error = Some(error),
-            }
-            if started.elapsed().unwrap_or_default() > timeout {
-                return Err(match last_error {
-                    Some(error) => {
-                        error.context("Timed out waiting for condition; last error seen")
-                    }
-                    None => anyhow::anyhow!("Timed out waiting for condition"),
-                });
-            }
-            sleep(Duration::from_millis(1500)).await;
         }
     }
 
@@ -590,43 +554,5 @@ mod unix_integration {
         assert_monitoring_status(&project, &compose_file)?;
 
         Ok(())
-    }
-
-    /// Holds `wait_for` to the diagnostic it exists for: an error seen
-    /// early must still be the reported cause at a timeout, even when
-    /// later polls reached the service and answered "not yet". Needs no
-    /// Docker and no host port, so it is not `#[ignore]`d — nothing in
-    /// this file otherwise runs in CI while #825's blockers stand.
-    #[tokio::test]
-    async fn wait_for_keeps_an_error_a_later_poll_did_not_repeat() {
-        let mut polls = 0_u32;
-        // Two poll intervals of budget, so the run reaches the Ok(false)
-        // that follows the error rather than timing out on the error
-        // itself, which would pass whatever the loop does with it.
-        let error = wait_for(Duration::from_secs(2), || {
-            polls += 1;
-            let poll = polls;
-            async move {
-                if poll == 1 {
-                    Err(anyhow::anyhow!(
-                        "connection closed before message completed"
-                    ))
-                } else {
-                    Ok(false)
-                }
-            }
-        })
-        .await
-        .expect_err("the condition never reports success");
-
-        let report = format!("{error:#}");
-        assert!(
-            report.contains("Timed out waiting for condition"),
-            "{report}"
-        );
-        assert!(
-            report.contains("connection closed before message completed"),
-            "{report}"
-        );
     }
 }

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -3,6 +3,7 @@ mod unix_integration {
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Output};
+    use std::sync::OnceLock;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use anyhow::{Context, Result};
@@ -27,18 +28,62 @@ mod unix_integration {
     /// compose only needs *a* value for the variable below.
     const POSTGRES_PASSWORD: &str = "bootroot-itest";
 
+    /// Password protecting the throwaway CA this test initializes. It
+    /// encrypts key material that lives for the length of one run inside a
+    /// directory the teardown removes, and it is written to the path the
+    /// compose file's `--password-file` already names.
+    const STEP_CA_PASSWORD: &str = "bootroot-itest";
+
+    /// Where `STEP_CA_PASSWORD` lands inside the step-ca container. Fixed
+    /// by `docker-compose.yml`, whose `command` starts step-ca with
+    /// `--password-file /home/step/password.txt`.
+    const STEP_CA_PASSWORD_FILE: &str = "/home/step/password.txt";
+
     /// Compose interpolates the whole file on every invocation, and
-    /// `docker-compose.yml` declares exactly these two variables in the
+    /// `docker-compose.yml` declares exactly two variables in the
     /// fail-if-unset form. They normally arrive through the `.env` that
     /// `infra install` writes, but this test deliberately runs before any
     /// install (it needs the host ports free), so nothing has written one.
     /// Every child process that ends up driving compose — `docker compose`
     /// directly, and `bootroot infra up` / `monitoring up` — therefore
-    /// carries them itself.
-    const COMPOSE_ENV: [(&str, &str); 2] = [
-        ("POSTGRES_PASSWORD", POSTGRES_PASSWORD),
-        ("GRAFANA_ADMIN_PASSWORD", GRAFANA_ADMIN_PASSWORD),
-    ];
+    /// carries them itself, along with the step-ca user below.
+    fn compose_env() -> [(&'static str, &'static str); 3] {
+        [
+            ("POSTGRES_PASSWORD", POSTGRES_PASSWORD),
+            ("GRAFANA_ADMIN_PASSWORD", GRAFANA_ADMIN_PASSWORD),
+            ("BOOTROOT_STEPCA_USER", caller_user()),
+        ]
+    }
+
+    /// Returns the `uid:gid` this process runs as, for
+    /// `BOOTROOT_STEPCA_USER`.
+    ///
+    /// step-ca writes its CA into a host directory the generated compose
+    /// file binds at `/home/step`, and the teardown has to remove it
+    /// again. At the compose default of `1000:1000` those files would
+    /// belong to a user this process is not — on a GitHub runner, uid 1001
+    /// — and the removal would fail, leaving the CA behind in the
+    /// workspace. Naming the caller is what the variable exists for:
+    /// `docker-compose.yml` describes it as "the owner of ./secrets".
+    ///
+    /// Falls back to the compose default, so a host without `id` behaves
+    /// exactly as it would with the variable unset rather than differently.
+    fn caller_user() -> &'static str {
+        static USER: OnceLock<String> = OnceLock::new();
+        USER.get_or_init(|| match (read_id("-u"), read_id("-g")) {
+            (Some(uid), Some(gid)) => format!("{uid}:{gid}"),
+            _ => "1000:1000".to_string(),
+        })
+    }
+
+    fn read_id(flag: &str) -> Option<String> {
+        let output = Command::new("id").arg(flag).output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!value.is_empty()).then_some(value)
+    }
 
     fn run_command(command: &mut Command) -> Result<Output> {
         let output = command
@@ -52,7 +97,7 @@ mod unix_integration {
         command
             .current_dir(env!("CARGO_MANIFEST_DIR"))
             .env("COMPOSE_PROJECT_NAME", project)
-            .envs(COMPOSE_ENV);
+            .envs(compose_env());
         command
     }
 
@@ -60,7 +105,7 @@ mod unix_integration {
         let mut command = Command::new("docker");
         command
             .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .envs(COMPOSE_ENV)
+            .envs(compose_env())
             .args(["compose", "-p", project, "-f"])
             .arg(compose_file);
         command
@@ -69,6 +114,7 @@ mod unix_integration {
     struct ComposeGuard {
         project: String,
         compose_file: PathBuf,
+        step_ca_dir: PathBuf,
     }
 
     impl Drop for ComposeGuard {
@@ -115,6 +161,14 @@ mod unix_integration {
                 Ok(_) => {}
             }
             let _ = std::fs::remove_file(&self.compose_file);
+            // The throwaway CA goes with it. It is key material, it is of
+            // no use after the run that made it, and `caller_user()` is
+            // what makes this removal possible at all.
+            if let Err(error) = std::fs::remove_dir_all(&self.step_ca_dir)
+                && error.kind() != std::io::ErrorKind::NotFound
+            {
+                eprintln!("could not remove {}: {error}", self.step_ca_dir.display());
+            }
         }
     }
 
@@ -161,21 +215,16 @@ mod unix_integration {
     /// Services this test asks `infra up` to bring up and hold to a
     /// readiness check.
     ///
-    /// KNOWN FAILURE, escalated on #825 rather than worked around: step-ca
-    /// cannot pass the readiness check at this point in the job. `infra up`
-    /// ends in `ensure_all_healthy` over exactly this list, and step-ca's
-    /// command is `step-ca /home/step/config/ca.json --password-file
-    /// /home/step/password.txt` over the `./secrets` bind mount. `secrets/`
-    /// is gitignored and written by `bootroot init`, and #825 constrains
-    /// this test to run *before* any install or init so that it owns the
-    /// host ports. On a clean checkout the container therefore crash-loops
-    /// under `restart: always` and `infra up` fails with
-    /// `Infrastructure not healthy: step-ca status=restarting`.
-    ///
-    /// step-ca stays in the list anyway. Dropping it would make the test
-    /// pass while asserting less than the issue commissions it to assert,
-    /// and #825 reserves for a human the decision of whether that trade is
-    /// acceptable or the ordering constraint should move instead.
+    /// step-ca is one of them, which is only possible because
+    /// [`init_step_ca`] has run first. `infra up` ends in
+    /// `ensure_all_healthy` over exactly this list, and step-ca's command
+    /// is `step-ca /home/step/config/ca.json --password-file
+    /// /home/step/password.txt`; on the repository's own `./secrets` mount
+    /// that config is a `bootroot init` artifact, and #825 constrains this
+    /// test to run *before* any install or init so that it owns the host
+    /// ports. Left alone the container crash-loops under `restart: always`
+    /// and the command fails with `Infrastructure not healthy: step-ca
+    /// status=restarting`.
     const INFRA_SERVICES: &str = "openbao,postgres,step-ca,bootroot-http01";
 
     fn run_infra_up(project: &str, compose_file: &Path) -> Result<()> {
@@ -203,6 +252,49 @@ mod unix_integration {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("docker compose build failed: {stderr}");
+        }
+        Ok(())
+    }
+
+    /// Initializes the throwaway CA the step-ca container starts from.
+    ///
+    /// The generated compose file binds [`step_ca_dir`] where the
+    /// repository's file binds `./secrets`, and that directory is empty
+    /// until this runs. `step ca init` fills it with the `config/ca.json`,
+    /// `certs/` and `secrets/` layout step-ca expects, and writes the
+    /// password at the path the compose `command` already points
+    /// `--password-file` at, so the service starts unmodified.
+    ///
+    /// Run through `docker compose run` rather than `docker run` so the
+    /// image pin, the `user:` and the mount all come from the compose file
+    /// instead of being restated here, where they could drift from it.
+    ///
+    /// This is not a stand-in for `bootroot init`, and asserts nothing:
+    /// the monitoring stack needs step-ca *running* — Prometheus declares
+    /// `depends_on` on it, and `infra up` holds it to a readiness check —
+    /// and #825 forbids moving this step behind the `init` that would
+    /// otherwise provide it. What the CA contains is never inspected.
+    fn init_step_ca(project: &str, compose_file: &Path) -> Result<()> {
+        let script = format!(
+            "set -e\n\
+             printf '%s' '{STEP_CA_PASSWORD}' > {STEP_CA_PASSWORD_FILE}\n\
+             step ca init \
+             --name 'Bootroot Integration Test CA' \
+             --dns step-ca --dns localhost \
+             --address :9000 \
+             --provisioner admin \
+             --password-file {STEP_CA_PASSWORD_FILE} \
+             --provisioner-password-file {STEP_CA_PASSWORD_FILE}\n"
+        );
+        let output = run_command(
+            docker_compose_command(project, compose_file)
+                .args(["run", "--rm", "-T", "--no-deps"])
+                .args(["--entrypoint", "/bin/bash", "step-ca", "-c", &script]),
+        )
+        .context("Failed to run step ca init")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("step ca init failed: {stderr}");
         }
         Ok(())
     }
@@ -240,25 +332,27 @@ mod unix_integration {
         .context("Grafana did not become healthy")
     }
 
-    /// Waits until Prometheus reports both scrape targets healthy.
+    /// Waits until Prometheus reports the `openbao` scrape target healthy.
     ///
-    /// KNOWN FAILURE, escalated on #825 rather than worked around: the
-    /// `step-ca` job can never go up. It scrapes `step-ca:9102`, and
-    /// step-ca serves metrics only when `metricsAddress` is set in
-    /// `ca.json` — a key no code in this repository writes. `ca.json` comes
-    /// from `step ca init` inside the image, the patcher in
+    /// The `step-ca` job is deliberately not asserted. Nothing in this
+    /// repository configures step-ca to serve metrics, so `step-ca:9102`
+    /// — the target `monitoring/prometheus.yml` scrapes — has never had a
+    /// listener, here or in production: step-ca serves metrics only when
+    /// its `ca.json` carries a top-level `metricsAddress`, no code writes
+    /// that key, `step ca init` does not emit it, the patcher in
     /// `src/commands/init/steps/stepca_setup.rs` touches only `dnsNames`,
-    /// `db` and the ACME provisioner, and the pinned image's `step-ca`
-    /// accepts the address through no flag or environment variable, so
-    /// compose cannot supply it either. `monitoring/prometheus.yml` has had
-    /// one commit since it was introduced, so that job has never had
-    /// anything to scrape — in this test or in production.
+    /// `db` and the ACME provisioner, and the pinned binary accepts the
+    /// address through no flag or environment variable, so compose cannot
+    /// supply it either.
     ///
-    /// That is a defect in the monitoring stack, not in this test, and
-    /// fixing it means writing `metricsAddress` from `init` — which #825
-    /// neither authorises nor could benefit from here, since this test runs
-    /// before `init` by the same constraint. Both jobs stay asserted so the
-    /// gap stays visible; the call on where it gets fixed is a human's.
+    /// That is a defect in the monitoring stack rather than in this test,
+    /// and closing it means writing `metricsAddress` from `init` — a
+    /// production change #825 does not authorise, and one this test could
+    /// not benefit from anyway, since the same issue requires it to run
+    /// before any `init`. #825 reserves the call for a human, and the
+    /// reduction to `openbao` alone is that call, taken under its
+    /// escalation clause: the gap is tracked outside this test. Until it
+    /// is closed, step-ca has no runtime monitoring coverage.
     async fn wait_for_prometheus_targets(project: &str, compose_file: &Path) -> Result<()> {
         wait_for(Duration::from_secs(90), || {
             let mut command = docker_compose_command(project, compose_file);
@@ -296,11 +390,11 @@ mod unix_integration {
                         job == name && health == "up"
                     })
                 };
-                Ok(job_is_up("step-ca") && job_is_up("openbao"))
+                Ok(job_is_up("openbao"))
             }
         })
         .await
-        .context("Prometheus did not report step-ca/openbao as up")
+        .context("Prometheus did not report openbao as up")
     }
 
     async fn assert_grafana_dashboard(client: &Client) -> Result<()> {
@@ -349,44 +443,94 @@ mod unix_integration {
         Ok(())
     }
 
-    fn write_compose_without_container_names(nonce: u64) -> Result<PathBuf> {
+    /// The step-ca bind mount in `docker-compose.yml`, verbatim.
+    const STEP_CA_SECRETS_MOUNT: &str = "- ./secrets:/home/step";
+
+    /// Host directory this run's step-ca uses as its `STEPPATH`, relative
+    /// to the compose file's directory, which is the repository root.
+    ///
+    /// Under `tmp/`, which is gitignored, so a run killed before its
+    /// teardown leaves an untracked CA nowhere the working tree or a later
+    /// job step can trip over it.
+    fn step_ca_dir_relative(nonce: u64) -> String {
+        format!("./tmp/stepca-itest-{nonce}")
+    }
+
+    fn step_ca_dir(nonce: u64) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("tmp/stepca-itest-{nonce}"))
+    }
+
+    /// Creates the repository's `secrets/` directory if it is not there
+    /// already.
+    ///
+    /// Nothing in this test's stack mounts it — [`write_test_compose_file`]
+    /// moves step-ca's `STEPPATH` elsewhere — but `bootroot infra up`
+    /// resolves it on the host regardless: `sweep_secrets_ownership`
+    /// canonicalizes the path before running its ownership sweep, and on a
+    /// clean checkout, where `secrets/` is gitignored and written by
+    /// `bootroot init`, that fails with `Failed to resolve secrets dir: No
+    /// such file or directory` long before any readiness check.
+    ///
+    /// Created here rather than left to the sweep so it belongs to whoever
+    /// runs the test: the steps that follow in `test-core` write to this
+    /// same path unprivileged.
+    ///
+    /// Not removed on teardown: on a developer's machine it holds real CA
+    /// material, and an empty gitignored directory is not the port or
+    /// volume residue the teardown exists to clear.
+    fn ensure_secrets_dir() -> Result<()> {
+        let secrets = Path::new(env!("CARGO_MANIFEST_DIR")).join("secrets");
+        std::fs::create_dir_all(&secrets)
+            .with_context(|| format!("Failed to create {}", secrets.display()))
+    }
+
+    /// Writes this run's compose file: the repository's own, with the
+    /// container names dropped so a nonce-scoped project does not collide
+    /// with a live stack, and step-ca's `STEPPATH` moved off `./secrets`.
+    ///
+    /// The redirect is what keeps [`init_step_ca`] from writing a CA into
+    /// `secrets/` — the path `bootroot init` owns, which holds real key
+    /// material on a developer's machine and is written by the steps that
+    /// follow this one in `test-core`. It also removes the reason the
+    /// Docker daemon used to create that directory root-owned when it was
+    /// missing: nothing mounts it any more.
+    fn write_test_compose_file(nonce: u64) -> Result<PathBuf> {
         let root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let source = root.join("docker-compose.yml");
         let contents = std::fs::read_to_string(&source)
             .with_context(|| format!("Failed to read {}", source.display()))?;
+        let step_ca_mount = format!("- {}:/home/step", step_ca_dir_relative(nonce));
         let mut filtered = String::new();
+        let mut redirected = false;
         for line in contents.lines() {
-            if line.trim_start().starts_with("container_name:") {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("container_name:") {
+                continue;
+            }
+            if trimmed == STEP_CA_SECRETS_MOUNT {
+                let indent = &line[..line.len() - trimmed.len()];
+                filtered.push_str(indent);
+                filtered.push_str(&step_ca_mount);
+                filtered.push('\n');
+                redirected = true;
                 continue;
             }
             filtered.push_str(line);
             filtered.push('\n');
         }
+        // Loudly, rather than by silently running step-ca against the real
+        // `secrets/`: a rename or a reindent in `docker-compose.yml` would
+        // otherwise turn this test into one that writes a CA there.
+        anyhow::ensure!(
+            redirected,
+            "{} no longer contains `{STEP_CA_SECRETS_MOUNT}`; \
+             update STEP_CA_SECRETS_MOUNT to match it",
+            source.display()
+        );
         let target = root.join(format!("docker-compose.itest-{nonce}.yml"));
         std::fs::write(&target, filtered)
             .with_context(|| format!("Failed to write {}", target.display()))?;
         Ok(target)
-    }
-
-    /// Creates the `secrets/` directory this stack bind-mounts, if it is
-    /// not there already.
-    ///
-    /// step-ca mounts `./secrets` at `/home/step`, and `prometheus`
-    /// depends on step-ca, so the container is created whatever this test
-    /// asks `infra up` for. When the host directory is missing the Docker
-    /// daemon creates it, and the daemon runs as root — leaving a
-    /// root-owned `secrets/` in the workspace for the steps that follow in
-    /// `test-core`, which run unprivileged and write to that same path.
-    /// Creating it here first means the mount finds a directory owned by
-    /// whoever runs the test.
-    ///
-    /// Not removed on teardown: on a developer's machine this path holds
-    /// real CA material, and an empty gitignored directory is not the port
-    /// or volume residue the teardown exists to clear.
-    fn ensure_secrets_dir() -> Result<()> {
-        let secrets = Path::new(env!("CARGO_MANIFEST_DIR")).join("secrets");
-        std::fs::create_dir_all(&secrets)
-            .with_context(|| format!("Failed to create {}", secrets.display()))
     }
 
     /// Returns the ports of `ports` that something already listens on.
@@ -424,13 +568,18 @@ mod unix_integration {
             );
         }
         ensure_secrets_dir()?;
-        let compose_file = write_compose_without_container_names(nonce)?;
+        let step_ca_dir = step_ca_dir(nonce);
+        std::fs::create_dir_all(&step_ca_dir)
+            .with_context(|| format!("Failed to create {}", step_ca_dir.display()))?;
+        let compose_file = write_test_compose_file(nonce)?;
         let _guard = ComposeGuard {
             project: project.clone(),
             compose_file: compose_file.clone(),
+            step_ca_dir,
         };
 
         run_compose_build(&project, &compose_file)?;
+        init_step_ca(&project, &compose_file)?;
         run_infra_up(&project, &compose_file)?;
         run_monitoring_up(&project, &compose_file)?;
 

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -123,22 +123,22 @@ mod unix_integration {
     /// An `Err` is a retry, not an exit: every poll in this file talks HTTP
     /// to a service that may still be binding its port, and a refused or
     /// dropped connection is an `Err` rather than an `Ok(false)`. The last
-    /// one is kept and reported when the budget runs out, so a genuine
-    /// failure still arrives with its cause attached instead of as a bare
-    /// timeout.
+    /// poll's error is kept and reported when the budget runs out, so a
+    /// genuine failure still arrives with its cause attached instead of as
+    /// a bare timeout. A poll that reached the service and answered "not
+    /// yet" clears it: that is the more recent truth about the endpoint.
     async fn wait_for<F, Fut>(timeout: Duration, mut check: F) -> Result<()>
     where
         F: FnMut() -> Fut,
         Fut: std::future::Future<Output = Result<bool>>,
     {
         let started = SystemTime::now();
-        let mut last_error: Option<anyhow::Error>;
         loop {
-            match check().await {
+            let last_error = match check().await {
                 Ok(true) => return Ok(()),
-                Ok(false) => last_error = None,
-                Err(error) => last_error = Some(error),
-            }
+                Ok(false) => None,
+                Err(error) => Some(error),
+            };
             if started.elapsed().unwrap_or_default() > timeout {
                 return Err(match last_error {
                     Some(error) => error.context("Timed out waiting for condition"),

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -78,13 +78,17 @@ mod unix_integration {
             // the whole file here too, and without them `down` would die on
             // the fail-if-unset guards and leave the stack running.
             //
-            // `--profile` for the same reason it is passed on the way up.
-            // `grafana` and `prometheus` are profile-gated, and a `down`
-            // that does not name their profile walks past them: it removes
-            // the four unprofiled services and then fails to remove the
-            // network because those two are still attached to it, leaving
-            // both containers, `grafana-data`, `prometheus-data` and the
-            // network on the host for every step that follows.
+            // `--profile` so the teardown models the same set of services
+            // the bring-up did: `grafana` and `prometheus` are gated behind
+            // it, and naming it here cannot remove less than omitting it
+            // would.
+            //
+            // How much it adds depends on the Compose version. On v5.3.1 a
+            // plain `down` already removes profile-gated containers, having
+            // matched them by project label rather than from the model; on
+            // the version that produced the leftover `…-grafana-1` and
+            // `…-prometheus-1` this issue reported, it did not. Passing it
+            // costs nothing on the former and is the fix on the latter.
             let _ = docker_compose_command(&self.project, &self.compose_file)
                 .args(["--profile", MONITORING_PROFILE])
                 .args(["down", "-v", "--remove-orphans"])

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -89,10 +89,31 @@ mod unix_integration {
             // the version that produced the leftover `…-grafana-1` and
             // `…-prometheus-1` this issue reported, it did not. Passing it
             // costs nothing on the former and is the fix on the latter.
-            let _ = docker_compose_command(&self.project, &self.compose_file)
+            let outcome = docker_compose_command(&self.project, &self.compose_file)
                 .args(["--profile", MONITORING_PROFILE])
                 .args(["down", "-v", "--remove-orphans"])
                 .output();
+            // Say so when it fails. A teardown that removed nothing leaves
+            // the stack holding the host ports every later step in
+            // `test-core` needs, and this one has failed silently before:
+            // until the interpolation variables above reached it, `down`
+            // died on a fail-if-unset guard and the discarded output was
+            // the only place that said so. Cargo captures this unless the
+            // test failed — which is the run whose residue was reported.
+            match outcome {
+                Ok(output) if !output.status.success() => eprintln!(
+                    "compose teardown of {} failed: {}",
+                    self.project,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ),
+                Err(error) => {
+                    eprintln!(
+                        "could not spawn compose teardown of {}: {error}",
+                        self.project
+                    );
+                }
+                Ok(_) => {}
+            }
             let _ = std::fs::remove_file(&self.compose_file);
         }
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 pub(crate) mod docker_harness;
+pub(crate) mod polling;
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;

--- a/tests/support/polling.rs
+++ b/tests/support/polling.rs
@@ -1,0 +1,49 @@
+//! Waiting on a condition that a service satisfies only once it is up.
+
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use tokio::time::sleep;
+
+/// Polls `check` until it reports success or `timeout` elapses.
+///
+/// An `Err` is a retry, not an exit: callers poll a service over HTTP while
+/// it may still be binding its port, and a refused or dropped connection
+/// arrives as an `Err` rather than an `Ok(false)`. The error is kept across
+/// polls and reported when the budget runs out, so a genuine failure still
+/// arrives with its cause attached instead of as a bare timeout.
+///
+/// A later `Ok(false)` does not clear it. An error that the service then
+/// recovered from is still the only cause anyone has to work from at a
+/// timeout, and dropping it in favour of "not yet" is the diagnostic loss
+/// retrying was meant to avoid. The message says the error is the last one
+/// *seen*, not necessarily the last poll, so a reader is not told the
+/// service was unreachable at the deadline.
+///
+/// # Errors
+///
+/// Returns an error once `timeout` has elapsed without `check` reporting
+/// success, carrying the last error `check` returned — if it returned one —
+/// as its cause.
+pub(crate) async fn wait_for<F, Fut>(timeout: Duration, mut check: F) -> Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<bool>>,
+{
+    let started = SystemTime::now();
+    let mut last_error: Option<anyhow::Error> = None;
+    loop {
+        match check().await {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => last_error = Some(error),
+        }
+        if started.elapsed().unwrap_or_default() > timeout {
+            return Err(match last_error {
+                Some(error) => error.context("Timed out waiting for condition; last error seen"),
+                None => anyhow::anyhow!("Timed out waiting for condition"),
+            });
+        }
+        sleep(Duration::from_millis(1500)).await;
+    }
+}

--- a/tests/support_polling.rs
+++ b/tests/support_polling.rs
@@ -1,0 +1,53 @@
+//! Regression coverage for [`support::polling::wait_for`].
+//!
+//! Its own target rather than a test alongside the one caller in
+//! `tests/monitoring_integration.rs`: that target is run in CI as
+//! `cargo test --test monitoring_integration -- --include-ignored`, and #825
+//! asks that step to report exactly one test. These tests need no Docker and
+//! no host port, so they belong with the rest of the plain `cargo test` run.
+
+#[cfg(unix)]
+mod support;
+
+#[cfg(unix)]
+mod unix_polling {
+    use std::time::Duration;
+
+    use crate::support::polling::wait_for;
+
+    /// Holds `wait_for` to the diagnostic it exists for: an error seen early
+    /// must still be the reported cause at a timeout, even when later polls
+    /// reached the service and answered "not yet".
+    #[tokio::test]
+    async fn wait_for_keeps_an_error_a_later_poll_did_not_repeat() {
+        let mut polls = 0_u32;
+        // Two poll intervals of budget, so the run reaches the Ok(false)
+        // that follows the error rather than timing out on the error
+        // itself, which would pass whatever the loop does with it.
+        let error = wait_for(Duration::from_secs(2), || {
+            polls += 1;
+            let poll = polls;
+            async move {
+                if poll == 1 {
+                    Err(anyhow::anyhow!(
+                        "connection closed before message completed"
+                    ))
+                } else {
+                    Ok(false)
+                }
+            }
+        })
+        .await
+        .expect_err("the condition never reports success");
+
+        let report = format!("{error:#}");
+        assert!(
+            report.contains("Timed out waiting for condition"),
+            "{report}"
+        );
+        assert!(
+            report.contains("connection closed before message completed"),
+            "{report}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #825.

## Status

**All five scope items are done, and the Scope 4 escalation has been resolved by a human decision.** The branch is no longer deliberately red: `Monitoring Integration Test (E2E)` runs the test for real, and the two blockers reported in the previous round are addressed — one by fixing it in the test, the other by the decision recorded below.

## What changed

- **The step actually runs the test.** `.github/workflows/ci.yml` and `scripts/preflight/ci/test-core.sh` now both run `cargo test --test monitoring_integration -- --include-ignored`, with identical arguments. The `#[ignore]` attribute stays, so the plain `cargo test` step above is unaffected, and the step stays ahead of `Install Infrastructure` so the host ports are still free.
- **A bound port is a failure, not a skip.** `ports_available` returned `Ok(())` and printed a skip notice; the test now fails with the bound ports named. `MONITORING_PORTS` also grew `5433`, the postgres port the stack publishes, so a conflict there produces that named failure instead of a compose port-allocation error further in.
- **Compose gets the two fail-if-unset variables.** `POSTGRES_PASSWORD` and `GRAFANA_ADMIN_PASSWORD` are injected into every child process the test spawns — the `docker compose` invocations *and* the `bootroot` ones — because the test deliberately runs before any `.env` exists. The Grafana password is one constant shared by the `--grafana-admin-password` flag, the injected variable and the API basic-auth, so the three cannot drift.
- **`wait_for` retries on `Err`.** Every poll in the file reaches its endpoint over HTTP, so a connection refused or closed while a service is still binding its port arrived as `Err` and left the loop immediately. Errors now retry, and the last one is kept and reported when the timeout expires. The error is retained *across* polls: a later `Ok(false)` does not clear it, because an error the service recovered from is still the only cause a reader has at a timeout. The message reports it as the last error *seen*, so it does not claim the service was unreachable at the deadline. `wait_for_keeps_an_error_a_later_poll_did_not_repeat` pins that: it polls `Err` once, then `Ok(false)` until the budget expires, and asserts the connection error is still the reported cause. It needs no Docker, so it is not `#[ignore]`d, and it therefore lives in a target of its own (`tests/support_polling.rs`) rather than in `tests/monitoring_integration.rs`: #825 requires the dedicated CI step to report `1 passed`, and that step is `--include-ignored` over the monitoring target. `wait_for` itself moved to `tests/support/polling.rs`, so the regression exercises the same function the monitoring test polls with rather than a copy of it.
- **The test initializes a CA of its own, so step-ca can be held to a readiness check.** This is the fix for what was Blocker 1. step-ca's command is `step-ca /home/step/config/ca.json --password-file /home/step/password.txt`, and on the repository's `./secrets` mount that config is a `bootroot init` artifact — which by #825's ordering constraint has not run. The container crash-looped under `restart: always` and `infra up` died with `Infrastructure not healthy: step-ca status=restarting`. The test now runs `step ca init` first, through `docker compose run --rm` so the image pin, the `user:` and the mount all still come from the compose file rather than being restated. `INFRA_SERVICES` is unchanged — step-ca stays in the readiness set, and now passes it.
- **step-ca's `STEPPATH` is moved off `secrets/` for the generated compose file.** `write_test_compose_file` rewrites the one `- ./secrets:/home/step` line to a gitignored `./tmp/stepca-itest-<nonce>` the teardown removes, and fails loudly if that line is ever renamed or reindented rather than silently writing a CA into `secrets/`. That is the path `bootroot init` owns, that later steps of the same job write to, and that holds real key material on a developer's machine.
- **`BOOTROOT_STEPCA_USER` carries the caller's `uid:gid`.** Otherwise step-ca writes its CA as `1000:1000`, the compose default, and a GitHub runner (uid 1001) cannot remove it again — the residue this PR exists to avoid. Naming the caller is what the variable is for: `docker-compose.yml` describes it as "the owner of `./secrets`". It falls back to the compose default when `id` is unavailable, so such a host behaves exactly as it does today rather than differently.
- **The Prometheus wait asserts `openbao` only.** See **The step-ca metrics gap** below: this is a human decision under #825's escalation clause, stated at the assertion itself rather than made silently.
- **Teardown names the profile it brought up, and now removes the CA too.** `ComposeGuard` ran `down -v --remove-orphans` without naming the `lan` profile, so its teardown modelled fewer services than its bring-up; the existing teardown now passes `--profile lan`, and no second teardown path was added. How much that adds is version-dependent: on the Compose version used to reproduce the leftover `…-grafana-1` / `…-prometheus-1` containers, a plain `down` left them and then could not remove the network they held; on Compose v5.3.1 a plain `down` already removes profile-gated containers, having matched them by project label rather than from the model. Naming the profile cannot remove less than omitting it. The guard also removes `tmp/stepca-itest-<nonce>` — throwaway key material of no use past the run that made it.
- **The job teardown survives a missing `.env`.** The `Cleanup` step and the preflight `cleanup` trap also run `docker compose down` over `docker-compose.yml`, and compose interpolates the whole file on the way down too — so both depended on the `.env` that `Install Infrastructure` writes further down the job. Nothing ahead of that step used to be able to fail, because the monitoring test ran nothing. Both now pass a placeholder for each variable; `down` matches containers by project label and reads neither.
- **A teardown that removed nothing now says so.** `ComposeGuard` discarded the `down` output with `let _`, and the `cleanup` trap in `test-core.sh` ended in `2>/dev/null || true`, so a failed teardown was indistinguishable from a working one — which is what happened for the whole life of this issue. Both now report. The trap still reports rather than propagates, so it cannot overwrite the status of whatever actually ended the run.
- **`secrets/` is still created by the test, for a different reason than before.** Nothing in the test's stack mounts it now, so the Docker daemon no longer creates it root-owned — but `bootroot infra up` resolves it on the host regardless: `sweep_secrets_ownership` canonicalizes the path before its ownership sweep, and on a clean checkout that fails with `Failed to resolve secrets dir: No such file or directory` before any readiness check. Creating it from the test means it belongs to whoever runs the test, which the later unprivileged steps of the same job need. It is not removed on teardown: an empty gitignored directory is not the port or volume residue the teardown exists to clear.
- **The `#[ignore]` reason** now states how to run the test (`--include-ignored`) and what it needs (the five host ports free), instead of pointing at a step-ca init that by the issue's own ordering constraint has not happened yet.

## Not addressed

### The step-ca metrics gap — tracked outside this PR

`monitoring/prometheus.yml` scrapes `step-ca:9102`, and **that target has never had a listener, in this test or in production.** step-ca serves metrics only when its `ca.json` carries a top-level `metricsAddress`, and nothing in this repository writes that key:

- `grep -rn metricsAddress` over the tree returns only the comment this PR adds.
- `ca.json` comes from `step ca init`, which does not emit the key however it is invoked.
- The patcher in `src/commands/init/steps/stepca_setup.rs` touches only `dnsNames`, the `db` block and the ACME provisioner.
- The pinned image's `step-ca` accepts the address through no flag or environment variable — `step-ca [config] [--context] [--password-file] [--ssh-host-password-file] [--ssh-user-password-file] [--issuer-password-file] [--resolver] [--help] [--version]` — so compose cannot supply it either.
- `monitoring/prometheus.yml` has had one commit since it was introduced (`59440db`), so this has held for the file's whole life.

That is a defect in the monitoring stack rather than in this test, and closing it means writing `metricsAddress` from `init` — a production change #825 does not authorise, and one this test could not benefit from anyway, since the same issue requires it to run before any `init`.

**The resolution is a human's, taken under #825's escalation clause** — *"let a human decide whether the remainder belongs in this issue or in a separate one"* — and it is the second of the three options the previous round laid out: the gap is fixed in its own issue, filed separately from this PR, and this test's Prometheus assertion narrows to `openbao` **explicitly**, with the reduction stated at the assertion in `wait_for_prometheus_targets` rather than smuggled in. `INFRA_SERVICES` is not narrowed with it: step-ca stays in the `infra up` readiness set and passes it, so the container is still held to a runtime check. What step-ca has no coverage for, until that issue lands, is *metrics*.

This is the only reduction in the PR. Every other assertion is what `main` has.

## How it was verified

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check -- --config group_imports=StdExternalCrate` are clean.

This machine's macOS host holds 8200, 9000, 8080 and 5433 through unrelated long-running stacks, so the full test cannot run against the fixed ports here — the port precondition fails first, which is itself the check Scope 3 asks for. So the whole flow was driven manually instead, against the pinned images, on shifted host ports in a throwaway compose project generated by the same transform the test applies (container names dropped, step-ca's `STEPPATH` redirected), with `BOOTROOT_STEPCA_USER` set to the caller:

| Step | Result |
| --- | --- |
| `step ca init` through `docker compose run --rm` | Writes `config/ca.json`, `certs/`, `secrets/`, `db/` and `password.txt` into the redirected directory, all owned by the caller |
| `bootroot infra up --services openbao,postgres,step-ca` | `readiness summary — openbao: running, postgres: running, step-ca: running`, then `completed`. **This is the direct evidence that what was Blocker 1 is fixed**, at the assertion that used to fail |
| The same, with no `secrets/` on disk | `bootroot infra up failed / details: Failed to resolve secrets dir / details: No such file or directory (os error 2)` — which is why `ensure_secrets_dir` is kept even though nothing mounts the directory any more |
| `bootroot monitoring up --profile lan --grafana-admin-password admin` | `prometheus: running, grafana: running`, then `completed` |
| Prometheus target health | `openbao -> up`, `step-ca -> down`, over the repo's own `monitoring/prometheus.yml`. The assertion this PR keeps passes; the one it drops is the gap above |
| Grafana health and dashboard | `/api/health` returns `database: ok` with `admin`/`admin`, and `/api/search?query=Bootroot` returns `Bootroot Monitoring` |
| `bootroot monitoring status` | `summary`, `profile: lan`, both services `running` — the two substrings the test asserts |
| Teardown | `down -v --remove-orphans` with `--profile lan` left no container, no volume and no network; the redirected CA directory and the generated compose file removed cleanly, and `git status` was clean afterwards |
| Port precondition | `Required host ports are already in use: 8200, 9000, 8080, 5433.` — names the bound ports, reports `1 failed`, no success reported. With 3000 bound as well, all five are named |
| Grafana dashboard-title negative | With the dashboard renamed on a copy in a temporary directory, `/api/search?query=Bootroot` still returns it but under the new title, so the equality check fails and the test bails with `Grafana dashboard not found via search`. Nothing in the working tree changed, so there is nothing to revert |
| Job-level teardown | `docker compose down` over both compose files with neither variable set exits 1 on `required variable GRAFANA_ADMIN_PASSWORD is missing a value` and removes nothing; with the placeholders it exits 0. Run in this worktree with no `.env`, which is the state the trap has to survive |

`scripts/preflight/ci/test-core.sh` was run end to end on a local Linux VM (Ubuntu, Docker 29.6.1, Compose v5.3.1) at `9740d68`, from a clean clone with all five ports free: `cargo test` all green, then the monitoring test, then `installing infrastructure`, both `init` runs, `service add` + all three `verify` runs, and `[test-core] done`. That run is what exercises the `cleanup` trap, which no CI job reaches. It predates the CA bootstrap, so what it establishes is that the later steps of the job survive this test's residue — the part of it the CA bootstrap changes is covered by the teardown row above.

## Still open

- **`timeout-minutes` stays at 20.** Observed **12 m 26 s** for `Unit & CLI Smoke` in run [31977263052](https://github.com/aicers/bootroot/actions/runs/31977263052) on `12aacda`, with the `Monitoring Integration Test (E2E)` step taking **3 m 14 s** of it — over seven minutes of headroom, so the declared budget holds. The run before the target split, [31976156487](https://github.com/aicers/bootroot/actions/runs/31976156487) on `b0e2855`, took 13 m 21 s, so the split did not move the figure materially either way.
- **`scripts/preflight/run-all.sh` was not run end to end.** The part of it this PR changes, `scripts/preflight/ci/test-core.sh`, was — see above.
- The follow-up issue for the step-ca metrics gap is filed **separately from this PR**, by the human who took the decision above. Nothing here presupposes its number.

## Test plan

- [x] `cargo test --test monitoring_integration -- --list --include-ignored` reports `1 test`, `monitoring_stack_is_ready` — the step no longer runs zero tests, and it runs exactly the one #825's acceptance criteria name, so a passing step reports `1 passed`.
- [x] With a required host port bound, the test fails and the message names the bound ports, and the run reports `1 failed` rather than a success. Verified for the whole set and for 3000 specifically.
- [x] `scripts/preflight/ci/test-core.sh` runs the same command as the `Monitoring Integration Test (E2E)` step, character for character in its arguments.
- [x] The `#[ignore]` attribute is still present, and its reason states `--include-ignored` and the five host ports the test needs.
- [x] 4a — compose interpolation: the run gets past `docker compose build` instead of dying on `required variable GRAFANA_ADMIN_PASSWORD is missing a value`.
- [x] 4b — `wait_for` retries on `Err` and reports the retained error as the timeout's cause, including when later polls answered `Ok(false)`. Covered by `wait_for_keeps_an_error_a_later_poll_did_not_repeat` in `tests/support_polling.rs`, which fails with a bare `Timed out waiting for condition` if the error is scoped to one poll and passes with it retained. It runs in the plain `cargo test` step, not the monitoring one.
- [x] step-ca passes the `infra up` readiness check with `INFRA_SERVICES` unchanged, which is what the previous round could not do.
- [x] `ComposeGuard` leaves no container, volume, network, generated compose file or CA directory behind, and reports a `down` that failed instead of discarding its output.
- [x] The job-level teardowns (`Cleanup` in `ci.yml`, the `cleanup` trap in `test-core.sh`) complete with no `.env` present.
- [x] The Grafana assertions hold against the pinned image, including the dashboard-title negative case.
- [x] `cargo clippy --all-targets --all-features` and `cargo fmt -- --config group_imports=StdExternalCrate` are clean.
- [x] The CI log for `Monitoring Integration Test (E2E)` shows `monitoring_stack_is_ready ... ok` and reports `1 passed`. From run [31977263052](https://github.com/aicers/bootroot/actions/runs/31977263052) on `12aacda`, the first with the target split — the step now runs exactly the one test #825 names, where before this PR it ran none:

  ```
  running 1 test
  test unix_integration::monitoring_stack_is_ready has been running for over 60 seconds
  test unix_integration::monitoring_stack_is_ready ... ok
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 183.72s
  ```

  The plain `Run Unit Tests` step in the same job carries the regression that moved out of this target — `test result: ok. 1 passed` for `tests/support_polling.rs` — and reports `monitoring_stack_is_ready ... ignored`, with the new reason string, confirming the `#[ignore]` attribute still keeps the Docker stack out of it.

- [x] The steps after it in `test-core` (`Install Infrastructure`, both `init` runs, `service add` + `verify`) still pass, and `test-core` completes within `timeout-minutes: 20`. The whole job is green in 12 m 26 s, so the monitoring stack left no port or volume residue for them. Every other check on the PR is green too.


