### PR TITLE
Correct stale schema version in test comments

### DIFF
--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1830,11 +1830,12 @@ fn assert_remote_bootstrap_artifact_shape(bootstrap: &serde_json::Value) {
     assert!(bootstrap["agent_config_path"].is_string());
     assert!(bootstrap["ca_bundle_path"].is_string());
     assert!(bootstrap["ca_bundle_pem"].is_string());
-    // schema_version 4 dropped the OpenBao Agent artifact paths: the
-    // remote agent self-authenticates and renders trust via fast-poll.
+    // The schema-5 artifact carries no OpenBao Agent artifact paths:
+    // they were dropped in schema_version 4, since the remote agent
+    // self-authenticates and renders trust via fast-poll.
     assert!(
         bootstrap.get("openbao_agent_config_path").is_none(),
-        "openbao_agent_config_path must be gone from the schema-4 artifact"
+        "openbao_agent_config_path must be absent from the schema-5 artifact"
     );
     assert!(bootstrap.get("openbao_agent_template_path").is_none());
     assert!(bootstrap.get("openbao_agent_token_path").is_none());

--- a/tests/e2e_remote_happy_path.rs
+++ b/tests/e2e_remote_happy_path.rs
@@ -60,9 +60,10 @@ async fn test_two_node_remote_bootstrap_happy_path() {
     assert!(eab_contents.contains("\"kid\": \"remote-kid\""));
     let agent_contents = fs::read_to_string(&agent_config_path).expect("read agent config");
     let ca_bundle_path = service_dir.join("certs").join("ca-bundle.pem");
-    // schema_version 4: remote bootstrap does not write OpenBao Agent
-    // artifacts (agent.hcl / agent.toml.ctmpl / token) — the remote
-    // agent self-authenticates and renders trust via the fast-poll loop.
+    // The schema-5 artifact carries no OpenBao Agent artifacts
+    // (agent.hcl / agent.toml.ctmpl / token): they were dropped in
+    // schema_version 4, since the remote agent self-authenticates and
+    // renders trust via the fast-poll loop.
     let openbao_agent_dir = service_dir
         .join("secrets")
         .join("openbao")


### PR DESCRIPTION
The registration-id split bumped the remote-bootstrap artifact from `schema_version` 4 to 5, but two tests still named 4 as the version of the artifact they exercise. `assert_remote_bootstrap_artifact_shape` asserts `schema_version == 5` and then, fourteen lines later, reports a failure against "the schema-4 artifact"; the remote happy-path comment describes current behaviour in the present tense under the heading `schema_version 4`.

Both now name 5 as the version under test. The note that the OpenBao Agent artifact paths were dropped in schema_version 4 is kept, since that is where they actually went — only the claim about which version is current changed.

No emitted artifact version, supported-version bound, or compatibility behaviour is touched.

Verification: `cargo fmt -- --config group_imports=StdExternalCrate --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --test bootroot_service --test e2e_remote_happy_path` (75 tests) all pass. The Docker preflight suites were skipped: the change is comments and one assertion message, touching no Docker lifecycle or E2E script.

Closes #870
