### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-08-17
 
 ### Security
 
@@ -2347,6 +2347,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Initial public release of the bootroot
 
-[Unreleased]: https://github.com/aicers/bootroot/compare/0.2.0...main
+[0.3.0]: https://github.com/aicers/bootroot/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/aicers/bootroot/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/aicers/bootroot/tree/0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "bootroot"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bootroot"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -85,7 +85,7 @@ services:
       ]
 
   bootroot-http01:
-    image: ${BOOTROOT_HTTP01_IMAGE:-bootroot-http01-responder:0.2.0}
+    image: ${BOOTROOT_HTTP01_IMAGE:-bootroot-http01-responder:0.3.0}
     container_name: ${BOOTROOT_INSTANCE:-bootroot}-http01
     restart: always
     ports:


### PR DESCRIPTION
Prepares the 0.3.0 release.

- `Cargo.toml` / `Cargo.lock`: 0.2.0 → 0.3.0. The accumulated entries include removals and behaviour changes, so this is a minor bump rather than a patch one.
- `CHANGELOG.md`: the `[Unreleased]` heading becomes `[0.3.0] - 2026-08-17` and its link reference becomes the `0.2.0...0.3.0` compare range. No empty `[Unreleased]` section is left behind — the release job locates the notes by the heading matching the tag.
- `docker-compose.deploy.yml`: the default `bootroot-http01-responder` image tag moves to `0.3.0`, since the file documents its defaults as matching the release-built tags.

Tagging and pushing the tag are done by hand after this merges.

Part of #866