### PR TITLE
Serve step-ca metrics on the scraped port (#864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,23 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Prometheus can now scrape step-ca. The bundled monitoring stack has
+  always declared a `step-ca` scrape target, but step-ca serves metrics
+  only when its `ca.json` carries a top-level `metricsAddress`, nothing
+  wrote that key, and the pinned image accepts the address through no
+  command-line flag and no environment variable — so the declared target
+  was permanently down. `bootroot init` now writes the address the
+  existing scrape job already points at, `:9102`, into both
+  `secrets/config/ca.json` and the OpenBao Agent template that file is
+  re-rendered from, so the listener survives the sidecar's next render.
+  An existing installation gains the working target by running
+  `bootroot init` again: the setting is added in place, without
+  re-running `step ca init` and without replacing the root or
+  intermediate CA material. The metrics port remains exposed to the
+  Compose network only and is still not published to the host, so the
+  endpoint — which carries no authentication, step-ca offering none for
+  it — stays reachable to the services on that network and to nothing
+  else.
 - Fixed the files bootroot writes being published by truncating the
   destination and writing over it, so a crash or a concurrent reader
   could see a half-written file at a name that is supposed to hold a

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -72,7 +72,7 @@ PR-critical Docker test set validates:
 - remote-delivery E2E scenario (`hosts`)
 - rotation/recovery matrix (`secret_id,eab,responder_hmac,trust_sync`)
 - reinit recovery
-- step-ca certificate SANs
+- step-ca certificate SANs and the Prometheus metrics listener
 - OpenBao TLS transition with no compose delta
 - OpenBao TLS re-issuance after `secrets/` is re-owned
 - two co-located instances stay independent (install, containers, volumes,

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -70,7 +70,7 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 - 원격 전달 E2E 시나리오 (`hosts`)
 - rotation/recovery matrix (`secret_id,eab,responder_hmac,trust_sync`)
 - reinit 복구
-- step-ca 인증서 SAN
+- step-ca 인증서 SAN 및 Prometheus 메트릭 리스너
 - compose 델타 없는 OpenBao TLS 전환
 - `secrets/` 소유자 변경 이후 OpenBao TLS 인증서 재발급
 - 같은 호스트의 두 인스턴스가 서로 독립적으로 유지되는지(설치,

--- a/scripts/impl/run-reinit-recovery.sh
+++ b/scripts/impl/run-reinit-recovery.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 #
 #   - step-ca root/intermediate fingerprint unchanged before vs. after
 #   - secrets/password.txt not overwritten
+#   - step-ca's `metricsAddress` survives, so the Prometheus target
+#     `init` configured is still live after a reinit (#864)
 #   - non-loopback OpenBao bind survives (compose override survives,
 #     intent persists in rewritten state.json, post-reinit OpenBao
 #     listens on the bind, the second init pass reaches it)
@@ -367,6 +369,27 @@ assert_post_reinit_contracts() {
   # 2. password.txt unchanged (byte-for-byte).
   if ! cmp -s "$dir/password.txt" "$SECRETS_DIR/password.txt"; then
     fail "[$label] secrets/password.txt was overwritten across reinit"
+  fi
+
+  # 2b. step-ca's metrics listener survives (#864).  `reinit` keeps
+  # `config/ca.json` and re-runs the init flow over it, so the address
+  # `monitoring/prometheus.yml` scrapes has to come back out the other
+  # side; a reinit that dropped it would take the declared Prometheus
+  # target down with no other assertion here noticing.  Retried for the
+  # same reason `run-stepca-san.sh` retries: `ca.json` is co-owned with
+  # the OpenBao Agent sidecar, whose render can land between reinit
+  # returning and this read.
+  local ca_json="$SECRETS_DIR/config/ca.json"
+  local metrics_address="" attempt
+  for attempt in $(seq 1 10); do
+    if [ -f "$ca_json" ]; then
+      metrics_address="$(jq -r '.metricsAddress // empty' "$ca_json" 2>/dev/null || true)"
+      [ "$metrics_address" = ":9102" ] && break
+    fi
+    sleep 2
+  done
+  if [ "$metrics_address" != ":9102" ]; then
+    fail "[$label] post-reinit ca.json metricsAddress='$metrics_address' expected ':9102'"
   fi
 
   # 3. Non-loopback bind survives.

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -21,8 +21,13 @@ set -euo pipefail
 #   scenario-b  already-initialized path — `init` on loopback first,
 #               then `infra install --stepca-bind <ip>:9000` and a
 #               second `init`
+#   scenario-c  metrics-only upgrade — on the stack scenario B leaves,
+#               `metricsAddress` is stripped and step-ca restarted
+#               without it, then `init` runs with `dnsNames` already
+#               settled, so nothing but the metrics address moves
 #
-# Both assert the same two contracts against the running step-ca:
+# Scenarios A and B assert the same three contracts against the running
+# step-ca:
 #
 #   - the presented certificate carries `IP Address:<ip>` (an IP SAN,
 #     not a `DNS:` entry, which would not satisfy verification of a
@@ -42,6 +47,12 @@ set -euo pipefail
 # the root and intermediate fingerprints are unchanged across the
 # second `init`, and the CA bundle captured *before* it still validates
 # the chain afterwards.
+#
+# Scenario C isolates the metrics gate.  A and B both move `dnsNames`,
+# so neither can tell an `init` that carried the reload sequence for the
+# name set from one that carried it for the metrics address; C removes
+# the name change and asserts the listener still comes back — with the
+# CA material, and the chain a consumer already trusts, untouched.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -181,6 +192,26 @@ compose_stop() {
 
 run_bootroot() {
   ( cd "$WORKSPACE_DIR" && "$BOOTROOT_BIN" "$@" )
+}
+
+# Prints the step-ca OpenBao Agent sidecar's container name.
+#
+# Named directly rather than driven through `compose`: the sidecar is
+# declared in the agent override file `init` writes under `secrets/`,
+# which this harness's compose file set does not include, so compose
+# does not know the service exists.
+#
+# The name is the recorded instance plus the suffix, resolved through
+# the same helper the leftover check uses — not `COMPOSE_PROJECT_NAME`,
+# which the Rust wrapper sets to a value that is not an instance name,
+# and not a hard-coded `bootroot`, which would quietly name the wrong
+# container the day this harness takes an `--instance-name`.  Resolved
+# per call because `.env` is written by `init`, not by the bring-up.
+stepca_agent_container() {
+  local instance
+  instance="$(resolve_recorded_instance_name "$(dirname "$COMPOSE_FILE")")" \
+    || fail "could not resolve the recorded instance name from $(dirname "$COMPOSE_FILE")/.env"
+  printf '%s-openbao-agent-stepca\n' "$instance"
 }
 
 # Finding *an* `openssl` on PATH is not enough. macOS ships LibreSSL as
@@ -486,6 +517,40 @@ assert_stepca_metrics_endpoint() {
   fail "[$label] step-ca served no Prometheus metrics at http://step-ca:9102/metrics from inside the compose network (see $out)"
 }
 
+# Asserts step-ca serves nothing on 9102 — the state an installation
+# predating the setting is in, and the baseline scenario C's upgrade is
+# measured against.
+#
+# step-ca is waited for first, on its ACME port.  Without that, a fetch
+# failing because the container is still coming back up reads exactly
+# like one failing because the listener is gone, and the baseline would
+# pass on a step-ca that was simply not there yet — which would make the
+# "it came back" assertion afterwards meaningless.  Past the wait the
+# process is serving, and 9102 answering or not is a statement about the
+# configuration alone.
+#
+# Then polls rather than probing once, because a container that has not
+# finished stopping still answers on the old listener.  The listener
+# exists or it does not, so the first empty fetch is conclusive and only
+# one that never goes away runs the loop out.
+assert_stepca_metrics_endpoint_absent() {
+  local label="$1"
+  local out="$ARTIFACT_DIR/stepca-metrics-${label}.txt"
+  local attempt
+  wait_for_stepca_tls "${STEPCA_BIND_HOST}:${STEPCA_BIND_PORT}"
+  for attempt in $(seq 1 "$STEPCA_READY_ATTEMPTS"); do
+    if ! compose exec -T openbao wget -qO- "http://step-ca:9102/metrics" \
+        >"$out" 2>>"$RUN_LOG"; then
+      return 0
+    fi
+    if ! grep -q '^# HELP ' "$out"; then
+      return 0
+    fi
+    sleep "$STEPCA_READY_DELAY_SECS"
+  done
+  fail "[$label] step-ca still served Prometheus metrics on 9102 after ca.json was stripped of metricsAddress (see $out)"
+}
+
 # Asserts Prometheus itself reports the `step-ca` scrape job healthy.
 #
 # The endpoint check above proves step-ca answers; this proves the target
@@ -764,6 +829,74 @@ scenario_b_repair_initialized_ca() {
 }
 
 # ---------------------------------------------------------------------------
+# Scenario C: an installation that predates the metrics setting
+# ---------------------------------------------------------------------------
+
+# Runs against the stack scenario B leaves behind, so the CA is already
+# initialized and the bind intent is already recorded: this `init` finds
+# `dnsNames` settled and moves nothing but `metricsAddress`.
+#
+# That is the upgrade every existing installation takes, and it is the
+# one case gating the template, the sidecar restart and the step-ca
+# restart on `dnsNames` alone would silently skip — leaving the operator
+# a rewritten `ca.json` and a scrape target still down (issue #864).
+# Scenario B exercises the same sequence, but drives it from a changed
+# name set, so it cannot tell the two gates apart.
+scenario_c_metrics_only_upgrade() {
+  log_phase "scenario-c-strip-metrics"
+  snapshot_ca_fingerprints "scenario-c"
+
+  # The sidecar re-renders `ca.json` from a template that still carries
+  # the key, so it is stopped for the length of the setup: otherwise the
+  # next render decides whether step-ca boots against the stripped
+  # document, and the baseline below becomes a coin toss.  `init`
+  # restarts it as part of the sequence under test.
+  local agent_container
+  agent_container="$(stepca_agent_container)"
+  docker stop "$agent_container" >>"$RUN_LOG" 2>&1 \
+    || fail "[scenario-c] could not stop $agent_container"
+
+  local ca_json="$SECRETS_DIR/config/ca.json"
+  local stripped="$ARTIFACT_DIR/ca-json-scenario-c-stripped.json"
+  jq 'del(.metricsAddress)' "$ca_json" >"$stripped" \
+    || fail "[scenario-c] could not strip metricsAddress from $ca_json"
+  cp "$stripped" "$ca_json"
+  [ "$(jq -c '.metricsAddress' "$ca_json")" = "null" ] \
+    || fail "[scenario-c] metricsAddress survived the strip"
+
+  # step-ca reads the key at boot only, so the listener scenario B left
+  # running outlives the edit until the container is restarted onto it.
+  compose restart step-ca >>"$RUN_LOG" 2>&1 \
+    || fail "[scenario-c] could not restart step-ca onto the stripped ca.json"
+  assert_stepca_metrics_endpoint_absent "scenario-c-baseline"
+
+  log_phase "scenario-c-init-upgrade"
+  run_second_init "$ARTIFACT_DIR/init-summary-b1.json" \
+    "$ARTIFACT_DIR/init-summary-c.json" "$ARTIFACT_DIR/init-c.raw.log"
+
+  log_phase "scenario-c-assert"
+  # The upgrade must not re-run `step ca init`: the root and
+  # intermediate keys an existing deployment is built on stay put.
+  assert_ca_fingerprints_unchanged "scenario-c"
+  # Unchanged, which is the whole point — the reload was driven by the
+  # metrics address alone.
+  assert_ca_json_dns_names "scenario-c" \
+    "localhost" "bootroot-ca" "stepca.internal" "$STEPCA_BIND_HOST"
+  assert_ca_json_metrics_address "scenario-c"
+  assert_stepca_metrics_endpoint "scenario-c"
+  # The bundle a consumer provisioned before the upgrade still validates
+  # the chain, so the upgrade is invisible to everything already issued.
+  assert_acme_directory_reachable "scenario-c" "$SNAPSHOT_DIR/scenario-c/ca-bundle.pem"
+
+  log_phase "scenario-c-assert-stable"
+  # And it survives the restarted sidecar's next render, which is what
+  # separates an `init` that regenerated the template from one that only
+  # rewrote the file the sidecar is about to overwrite.
+  assert_ca_json_dns_names_stable "scenario-c-stable" \
+    "localhost" "bootroot-ca" "stepca.internal" "$STEPCA_BIND_HOST"
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -793,6 +926,10 @@ main() {
 
   scenario_a_fresh_install_with_bind
   scenario_b_repair_initialized_ca
+  # Chained onto scenario B's stack rather than given its own: the case
+  # it exercises only exists on a CA that is already initialized and
+  # already carries the recorded bind, which is precisely what B leaves.
+  scenario_c_metrics_only_upgrade
 
   log_phase "done"
 }

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -29,6 +29,14 @@ set -euo pipefail
 #     connection made to that address)
 #   - `curl --cacert <ca-bundle> https://<ip>:9000/acme/acme/directory`
 #     returns the ACME directory with no hostname-verification error
+#   - `ca.json` and the template it is re-rendered from both carry
+#     `metricsAddress: ":9102"`, and step-ca serves Prometheus
+#     exposition data there to a client on the compose network
+#
+# Scenario A additionally brings Prometheus up and waits for the
+# `step-ca` scrape job the bundled config has always declared to report
+# `up`, which is the claim an operator reads and is not the same as the
+# endpoint answering a direct fetch.
 #
 # Scenario B additionally asserts that the repair is non-destructive:
 # the root and intermediate fingerprints are unchanged across the
@@ -58,6 +66,19 @@ STEPCA_READY_ATTEMPTS="${STEPCA_READY_ATTEMPTS:-40}"
 STEPCA_READY_DELAY_SECS="${STEPCA_READY_DELAY_SECS:-3}"
 CA_JSON_ATTEMPTS="${CA_JSON_ATTEMPTS:-10}"
 CA_JSON_DELAY_SECS="${CA_JSON_DELAY_SECS:-2}"
+# Prometheus scrapes on a 15s interval (`monitoring/prometheus.yml`), so
+# a target that is going to come up does so well inside this window; the
+# budget is generous because the first scrape has to wait for the
+# container to finish starting as well.
+PROMETHEUS_READY_ATTEMPTS="${PROMETHEUS_READY_ATTEMPTS:-40}"
+PROMETHEUS_READY_DELAY_SECS="${PROMETHEUS_READY_DELAY_SECS:-3}"
+# Profile the monitoring services are gated behind in both bundled
+# compose files.  Named on the bring-up of `prometheus` and on every
+# teardown: a `down` that does not name it leaves the container behind
+# on the Compose versions that build their removal list from the model
+# rather than from the project label, and the leftover check that closes
+# the run reports `<instance>-prometheus` as residue.
+MONITORING_PROFILE="${MONITORING_PROFILE:-lan}"
 # Must exceed the OpenBao Agent render interval bootroot writes into the
 # sidecar config (`STATIC_SECRET_RENDER_INTERVAL`, 30s), so at least one
 # full render cycle is observed before the stability re-check.
@@ -140,7 +161,7 @@ compose() {
 # removed everything.  The status is the caller's to decide — the
 # start-of-run call tolerates a failure, `cleanup` does not.
 compose_down() {
-  compose down -v --remove-orphans >>"$RUN_LOG" 2>&1
+  compose --profile "$MONITORING_PROFILE" down -v --remove-orphans >>"$RUN_LOG" 2>&1
 }
 
 # Stops the stack without touching the named volumes.
@@ -465,6 +486,48 @@ assert_stepca_metrics_endpoint() {
   fail "[$label] step-ca served no Prometheus metrics at http://step-ca:9102/metrics from inside the compose network (see $out)"
 }
 
+# Asserts Prometheus itself reports the `step-ca` scrape job healthy.
+#
+# The endpoint check above proves step-ca answers; this proves the target
+# `monitoring/prometheus.yml` has always declared actually resolves to
+# it.  The two can disagree — a job name, a `metrics_path` or a target
+# host that no longer matches the service would leave the endpoint
+# serving and the target down — and it is the target the operator reads.
+#
+# Prometheus sits behind the `lan`/`public` profiles, so it is brought up
+# by name here rather than by the harness's plain `up`; `grafana` is left
+# alone, because it publishes a host port this harness has no reason to
+# claim.  The API is queried from inside the container for the same
+# reason the metrics fetch is: Prometheus publishes no host port either.
+#
+# `--no-deps` is load-bearing.  Prometheus `depends_on` step-ca and
+# OpenBao, and `compose()` here names only the base and test files —
+# `init` started step-ca with the `--stepca-bind` override on top, so
+# without this flag Compose would find the running container diverging
+# from the model it can see and recreate step-ca *without* the exposed
+# bind, taking the SAN and ACME assertions that follow with it.  Both
+# dependencies are already up: this is the last assertion of a scenario
+# that has been talking to them throughout.
+assert_prometheus_scrapes_stepca() {
+  local label="$1"
+  local out="$ARTIFACT_DIR/prometheus-targets-${label}.json"
+  compose --profile "$MONITORING_PROFILE" up -d --no-deps prometheus \
+    >>"$RUN_LOG" 2>&1 || fail "[$label] could not start prometheus"
+  local attempt
+  for attempt in $(seq 1 "$PROMETHEUS_READY_ATTEMPTS"); do
+    if compose exec -T prometheus wget -qO- \
+        "http://localhost:9090/api/v1/targets" >"$out" 2>>"$RUN_LOG"; then
+      if jq -e '[.data.activeTargets[]
+                 | select(.labels.job == "step-ca" and .health == "up")]
+                | length > 0' "$out" >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+    sleep "$PROMETHEUS_READY_DELAY_SECS"
+  done
+  fail "[$label] Prometheus never reported the step-ca scrape target as up (see $out)"
+}
+
 # Re-checks the name set after a full agent render interval has elapsed.
 #
 # This is the assertion that actually proves the repair sticks: the
@@ -636,6 +699,11 @@ scenario_a_fresh_install_with_bind() {
   assert_stepca_ip_san "scenario-a"
   build_ca_bundle "$ARTIFACT_DIR/ca-bundle-a.pem"
   assert_acme_directory_reachable "scenario-a" "$ARTIFACT_DIR/ca-bundle-a.pem"
+  # Last, because it is the one assertion here that starts a container:
+  # the scrape job the operator actually reads, on the clean install the
+  # issue's test plan names.  The endpoint answering a direct fetch and
+  # Prometheus resolving its declared target to it are two claims.
+  assert_prometheus_scrapes_stepca "scenario-a"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/impl/run-stepca-san.sh
+++ b/scripts/impl/run-stepca-san.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Docker-backed E2E harness for step-ca's certificate SANs (#733).
+# Docker-backed E2E harness for step-ca's certificate SANs (#733) and,
+# alongside them, its metrics listener (#864) — both are top-level keys
+# in the `ca.json` bootroot co-owns with the step-ca OpenBao Agent
+# sidecar, and both are read by step-ca at boot only, so both fail the
+# same way if the template and the sidecar are not carried along.
 #
 # `step ca init` used to be invoked with a compile-time `--dns`
 # constant, so step-ca's own serving certificate carried no SAN for the
@@ -227,7 +231,7 @@ capture_artifacts() {
   compose ps >"$ARTIFACT_DIR/compose-ps.log" 2>&1 || true
   compose logs --no-color >"$ARTIFACT_DIR/compose-logs.log" 2>&1 || true
   if [ -f "$SECRETS_DIR/config/ca.json" ]; then
-    jq -c '.dnsNames' "$SECRETS_DIR/config/ca.json" \
+    jq -c '{dnsNames, metricsAddress}' "$SECRETS_DIR/config/ca.json" \
       >"$ARTIFACT_DIR/ca-json-dns-names.log" 2>&1 || true
   fi
 }
@@ -402,6 +406,65 @@ assert_ca_json_dns_names() {
   done
 }
 
+# Asserts `ca.json` carries the fixed metrics address, and that the
+# template it is re-rendered from carries it too.
+#
+# `metricsAddress` is what starts step-ca's Prometheus listener at all:
+# the pinned binary takes the address through no flag and no environment
+# variable, so the file is the only place it can come from, and a
+# template missing it hands the next agent render a `ca.json` that
+# silently turns the listener off again (issue #864).  Retries for the
+# same reason `assert_ca_json_dns_names` does — a render can land
+# between `init` returning and this read.
+assert_ca_json_metrics_address() {
+  local label="$1"
+  local ca_json="$SECRETS_DIR/config/ca.json"
+  local expected='":9102"'
+  local actual=""
+  local attempt
+  for attempt in $(seq 1 "$CA_JSON_ATTEMPTS"); do
+    if [ -f "$ca_json" ]; then
+      actual="$(jq -c '.metricsAddress' "$ca_json" 2>/dev/null || true)"
+      [ "$expected" = "$actual" ] && break
+    fi
+    sleep "$CA_JSON_DELAY_SECS"
+  done
+  [ -f "$ca_json" ] || fail "[$label] missing $ca_json"
+  if [ "$expected" != "$actual" ]; then
+    fail "[$label] ca.json metricsAddress mismatch: expected $expected got $actual"
+  fi
+  local ctmpl="$SECRETS_DIR/templates/ca.json.ctmpl"
+  [ -f "$ctmpl" ] || fail "[$label] missing $ctmpl"
+  grep -q '"metricsAddress": ":9102"' "$ctmpl" \
+    || fail "[$label] ca.json.ctmpl does not carry metricsAddress \":9102\""
+}
+
+# Asserts step-ca actually serves Prometheus exposition data on 9102,
+# fetched from *inside* the compose network.
+#
+# The fetch runs in the OpenBao container rather than on the host on
+# purpose: 9102 is `expose`d and deliberately not published, so a probe
+# that succeeded from the host would mean the network boundary this
+# endpoint's only protection rests on had been widened.  OpenBao's image
+# is the same busybox-carrying Alpine the monitoring integration test
+# already fetches through, and `step-ca` is the compose service name
+# Prometheus itself scrapes by.
+assert_stepca_metrics_endpoint() {
+  local label="$1"
+  local out="$ARTIFACT_DIR/stepca-metrics-${label}.txt"
+  local attempt
+  for attempt in $(seq 1 "$STEPCA_READY_ATTEMPTS"); do
+    if compose exec -T openbao wget -qO- "http://step-ca:9102/metrics" \
+        >"$out" 2>>"$RUN_LOG"; then
+      if grep -q '^# HELP ' "$out"; then
+        return 0
+      fi
+    fi
+    sleep "$STEPCA_READY_DELAY_SECS"
+  done
+  fail "[$label] step-ca served no Prometheus metrics at http://step-ca:9102/metrics from inside the compose network (see $out)"
+}
+
 # Re-checks the name set after a full agent render interval has elapsed.
 #
 # This is the assertion that actually proves the repair sticks: the
@@ -415,6 +478,11 @@ assert_ca_json_dns_names_stable() {
   shift
   sleep "$STEPCA_RENDER_STABILITY_SECS"
   assert_ca_json_dns_names "$label" "$@"
+  # The metrics address is co-owned with the same sidecar and has the
+  # same failure mode: an `init` that wrote it without regenerating the
+  # template and restarting the sidecar would look correct until the
+  # next render took the listener away again (issue #864).
+  assert_ca_json_metrics_address "$label"
 }
 
 snapshot_ca_fingerprints() {
@@ -561,6 +629,10 @@ scenario_a_fresh_install_with_bind() {
   # with the bind IP in `dnsNames` — no reconciliation was needed.
   assert_ca_json_dns_names "scenario-a" \
     "localhost" "bootroot-ca" "stepca.internal" "$STEPCA_BIND_HOST"
+  # A fresh `init` configures the metrics listener too: `step ca init`
+  # emits no `metricsAddress`, so this is the reconciliation's work.
+  assert_ca_json_metrics_address "scenario-a"
+  assert_stepca_metrics_endpoint "scenario-a"
   assert_stepca_ip_san "scenario-a"
   build_ca_bundle "$ARTIFACT_DIR/ca-bundle-a.pem"
   assert_acme_directory_reachable "scenario-a" "$ARTIFACT_DIR/ca-bundle-a.pem"
@@ -609,6 +681,8 @@ scenario_b_repair_initialized_ca() {
   assert_ca_fingerprints_unchanged "scenario-b"
   assert_ca_json_dns_names "scenario-b-repaired" \
     "localhost" "bootroot-ca" "stepca.internal" "$STEPCA_BIND_HOST"
+  assert_ca_json_metrics_address "scenario-b-repaired"
+  assert_stepca_metrics_endpoint "scenario-b"
   assert_stepca_ip_san "scenario-b"
   # The bundle captured before the repair — what an already-provisioned
   # consumer holds — still validates the chain step-ca presents.

--- a/src/commands/init/steps/orchestrator.rs
+++ b/src/commands/init/steps/orchestrator.rs
@@ -35,7 +35,7 @@ use super::responder_setup::{
 };
 use super::secrets::{maybe_register_eab, resolve_init_secrets};
 use super::stepca_setup::{
-    ensure_step_ca_initialized, reconcile_ca_json_dns_names, resolve_stepca_ca_dns_names,
+    ensure_step_ca_initialized, reconcile_ca_json_managed_keys, resolve_stepca_ca_dns_names,
     restart_stepca_openbao_agent, snapshot_stepca_ca_json_template, update_ca_json_with_backup,
     write_password_file_with_backup, write_stepca_templates,
 };
@@ -622,10 +622,10 @@ async fn run_init_inner(
         fix_secrets_permissions(&secrets_dir).await?;
     }
 
-    // Reconciles the `db` section, the ACME provisioner's cert duration
-    // and the top-level `dnsNames`.  Runs before `write_stepca_templates`
-    // so the generated `ca.json.ctmpl` is built from the patched document
-    // (notably `db.type`).
+    // Reconciles the `db` section, the ACME provisioner's cert duration,
+    // the top-level `dnsNames` and the top-level `metricsAddress`.  Runs
+    // before `write_stepca_templates` so the generated `ca.json.ctmpl`
+    // is built from the patched document (notably `db.type`).
     let ca_json_update = update_ca_json_with_backup(
         &secrets_dir,
         &secrets.db_dsn,
@@ -635,7 +635,11 @@ async fn run_init_inner(
         messages,
     )
     .await?;
-    let stepca_dns_names_changed = ca_json_update.dns_names_changed;
+    // Covers both boot-time keys, not `dnsNames` alone: an installation
+    // predating the metrics setting has an unchanged name set, and
+    // gating on that alone would leave the new template unrendered, the
+    // sidecar on the old one and step-ca without the listener.
+    let stepca_reload_required = ca_json_update.stepca_reload_required();
     rollback.ca_json_backup = Some(ca_json_update.rollback);
 
     // The templates are written here — before step-ca is restarted —
@@ -662,12 +666,12 @@ async fn run_init_inner(
     )
     .await?;
 
-    if stepca_dns_names_changed {
-        // On a fresh install the sidecar does not exist yet (and
-        // `step ca init --dns` already produced the right name set, so
-        // this branch is normally not taken there).  `docker restart`
-        // returns only once the old process is gone, so the re-assert
-        // below cannot race a render from it.
+    if stepca_reload_required {
+        // On a fresh install the sidecar does not exist yet, so the
+        // restart is a no-op there and the re-assert below finds the
+        // document it just wrote.  `docker restart` returns only once
+        // the old process is gone, so the re-assert cannot race a
+        // render from it.
         //
         // Record the restart before performing it so that a rollback
         // triggered by a later failure restarts the sidecar back onto the
@@ -677,22 +681,25 @@ async fn run_init_inner(
             &identity.container(BootrootContainer::OpenBaoAgentStepCa),
             rollback.docker(),
         );
-        reconcile_ca_json_dns_names(&secrets_dir, &stepca_dns_names, messages).await?;
+        reconcile_ca_json_managed_keys(&secrets_dir, &stepca_dns_names, messages).await?;
     }
 
     if step_ca_result == super::super::types::StepCaInitResult::Initialized
-        || stepca_dns_names_changed
+        || stepca_reload_required
     {
         // Restart step-ca after ca.json is patched with the DB DSN so it
         // loads the fully configured file on first boot.
         //
-        // The `dnsNames` arm covers the already-initialized CA: step-ca
-        // derives its serving leaf from `dnsNames` at boot and keeps it
-        // in memory, so a restart — not a re-run of `step ca init`,
-        // which would replace the root and intermediate keys — is what
-        // makes `infra install --stepca-bind` followed by `init` repair
-        // an installed system.  Gating on the change keeps a repeat
-        // `init` with the same recorded intent restart-free.
+        // The second arm covers the already-initialized CA: step-ca
+        // reads both `dnsNames` and `metricsAddress` at boot and keeps
+        // the results in memory — the serving leaf in the one case, the
+        // metrics listener's existence in the other — so a restart, not
+        // a re-run of `step ca init` (which would replace the root and
+        // intermediate keys), is what makes `infra install
+        // --stepca-bind` followed by `init` repair an installed system,
+        // and what gives an installation predating the metrics setting
+        // its listener.  Gating on the change keeps a repeat `init` on a
+        // settled document restart-free.
         let compose_str = args.compose.compose_file.to_string_lossy();
         let restart = identity.compose(&[&compose_str], None, &["restart", "step-ca"]);
         let _ = run_compose(&restart, "docker compose restart step-ca", messages);

--- a/src/commands/init/steps/stepca_setup.rs
+++ b/src/commands/init/steps/stepca_setup.rs
@@ -34,15 +34,40 @@ const LOOPBACK_IPV6: &str = "::1";
 /// an IP become `iPAddress` SANs, the rest become `dNSName` SANs.
 const CA_JSON_DNS_NAMES_KEY: &str = "dnsNames";
 
+/// Top-level `ca.json` key naming the address step-ca serves its
+/// Prometheus metrics on.  step-ca starts that listener only when the
+/// key is present, and the pinned image accepts the address through no
+/// command-line flag and no environment variable — so the configuration
+/// file is the only place it can come from, and the fixed Compose
+/// `command` cannot supply it.
+const CA_JSON_METRICS_ADDRESS_KEY: &str = "metricsAddress";
+
+/// The address step-ca serves `/metrics` on.
+///
+/// Fixed rather than operator-selectable: `monitoring/prometheus.yml`
+/// scrapes `step-ca:9102` as a static target and both bundled Compose
+/// files declare `expose: "9102"` on the service, so any other value
+/// here would simply take the listener away from the scraper.
+///
+/// SECURITY: the listener is unauthenticated and plaintext — step-ca
+/// offers no authentication for it — and the empty host part binds it
+/// on every interface *inside the container*, which is what lets
+/// Prometheus reach it as `step-ca:9102`.  The boundary is therefore
+/// the Compose network alone: 9102 is `expose`d and never published as
+/// a host port.  Publishing it, or otherwise widening that boundary,
+/// puts unauthenticated internal telemetry on the host's network.
+const STEPCA_METRICS_ADDRESS: &str = ":9102";
+
 /// Writes the `OpenBao` Agent templates step-ca renders its runtime
 /// configuration from.
 ///
-/// `dns_names` is stamped into the generated `ca.json.ctmpl` rather than
-/// inherited from whatever `ca.json` holds when this runs: the step-ca
-/// agent sidecar re-renders `ca.json` from the *previous* template on
-/// its own schedule, so a render landing between the reconciliation and
-/// this call would otherwise bake the stale name set back into the new
-/// template and make the regression permanent (issue #733).
+/// `dns_names` and the metrics address are stamped into the generated
+/// `ca.json.ctmpl` rather than inherited from whatever `ca.json` holds
+/// when this runs: the step-ca agent sidecar re-renders `ca.json` from
+/// the *previous* template on its own schedule, so a render landing
+/// between the reconciliation and this call would otherwise bake the
+/// stale value back into the new template and make the regression
+/// permanent (issue #733).
 pub(super) async fn write_stepca_templates(
     secrets_dir: &Path,
     kv_mount: &str,
@@ -176,6 +201,7 @@ fn build_ca_json_template(
     let mut value: serde_json::Value =
         serde_json::from_str(contents).context(messages.error_parse_ca_json_failed())?;
     set_ca_json_dns_names(&mut value, dns_names);
+    set_ca_json_metrics_address(&mut value);
     let db = value
         .get_mut("db")
         .ok_or_else(|| anyhow::anyhow!(messages.error_ca_json_db_missing()))?;
@@ -388,6 +414,27 @@ fn set_ca_json_dns_names(value: &mut serde_json::Value, dns_names: &[String]) ->
     false
 }
 
+/// Sets the top-level `metricsAddress` on a parsed `ca.json` to
+/// [`STEPCA_METRICS_ADDRESS`], returning whether the value actually
+/// changed.
+///
+/// Takes no argument for the same reason the constant is fixed: the
+/// scrape target is a compile-time constant on the Prometheus side.
+/// Like [`set_ca_json_dns_names`] it inserts into the parsed document,
+/// so every other key survives and the document ends up carrying
+/// exactly one `metricsAddress`.
+fn set_ca_json_metrics_address(value: &mut serde_json::Value) -> bool {
+    let desired = serde_json::Value::String(STEPCA_METRICS_ADDRESS.to_string());
+    if value.get(CA_JSON_METRICS_ADDRESS_KEY) == Some(&desired) {
+        return false;
+    }
+    if let Some(object) = value.as_object_mut() {
+        object.insert(CA_JSON_METRICS_ADDRESS_KEY.to_string(), desired);
+        return true;
+    }
+    false
+}
+
 /// Outcome of `update_ca_json_with_backup`.
 pub(super) struct CaJsonUpdate {
     /// Snapshot of the pre-update `ca.json` for the init rollback.
@@ -397,7 +444,30 @@ pub(super) struct CaJsonUpdate {
     /// The caller restarts step-ca when this is set: step-ca derives its
     /// serving leaf from `dnsNames` at boot and holds it in memory, so
     /// only a restart re-issues it with the new name set.
-    pub(super) dns_names_changed: bool,
+    dns_names_changed: bool,
+    /// Whether the reconciliation moved the top-level `metricsAddress`.
+    ///
+    /// Set on every installation that predates the setting, whose
+    /// `dnsNames` are by definition unchanged — which is why the caller
+    /// gates on [`CaJsonUpdate::stepca_reload_required`] rather than on
+    /// `dns_names_changed` alone.
+    metrics_address_changed: bool,
+}
+
+impl CaJsonUpdate {
+    /// Whether the co-owned `ca.json` has to be carried through the rest
+    /// of the sequence: regenerate the template, restart the sidecar
+    /// onto it, re-assert the file, and restart step-ca.
+    ///
+    /// Both keys are read by step-ca at boot only — the name set decides
+    /// its serving leaf, the metrics address decides whether the
+    /// listener exists at all — so neither takes effect in a running
+    /// container, and a sidecar still holding the previous template
+    /// would render either of them back out.
+    #[must_use]
+    pub(super) fn stepca_reload_required(&self) -> bool {
+        self.dns_names_changed || self.metrics_address_changed
+    }
 }
 
 pub(super) async fn write_password_file_with_backup(
@@ -441,10 +511,12 @@ pub(super) async fn write_password_file_with_backup(
 /// Patches `ca.json` in place, backing the original up for rollback.
 ///
 /// Rewrites the `db` section, the ACME provisioner's
-/// `claims.defaultTLSCertDuration`, and the top-level `dnsNames` — the
-/// last of these is what gives step-ca's own serving certificate the
-/// address `--stepca-bind` publishes it on.  The document is parsed and
-/// re-serialised rather than regenerated, so keys bootroot does not
+/// `claims.defaultTLSCertDuration`, the top-level `dnsNames` — what
+/// gives step-ca's own serving certificate the address
+/// `--stepca-bind` publishes it on — and the top-level
+/// `metricsAddress`, which is what starts the listener
+/// `monitoring/prometheus.yml` already scrapes.  The document is parsed
+/// and re-serialised rather than regenerated, so keys bootroot does not
 /// model survive untouched.
 pub(super) async fn update_ca_json_with_backup(
     secrets_dir: &Path,
@@ -469,6 +541,7 @@ pub(super) async fn update_ca_json_with_backup(
         );
     }
     let dns_names_changed = set_ca_json_dns_names(&mut value, dns_names);
+    let metrics_address_changed = set_ca_json_metrics_address(&mut value);
     let updated =
         serde_json::to_string_pretty(&value).context(messages.error_serialize_ca_json_failed())?;
     publish_ca_json(&path, &updated, messages).await?;
@@ -478,21 +551,23 @@ pub(super) async fn update_ca_json_with_backup(
             original: Some(contents),
         },
         dns_names_changed,
+        metrics_address_changed,
     })
 }
 
-/// Re-applies `dns_names` to `ca.json`'s top-level `dnsNames`, returning
-/// whether the file had drifted.
+/// Re-applies `dns_names` to `ca.json`'s top-level `dnsNames` and the
+/// fixed metrics address to its `metricsAddress`, returning whether the
+/// file had drifted.
 ///
-/// `update_ca_json_with_backup` already writes the reconciled set, but
-/// the step-ca `OpenBao` Agent sidecar re-renders `ca.json` from its
-/// template on a fixed interval and can clobber that write moments
-/// later.  The orchestrator calls this once the sidecar has been
-/// restarted onto the regenerated template, so the file `init` leaves
-/// behind — and every later render — carries the same name set.  No
-/// backup is taken: the rollback entry from `update_ca_json_with_backup`
-/// already holds the pre-`init` document.
-pub(super) async fn reconcile_ca_json_dns_names(
+/// `update_ca_json_with_backup` already writes both, but the step-ca
+/// `OpenBao` Agent sidecar re-renders `ca.json` from its template on a
+/// fixed interval and can clobber that write moments later.  The
+/// orchestrator calls this once the sidecar has been restarted onto the
+/// regenerated template, so the file `init` leaves behind — and every
+/// later render — carries the same values.  No backup is taken: the
+/// rollback entry from `update_ca_json_with_backup` already holds the
+/// pre-`init` document.
+pub(super) async fn reconcile_ca_json_managed_keys(
     secrets_dir: &Path,
     dns_names: &[String],
     messages: &Messages,
@@ -503,7 +578,12 @@ pub(super) async fn reconcile_ca_json_dns_names(
         .with_context(|| messages.error_read_file_failed(&path.display().to_string()))?;
     let mut value: serde_json::Value =
         serde_json::from_str(&contents).context(messages.error_parse_ca_json_failed())?;
-    if !set_ca_json_dns_names(&mut value, dns_names) {
+    // Both keys are re-asserted before the early return is decided:
+    // combining the two calls into one `||` would skip the metrics
+    // address on exactly the runs where the name set had drifted.
+    let dns_names_changed = set_ca_json_dns_names(&mut value, dns_names);
+    let metrics_address_changed = set_ca_json_metrics_address(&mut value);
+    if !dns_names_changed && !metrics_address_changed {
         return Ok(false);
     }
     let updated =
@@ -1138,7 +1218,7 @@ mod tests {
         let dns_names =
             build_stepca_ca_dns_names(Some("192.168.139.144:9000"), None, DEFAULT_CA_CONTAINER);
 
-        let changed = reconcile_ca_json_dns_names(&secrets_dir, &dns_names, &messages)
+        let changed = reconcile_ca_json_managed_keys(&secrets_dir, &dns_names, &messages)
             .await
             .unwrap();
         assert!(changed);
@@ -1153,7 +1233,7 @@ mod tests {
             serde_json::json!([1, 2, 3])
         );
 
-        let changed_again = reconcile_ca_json_dns_names(&secrets_dir, &dns_names, &messages)
+        let changed_again = reconcile_ca_json_managed_keys(&secrets_dir, &dns_names, &messages)
             .await
             .unwrap();
         assert!(
@@ -1161,6 +1241,174 @@ mod tests {
             "an already-reconciled ca.json must not be rewritten"
         );
         assert_eq!(read_ca_json(&secrets_dir), after);
+    }
+
+    /// The direct reconciliation owns `metricsAddress`: step-ca serves
+    /// `/metrics` only when `ca.json` carries it, and
+    /// `monitoring/prometheus.yml` scrapes that listener as a static
+    /// target.
+    #[tokio::test]
+    async fn update_ca_json_writes_one_metrics_address_and_is_idempotent() {
+        let temp_dir = tempdir().unwrap();
+        let secrets_dir = temp_dir.path().join("secrets");
+        write_ca_json(&secrets_dir, CA_JSON_FIXTURE);
+        let messages = test_messages();
+        let dns_names = build_stepca_ca_dns_names(None, None, DEFAULT_CA_CONTAINER);
+
+        let first = update_ca_json_with_backup(
+            &secrets_dir,
+            "postgresql://step@postgres:5432/stepca",
+            "48h",
+            "acme",
+            &dns_names,
+            &messages,
+        )
+        .await
+        .unwrap();
+        assert!(first.metrics_address_changed);
+        assert!(first.stepca_reload_required());
+        assert_eq!(
+            read_ca_json(&secrets_dir)["metricsAddress"]
+                .as_str()
+                .unwrap(),
+            ":9102"
+        );
+        let raw = fs::read_to_string(secrets_dir.join("config").join("ca.json")).unwrap();
+        assert_eq!(
+            raw.matches("\"metricsAddress\"").count(),
+            1,
+            "ca.json must carry exactly one top-level metricsAddress"
+        );
+
+        let second = update_ca_json_with_backup(
+            &secrets_dir,
+            "postgresql://step@postgres:5432/stepca",
+            "48h",
+            "acme",
+            &dns_names,
+            &messages,
+        )
+        .await
+        .unwrap();
+        assert!(
+            !second.metrics_address_changed,
+            "a settled metricsAddress must not be rewritten"
+        );
+        assert!(
+            !second.stepca_reload_required(),
+            "a repeat init on a settled document must not restart step-ca"
+        );
+        assert_eq!(
+            fs::read_to_string(secrets_dir.join("config").join("ca.json")).unwrap(),
+            raw,
+            "second run must be a no-op"
+        );
+    }
+
+    /// The upgrade path the issue names: an installation whose
+    /// `dnsNames` are already correct and whose `ca.json` predates the
+    /// metrics setting.  Gating the template, sidecar and step-ca
+    /// restart on `dnsNames` alone would leave it without a listener.
+    #[tokio::test]
+    async fn update_ca_json_requires_reload_when_only_the_metrics_address_moves() {
+        let temp_dir = tempdir().unwrap();
+        let secrets_dir = temp_dir.path().join("secrets");
+        // `dnsNames` already carries exactly what the defaults derive.
+        write_ca_json(&secrets_dir, CA_JSON_FIXTURE);
+        let messages = test_messages();
+        let dns_names = build_stepca_ca_dns_names(None, None, DEFAULT_CA_CONTAINER);
+
+        let update = update_ca_json_with_backup(
+            &secrets_dir,
+            "postgresql://step@postgres:5432/stepca",
+            "48h",
+            "acme",
+            &dns_names,
+            &messages,
+        )
+        .await
+        .unwrap();
+        assert!(
+            !update.dns_names_changed,
+            "the fixture already carries the derived name set"
+        );
+        assert!(update.metrics_address_changed);
+        assert!(update.stepca_reload_required());
+    }
+
+    /// An operator (or a stale render) leaving another address behind
+    /// must not survive: the value has to match the scrape target
+    /// `monitoring/prometheus.yml` declares, so the reconciliation
+    /// overwrites rather than inherits.
+    #[tokio::test]
+    async fn reconcile_ca_json_managed_keys_repairs_a_clobbered_metrics_address() {
+        let temp_dir = tempdir().unwrap();
+        let secrets_dir = temp_dir.path().join("secrets");
+        write_ca_json(
+            &secrets_dir,
+            r#"{
+                "dnsNames": ["localhost", "bootroot-ca", "stepca.internal"],
+                "metricsAddress": ":9999",
+                "db": {"type": "postgresql", "dataSource": "dsn"},
+                "authority": {"provisioners": [{"type": "ACME", "name": "acme"}]}
+            }"#,
+        );
+        let messages = test_messages();
+        let dns_names = build_stepca_ca_dns_names(None, None, DEFAULT_CA_CONTAINER);
+
+        let changed = reconcile_ca_json_managed_keys(&secrets_dir, &dns_names, &messages)
+            .await
+            .unwrap();
+        assert!(
+            changed,
+            "an unchanged name set must not mask a drifted metrics address"
+        );
+        let after = read_ca_json(&secrets_dir);
+        assert_eq!(after["metricsAddress"].as_str().unwrap(), ":9102");
+        assert_eq!(dns_names_of(&after), dns_names);
+        assert_eq!(after["db"]["dataSource"].as_str().unwrap(), "dsn");
+
+        let changed_again = reconcile_ca_json_managed_keys(&secrets_dir, &dns_names, &messages)
+            .await
+            .unwrap();
+        assert!(!changed_again);
+        assert_eq!(read_ca_json(&secrets_dir), after);
+    }
+
+    /// The template is stamped, not inherited: the sidecar can re-render
+    /// `ca.json` from the previous template between the reconciliation
+    /// and the template write, so a `ca.json` without the key must still
+    /// produce a template that carries it (the #733 hazard, applied to
+    /// `metricsAddress`).
+    #[tokio::test]
+    async fn stepca_template_stamps_metrics_address_absent_from_ca_json() {
+        let temp_dir = tempdir().unwrap();
+        let secrets_dir = temp_dir.path().join("secrets");
+        write_ca_json(&secrets_dir, CA_JSON_FIXTURE);
+        let messages = test_messages();
+        let dns_names = build_stepca_ca_dns_names(None, None, DEFAULT_CA_CONTAINER);
+
+        assert!(
+            read_ca_json(&secrets_dir).get("metricsAddress").is_none(),
+            "the fixture stands in for a pre-metrics ca.json"
+        );
+        let paths =
+            write_stepca_templates(&secrets_dir, "secret", "48h", "acme", &dns_names, &messages)
+                .await
+                .unwrap();
+
+        // The .ctmpl embeds a raw Go directive in place of the DSN, so it
+        // is not valid JSON — match the serialised key/value textually.
+        let template = fs::read_to_string(&paths.ca_json_template_path).unwrap();
+        assert!(
+            template.contains("\"metricsAddress\": \":9102\""),
+            "ca.json.ctmpl must carry the metrics address: {template}"
+        );
+        assert_eq!(
+            template.matches("\"metricsAddress\"").count(),
+            1,
+            "ca.json.ctmpl must carry exactly one metricsAddress"
+        );
     }
 
     /// The snapshot feeding the init rollback must capture the template

--- a/src/commands/init/steps/stepca_setup.rs
+++ b/src/commands/init/steps/stepca_setup.rs
@@ -1407,6 +1407,27 @@ mod tests {
         );
     }
 
+    /// The two halves of the scrape live in different files and different
+    /// languages: `STEPCA_METRICS_ADDRESS` decides where step-ca listens,
+    /// `monitoring/prometheus.yml` decides where Prometheus knocks.  A
+    /// port changed on one side alone leaves the endpoint serving and the
+    /// declared target down, and every other test here would still pass —
+    /// only the Docker-gated E2E would notice, and only when it is run.
+    #[test]
+    fn metrics_address_port_matches_the_declared_scrape_target() {
+        let port = STEPCA_METRICS_ADDRESS
+            .strip_prefix(':')
+            .expect("the metrics address binds every in-container interface, so it is :<port>");
+        let scrape_config = fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("monitoring/prometheus.yml"),
+        )
+        .expect("read monitoring/prometheus.yml");
+        assert!(
+            scrape_config.contains(&format!("[\"step-ca:{port}\"]")),
+            "monitoring/prometheus.yml must scrape step-ca:{port}: {scrape_config}"
+        );
+    }
+
     /// The snapshot feeding the init rollback must capture the template
     /// as it stood *before* `write_stepca_templates` regenerates it, and
     /// must report "no template" rather than failing on a fresh install.

--- a/src/commands/init/steps/stepca_setup.rs
+++ b/src/commands/init/steps/stepca_setup.rs
@@ -391,27 +391,33 @@ pub(super) fn resolve_stepca_ca_dns_names(
     ))
 }
 
-/// Sets the top-level `dnsNames` array on a parsed `ca.json`, returning
-/// whether the value actually changed.
+/// Sets one top-level key on a parsed `ca.json`, returning whether the
+/// value actually changed.
 ///
-/// Every other key — `db`, `authority.provisioners`, and anything
-/// step-ca or an operator added that bootroot does not model — is left
-/// untouched, so the caller can re-serialise the same document.
-fn set_ca_json_dns_names(value: &mut serde_json::Value, dns_names: &[String]) -> bool {
-    let desired = serde_json::Value::Array(
-        dns_names
-            .iter()
-            .map(|name| serde_json::Value::String(name.clone()))
-            .collect(),
-    );
-    if value.get(CA_JSON_DNS_NAMES_KEY) == Some(&desired) {
+/// Inserts into the parsed document rather than rebuilding it: every
+/// other key — `db`, `authority.provisioners`, and anything step-ca or
+/// an operator added that bootroot does not model — is left untouched,
+/// so the caller can re-serialise the same document, and the key ends up
+/// present exactly once whether or not it was there before.
+fn set_ca_json_key(value: &mut serde_json::Value, key: &str, desired: serde_json::Value) -> bool {
+    if value.get(key) == Some(&desired) {
         return false;
     }
     if let Some(object) = value.as_object_mut() {
-        object.insert(CA_JSON_DNS_NAMES_KEY.to_string(), desired);
+        object.insert(key.to_string(), desired);
         return true;
     }
     false
+}
+
+/// Sets the top-level `dnsNames` array on a parsed `ca.json`, returning
+/// whether the value actually changed.
+fn set_ca_json_dns_names(value: &mut serde_json::Value, dns_names: &[String]) -> bool {
+    let desired = dns_names
+        .iter()
+        .map(|name| serde_json::Value::String(name.clone()))
+        .collect();
+    set_ca_json_key(value, CA_JSON_DNS_NAMES_KEY, desired)
 }
 
 /// Sets the top-level `metricsAddress` on a parsed `ca.json` to
@@ -420,19 +426,9 @@ fn set_ca_json_dns_names(value: &mut serde_json::Value, dns_names: &[String]) ->
 ///
 /// Takes no argument for the same reason the constant is fixed: the
 /// scrape target is a compile-time constant on the Prometheus side.
-/// Like [`set_ca_json_dns_names`] it inserts into the parsed document,
-/// so every other key survives and the document ends up carrying
-/// exactly one `metricsAddress`.
 fn set_ca_json_metrics_address(value: &mut serde_json::Value) -> bool {
     let desired = serde_json::Value::String(STEPCA_METRICS_ADDRESS.to_string());
-    if value.get(CA_JSON_METRICS_ADDRESS_KEY) == Some(&desired) {
-        return false;
-    }
-    if let Some(object) = value.as_object_mut() {
-        object.insert(CA_JSON_METRICS_ADDRESS_KEY.to_string(), desired);
-        return true;
-    }
-    false
+    set_ca_json_key(value, CA_JSON_METRICS_ADDRESS_KEY, desired)
 }
 
 /// Outcome of `update_ca_json_with_backup`.

--- a/tests/docker_compose_security.rs
+++ b/tests/docker_compose_security.rs
@@ -46,28 +46,139 @@ fn deploy_core_service_host_ports_are_interpolated_with_todays_defaults() {
     }
 }
 
+const METRICS_PORT: &str = "9102";
+
+fn line_indent(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// Returns the lines nested under `services.<service>.<key>`, or `None`
+/// when the service declares no such key. Compose is read structurally
+/// rather than by substring so a mapping can be judged by the section it
+/// sits in: the same `- "9102"` entry is the wanted exposure under
+/// `expose:` and a host publication under `ports:`.
+fn service_key_block<'a>(compose: &'a str, service: &str, key: &str) -> Option<Vec<&'a str>> {
+    let significant = |line: &&str| {
+        let trimmed = line.trim();
+        !trimmed.is_empty() && !trimmed.starts_with('#')
+    };
+    let mut lines = compose.lines().filter(significant).peekable();
+    let mut in_services = false;
+    let mut in_service = false;
+    while let Some(line) = lines.next() {
+        let indent = line_indent(line);
+        let trimmed = line.trim();
+        match indent {
+            0 => in_services = trimmed == "services:",
+            2 if in_services => in_service = trimmed == format!("{service}:"),
+            4 if in_service && trimmed == format!("{key}:") => {
+                let mut block = Vec::new();
+                while let Some(entry) = lines.peek() {
+                    if line_indent(entry) <= 4 {
+                        break;
+                    }
+                    block.push(entry.trim());
+                    lines.next();
+                }
+                return Some(block);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// step-ca's Prometheus metrics listener (issue #864). `bootroot init`
 /// writes `metricsAddress: ":9102"` into `ca.json`, which starts an
 /// unauthenticated, plaintext endpoint; the only boundary it has is the
 /// Compose network. The port is therefore `expose`d — so Prometheus can
-/// reach `step-ca:9102` — and must never appear in a `ports:` mapping,
-/// which would put internal telemetry on the host's network.
+/// reach `step-ca:9102` — and must never appear under `ports:`, which
+/// would put internal telemetry on the host's network.
 ///
-/// A publish is `- "9102:9102"` or `- "127.0.0.1:9102:9102"`; the
-/// expose is the bare `- "9102"`. Any other quoted list entry carrying
-/// the port is therefore a publish, whichever key it sits under.
+/// Every `ports:` syntax is rejected by looking for the port anywhere in
+/// the section: the short `- "9102:9102"` and `- "127.0.0.1:9102:9102"`,
+/// the short `- "9102"` that Compose publishes to an ephemeral host port
+/// on every interface, and the long `- target: 9102` mapping.
 fn assert_metrics_port_exposed_never_published(compose: &str, file_name: &str) {
+    let exposed = service_key_block(compose, "step-ca", "expose")
+        .unwrap_or_else(|| panic!("{file_name} must declare expose: on step-ca"));
     assert!(
-        compose.contains("    expose:\n      - \"9102\"\n"),
-        "{file_name} must expose 9102 on step-ca so Prometheus can scrape it"
+        exposed
+            .iter()
+            .any(|entry| entry.trim_start_matches("- ").trim_matches('"') == METRICS_PORT),
+        "{file_name} must expose {METRICS_PORT} on step-ca so Prometheus can scrape it, found: {exposed:?}"
     );
-    for line in compose.lines() {
-        let entry = line.trim();
+    let published = service_key_block(compose, "step-ca", "ports").unwrap_or_default();
+    for entry in published {
         assert!(
-            !(entry.starts_with("- \"") && entry.contains("9102") && entry != "- \"9102\""),
-            "{file_name} must not publish step-ca's metrics port to the host, found: {line}"
+            !entry.contains(METRICS_PORT),
+            "{file_name} must not publish step-ca's metrics port to the host, \
+             found under step-ca ports: {entry}"
         );
     }
+}
+
+/// The guard above judges a mapping by the section it sits in, so a
+/// reader that silently found the wrong section — or none — would let
+/// every publication pass. Pin it against a document that puts the port
+/// under a neighbouring service's `ports:` and under step-ca's `expose:`.
+const SECTION_FIXTURE: &str = concat!(
+    "services:\n",
+    "  openbao:\n",
+    "    ports:\n",
+    "      # a neighbour publishing 9102 says nothing about step-ca\n",
+    "      - \"127.0.0.1:9102:9102\"\n",
+    "\n",
+    "  step-ca:\n",
+    "    ports:\n",
+    "      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
+    "    expose:\n",
+    "      - \"9102\"\n",
+    "    volumes:\n",
+    "      - ./secrets:/home/step\n",
+    "volumes:\n",
+    "  openbao-data:\n",
+);
+
+#[test]
+fn service_key_block_reads_the_named_section_only() {
+    assert_eq!(
+        service_key_block(SECTION_FIXTURE, "step-ca", "ports"),
+        Some(vec!["- \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\""])
+    );
+    assert_eq!(
+        service_key_block(SECTION_FIXTURE, "step-ca", "expose"),
+        Some(vec!["- \"9102\""])
+    );
+    assert_eq!(
+        service_key_block(SECTION_FIXTURE, "step-ca", "healthcheck"),
+        None
+    );
+    assert_metrics_port_exposed_never_published(SECTION_FIXTURE, "fixture");
+}
+
+/// Compose publishes a bare `- "9102"` under `ports:` to an ephemeral
+/// host port on every interface — the same entry the exposure needs.
+#[test]
+#[should_panic(expected = "must not publish step-ca's metrics port")]
+fn short_form_publication_of_the_metrics_port_is_rejected() {
+    let published = SECTION_FIXTURE.replace(
+        "    ports:\n      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
+        "    ports:\n      - \"9102\"\n",
+    );
+    assert_metrics_port_exposed_never_published(&published, "fixture");
+}
+
+/// The long syntax names the container port under `target:`, so nothing
+/// in the entry looks like a `host:container` mapping.
+#[test]
+#[should_panic(expected = "must not publish step-ca's metrics port")]
+fn long_form_publication_of_the_metrics_port_is_rejected() {
+    let published = SECTION_FIXTURE.replace(
+        "      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
+        "      - target: 9102\n        published: \"19102\"\n",
+    );
+    assert_metrics_port_exposed_never_published(&published, "fixture");
 }
 
 #[test]

--- a/tests/docker_compose_security.rs
+++ b/tests/docker_compose_security.rs
@@ -46,6 +46,44 @@ fn deploy_core_service_host_ports_are_interpolated_with_todays_defaults() {
     }
 }
 
+/// step-ca's Prometheus metrics listener (issue #864). `bootroot init`
+/// writes `metricsAddress: ":9102"` into `ca.json`, which starts an
+/// unauthenticated, plaintext endpoint; the only boundary it has is the
+/// Compose network. The port is therefore `expose`d — so Prometheus can
+/// reach `step-ca:9102` — and must never appear in a `ports:` mapping,
+/// which would put internal telemetry on the host's network.
+///
+/// A publish is `- "9102:9102"` or `- "127.0.0.1:9102:9102"`; the
+/// expose is the bare `- "9102"`. Any other quoted list entry carrying
+/// the port is therefore a publish, whichever key it sits under.
+fn assert_metrics_port_exposed_never_published(compose: &str, file_name: &str) {
+    assert!(
+        compose.contains("    expose:\n      - \"9102\"\n"),
+        "{file_name} must expose 9102 on step-ca so Prometheus can scrape it"
+    );
+    for line in compose.lines() {
+        let entry = line.trim();
+        assert!(
+            !(entry.starts_with("- \"") && entry.contains("9102") && entry != "- \"9102\""),
+            "{file_name} must not publish step-ca's metrics port to the host, found: {line}"
+        );
+    }
+}
+
+#[test]
+fn stepca_metrics_port_is_exposed_but_never_published() {
+    let compose_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docker-compose.yml");
+    let compose = fs::read_to_string(compose_path).expect("read docker-compose.yml");
+    assert_metrics_port_exposed_never_published(&compose, "docker-compose.yml");
+}
+
+#[test]
+fn deploy_stepca_metrics_port_is_exposed_but_never_published() {
+    let compose_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docker-compose.deploy.yml");
+    let compose = fs::read_to_string(compose_path).expect("read docker-compose.deploy.yml");
+    assert_metrics_port_exposed_never_published(&compose, "docker-compose.deploy.yml");
+}
+
 #[test]
 fn postgres_volume_uses_postgresql_root_for_postgres_18() {
     let compose_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docker-compose.yml");

--- a/tests/docker_compose_security.rs
+++ b/tests/docker_compose_security.rs
@@ -52,12 +52,46 @@ fn line_indent(line: &str) -> usize {
     line.len() - line.trim_start().len()
 }
 
-/// Returns the lines nested under `services.<service>.<key>`, or `None`
-/// when the service declares no such key. Compose is read structurally
-/// rather than by substring so a mapping can be judged by the section it
-/// sits in: the same `- "9102"` entry is the wanted exposure under
-/// `expose:` and a host publication under `ports:`.
-fn service_key_block<'a>(compose: &'a str, service: &str, key: &str) -> Option<Vec<&'a str>> {
+/// The value of `services.<service>.<key>`, classified by the YAML form
+/// it is written in. A guard that judges entries has to know when it is
+/// looking at all of them: a form it cannot enumerate is not an empty
+/// section.
+#[derive(Debug, PartialEq)]
+enum SectionValue<'a> {
+    /// A block sequence — one entry per line nested under the key.
+    Block(Vec<&'a str>),
+    /// A flow sequence written on the key's own line: `ports: ["9102"]`.
+    Flow(Vec<&'a str>),
+    /// Anything else on the key's own line: an alias (`ports: *shared`),
+    /// a flow mapping, a scalar. The entries live elsewhere in the
+    /// document, or nowhere this reader can follow.
+    Unreadable(&'a str),
+}
+
+impl<'a> SectionValue<'a> {
+    /// Returns the section's entries, or `None` when the form does not
+    /// carry them.
+    fn entries(&self) -> Option<&[&'a str]> {
+        match self {
+            SectionValue::Block(entries) | SectionValue::Flow(entries) => Some(entries),
+            SectionValue::Unreadable(_) => None,
+        }
+    }
+}
+
+/// An anchor declared on a block value (`ports: &stepca_ports`) leaves
+/// the entries where they were, on the lines below.
+fn is_bare_anchor(rest: &str) -> bool {
+    rest.strip_prefix('&')
+        .is_some_and(|name| !name.is_empty() && !name.contains(char::is_whitespace))
+}
+
+/// Returns the value of `services.<service>.<key>`, or `None` when the
+/// service declares no such key. Compose is read structurally rather
+/// than by substring so a mapping can be judged by the section it sits
+/// in: the same `- "9102"` entry is the wanted exposure under `expose:`
+/// and a host publication under `ports:`.
+fn service_key_value<'a>(compose: &'a str, service: &str, key: &str) -> Option<SectionValue<'a>> {
     let significant = |line: &&str| {
         let trimmed = line.trim();
         !trimmed.is_empty() && !trimmed.starts_with('#')
@@ -69,9 +103,33 @@ fn service_key_block<'a>(compose: &'a str, service: &str, key: &str) -> Option<V
         let indent = line_indent(line);
         let trimmed = line.trim();
         match indent {
-            0 => in_services = trimmed == "services:",
-            2 if in_services => in_service = trimmed == format!("{service}:"),
-            4 if in_service && trimmed == format!("{key}:") => {
+            0 => {
+                in_services = trimmed == "services:";
+                in_service = false;
+            }
+            2 => in_service = in_services && trimmed == format!("{service}:"),
+            4 if in_service => {
+                let Some(rest) = trimmed
+                    .strip_prefix(key)
+                    .and_then(|rest| rest.strip_prefix(':'))
+                    .map(str::trim)
+                else {
+                    continue;
+                };
+                if !rest.is_empty() && !is_bare_anchor(rest) {
+                    let flow = rest
+                        .strip_prefix('[')
+                        .and_then(|inner| inner.strip_suffix(']'));
+                    return Some(flow.map_or(SectionValue::Unreadable(rest), |inner| {
+                        SectionValue::Flow(
+                            inner
+                                .split(',')
+                                .map(str::trim)
+                                .filter(|entry| !entry.is_empty())
+                                .collect(),
+                        )
+                    }));
+                }
                 let mut block = Vec::new();
                 while let Some(entry) = lines.peek() {
                     if line_indent(entry) <= 4 {
@@ -80,12 +138,22 @@ fn service_key_block<'a>(compose: &'a str, service: &str, key: &str) -> Option<V
                     block.push(entry.trim());
                     lines.next();
                 }
-                return Some(block);
+                return Some(SectionValue::Block(block));
             }
             _ => {}
         }
     }
     None
+}
+
+/// Strips the block sequence's `- ` and the quoting either form may
+/// carry, leaving the entry's text.
+fn entry_text(entry: &str) -> &str {
+    entry
+        .strip_prefix("- ")
+        .unwrap_or(entry)
+        .trim()
+        .trim_matches(['"', '\''])
 }
 
 /// step-ca's Prometheus metrics listener (issue #864). `bootroot init`
@@ -95,21 +163,42 @@ fn service_key_block<'a>(compose: &'a str, service: &str, key: &str) -> Option<V
 /// reach `step-ca:9102` — and must never appear under `ports:`, which
 /// would put internal telemetry on the host's network.
 ///
-/// Every `ports:` syntax is rejected by looking for the port anywhere in
-/// the section: the short `- "9102:9102"` and `- "127.0.0.1:9102:9102"`,
-/// the short `- "9102"` that Compose publishes to an ephemeral host port
-/// on every interface, and the long `- target: 9102` mapping.
+/// Every `ports:` syntax that names the port is rejected by looking for
+/// it anywhere in the section: the short `- "9102:9102"` and
+/// `- "127.0.0.1:9102:9102"`, the short `- "9102"` that Compose
+/// publishes to an ephemeral host port on every interface, the long
+/// `- target: 9102` mapping, and the flow `ports: ["9102"]`. A `ports:`
+/// whose entries this reader cannot enumerate — an alias, a scalar — is
+/// rejected outright rather than read as an absent section, because a
+/// guard that cannot see the entries cannot clear them.
 fn assert_metrics_port_exposed_never_published(compose: &str, file_name: &str) {
-    let exposed = service_key_block(compose, "step-ca", "expose")
+    let exposed = service_key_value(compose, "step-ca", "expose")
         .unwrap_or_else(|| panic!("{file_name} must declare expose: on step-ca"));
+    let exposed = exposed.entries().unwrap_or_else(|| {
+        panic!(
+            "{file_name} writes step-ca's expose: in a form this guard cannot read: {exposed:?}. \
+             Write it as a list, or teach the reader the form."
+        )
+    });
     assert!(
         exposed
             .iter()
-            .any(|entry| entry.trim_start_matches("- ").trim_matches('"') == METRICS_PORT),
+            .copied()
+            .map(entry_text)
+            .any(|entry| entry == METRICS_PORT),
         "{file_name} must expose {METRICS_PORT} on step-ca so Prometheus can scrape it, found: {exposed:?}"
     );
-    let published = service_key_block(compose, "step-ca", "ports").unwrap_or_default();
-    for entry in published {
+    let Some(published) = service_key_value(compose, "step-ca", "ports") else {
+        return;
+    };
+    let entries = published.entries().unwrap_or_else(|| {
+        panic!(
+            "{file_name} writes step-ca's ports: in a form this guard cannot read: {published:?}. \
+             Write it as a list, or teach the reader the form — an unreadable ports: cannot be \
+             cleared of {METRICS_PORT}."
+        )
+    });
+    for entry in entries {
         assert!(
             !entry.contains(METRICS_PORT),
             "{file_name} must not publish step-ca's metrics port to the host, \
@@ -141,20 +230,61 @@ const SECTION_FIXTURE: &str = concat!(
 );
 
 #[test]
-fn service_key_block_reads_the_named_section_only() {
+fn service_key_value_reads_the_named_section_only() {
     assert_eq!(
-        service_key_block(SECTION_FIXTURE, "step-ca", "ports"),
-        Some(vec!["- \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\""])
+        service_key_value(SECTION_FIXTURE, "step-ca", "ports"),
+        Some(SectionValue::Block(vec![
+            "- \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\""
+        ]))
     );
     assert_eq!(
-        service_key_block(SECTION_FIXTURE, "step-ca", "expose"),
-        Some(vec!["- \"9102\""])
+        service_key_value(SECTION_FIXTURE, "step-ca", "expose"),
+        Some(SectionValue::Block(vec!["- \"9102\""]))
     );
     assert_eq!(
-        service_key_block(SECTION_FIXTURE, "step-ca", "healthcheck"),
+        service_key_value(SECTION_FIXTURE, "step-ca", "healthcheck"),
         None
     );
     assert_metrics_port_exposed_never_published(SECTION_FIXTURE, "fixture");
+}
+
+/// A key whose value shares its line is a different YAML form, not a
+/// missing key: the flow sequence carries its entries there, and an
+/// alias carries them somewhere this reader does not follow. An anchor
+/// alone still leaves a block underneath.
+#[test]
+fn service_key_value_classifies_the_forms_that_share_the_keys_line() {
+    let flow = SECTION_FIXTURE.replace(
+        "    ports:\n      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
+        "    ports: [\"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\", \"9102\"]\n",
+    );
+    assert_eq!(
+        service_key_value(&flow, "step-ca", "ports"),
+        Some(SectionValue::Flow(vec![
+            "\"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"",
+            "\"9102\""
+        ]))
+    );
+
+    let aliased = SECTION_FIXTURE.replace(
+        "    ports:\n      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
+        "    ports: *shared_ports\n",
+    );
+    assert_eq!(
+        service_key_value(&aliased, "step-ca", "ports"),
+        Some(SectionValue::Unreadable("*shared_ports"))
+    );
+
+    let anchored = SECTION_FIXTURE.replace(
+        "    ports:\n      - \"127",
+        "    ports: &shared_ports\n      - \"127",
+    );
+    assert_eq!(
+        service_key_value(&anchored, "step-ca", "ports"),
+        Some(SectionValue::Block(vec![
+            "- \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\""
+        ]))
+    );
 }
 
 /// Compose publishes a bare `- "9102"` under `ports:` to an ephemeral
@@ -177,6 +307,32 @@ fn long_form_publication_of_the_metrics_port_is_rejected() {
     let published = SECTION_FIXTURE.replace(
         "      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
         "      - target: 9102\n        published: \"19102\"\n",
+    );
+    assert_metrics_port_exposed_never_published(&published, "fixture");
+}
+
+/// The flow sequence is the same publication written on the key's own
+/// line; the section reader has to carry its entries out, not report the
+/// key missing.
+#[test]
+#[should_panic(expected = "must not publish step-ca's metrics port")]
+fn flow_sequence_publication_of_the_metrics_port_is_rejected() {
+    let published = SECTION_FIXTURE.replace(
+        "    ports:\n      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
+        "    ports: [\"9102\"]\n",
+    );
+    assert_metrics_port_exposed_never_published(&published, "fixture");
+}
+
+/// An alias puts the entries in an anchor elsewhere in the document. The
+/// guard cannot tell whether they name the metrics port, so it fails
+/// rather than clearing a section it never read.
+#[test]
+#[should_panic(expected = "ports: in a form this guard cannot read")]
+fn aliased_ports_are_rejected() {
+    let published = SECTION_FIXTURE.replace(
+        "    ports:\n      - \"127.0.0.1:${STEPCA_HOST_PORT:-9000}:9000\"\n",
+        "    ports: *shared_ports\n",
     );
     assert_metrics_port_exposed_never_published(&published, "fixture");
 }

--- a/tests/docker_e2e_stepca_san.rs
+++ b/tests/docker_e2e_stepca_san.rs
@@ -20,6 +20,13 @@ mod unix_integration {
     /// additionally re-checks the name set after a full `OpenBao` Agent
     /// render interval, because the step-ca sidecar re-renders `ca.json`
     /// from its template and would otherwise silently regress it.
+    ///
+    /// Also covers #864, which rides on the same co-ownership: `init`
+    /// writes the top-level `metricsAddress` step-ca needs before it
+    /// will serve `/metrics` at all, and the script asserts both that
+    /// the value survives a real sidecar render and that the endpoint
+    /// answers from inside the Compose network — where the port is
+    /// reachable — rather than from the host, where it is not published.
     #[test]
     #[ignore = "Requires local Docker and a non-loopback bind host for step-ca SAN validation"]
     fn docker_stepca_san_bind_and_repair() -> Result<()> {
@@ -79,6 +86,21 @@ mod unix_integration {
             assert!(
                 san.contains("IP Address:"),
                 "{label} step-ca certificate carries no IP SAN: {san}"
+            );
+        }
+
+        // The metrics dumps are the #864 artefact, and asserting them
+        // here is what stops a script that skipped the scrape from
+        // passing: the endpoint is fetched from inside the Compose
+        // network, so nothing on the host can produce this file.
+        for label in ["scenario-a", "scenario-b"] {
+            let metrics = artifact_dir.join(format!("stepca-metrics-{label}.txt"));
+            assert!(metrics.exists(), "missing step-ca metrics dump for {label}");
+            let body = std::fs::read_to_string(&metrics)
+                .with_context(|| format!("Failed to read step-ca metrics for {label}"))?;
+            assert!(
+                body.lines().any(|line| line.starts_with("# HELP ")),
+                "{label} step-ca /metrics returned no Prometheus exposition data: {body}"
             );
         }
 

--- a/tests/docker_e2e_stepca_san.rs
+++ b/tests/docker_e2e_stepca_san.rs
@@ -3,10 +3,140 @@ mod support;
 
 #[cfg(unix)]
 mod unix_integration {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
     use anyhow::{Context, Result};
+
+    /// Phases the harness must log, in the order it runs them.  A
+    /// scenario that was skipped or died half-way leaves a gap here, so
+    /// the wrapper fails rather than trusting the script's exit status
+    /// alone.
+    const REQUIRED_PHASES: &[&str] = &[
+        "scenario-a-install",
+        "scenario-a-init",
+        "scenario-a-assert",
+        "scenario-b-install-loopback",
+        "scenario-b-init-loopback",
+        "scenario-b-install-bind",
+        "scenario-b-init-repair",
+        "scenario-b-assert",
+        "scenario-b-assert-stable",
+        "scenario-c-strip-metrics",
+        "scenario-c-init-upgrade",
+        "scenario-c-assert",
+        "scenario-c-assert-stable",
+    ];
+
+    fn assert_phases_logged(artifact_dir: &Path) -> Result<()> {
+        let phase_log = artifact_dir.join("phases.log");
+        assert!(phase_log.exists(), "missing phase log");
+        let phases =
+            std::fs::read_to_string(&phase_log).with_context(|| "Failed to read phase log")?;
+        for phase in REQUIRED_PHASES {
+            assert!(
+                phases.contains(&format!("\"phase\":\"{phase}\"")),
+                "missing phase {phase} in {phases}"
+            );
+        }
+        Ok(())
+    }
+
+    /// The SAN dumps are the artefact #733's acceptance criteria name;
+    /// keeping them asserted here is what stops a script that silently
+    /// stopped short of the certificate checks from passing.
+    fn assert_ip_sans(artifact_dir: &Path) -> Result<()> {
+        let cert_meta = artifact_dir.join("cert-meta");
+        for label in ["scenario-a", "scenario-b"] {
+            let san_file = cert_meta.join(format!("{label}-stepca-san.txt"));
+            assert!(san_file.exists(), "missing SAN dump for {label}");
+            let san = std::fs::read_to_string(&san_file)
+                .with_context(|| format!("Failed to read SAN dump for {label}"))?;
+            assert!(
+                san.contains("IP Address:"),
+                "{label} step-ca certificate carries no IP SAN: {san}"
+            );
+        }
+        Ok(())
+    }
+
+    /// The metrics dumps are the #864 artefact: the endpoint is fetched
+    /// from inside the Compose network, so nothing running on the host
+    /// can produce these files.
+    ///
+    /// Scenario C contributes two of them, and both matter.  Its
+    /// baseline is step-ca restarted onto a `ca.json` stripped of
+    /// `metricsAddress`; without it, the scenario's own dump would prove
+    /// only that a listener from an earlier boot outlived the edit.  The
+    /// endpoint going away and then coming back is what attributes it to
+    /// `init`.
+    fn assert_metrics_dumps(artifact_dir: &Path) -> Result<()> {
+        for label in ["scenario-a", "scenario-b", "scenario-c"] {
+            let metrics = artifact_dir.join(format!("stepca-metrics-{label}.txt"));
+            assert!(metrics.exists(), "missing step-ca metrics dump for {label}");
+            let body = std::fs::read_to_string(&metrics)
+                .with_context(|| format!("Failed to read step-ca metrics for {label}"))?;
+            assert!(
+                body.lines().any(|line| line.starts_with("# HELP ")),
+                "{label} step-ca /metrics returned no Prometheus exposition data: {body}"
+            );
+        }
+
+        let baseline = artifact_dir.join("stepca-metrics-scenario-c-baseline.txt");
+        assert!(
+            baseline.exists(),
+            "missing step-ca metrics baseline dump for scenario-c"
+        );
+        let baseline_body = std::fs::read_to_string(&baseline)
+            .with_context(|| "Failed to read step-ca metrics baseline for scenario-c")?;
+        assert!(
+            !baseline_body
+                .lines()
+                .any(|line| line.starts_with("# HELP ")),
+            "step-ca still served metrics without metricsAddress: {baseline_body}"
+        );
+        Ok(())
+    }
+
+    /// Prometheus's own view of the same endpoint, on the clean install.
+    /// The endpoint answering and the declared scrape target resolving
+    /// to it are two claims, and the operator reads the second one.
+    fn assert_prometheus_reports_stepca_up(artifact_dir: &Path) -> Result<()> {
+        let targets = artifact_dir.join("prometheus-targets-scenario-a.json");
+        assert!(targets.exists(), "missing Prometheus targets dump");
+        let body = std::fs::read_to_string(&targets)
+            .with_context(|| "Failed to read Prometheus targets dump")?;
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).with_context(|| "Prometheus targets dump is not JSON")?;
+        let step_ca_is_up = parsed["data"]["activeTargets"]
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .any(|target| target["labels"]["job"] == "step-ca" && target["health"] == "up");
+        assert!(
+            step_ca_is_up,
+            "Prometheus did not report the step-ca scrape target as up: {body}"
+        );
+        Ok(())
+    }
+
+    fn assert_acme_directories(artifact_dir: &Path) -> Result<()> {
+        for label in ["scenario-a", "scenario-b", "scenario-c"] {
+            let directory = artifact_dir.join(format!("acme-directory-{label}.json"));
+            assert!(
+                directory.exists(),
+                "missing ACME directory response for {label}"
+            );
+            let body = std::fs::read_to_string(&directory)
+                .with_context(|| format!("Failed to read ACME directory for {label}"))?;
+            assert!(
+                body.contains("newNonce"),
+                "{label} ACME directory response is not a directory: {body}"
+            );
+        }
+        Ok(())
+    }
 
     /// Closes #733: step-ca's own serving certificate must carry the
     /// address `--stepca-bind` publishes it on, otherwise every off-host
@@ -30,6 +160,13 @@ mod unix_integration {
     /// On the clean install it also brings Prometheus up and waits for
     /// the `step-ca` job the bundled scrape config has always declared
     /// to report `up`.
+    ///
+    /// A third scenario isolates the upgrade every existing installation
+    /// takes: with `dnsNames` already settled, the only thing an `init`
+    /// moves is the metrics address, and the listener still has to come
+    /// back without the CA material being replaced.  The first two
+    /// scenarios both change the name set, so neither can tell that gate
+    /// from the one beside it.
     #[test]
     #[ignore = "Requires local Docker and a non-loopback bind host for step-ca SAN validation"]
     fn docker_stepca_san_bind_and_repair() -> Result<()> {
@@ -56,91 +193,11 @@ mod unix_integration {
             anyhow::bail!("step-ca SAN script failed: {stderr}");
         }
 
-        let phase_log = artifact_dir.join("phases.log");
-        assert!(phase_log.exists());
-        let phases =
-            std::fs::read_to_string(&phase_log).with_context(|| "Failed to read phase log")?;
-        for phase in [
-            "scenario-a-install",
-            "scenario-a-init",
-            "scenario-a-assert",
-            "scenario-b-install-loopback",
-            "scenario-b-init-loopback",
-            "scenario-b-install-bind",
-            "scenario-b-init-repair",
-            "scenario-b-assert",
-            "scenario-b-assert-stable",
-        ] {
-            assert!(
-                phases.contains(&format!("\"phase\":\"{phase}\"")),
-                "missing phase {phase} in {phases}"
-            );
-        }
-
-        // The SAN dumps are the artefact the acceptance criteria name;
-        // keep them asserted here so a script that silently stopped
-        // short of the certificate checks cannot pass.
-        let cert_meta = artifact_dir.join("cert-meta");
-        for label in ["scenario-a", "scenario-b"] {
-            let san_file = cert_meta.join(format!("{label}-stepca-san.txt"));
-            assert!(san_file.exists(), "missing SAN dump for {label}");
-            let san = std::fs::read_to_string(&san_file)
-                .with_context(|| format!("Failed to read SAN dump for {label}"))?;
-            assert!(
-                san.contains("IP Address:"),
-                "{label} step-ca certificate carries no IP SAN: {san}"
-            );
-        }
-
-        // The metrics dumps are the #864 artefact, and asserting them
-        // here is what stops a script that skipped the scrape from
-        // passing: the endpoint is fetched from inside the Compose
-        // network, so nothing on the host can produce this file.
-        for label in ["scenario-a", "scenario-b"] {
-            let metrics = artifact_dir.join(format!("stepca-metrics-{label}.txt"));
-            assert!(metrics.exists(), "missing step-ca metrics dump for {label}");
-            let body = std::fs::read_to_string(&metrics)
-                .with_context(|| format!("Failed to read step-ca metrics for {label}"))?;
-            assert!(
-                body.lines().any(|line| line.starts_with("# HELP ")),
-                "{label} step-ca /metrics returned no Prometheus exposition data: {body}"
-            );
-        }
-
-        // Prometheus's own view of the same endpoint, on the clean
-        // install. The endpoint answering and the declared scrape target
-        // resolving to it are two claims, and the operator reads the
-        // second one.
-        let targets = artifact_dir.join("prometheus-targets-scenario-a.json");
-        assert!(targets.exists(), "missing Prometheus targets dump");
-        let body = std::fs::read_to_string(&targets)
-            .with_context(|| "Failed to read Prometheus targets dump")?;
-        let parsed: serde_json::Value =
-            serde_json::from_str(&body).with_context(|| "Prometheus targets dump is not JSON")?;
-        let step_ca_is_up = parsed["data"]["activeTargets"]
-            .as_array()
-            .map(Vec::as_slice)
-            .unwrap_or_default()
-            .iter()
-            .any(|target| target["labels"]["job"] == "step-ca" && target["health"] == "up");
-        assert!(
-            step_ca_is_up,
-            "Prometheus did not report the step-ca scrape target as up: {body}"
-        );
-
-        for label in ["scenario-a", "scenario-b"] {
-            let directory = artifact_dir.join(format!("acme-directory-{label}.json"));
-            assert!(
-                directory.exists(),
-                "missing ACME directory response for {label}"
-            );
-            let body = std::fs::read_to_string(&directory)
-                .with_context(|| format!("Failed to read ACME directory for {label}"))?;
-            assert!(
-                body.contains("newNonce"),
-                "{label} ACME directory response is not a directory: {body}"
-            );
-        }
+        assert_phases_logged(&artifact_dir)?;
+        assert_ip_sans(&artifact_dir)?;
+        assert_metrics_dumps(&artifact_dir)?;
+        assert_prometheus_reports_stepca_up(&artifact_dir)?;
+        assert_acme_directories(&artifact_dir)?;
 
         Ok(())
     }

--- a/tests/docker_e2e_stepca_san.rs
+++ b/tests/docker_e2e_stepca_san.rs
@@ -27,6 +27,9 @@ mod unix_integration {
     /// the value survives a real sidecar render and that the endpoint
     /// answers from inside the Compose network — where the port is
     /// reachable — rather than from the host, where it is not published.
+    /// On the clean install it also brings Prometheus up and waits for
+    /// the `step-ca` job the bundled scrape config has always declared
+    /// to report `up`.
     #[test]
     #[ignore = "Requires local Docker and a non-loopback bind host for step-ca SAN validation"]
     fn docker_stepca_san_bind_and_repair() -> Result<()> {
@@ -103,6 +106,27 @@ mod unix_integration {
                 "{label} step-ca /metrics returned no Prometheus exposition data: {body}"
             );
         }
+
+        // Prometheus's own view of the same endpoint, on the clean
+        // install. The endpoint answering and the declared scrape target
+        // resolving to it are two claims, and the operator reads the
+        // second one.
+        let targets = artifact_dir.join("prometheus-targets-scenario-a.json");
+        assert!(targets.exists(), "missing Prometheus targets dump");
+        let body = std::fs::read_to_string(&targets)
+            .with_context(|| "Failed to read Prometheus targets dump")?;
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).with_context(|| "Prometheus targets dump is not JSON")?;
+        let step_ca_is_up = parsed["data"]["activeTargets"]
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .any(|target| target["labels"]["job"] == "step-ca" && target["health"] == "up");
+        assert!(
+            step_ca_is_up,
+            "Prometheus did not report the step-ca scrape target as up: {body}"
+        );
 
         for label in ["scenario-a", "scenario-b"] {
             let directory = artifact_dir.join(format!("acme-directory-{label}.json"));

--- a/tests/monitoring_integration.rs
+++ b/tests/monitoring_integration.rs
@@ -298,25 +298,23 @@ mod unix_integration {
 
     /// Waits until Prometheus reports the `openbao` scrape target healthy.
     ///
-    /// The `step-ca` job is deliberately not asserted. Nothing in this
-    /// repository configures step-ca to serve metrics, so `step-ca:9102`
-    /// — the target `monitoring/prometheus.yml` scrapes — has never had a
-    /// listener, here or in production: step-ca serves metrics only when
-    /// its `ca.json` carries a top-level `metricsAddress`, no code writes
-    /// that key, `step ca init` does not emit it, the patcher in
-    /// `src/commands/init/steps/stepca_setup.rs` touches only `dnsNames`,
-    /// `db` and the ACME provisioner, and the pinned binary accepts the
-    /// address through no flag or environment variable, so compose cannot
-    /// supply it either.
+    /// The `step-ca` job is deliberately not asserted, and that is a
+    /// property of this test's starting point rather than a gap in the
+    /// product. step-ca serves metrics only when its `ca.json` carries a
+    /// top-level `metricsAddress`, and the pinned binary accepts the
+    /// address through no flag and no environment variable, so compose
+    /// cannot supply it. `bootroot init` writes the key — the address
+    /// `monitoring/prometheus.yml` scrapes, `:9102` — into both
+    /// `secrets/config/ca.json` and the `OpenBao` Agent template it is
+    /// re-rendered from, so a production install has the listener from
+    /// its first `init` onwards (issue #864).
     ///
-    /// That is a defect in the monitoring stack rather than in this test,
-    /// and closing it means writing `metricsAddress` from `init` — a
-    /// production change #825 does not authorise, and one this test could
-    /// not benefit from anyway, since the same issue requires it to run
-    /// before any `init`. #825 reserves the call for a human, and the
-    /// reduction to `openbao` alone is that call, taken under its
-    /// escalation clause: the gap is tracked outside this test. Until it
-    /// is closed, step-ca has no runtime monitoring coverage.
+    /// This test deliberately runs before any `init` (it needs the host
+    /// ports free), so the step-ca it brings up is configured by nothing
+    /// and has no metrics listener to scrape. Asserting the job here
+    /// would therefore be asserting something `init` has not yet had the
+    /// chance to configure; the step-ca metrics path is covered where a
+    /// CA actually exists, by `scripts/impl/run-stepca-san.sh`.
     async fn wait_for_prometheus_targets(project: &str, compose_file: &Path) -> Result<()> {
         wait_for(Duration::from_secs(90), || {
             let mut command = docker_compose_command(project, compose_file);


### PR DESCRIPTION
## Summary

`monitoring/prometheus.yml` has always scraped `step-ca:9102`, and both bundled compose files expose the port — but step-ca starts that listener only when `ca.json` carries a top-level `metricsAddress`. Nothing wrote the key, and the pinned `smallstep/step-ca:0.30.2` accepts the address through no flag and no environment variable, so compose could not supply it either: the declared target was permanently down.

`bootroot init` now writes the fixed `:9102` into `secrets/config/ca.json` and stamps it explicitly into `secrets/templates/ca.json.ctmpl`, independent of what the co-owned file holds when the template is generated — the step-ca OpenBao Agent sidecar can render the previous template in between, and an inherited value would bake the stale state back in (the #733 hazard, applied to a second key).

`CaJsonUpdate` now reports the metrics change alongside `dns_names_changed`, and `run_init_inner`'s previously `dnsNames`-gated branches gate on `CaJsonUpdate::stepca_reload_required()` instead. That matters for the upgrade path: an installation predating the setting has an unchanged name set, so gating on `dnsNames` alone would regenerate nothing, leave the sidecar on the old template and leave step-ca without a listener.

The port stays `expose`d to the compose network and unpublished. The endpoint carries no authentication — step-ca offers none for it — so that boundary is its only protection, and the reasoning is recorded next to the constant in `stepca_setup.rs`.

Closes #864

## Changes

- `src/commands/init/steps/stepca_setup.rs` — `metricsAddress` constants (with the security note), `set_ca_json_metrics_address`, stamped into `build_ca_json_template`, written by `update_ca_json_with_backup`, re-asserted by `reconcile_ca_json_dns_names` (renamed `reconcile_ca_json_managed_keys`, since it now owns two keys). The two managed keys are set through one `set_ca_json_key` helper, so both insert into the parsed document and land exactly once whether or not they were there before; the re-assertion sets both before deciding its early return, so a drifted name set cannot short-circuit the metrics address. Unmodelled `ca.json` keys still survive, and the atomic write / snapshot / rollback / sidecar-restart ordering is unchanged.
- `src/commands/init/steps/orchestrator.rs` — the template, sidecar-restart, re-assertion and `docker compose restart step-ca` branches gate on `stepca_reload_required()`.
- `tests/docker_compose_security.rs` — 9102 is exposed and never published, in both bundled compose files. `services.step-ca` is read structurally and each mapping judged by the key it sits under, since the bare `- "9102"` that is the wanted entry under `expose:` is a publication to an ephemeral host port under `ports:`. The section reader classifies the key's value by the YAML form it is written in — block sequence, flow sequence on the key's own line, or a form whose entries live elsewhere (an alias, a scalar) — so a `ports:` it cannot enumerate fails the guard instead of reading as an absent section; an anchor alone still resolves to the block beneath it. Fixture tests pin the reader against each form and hold the short, long and flow publication syntaxes rejected along with an aliased `ports:`.
- `scripts/impl/run-stepca-san.sh` / `tests/docker_e2e_stepca_san.rs` — the harness that already drives a fresh install, an already-initialized repair and a full OpenBao Agent render interval now also asserts `metricsAddress` in `ca.json` and the template at each point, and fetches `http://step-ca:9102/metrics` from inside the compose network (deliberately not from the host, where a successful probe would mean the boundary had been widened). A new scenario C isolates the metrics gate: on the stack scenario B leaves behind it strips `metricsAddress`, restarts step-ca to confirm the endpoint goes silent, and re-runs `init` with `dnsNames` settled — so nothing but the metrics address moves — then asserts the listener is back. Scenario A additionally brings Prometheus up (by name, behind its profile, `--no-deps` so compose cannot recreate step-ca without the `--stepca-bind` override) and waits for the declared `step-ca` scrape job to report `up` — the endpoint answering a direct fetch and Prometheus resolving its target to it are two claims, and the second is the one an operator reads. The Rust wrapper asserts the dumped phase log, SAN dumps, metrics dumps and targets response, so a script that skipped a step cannot pass on its exit status alone.
- `scripts/impl/run-reinit-recovery.sh` — `reinit` preserves `metricsAddress` alongside the CA material.
- `tests/monitoring_integration.rs` — comment rewritten: step-ca metrics are configured by `init`, and this test deliberately runs before any `init`, so it still asserts the OpenBao target only.
- `docs/en/e2e-ci.md`, `docs/ko/e2e-ci.md` — the PR-critical scope list names the metrics listener now that `run-stepca-san.sh` covers it.
- `CHANGELOG.md` — Unreleased entry telling existing installations to run `bootroot init`.

## Test plan

Run locally against Docker (macOS, Docker Desktop):

- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` and `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test --bins` — including the `stepca_setup` tests for direct reconciliation, template stamping from a `ca.json` that lacks the key, metrics-only reload gating, clobbered-address repair and idempotence.
- [x] `cargo test --test docker_compose_security` — 9102 exposed and never published in both bundled compose files.
- [x] `cargo test --test monitoring_integration -- --include-ignored` — exactly 1 test, passed.
- [x] `scripts/preflight/ci/test-core.sh` — passed end to end (unit tests, monitoring integration, install, zero-config init, clean + reinstall, CLI init, three `service add`s, three `verify`s, CA health, agent issuance).
- [x] `scripts/impl/run-stepca-san.sh` and `cargo test --test docker_e2e_stepca_san -- --ignored` (with `STEPCA_BIND_HOST` set to a real interface, as `172.17.0.1` does not exist under Docker Desktop) — passed, including `scenario-b-assert-stable` after a full render interval.
- [x] `scripts/impl/run-reinit-recovery.sh` — all three scenarios passed; `ca.json` still carries `:9102` afterwards.
- [x] A scripted walk of the issue's test plan on a real compose install: fresh `init` writes exactly one `metricsAddress: ":9102"`; Prometheus reports the `step-ca` target `up` and the prometheus container fetches `http://step-ca:9102/metrics`; stripping the key from `ca.json` *and* the template and restarting reproduces the pre-fix state (no listener); a second `init` with unchanged `dnsNames` restores it with root and intermediate fingerprints unchanged, the target back `up`, and the setting still present after a 40s render interval; a third `init` and a `bootroot reinit` both preserve it and the CA material; `127.0.0.1:9102` is not reachable from the host.
- [x] Full `scripts/preflight/ci/e2e-matrix.sh` and `scripts/preflight/ci/e2e-extended.sh` sweeps — run on CI rather than on this host, see below.

## Sweeps run on CI

The full `e2e-matrix.sh` and `e2e-extended.sh` sweeps cannot run on this host: it has no passwordless `sudo` (hosts-mode steps, `run-openbao-tls-reown.sh`) and its hostname is not a DNS label (the extended suite's runner cases). Both are host limits rather than properties of this change, so the sweeps were run on CI against this branch instead.

- Matrix: every PR-critical Docker E2E job on this branch is green, including `stepca-san`, `reinit-recovery`, `rotation`, `two-instance`, both `local-*` and both `remote-*` lifecycles and both `openbao-tls-*` cases.
- Extended: [run 31993910365](https://github.com/aicers/bootroot/actions/runs/31993910365), dispatched against this branch, passed with all seven cases `pass` — `scale-contention`, `failure-recovery`, `runner-timer`, `runner-cron`, `ca-key-recovery`, `reinit-recovery`, `infra-lifecycle` — covering the three cases this host cannot run.



