### PR TITLE
Read the rendered registrar config and derive identities (#757)

### DIFF
--- a/docs/reference/provisioning.toml.example
+++ b/docs/reference/provisioning.toml.example
@@ -1,0 +1,28 @@
+fingerprint = "62299a244c4b3833c4cb3a36b4d3da763bd87f664c7d31845f48e53be4170f3e"
+# Rendered by the provisioning tool (bootler) onto BOTH the
+# bootroot/registrar host and the REView host at install, at the same
+# absolute path on each. bootroot only reads this file; nothing in this
+# repository writes it in production.
+#
+# The first line is the fingerprint and is NOT part of the digested body.
+schema_version = 1
+domain = "trusted.domain"
+
+# One table per component, keyed by package-id. A component absent from
+# this file is refused, never defaulted. `bootroot` has no entry: it is
+# the issuer and never enrolls through the registrar.
+[components.review]
+multiplicity = "one-per-deployment"   # | "one-per-host" | "many-per-host"
+cert_group = 3000                     # numeric gid; omit the key to mean
+                                      # "registrations carry no cert-group policy"
+reload = { kind = "docker-restart", target = "review" }
+
+[components.roxyd]
+multiplicity = "one-per-host"
+# cert_group omitted on purpose
+reload = { kind = "systemd", target = "roxyd.service" }
+
+[components.piglet]
+multiplicity = "many-per-host"
+cert_group = 3001
+reload = { kind = "docker-restart", target = "piglet" }

--- a/docs/reference/registrar-provisioning-config.md
+++ b/docs/reference/registrar-provisioning-config.md
@@ -78,10 +78,19 @@ under a guessed domain would issue a certificate no peer will ever verify.
 
 ## 3. Component entries
 
-`[components.<package-id>]`, one per component. A component **absent** from
-this file is refused, never defaulted — fail-open would let a module whose
-`instance` was wrongly omitted mint a valid-but-phantom two-part identity that
-a later correct request then duplicates. `bootroot` has no entry: it is the
+`[components.<package-id>]`, one per component. The key is spent twice — a
+wire `service_name` selects the entry, and the same value is the
+`<component>` segment of every `registration_id` derived for it — so it must
+be both a single DNS label and path-safe: lowercase letters, digits and
+hyphens, starting and ending alphanumeric, at most 63 octets. A key that is
+not is `RegistrarError::InvalidComponentKey` at load, rather than an entry
+that loads and then refuses every one of its enrollments at the derivation
+step.
+
+A component **absent** from this file is refused, never defaulted — fail-open
+would let a module whose `instance` was wrongly omitted mint a
+valid-but-phantom two-part identity that a later correct request then
+duplicates. `bootroot` has no entry: it is the
 issuer and never enrolls through the registrar.
 
 | Key | Type | Required | Meaning |

--- a/docs/reference/registrar-provisioning-config.md
+++ b/docs/reference/registrar-provisioning-config.md
@@ -1,0 +1,263 @@
+<!-- markdownlint-configure-file {
+  "MD013": { "tables": false, "code_blocks": false }
+} -->
+
+# Registrar provisioning config (`provisioning.toml`)
+
+**Writer rule.** This repository *reads* this file and never writes it in
+production. It is rendered by the provisioning tool, `aicers/bootler`, whose
+issue [#200](https://github.com/aicers/bootler/issues/200) owns the path, the
+envelope, the field set, the ordering and the digest rule. Where this file and
+that issue disagree, **#200 wins and this file is corrected.** A change made
+here that is not also made there breaks every enrollment in the deployment, and
+breaks it at deploy time rather than in either repository's tests.
+
+Like `registrar-wire-contract.md`, this reference sits outside the mirrored
+`docs/en/` + `docs/ko/` operator pair: it is a cross-repository contract rather
+than operator documentation, so `mkdocs.yml` lists it in neither locale's nav
+and there is no `docs/ko/` counterpart. Its path is stable and is what a test
+reads it by.
+
+## 1. Path
+
+| Item | Value |
+| --- | --- |
+| Absolute path | `/etc/clumit-security/provisioning.toml` |
+| Constant | `bootroot::registrar::DEFAULT_CONFIG_PATH` |
+| Rendered onto | the bootroot/registrar host **and** the REView host, at the same path on each |
+
+The path is the writer's product-namespaced one, deliberately **not** under
+`/etc/bootroot/`. The same file is rendered onto the REView host — the
+upload-time safe-set check runs there — and that host has no bootroot and no
+`/etc/bootroot`. One product-namespaced path is what lets both readers use one
+constant. `clumit-security` is the Security product's namespace, the same one
+bootler stamps into its managed `/etc/hosts` block.
+
+`RegistrarConfig::load` takes the path as a parameter, so no test reads the
+real one.
+
+## 2. Envelope
+
+One TOML file, not three and not a format the writer picks independently. A
+single file makes the render atomic: with a partial render, `domain` could be
+present while the component table was missing, which is exactly the fail-open
+the digest gate exists to close.
+
+| Key | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `fingerprint` | 64 lowercase hex characters | yes | SHA-256 of the file's body. **Must be the first line**, exactly `fingerprint = "<64 lowercase hex>"` followed by one `\n`. Not part of the digested body. |
+| `schema_version` | `u32` | yes | Compatibility gate. This build implements **1**. Never defaulted when absent. |
+| `domain` | dot-separated DNS name | yes | The deployment-wide domain, the SAN's fourth segment. Read only from this file, never from the wire. |
+| `components` | table of tables | yes in practice | One entry per component, keyed by package-id. |
+
+### 2.1 The two integrity gates
+
+Both are load-bearing on this side, not the writer's business alone.
+
+1. **The digest is validated before the body is parsed.** Split at the first
+   `\n`, SHA-256 the remaining bytes **verbatim as written**, compare with the
+   declared value, and only then parse. The digested region is a byte range;
+   nothing is re-serialized to compute it. A truncated file can still parse as
+   valid TOML with entries missing, and under the no-entry rule those
+   components would then be refused *individually* — a silent per-component
+   enrollment outage indistinguishable from a component that was never
+   provisioned. The digest turns that into one loud failure,
+   `RegistrarError::FingerprintMismatch`, carrying both the declared and the
+   computed digest.
+2. **An unimplemented `schema_version` is refused** with
+   `RegistrarError::UnsupportedSchemaVersion`, carrying the found version and
+   the one this build implements. It is never best-effort parsed, and never
+   defaulted when absent.
+
+The declared fingerprint is reachable only through a successfully validated
+load (`RegistrarConfig::fingerprint`), so no caller can report a digest it did
+not check.
+
+A missing or unreadable file is a **hard failure**, never a default: minting
+under a guessed domain would issue a certificate no peer will ever verify.
+
+## 3. Component entries
+
+`[components.<package-id>]`, one per component. A component **absent** from
+this file is refused, never defaulted — fail-open would let a module whose
+`instance` was wrongly omitted mint a valid-but-phantom two-part identity that
+a later correct request then duplicates. `bootroot` has no entry: it is the
+issuer and never enrolls through the registrar.
+
+| Key | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `multiplicity` | enum, see §3.1 | yes | How many times the component may be installed. Selects the `registration_id` derivation arm. |
+| `cert_group` | bare `u32` | no | Numeric gid. **Omitting the key means "registrations carry no cert-group policy"** — not "any gid is allowed". |
+| `reload` | inline table, see §3.2 | yes | The post-renew hook. |
+
+`cert_group` mirrors `cert_group_gid: Option<u32>`, the type this repository
+already applies to a service certificate (`src/commands/service/resolve.rs`,
+`src/state.rs`), and it is the policy `src/cert_group.rs` applies at issuance
+and at every rotation. It is a bare number, never a tagged table.
+
+### 3.1 `multiplicity`
+
+| Value | `registration_id` arm |
+| --- | --- |
+| `one-per-deployment` | `<component>` |
+| `one-per-host` | `<host>-<component>` |
+| `many-per-host` | `<host>-<component>-<instance>` |
+
+An unrecognised value is a typed load failure carrying the offending string
+(`RegistrarError::UnknownMultiplicity`), never an unknown-variant fallback and
+never stored as a bare string.
+
+### 3.2 `reload`
+
+An inline table `{ kind, target }`, mirroring `ReloadStyle`
+(`src/cli/args.rs`) — the type this repository already applies to a **service**
+certificate.
+
+| `kind` | Meaning | `target` |
+| --- | --- | --- |
+| `sighup` | Send `SIGHUP` to a process by name | required |
+| `systemd` | Reload a systemd unit | required |
+| `docker-restart` | Restart a Docker container | required |
+| `none` | No post-renew hook | must be absent |
+
+`ReloadStrategy` in `src/state.rs` is **not** this type. It is the
+*infrastructure*-certificate rotation strategy, and its
+`container_restart` / `container_signal` vocabulary must not appear here.
+
+An unrecognised `kind` is `RegistrarError::UnknownReloadKind`, carrying the
+offending string.
+
+`target` is compared **literally**. There is no template language, no
+placeholder, no glob, no regex and no per-instance parameterization: a rendered
+`target` of `piglet-{instance}` is the literal string `piglet-{instance}`, and
+a request presenting the expanded `piglet-001` is outside the safe-set. A
+component's rendered spec is instance-independent and every registration of
+that component — including each instance of a many-per-host one — must present
+it byte-for-byte. A component that genuinely needs a per-instance container
+name is a coordinated format change in the provisioning repository, not
+something this validator pattern-matches around.
+
+## 4. The safe-set
+
+A component has **exactly one** allowed spec: its rendered `cert_group` and
+`reload`. A requested spec is inside the safe-set only when **both** are equal
+to it.
+
+It is not a per-field allow-list — independent per-field sets would admit
+cross-products no component ever declares, an allowed `cert_group` paired with
+a `reload` it never co-occurs with. It is not a list of allowed pairs either:
+RFC-F §5.1 makes the spec **host-agnostic**, the same `cert_group`/`reload` for
+every host of a component, and a `version-invariant` property of the package-id
+— which only means something if the component has one canonical shape for an
+uploaded template to be compared against.
+
+Where a component's rendered spec **omits** `cert_group`, its registrations
+must carry none: a request supplying any gid is refused with
+`RegistrarError::ServiceSpecOutsideSafeSet`.
+
+The safe-set reference is this locally rendered file, never a signed package —
+the registrar is the bootroot-co-located roxyd, which never receives the signed
+package and cannot read the review-host module store. It is fixed at install
+and has no runtime-update channel.
+
+## 5. What the file does **not** decide
+
+| Not here | Where it lives |
+| --- | --- |
+| A privilege field | Does not exist. bootroot derives every service's authority from the fixed derived policy, so no component differs from another on a privilege dimension. |
+| The composed identity name | Derived on this side from the wire's parts (§6). The wire carries no composed name. |
+| A conflict with a previously stored spec | The verb layer's `ServiceSpecConflict`. Nothing in this library reads registration state. |
+
+## 6. What this repository derives from it
+
+`bootroot::registrar::identity` owns the derivation. There is exactly one
+keyword: the wire `service_name` selects the config entry, supplies the
+`<component>` segment of the derived `registration_id`, and supplies the
+`<service>` segment of the SAN. There is no second selector, and
+`spec.service_name` is never any of those three.
+
+| Output | Rule |
+| --- | --- |
+| `registration_id` | The multiplicity arm in §3.1, with `instance` rendered three digits zero-padded. |
+| SAN | `<instance>.<service>.<host>.<domain>`, always four segments. A request that correctly omits `instance` takes the literal `001` in the first segment. |
+
+The `001` default is **SAN-only**. A one-per-host component's id stays
+`<host>-<component>` and a one-per-deployment component's stays `<component>`;
+the default is applied only when composing the SAN, after the id has been
+derived.
+
+`host` is required on every request and validated as a DNS label regardless of
+class. The one-per-deployment arm ignores it, but the SAN's third segment still
+needs it, so "not used by the id arm" is not "optional".
+
+### 6.1 The three SAN composition sites
+
+This repository composes `<instance>.<service>.<host>.<domain>` in **three**
+places, and they must agree byte for byte or the fleet gets certificates whose
+name the verification path rejects.
+
+| Site | Takes | Kept in step by |
+| --- | --- | --- |
+| `bootroot::registrar::identity::compose_san` | the four parts | this table, and the test below |
+| `bootroot::config::profile_domain` | a `Settings` plus a `DaemonProfileSettings` | a test asserting byte-identical output for the same four values |
+| `commands::verify::expected_dns_name` | a `ServiceEntry` | this table alone — it is private to the binary crate and no test here can call it |
+
+`RegistrarConfig::san_for` is the same composer with the domain taken from
+the loaded file, and is what a verb should call: it makes composing under a
+wire-supplied domain structurally impossible.
+
+## 7. The example
+
+`docs/reference/provisioning.toml.example` is the shipped example, and a test
+loads it through the production loader so the documented contract and the
+parser cannot drift apart. Its `fingerprint` is a real digest of its own
+body. The block below is that file verbatim, and a test asserts the two have
+not drifted.
+
+```toml
+fingerprint = "62299a244c4b3833c4cb3a36b4d3da763bd87f664c7d31845f48e53be4170f3e"
+# Rendered by the provisioning tool (bootler) onto BOTH the
+# bootroot/registrar host and the REView host at install, at the same
+# absolute path on each. bootroot only reads this file; nothing in this
+# repository writes it in production.
+#
+# The first line is the fingerprint and is NOT part of the digested body.
+schema_version = 1
+domain = "trusted.domain"
+
+# One table per component, keyed by package-id. A component absent from
+# this file is refused, never defaulted. `bootroot` has no entry: it is
+# the issuer and never enrolls through the registrar.
+[components.review]
+multiplicity = "one-per-deployment"   # | "one-per-host" | "many-per-host"
+cert_group = 3000                     # numeric gid; omit the key to mean
+                                      # "registrations carry no cert-group policy"
+reload = { kind = "docker-restart", target = "review" }
+
+[components.roxyd]
+multiplicity = "one-per-host"
+# cert_group omitted on purpose
+reload = { kind = "systemd", target = "roxyd.service" }
+
+[components.piglet]
+multiplicity = "many-per-host"
+cert_group = 3001
+reload = { kind = "docker-restart", target = "piglet" }
+```
+
+## 8. The test fixture
+
+`bootroot::registrar::fixture::RegistrarConfigFixture` is the canonical way to
+fabricate this file in a test. Nothing in this repository renders it in
+production, so without a shared fixture the verb, endpoint and acceptance-suite
+tests would each hand-write their own approximation of an artifact this
+repository never produces, and the three would drift from each other and from
+the real one.
+
+It renders the three components above under the domain `trusted.domain`, and a
+test overrides only what it varies: `with_domain`, `with_multiplicity`,
+`with_spec`, `with_component`, `without_component`, `with_schema_version`,
+`with_fingerprint` (for a deliberate digest mismatch) and `with_raw_component`
+(for a `multiplicity` or `reload.kind` the loader must refuse).
+`write_to(dir)` places it as `provisioning.toml` inside a caller-supplied
+directory and returns the path.

--- a/docs/reference/registrar-provisioning-config.md
+++ b/docs/reference/registrar-provisioning-config.md
@@ -190,9 +190,9 @@ derived.
 class. The one-per-deployment arm ignores it, but the SAN's third segment still
 needs it, so "not used by the id arm" is not "optional".
 
-### 6.1 The three SAN composition sites
+### 6.1 The SAN composition sites
 
-This repository composes `<instance>.<service>.<host>.<domain>` in **three**
+This repository composes `<instance>.<service>.<host>.<domain>` in **four**
 places, and they must agree byte for byte or the fleet gets certificates whose
 name the verification path rejects.
 
@@ -201,6 +201,11 @@ name the verification path rejects.
 | `bootroot::registrar::identity::compose_san` | the four parts | this table, and the test below |
 | `bootroot::config::profile_domain` | a `Settings` plus a `DaemonProfileSettings` | a test asserting byte-identical output for the same four values |
 | `commands::verify::expected_dns_name` | a `ServiceEntry` | this table alone — it is private to the binary crate and no test here can call it |
+| `commands::dns_alias::dns_alias_for_entry` | a `ServiceEntry` | this table alone, for the same reason |
+
+The last one composes the HTTP-01 DNS alias rather than the certificate SAN,
+but from the same four values and in the same shape, so a change to the shape
+that misses it desynchronises the alias from the name the certificate carries.
 
 `RegistrarConfig::san_for` is the same composer with the domain taken from
 the loaded file, and is what a verb should call: it makes composing under a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod kv_payload;
 pub mod locale;
 pub mod openbao;
 pub mod profile;
+pub mod registrar;
 pub mod tls;
 pub mod toml_util;
 pub mod trust_bootstrap;

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -1,0 +1,40 @@
+//! The registrar's provisioning config and the registration identities
+//! derived from it.
+//!
+//! Two repositories must agree on the derivation rule exactly, or every
+//! enrollment in the fleet fails — and it fails after deployment, with
+//! both repositories' tests green. So the rule lives here as one small,
+//! densely tested unit, separate from the verbs that call it:
+//!
+//! - [`config`] reads the file the provisioning tool renders onto this
+//!   host, validates its digest and schema version, and yields the
+//!   deployment `domain` plus one entry per component.
+//! - [`identity`] derives the `registration_id`, composes the SAN,
+//!   checks the identity shape and validates a requested spec against
+//!   the component's rendered safe-set — as separately callable steps,
+//!   because the verb layer interleaves its own checks between them.
+//! - [`error`] declares every refusal the two produce.
+//! - [`fixture`] builds a rendered config for tests.
+//!
+//! Nothing here reads or requires registration state. That is what makes
+//! the durable-binding collision check the caller's step rather than a
+//! missing one here, and it is why no variant in [`error`] refers to a
+//! stored or previously applied spec.
+
+pub mod config;
+pub mod error;
+pub mod fixture;
+pub mod identity;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::{
+    CONFIG_FILE_NAME, ComponentEntry, DEFAULT_CONFIG_PATH, Multiplicity, RegistrarConfig,
+    RegistrationSpec, ReloadKind, ReloadSpec, SUPPORTED_SCHEMA_VERSION,
+};
+pub use error::{RegistrarError, SpecIdentityField};
+pub use identity::{
+    DerivedIdentity, RequestedSpec, check_instance_shape, check_spec_identity, compose_san,
+    derive_registration_id, validate_request_labels,
+};

--- a/src/registrar/config.rs
+++ b/src/registrar/config.rs
@@ -539,7 +539,20 @@ fn resolve_component(name: &str, raw: RawComponent) -> Result<ComponentEntry, Re
             value: raw.reload.kind.clone(),
         })?;
     let target = raw.reload.target;
-    if kind.takes_target() != target.as_ref().is_some_and(|value| !value.is_empty()) {
+    // `none` must carry no `target` key at all, not merely an empty one:
+    // an empty string is still `Some`, and storing it would break the
+    // "`target` is `None` exactly when `kind` is `None`" invariant that
+    // makes `ReloadSpec::none()` the one value a `none` component's
+    // registrations can present. A request built from that constructor
+    // would then fail the safe-set comparison for every registration of
+    // the component, which is the enrollment outage the loader exists to
+    // turn into one loud failure at load time.
+    let target_agrees = match (kind.takes_target(), target.as_deref()) {
+        (true, Some(value)) => !value.is_empty(),
+        (false, None) => true,
+        (true, None) | (false, Some(_)) => false,
+    };
+    if !target_agrees {
         return Err(RegistrarError::InvalidReloadTarget {
             component: name.to_string(),
             kind,

--- a/src/registrar/config.rs
+++ b/src/registrar/config.rs
@@ -1,0 +1,555 @@
+//! The bootler-rendered registrar config: its on-disk shape, its two
+//! integrity gates, and the typed values it yields.
+//!
+//! The file is rendered by the provisioning tool (`aicers/bootler`) onto
+//! both the bootroot/registrar host and the `REView` host at install, at
+//! the same absolute path on each. **bootroot only reads it; nothing in
+//! this repository writes it in production.** The shape is a
+//! cross-repository contract owned by `aicers/bootler` #200; where that
+//! issue and this module disagree, that issue wins and this module is
+//! corrected. A unilateral change here breaks every enrollment in the
+//! deployment, and breaks it at deploy time rather than in either
+//! repository's tests.
+//!
+//! See `docs/reference/registrar-provisioning-config.md` for the
+//! documented schema and `docs/reference/provisioning.toml.example` for
+//! the example this module's tests load through the production loader.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use serde::Deserialize;
+
+use crate::input_validation::{validate_dns_label, validate_domain_name};
+use crate::registrar::error::RegistrarError;
+use crate::tls::sha256_hex;
+
+/// Absolute path the provisioning tool renders the registrar config to.
+///
+/// It is the writer's product-namespaced path, deliberately not under
+/// `/etc/bootroot/`: the same file is rendered onto the `REView` host,
+/// which has no bootroot and no `/etc/bootroot`. One product-namespaced
+/// path is what lets both readers use one constant.
+///
+/// [`RegistrarConfig::load`] takes the path as a parameter so no test
+/// ever reads this one.
+pub const DEFAULT_CONFIG_PATH: &str = "/etc/clumit-security/provisioning.toml";
+
+/// File name component of [`DEFAULT_CONFIG_PATH`], for a caller — a
+/// test fixture, an installer check — that needs to place or find the
+/// file in a directory of its own choosing.
+pub const CONFIG_FILE_NAME: &str = "provisioning.toml";
+
+/// The `schema_version` this build implements. A file declaring any
+/// other version is refused with
+/// [`RegistrarError::UnsupportedSchemaVersion`] rather than
+/// best-effort parsed.
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 1;
+
+/// Exact prefix of the fingerprint line, which is the file's first line.
+const FINGERPRINT_PREFIX: &str = "fingerprint = \"";
+/// Length of a SHA-256 digest rendered as lowercase hex.
+const FINGERPRINT_HEX_LEN: usize = 64;
+
+/// How many times a component may be installed, which is what selects
+/// the `registration_id` derivation arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Multiplicity {
+    /// Installed once across the deployment; the id is `<component>`.
+    OnePerDeployment,
+    /// Installed once on each host; the id is `<host>-<component>`.
+    OnePerHost,
+    /// Installed several times on one host; the id is
+    /// `<host>-<component>-<instance>`.
+    ManyPerHost,
+}
+
+impl Multiplicity {
+    /// Returns the exact kebab-case string the rendered file spells this
+    /// class with.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OnePerDeployment => "one-per-deployment",
+            Self::OnePerHost => "one-per-host",
+            Self::ManyPerHost => "many-per-host",
+        }
+    }
+
+    /// Returns whether a registration of a component in this class
+    /// carries an `instance`.
+    #[must_use]
+    pub fn takes_instance(self) -> bool {
+        matches!(self, Self::ManyPerHost)
+    }
+}
+
+impl fmt::Display for Multiplicity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Multiplicity {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "one-per-deployment" => Ok(Self::OnePerDeployment),
+            "one-per-host" => Ok(Self::OnePerHost),
+            "many-per-host" => Ok(Self::ManyPerHost),
+            _ => Err(()),
+        }
+    }
+}
+
+/// The post-renew hook style a component's registration carries.
+///
+/// These are the four styles of `ReloadStyle` (`src/cli/args.rs`), which
+/// is what this repository already applies to a *service* certificate.
+/// The infrastructure-certificate `ReloadStrategy` (`src/state.rs`) is a
+/// different type with a different vocabulary and is deliberately not
+/// this one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReloadKind {
+    /// Send `SIGHUP` to a process by name.
+    Sighup,
+    /// Reload a systemd unit.
+    Systemd,
+    /// Restart a Docker container.
+    DockerRestart,
+    /// No post-renew hook. Carries no `target`.
+    None,
+}
+
+impl ReloadKind {
+    /// Returns the exact kebab-case string the rendered file spells this
+    /// style with.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sighup => "sighup",
+            Self::Systemd => "systemd",
+            Self::DockerRestart => "docker-restart",
+            Self::None => "none",
+        }
+    }
+
+    /// Returns whether this style names a target. `none` does not; the
+    /// other three require one.
+    #[must_use]
+    pub fn takes_target(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+impl fmt::Display for ReloadKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ReloadKind {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "sighup" => Ok(Self::Sighup),
+            "systemd" => Ok(Self::Systemd),
+            "docker-restart" => Ok(Self::DockerRestart),
+            "none" => Ok(Self::None),
+            _ => Err(()),
+        }
+    }
+}
+
+/// A `reload` inline table: `{ kind, target }`.
+///
+/// `target` is compared **literally**. There is no template language,
+/// no placeholder and no per-instance parameterisation: a token that
+/// looks like `{instance}` is a literal string, and a request whose
+/// `reload` carries an expanded form of it is outside the safe-set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReloadSpec {
+    /// The hook style.
+    pub kind: ReloadKind,
+    /// The process, unit or container the hook acts on. `None` exactly
+    /// when `kind` is [`ReloadKind::None`].
+    pub target: Option<String>,
+}
+
+impl ReloadSpec {
+    /// Creates a reload spec naming a target.
+    #[must_use]
+    pub fn new(kind: ReloadKind, target: &str) -> Self {
+        Self {
+            kind,
+            target: Some(target.to_string()),
+        }
+    }
+
+    /// Creates the target-free `none` reload spec.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            kind: ReloadKind::None,
+            target: None,
+        }
+    }
+}
+
+/// The registration spec a component's registrations must present: the
+/// two fields that vary per component.
+///
+/// A component has **exactly one** allowed spec. This is not a per-field
+/// allow-list and not a list of allowed pairs — independent per-field
+/// sets would admit cross-products no component ever declares, and a
+/// list of pairs is ruled out by the spec being host-agnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistrationSpec {
+    /// Numeric gid the issued cert/key files are owned by, or `None`
+    /// when the component's registrations carry no cert-group policy.
+    pub cert_group: Option<u32>,
+    /// The post-renew hook.
+    pub reload: ReloadSpec,
+}
+
+/// One `[components.<package-id>]` entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentEntry {
+    multiplicity: Multiplicity,
+    spec: RegistrationSpec,
+}
+
+impl ComponentEntry {
+    /// Returns the component's multiplicity class.
+    #[must_use]
+    pub fn multiplicity(&self) -> Multiplicity {
+        self.multiplicity
+    }
+
+    /// Returns the component's single rendered spec, which is its
+    /// entire safe-set.
+    #[must_use]
+    pub fn spec(&self) -> &RegistrationSpec {
+        &self.spec
+    }
+}
+
+/// A validated registrar config.
+///
+/// Constructible only through [`RegistrarConfig::load`], so the declared
+/// fingerprint this exposes is reachable only from a load whose digest
+/// was checked — no caller can report a digest it did not verify.
+#[derive(Debug, Clone)]
+pub struct RegistrarConfig {
+    path: PathBuf,
+    fingerprint: String,
+    schema_version: u32,
+    domain: String,
+    components: BTreeMap<String, ComponentEntry>,
+}
+
+/// The envelope and component table, as the body parses before its
+/// enum-valued fields are resolved.
+///
+/// `multiplicity` and `reload.kind` are read here as strings and
+/// converted immediately below; neither is *stored* as a string. The
+/// conversion happens outside serde because the refusal has to carry the
+/// offending value in a typed field, and a serde error can only carry it
+/// inside a message.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    schema_version: u32,
+    domain: String,
+    #[serde(default)]
+    components: BTreeMap<String, RawComponent>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawComponent {
+    multiplicity: String,
+    #[serde(default)]
+    cert_group: Option<u32>,
+    reload: RawReload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawReload {
+    kind: String,
+    #[serde(default)]
+    target: Option<String>,
+}
+
+/// Just enough of the envelope to gate on the version before the rest of
+/// the body is parsed against this build's shape.
+#[derive(Debug, Deserialize)]
+struct SchemaProbe {
+    schema_version: u32,
+}
+
+impl RegistrarConfig {
+    /// Reads, validates and parses the rendered registrar config at
+    /// `path`.
+    ///
+    /// Call this at verb-invocation time rather than caching the result
+    /// indefinitely: a re-render must take effect. A missing or
+    /// unreadable file is a hard failure, never a default — minting
+    /// under a guessed domain would issue a certificate no peer will
+    /// ever verify.
+    ///
+    /// The two integrity gates run in this order:
+    ///
+    /// 1. The first line must be exactly
+    ///    `fingerprint = "<64 lowercase hex>"` followed by one newline,
+    ///    and the SHA-256 of the remaining bytes **verbatim as written**
+    ///    must equal it. A truncated file can still parse as valid TOML
+    ///    with entries missing, and those components would then be
+    ///    refused individually — a silent per-component enrollment
+    ///    outage indistinguishable from a component that was never
+    ///    provisioned. The digest is what turns that into one loud
+    ///    failure.
+    /// 2. `schema_version` must be [`SUPPORTED_SCHEMA_VERSION`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistrarError::ConfigUnreadable`] when the file is
+    /// missing or cannot be read, [`RegistrarError::FingerprintLineMalformed`]
+    /// when the first line is not the exact fingerprint form,
+    /// [`RegistrarError::FingerprintMismatch`] when the body's digest
+    /// disagrees with it, [`RegistrarError::UnsupportedSchemaVersion`]
+    /// when the version is not this build's,
+    /// [`RegistrarError::ConfigMalformed`] when the body is not UTF-8 or
+    /// not the documented TOML shape, and the
+    /// `UnknownMultiplicity` / `UnknownReloadKind` /
+    /// `InvalidReloadTarget` / `InvalidDomain` / `InvalidComponentKey`
+    /// variants when a parsed value is not one this build accepts.
+    pub fn load(path: &Path) -> Result<Self, RegistrarError> {
+        let bytes = std::fs::read(path).map_err(|source| RegistrarError::ConfigUnreadable {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::from_bytes(path, &bytes)
+    }
+
+    /// Returns the fingerprint the file declared, which this load
+    /// verified against the body.
+    #[must_use]
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    /// Returns the `schema_version` the file declared.
+    #[must_use]
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Returns the deployment-wide domain, the SAN's fourth segment.
+    ///
+    /// This is read only from the rendered file, never from the wire: a
+    /// caller that could supply it could mint certificates under a name
+    /// suffix of its choosing.
+    #[must_use]
+    pub fn domain(&self) -> &str {
+        &self.domain
+    }
+
+    /// Returns the path this config was loaded from.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the component keys the file declares, in sorted order.
+    pub fn component_names(&self) -> impl Iterator<Item = &str> {
+        self.components.keys().map(String::as_str)
+    }
+
+    /// Returns the entry the wire `service_name` selects.
+    ///
+    /// A component absent from the file is refused, never defaulted:
+    /// fail-open would let a module whose `instance` was wrongly omitted
+    /// mint a valid-but-phantom two-part identity that a later correct
+    /// request then duplicates.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistrarError::ComponentNotConfigured`] when the file
+    /// has no entry for `service_name`.
+    pub fn component(&self, service_name: &str) -> Result<&ComponentEntry, RegistrarError> {
+        self.components
+            .get(service_name)
+            .ok_or_else(|| RegistrarError::ComponentNotConfigured {
+                component: service_name.to_string(),
+            })
+    }
+
+    /// Resolves the multiplicity class of the component the wire
+    /// `service_name` selects.
+    ///
+    /// This is the class-resolution step, callable without deriving
+    /// anything, so a refusal on this arm has no `registration_id` to
+    /// report and none is computed as a side effect.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistrarError::ComponentNotConfigured`] when the file
+    /// has no entry for `service_name`.
+    pub fn multiplicity(&self, service_name: &str) -> Result<Multiplicity, RegistrarError> {
+        Ok(self.component(service_name)?.multiplicity())
+    }
+
+    fn from_bytes(path: &Path, bytes: &[u8]) -> Result<Self, RegistrarError> {
+        let declared = read_fingerprint_line(path, bytes)?;
+        let body = digested_body(path, bytes)?;
+        verify_fingerprint(path, &declared, body)?;
+
+        let text = std::str::from_utf8(body).map_err(|err| RegistrarError::ConfigMalformed {
+            path: path.to_path_buf(),
+            message: format!("body is not UTF-8: {err}"),
+        })?;
+
+        let probe: SchemaProbe = parse_toml(path, text)?;
+        if probe.schema_version != SUPPORTED_SCHEMA_VERSION {
+            return Err(RegistrarError::UnsupportedSchemaVersion {
+                path: path.to_path_buf(),
+                found: probe.schema_version,
+                supported: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+
+        let raw: RawConfig = parse_toml(path, text)?;
+        validate_domain_name(&raw.domain).map_err(|kind| RegistrarError::InvalidDomain {
+            domain: raw.domain.clone(),
+            kind,
+        })?;
+
+        let mut components = BTreeMap::new();
+        for (name, entry) in raw.components {
+            validate_dns_label(&name).map_err(|kind| RegistrarError::InvalidComponentKey {
+                component: name.clone(),
+                kind,
+            })?;
+            let resolved = resolve_component(&name, entry)?;
+            components.insert(name, resolved);
+        }
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            fingerprint: declared,
+            schema_version: raw.schema_version,
+            domain: raw.domain,
+            components,
+        })
+    }
+}
+
+/// Reads the declared digest out of the file's first line, which must be
+/// exactly `fingerprint = "<64 lowercase hex>"`.
+fn read_fingerprint_line(path: &Path, bytes: &[u8]) -> Result<String, RegistrarError> {
+    let malformed = || RegistrarError::FingerprintLineMalformed {
+        path: path.to_path_buf(),
+    };
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .ok_or_else(malformed)?;
+    let (line, _) = bytes.split_at_checked(end).ok_or_else(malformed)?;
+    let line = std::str::from_utf8(line).map_err(|_| malformed())?;
+    let declared = line
+        .strip_prefix(FINGERPRINT_PREFIX)
+        .and_then(|rest| rest.strip_suffix('"'))
+        .ok_or_else(malformed)?;
+    if declared.len() != FINGERPRINT_HEX_LEN
+        || !declared
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(malformed());
+    }
+    Ok(declared.to_string())
+}
+
+/// Returns the digested region: every byte after the newline that ends
+/// the fingerprint line, verbatim as written.
+fn digested_body<'a>(path: &Path, bytes: &'a [u8]) -> Result<&'a [u8], RegistrarError> {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .ok_or_else(|| RegistrarError::FingerprintLineMalformed {
+            path: path.to_path_buf(),
+        })?;
+    bytes
+        .get(end + 1..)
+        .ok_or_else(|| RegistrarError::FingerprintLineMalformed {
+            path: path.to_path_buf(),
+        })
+}
+
+fn verify_fingerprint(path: &Path, declared: &str, body: &[u8]) -> Result<(), RegistrarError> {
+    let computed = sha256_hex(body);
+    // A plain comparison, deliberately. This digest is an integrity
+    // check over a local file rather than a MAC over a secret: it is
+    // computed from bytes the comparing process just read, and anyone
+    // able to write the file can compute the matching digest, so there
+    // is nothing a timing side channel could reveal. `ring`'s
+    // constant-time helper is deprecated besides.
+    if declared != computed {
+        return Err(RegistrarError::FingerprintMismatch {
+            path: path.to_path_buf(),
+            declared: declared.to_string(),
+            computed,
+        });
+    }
+    Ok(())
+}
+
+/// Parses `text` as TOML through the `config` crate, the same loading
+/// idiom the agent's own settings use.
+fn parse_toml<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    text: &str,
+) -> Result<T, RegistrarError> {
+    config::Config::builder()
+        .add_source(config::File::from_str(text, config::FileFormat::Toml))
+        .build()
+        .and_then(config::Config::try_deserialize)
+        .map_err(|err| RegistrarError::ConfigMalformed {
+            path: path.to_path_buf(),
+            message: err.to_string(),
+        })
+}
+
+fn resolve_component(name: &str, raw: RawComponent) -> Result<ComponentEntry, RegistrarError> {
+    let multiplicity = Multiplicity::from_str(&raw.multiplicity).map_err(|()| {
+        RegistrarError::UnknownMultiplicity {
+            component: name.to_string(),
+            value: raw.multiplicity.clone(),
+        }
+    })?;
+    let kind =
+        ReloadKind::from_str(&raw.reload.kind).map_err(|()| RegistrarError::UnknownReloadKind {
+            component: name.to_string(),
+            value: raw.reload.kind.clone(),
+        })?;
+    let target = raw.reload.target;
+    if kind.takes_target() != target.as_ref().is_some_and(|value| !value.is_empty()) {
+        return Err(RegistrarError::InvalidReloadTarget {
+            component: name.to_string(),
+            kind,
+        });
+    }
+    Ok(ComponentEntry {
+        multiplicity,
+        spec: RegistrationSpec {
+            cert_group: raw.cert_group,
+            reload: ReloadSpec { kind, target },
+        },
+    })
+}

--- a/src/registrar/config.rs
+++ b/src/registrar/config.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 
 use serde::Deserialize;
 
-use crate::input_validation::{validate_dns_label, validate_domain_name};
+use crate::input_validation::{validate_dns_label, validate_domain_name, validate_registration_id};
 use crate::registrar::error::RegistrarError;
 use crate::tls::sha256_hex;
 
@@ -432,10 +432,7 @@ impl RegistrarConfig {
 
         let mut components = BTreeMap::new();
         for (name, entry) in raw.components {
-            validate_dns_label(&name).map_err(|kind| RegistrarError::InvalidComponentKey {
-                component: name.clone(),
-                kind,
-            })?;
+            validate_component_key(&name)?;
             let resolved = resolve_component(&name, entry)?;
             components.insert(name, resolved);
         }
@@ -524,6 +521,29 @@ fn parse_toml<T: serde::de::DeserializeOwned>(
             path: path.to_path_buf(),
             message: err.to_string(),
         })
+}
+
+/// Refuses a `[components.<key>]` key that no registration could ever
+/// use.
+///
+/// Two rules, because the key is spent twice. A wire `service_name`
+/// selects the entry, so the key has to be a single DNS label. And that
+/// same value is the `<component>` segment of every id derived for the
+/// component, so it also has to be path-safe — which is the stricter of
+/// the two, since a DNS label may carry uppercase and a
+/// `registration_id` may not. Without the second rule a key like
+/// `Review` would load and then refuse every one of its enrollments at
+/// the derivation step, one request at a time: the silent
+/// per-component outage this loader's gates exist to turn into one loud
+/// failure.
+fn validate_component_key(name: &str) -> Result<(), RegistrarError> {
+    let refuse = |kind| RegistrarError::InvalidComponentKey {
+        component: name.to_string(),
+        kind,
+    };
+    validate_dns_label(name).map_err(refuse)?;
+    validate_registration_id(name).map_err(refuse)?;
+    Ok(())
 }
 
 fn resolve_component(name: &str, raw: RawComponent) -> Result<ComponentEntry, RegistrarError> {

--- a/src/registrar/error.rs
+++ b/src/registrar/error.rs
@@ -1,0 +1,257 @@
+//! The typed refusals the registrar's config loader and derivation
+//! library produce.
+//!
+//! This enum is *the* definition of these refusals for the whole
+//! repository. Downstream verb, endpoint and audit code wraps these
+//! variants; none of them redeclares one, so every refusal these checks
+//! can produce is declared here rather than left for a caller to invent
+//! a parallel name for.
+//!
+//! Deliberately absent: anything about a *stored* spec. Comparing a
+//! request against what a registration was previously minted with is the
+//! verb layer's step and produces a different refusal
+//! (`ServiceSpecConflict`); this library has no access to registration
+//! state and cannot express it.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use crate::input_validation::ValidationError;
+use crate::registrar::config::{Multiplicity, ReloadKind};
+
+/// Which identity-restating field of a requested spec disagreed with the
+/// wire `service_name`.
+///
+/// The disagreement is one refusal semantically — the spec names an
+/// identity other than the one the wire selected — so it is one error
+/// variant, and this is what tells an operator and the audit record
+/// which field the caller got wrong.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecIdentityField {
+    /// `spec.component` disagreed; `spec.service_name` did not.
+    Component,
+    /// `spec.service_name` disagreed; `spec.component` did not.
+    ServiceName,
+    /// Both fields disagreed.
+    Both,
+}
+
+impl SpecIdentityField {
+    /// Returns the stable lowercase name of the disagreeing field, or
+    /// `"component and service_name"` when both did.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Component => "component",
+            Self::ServiceName => "service_name",
+            Self::Both => "component and service_name",
+        }
+    }
+}
+
+impl fmt::Display for SpecIdentityField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Every refusal the registrar config loader and the registration
+/// derivation library can produce.
+#[derive(Debug, Error)]
+pub enum RegistrarError {
+    /// The rendered config is missing or could not be read. Never a
+    /// default: minting under a guessed domain would issue a
+    /// certificate no peer will ever verify.
+    #[error("registrar config at {path} is missing or unreadable")]
+    ConfigUnreadable {
+        /// The path that was read.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        source: std::io::Error,
+    },
+
+    /// The first line of the rendered config is not exactly
+    /// `fingerprint = "<64 lowercase hex>"` followed by one newline.
+    #[error("registrar config at {path} does not open with a fingerprint line")]
+    FingerprintLineMalformed {
+        /// The path that was read.
+        path: PathBuf,
+    },
+
+    /// The digest of the body does not match the fingerprint the first
+    /// line declares — the file was truncated, edited or partially
+    /// rendered. Carries both digests so an operator can tell this from
+    /// a file written by a newer provisioning tool.
+    #[error(
+        "registrar config at {path} declares fingerprint {declared} but its body digests to {computed}"
+    )]
+    FingerprintMismatch {
+        /// The path that was read.
+        path: PathBuf,
+        /// The digest the first line declared.
+        declared: String,
+        /// The digest the body actually has.
+        computed: String,
+    },
+
+    /// The body is not UTF-8, is not TOML, or does not have the shape
+    /// this build parses.
+    #[error("registrar config at {path} is malformed: {message}")]
+    ConfigMalformed {
+        /// The path that was read.
+        path: PathBuf,
+        /// What the parser objected to.
+        message: String,
+    },
+
+    /// The file declares a `schema_version` this build does not
+    /// implement. Carries the found and the supported version so an
+    /// operator can tell a newer provisioning tool from a corrupt file.
+    #[error(
+        "registrar config at {path} declares schema_version {found}, but this build implements {supported}"
+    )]
+    UnsupportedSchemaVersion {
+        /// The path that was read.
+        path: PathBuf,
+        /// The version the file declares.
+        found: u32,
+        /// The version this build implements.
+        supported: u32,
+    },
+
+    /// A component's `multiplicity` is not one of the three classes.
+    #[error("component {component} declares unrecognised multiplicity {value:?}")]
+    UnknownMultiplicity {
+        /// The component whose entry carried the value.
+        component: String,
+        /// The offending value, verbatim.
+        value: String,
+    },
+
+    /// A component's `reload.kind` is not one of the four styles.
+    #[error("component {component} declares unrecognised reload kind {value:?}")]
+    UnknownReloadKind {
+        /// The component whose entry carried the value.
+        component: String,
+        /// The offending value, verbatim.
+        value: String,
+    },
+
+    /// A component's `reload` omits a `target` its `kind` requires, or
+    /// carries one its `kind` forbids.
+    #[error("component {component} declares a reload of kind {kind} with an invalid target")]
+    InvalidReloadTarget {
+        /// The component whose entry carried the reload.
+        component: String,
+        /// The reload style that was declared.
+        kind: ReloadKind,
+    },
+
+    /// The file's `domain` is not a dot-separated DNS name.
+    #[error("registrar config declares invalid domain {domain:?} ({kind:?})")]
+    InvalidDomain {
+        /// The offending value, verbatim.
+        domain: String,
+        /// Why the shared validator refused it.
+        kind: ValidationError,
+    },
+
+    /// A `[components.<key>]` key is not a single DNS label, so no wire
+    /// `service_name` could ever select it.
+    #[error("registrar config declares invalid component key {component:?} ({kind:?})")]
+    InvalidComponentKey {
+        /// The offending key, verbatim.
+        component: String,
+        /// Why the shared validator refused it.
+        kind: ValidationError,
+    },
+
+    /// The wire `service_name` is not a single DNS label. Refused
+    /// before any derivation, so the refusal carries no
+    /// `registration_id`.
+    #[error("service_name {value:?} is not a single DNS label ({kind:?})")]
+    InvalidServiceName {
+        /// The offending value, verbatim, for the caller to record.
+        value: String,
+        /// Why the shared validator refused it.
+        kind: ValidationError,
+    },
+
+    /// The wire `host` is not a single DNS label. Refused for every
+    /// multiplicity class, including the one-per-deployment class whose
+    /// derivation arm does not read it.
+    #[error("host {value:?} is not a single DNS label ({kind:?})")]
+    InvalidHost {
+        /// The offending value, verbatim, for the caller to record.
+        value: String,
+        /// Why the shared validator refused it.
+        kind: ValidationError,
+    },
+
+    /// The component has no entry in the rendered config, so it has no
+    /// multiplicity class and no safe-set. Never defaulted.
+    ///
+    /// Distinct from [`RegistrarError::ServiceInstanceMismatch`] even
+    /// though the endpoint maps both onto that one caller-facing
+    /// identifier: the audit record stores the internal variant, and
+    /// collapsing them there would erase the difference between a
+    /// caller sending the wrong `instance` shape for a known component
+    /// and a caller probing component names that do not exist.
+    #[error("component {component} has no entry in the registrar config")]
+    ComponentNotConfigured {
+        /// The component the wire `service_name` named.
+        component: String,
+    },
+
+    /// The request's `instance` presence contradicts the component's
+    /// multiplicity class.
+    #[error(
+        "component {component} is {multiplicity}, and the request's instance presence \
+         (supplied: {instance_supplied}) contradicts that class"
+    )]
+    ServiceInstanceMismatch {
+        /// The component whose class was resolved.
+        component: String,
+        /// The class the rendered config gives that component.
+        multiplicity: Multiplicity,
+        /// Whether the request carried an `instance`.
+        instance_supplied: bool,
+    },
+
+    /// The derived `registration_id` is not a path-safe key — it
+    /// exceeds 131 octets or carries a character outside `[a-z0-9-]`.
+    /// The bound is enforced on the derived string rather than inferred
+    /// from the inputs, which are what a caller controls.
+    #[error("derived registration_id {key:?} is not a path-safe key ({kind:?})")]
+    DerivedKeyInvalid {
+        /// The key that was derived.
+        key: String,
+        /// Why the shared validator refused it.
+        kind: ValidationError,
+    },
+
+    /// The requested spec restates an identity other than the one the
+    /// wire `service_name` selected.
+    #[error("spec restates {field}, which disagrees with the requested service_name {expected:?}")]
+    SpecIdentityDisagreement {
+        /// Which of the two identity-restating fields disagreed.
+        field: SpecIdentityField,
+        /// The wire `service_name` the spec had to agree with.
+        expected: String,
+        /// `spec.component` as supplied, when present.
+        spec_component: Option<String>,
+        /// `spec.service_name` as supplied, when present.
+        spec_service_name: Option<String>,
+    },
+
+    /// The requested spec is not the component's single rendered spec.
+    /// Comparison is equality on both `cert_group` and `reload`; there
+    /// is no template language and no per-instance parameterisation.
+    #[error("requested spec is outside the safe-set rendered for component {component}")]
+    ServiceSpecOutsideSafeSet {
+        /// The component whose rendered spec the request failed.
+        component: String,
+    },
+}

--- a/src/registrar/error.rs
+++ b/src/registrar/error.rs
@@ -158,8 +158,10 @@ pub enum RegistrarError {
         kind: ValidationError,
     },
 
-    /// A `[components.<key>]` key is not a single DNS label, so no wire
-    /// `service_name` could ever select it.
+    /// A `[components.<key>]` key no registration could ever use: it is
+    /// not a single DNS label, so no wire `service_name` could select
+    /// it, or it is not path-safe, so no id derived for it could pass
+    /// [`RegistrarError::DerivedKeyInvalid`].
     #[error("registrar config declares invalid component key {component:?} ({kind:?})")]
     InvalidComponentKey {
         /// The offending key, verbatim.

--- a/src/registrar/fixture.rs
+++ b/src/registrar/fixture.rs
@@ -1,0 +1,289 @@
+//! A builder for the rendered registrar config, for tests.
+//!
+//! Nothing in this repository renders this file in production — it comes
+//! from the provisioning tool in another repository — so every test that
+//! needs one has to fabricate it. This builder is the canonical
+//! fabrication, so the verb, endpoint and acceptance-suite tests consume
+//! one shape rather than drifting hand-written approximations of an
+//! artifact this repository never produces.
+//!
+//! It is compiled unconditionally rather than behind `cfg(test)` or a
+//! `test-support` feature, because the siblings that must share it are
+//! not all in one compilation unit: unit tests in this library, unit
+//! tests in the binary crate (which links this library built *without*
+//! `cfg(test)`), and integration tests under `tests/` (which cannot see
+//! a feature they have no way to enable on a package they are part of).
+//! Gating it would leave exactly the callers it exists for writing their
+//! own. Nothing here panics or is reachable from a production code path.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use crate::registrar::config::{
+    CONFIG_FILE_NAME, Multiplicity, RegistrationSpec, ReloadKind, ReloadSpec,
+    SUPPORTED_SCHEMA_VERSION,
+};
+use crate::tls::sha256_hex;
+
+/// The domain a fixture renders unless a test overrides it.
+pub const FIXTURE_DOMAIN: &str = "trusted.domain";
+
+/// One `[components.<key>]` entry as a fixture renders it.
+///
+/// `multiplicity` and `reload_kind` are held as strings so a test can
+/// render a value the loader must refuse. Use the typed builder methods
+/// for every other case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentFixture {
+    /// The `multiplicity` value to render, verbatim.
+    pub multiplicity: String,
+    /// The `cert_group` value to render, or `None` to omit the key.
+    pub cert_group: Option<u32>,
+    /// The `reload.kind` value to render, verbatim.
+    pub reload_kind: String,
+    /// The `reload.target` value to render, or `None` to omit the key.
+    pub reload_target: Option<String>,
+}
+
+impl ComponentFixture {
+    /// Creates an entry from a multiplicity class and a rendered spec.
+    #[must_use]
+    pub fn new(multiplicity: Multiplicity, spec: &RegistrationSpec) -> Self {
+        Self {
+            multiplicity: multiplicity.as_str().to_string(),
+            cert_group: spec.cert_group,
+            reload_kind: spec.reload.kind.as_str().to_string(),
+            reload_target: spec.reload.target.clone(),
+        }
+    }
+}
+
+/// Builds a rendered registrar config a test can write to a directory of
+/// its own.
+///
+/// [`RegistrarConfigFixture::default`] carries the three components of
+/// the documented example — `review` (one-per-deployment), `roxyd`
+/// (one-per-host, no `cert_group`) and `piglet` (many-per-host) — under
+/// [`FIXTURE_DOMAIN`]. Every override returns `Self`, so a test states
+/// only what it varies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistrarConfigFixture {
+    schema_version: u32,
+    domain: String,
+    components: BTreeMap<String, ComponentFixture>,
+    fingerprint: Option<String>,
+    header: Option<String>,
+}
+
+impl Default for RegistrarConfigFixture {
+    fn default() -> Self {
+        let mut components = BTreeMap::new();
+        components.insert(
+            "review".to_string(),
+            ComponentFixture::new(
+                Multiplicity::OnePerDeployment,
+                &RegistrationSpec {
+                    cert_group: Some(3000),
+                    reload: ReloadSpec::new(ReloadKind::DockerRestart, "review"),
+                },
+            ),
+        );
+        components.insert(
+            "roxyd".to_string(),
+            ComponentFixture::new(
+                Multiplicity::OnePerHost,
+                &RegistrationSpec {
+                    cert_group: None,
+                    reload: ReloadSpec::new(ReloadKind::Systemd, "roxyd.service"),
+                },
+            ),
+        );
+        components.insert(
+            "piglet".to_string(),
+            ComponentFixture::new(
+                Multiplicity::ManyPerHost,
+                &RegistrationSpec {
+                    cert_group: Some(3001),
+                    reload: ReloadSpec::new(ReloadKind::DockerRestart, "piglet"),
+                },
+            ),
+        );
+        Self {
+            schema_version: SUPPORTED_SCHEMA_VERSION,
+            domain: FIXTURE_DOMAIN.to_string(),
+            components,
+            fingerprint: None,
+            header: None,
+        }
+    }
+}
+
+impl RegistrarConfigFixture {
+    /// Creates a fixture carrying the documented example's components.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a fixture with no components at all.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            components: BTreeMap::new(),
+            ..Self::default()
+        }
+    }
+
+    /// Overrides the deployment-wide domain.
+    #[must_use]
+    pub fn with_domain(mut self, domain: &str) -> Self {
+        self.domain = domain.to_string();
+        self
+    }
+
+    /// Overrides the declared `schema_version`.
+    #[must_use]
+    pub fn with_schema_version(mut self, version: u32) -> Self {
+        self.schema_version = version;
+        self
+    }
+
+    /// Renders a fingerprint line carrying `fingerprint` instead of the
+    /// body's real digest, for a test that needs the digest gate to
+    /// fail.
+    #[must_use]
+    pub fn with_fingerprint(mut self, fingerprint: &str) -> Self {
+        self.fingerprint = Some(fingerprint.to_string());
+        self
+    }
+
+    /// Renders `header` between the fingerprint line and the envelope,
+    /// verbatim. Used to ship the documented example's commentary.
+    #[must_use]
+    pub fn with_header(mut self, header: &str) -> Self {
+        self.header = Some(header.to_string());
+        self
+    }
+
+    /// Adds or replaces a component's whole entry.
+    #[must_use]
+    pub fn with_component(
+        mut self,
+        name: &str,
+        multiplicity: Multiplicity,
+        spec: &RegistrationSpec,
+    ) -> Self {
+        self.components
+            .insert(name.to_string(), ComponentFixture::new(multiplicity, spec));
+        self
+    }
+
+    /// Adds or replaces a component's entry from raw strings, so a test
+    /// can render a `multiplicity` or `reload.kind` the loader refuses.
+    #[must_use]
+    pub fn with_raw_component(mut self, name: &str, entry: ComponentFixture) -> Self {
+        self.components.insert(name.to_string(), entry);
+        self
+    }
+
+    /// Overrides a component's multiplicity class, adding the component
+    /// with the default reload spec when it is not already present.
+    #[must_use]
+    pub fn with_multiplicity(mut self, name: &str, multiplicity: Multiplicity) -> Self {
+        let entry = self
+            .components
+            .entry(name.to_string())
+            .or_insert_with(|| default_entry(multiplicity));
+        entry.multiplicity = multiplicity.as_str().to_string();
+        self
+    }
+
+    /// Overrides a component's safe-set — its single rendered spec —
+    /// adding the component as many-per-host when it is not already
+    /// present.
+    #[must_use]
+    pub fn with_spec(mut self, name: &str, spec: &RegistrationSpec) -> Self {
+        let entry = self
+            .components
+            .entry(name.to_string())
+            .or_insert_with(|| default_entry(Multiplicity::ManyPerHost));
+        entry.cert_group = spec.cert_group;
+        entry.reload_kind = spec.reload.kind.as_str().to_string();
+        entry.reload_target.clone_from(&spec.reload.target);
+        self
+    }
+
+    /// Removes a component, so a test can exercise the
+    /// component-absent refusal.
+    #[must_use]
+    pub fn without_component(mut self, name: &str) -> Self {
+        self.components.remove(name);
+        self
+    }
+
+    /// Renders the whole file, fingerprint line first.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let body = self.render_body();
+        let fingerprint = self
+            .fingerprint
+            .clone()
+            .unwrap_or_else(|| sha256_hex(body.as_bytes()));
+        format!("fingerprint = \"{fingerprint}\"\n{body}")
+    }
+
+    /// Renders the digested body: everything after the fingerprint line.
+    #[must_use]
+    pub fn render_body(&self) -> String {
+        let mut out = String::new();
+        if let Some(header) = &self.header {
+            out.push_str(header);
+        }
+        let _ = writeln!(out, "schema_version = {}", self.schema_version);
+        let _ = writeln!(out, "domain = \"{}\"", self.domain);
+        for (name, entry) in &self.components {
+            let _ = writeln!(out, "\n[components.{name}]");
+            let _ = writeln!(out, "multiplicity = \"{}\"", entry.multiplicity);
+            if let Some(gid) = entry.cert_group {
+                let _ = writeln!(out, "cert_group = {gid}");
+            }
+            match &entry.reload_target {
+                Some(target) => {
+                    let _ = writeln!(
+                        out,
+                        "reload = {{ kind = \"{}\", target = \"{target}\" }}",
+                        entry.reload_kind
+                    );
+                }
+                None => {
+                    let _ = writeln!(out, "reload = {{ kind = \"{}\" }}", entry.reload_kind);
+                }
+            }
+        }
+        out
+    }
+
+    /// Writes the rendered file as `provisioning.toml` inside `dir` and
+    /// returns its path.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying I/O failure when the file cannot be
+    /// written.
+    pub fn write_to(&self, dir: &Path) -> std::io::Result<PathBuf> {
+        let path = dir.join(CONFIG_FILE_NAME);
+        std::fs::write(&path, self.render())?;
+        Ok(path)
+    }
+}
+
+fn default_entry(multiplicity: Multiplicity) -> ComponentFixture {
+    ComponentFixture::new(
+        multiplicity,
+        &RegistrationSpec {
+            cert_group: None,
+            reload: ReloadSpec::none(),
+        },
+    )
+}

--- a/src/registrar/identity.rs
+++ b/src/registrar/identity.rs
@@ -268,13 +268,16 @@ pub fn derive_registration_id(
 /// and not a certificate field. `domain` comes only from the rendered
 /// file.
 ///
-/// This is the repository's third site composing this name, by necessity
-/// rather than choice: [`crate::config::profile_domain`] formats it from
-/// a `Settings` plus a `DaemonProfileSettings`, and
+/// This is a third site composing this name, by necessity rather than
+/// choice: [`crate::config::profile_domain`] formats it from a
+/// `Settings` plus a `DaemonProfileSettings`, and
 /// `commands::verify::expected_dns_name` from a `ServiceEntry`, and
 /// neither takes bare parts. A test pins byte-identical agreement with
-/// the first; the second is private to the binary crate and is named
-/// here as the third site that must stay in step.
+/// the first; the second is private to the binary crate and is named in
+/// `docs/reference/registrar-provisioning-config.md` §6.1 instead, along
+/// with `commands::dns_alias::dns_alias_for_entry`, which composes the
+/// HTTP-01 alias from the same four values and must stay in step for the
+/// same reason.
 #[must_use]
 pub fn compose_san(instance: Option<u32>, service_name: &str, host: &str, domain: &str) -> String {
     let instance = instance.unwrap_or(DEFAULT_SAN_INSTANCE);

--- a/src/registrar/identity.rs
+++ b/src/registrar/identity.rs
@@ -1,0 +1,399 @@
+//! Registration identity derivation: the `registration_id` rule, the SAN
+//! composition, the identity-shape check and safe-set validation.
+//!
+//! # Why these are separate steps
+//!
+//! The verb layer interleaves its own checks between them, in this fixed
+//! order:
+//!
+//! 1. [`validate_request_labels`] — the wire `service_name` and `host`.
+//! 2. [`check_spec_identity`] — the spec must not restate a different
+//!    identity.
+//! 3. [`RegistrarConfig::multiplicity`](crate::registrar::RegistrarConfig::multiplicity)
+//!    — resolve the class, refusing a component with no entry.
+//! 4. [`check_instance_shape`] — the `instance`-presence check.
+//! 5. [`derive_registration_id`] — the key.
+//! 6. *the verb's own* per-identity mutex and durable-binding collision
+//!    check, which read state this library has no access to.
+//! 7. [`RegistrarConfig::validate_spec`](crate::registrar::RegistrarConfig::validate_spec)
+//!    — the safe-set comparison.
+//!
+//! Two properties break under a fused call. A pre-derivation refusal
+//! must carry **no** `registration_id`, so steps 1–4 are reachable
+//! without deriving anything. And the collision check runs *between*
+//! derivation and safe-set validation: the rendered spec is
+//! host-agnostic, so two hosts of one component present the identical
+//! spec, and a flow that validated the spec first would match and
+//! re-wrap the first host's identity for the second.
+//!
+//! [`RegistrarConfig::resolve_end_to_end`](crate::registrar::RegistrarConfig::resolve_end_to_end)
+//! runs them in order for tests. The verb layer must not use it, because
+//! it has nowhere to put step 6.
+
+use crate::input_validation::{validate_dns_label, validate_registration_id};
+use crate::registrar::config::{Multiplicity, RegistrarConfig, RegistrationSpec, ReloadSpec};
+use crate::registrar::error::{RegistrarError, SpecIdentityField};
+
+/// The `<instance>` segment a SAN takes when the request carries no
+/// `instance`, per RFC §5.1.
+///
+/// This default is **SAN-only**. It must never reach
+/// [`derive_registration_id`]: a one-per-host component's id stays
+/// `<host>-<component>`, and defaulting before the derivation arm is
+/// selected would collapse the two-part/three-part distinction the
+/// identity-shape check exists to enforce.
+const DEFAULT_SAN_INSTANCE: u32 = 1;
+
+/// A registration spec as it arrives on the wire.
+///
+/// This mirrors the ecosystem's `ServiceRegistration`: `component`,
+/// `service_name`, `reload` and `cert_group`, and four is the whole
+/// shape. There is no privilege field and none is being added — bootroot
+/// derives every service's authority from the fixed derived policy, so
+/// no component differs from another on a privilege dimension.
+///
+/// The two identity fields are `Option` because a caller may omit them;
+/// present, they must agree with the wire `service_name`. Neither is
+/// ever a selector, a segment of the derived `registration_id`, or a
+/// source of the SAN.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestedSpec {
+    /// The spec's restatement of the component's package id.
+    pub component: Option<String>,
+    /// The spec's restatement of the component's plain keyword.
+    pub service_name: Option<String>,
+    /// The requested post-renew hook.
+    pub reload: ReloadSpec,
+    /// The requested numeric gid, or `None` for no cert-group policy.
+    pub cert_group: Option<u32>,
+}
+
+impl RequestedSpec {
+    /// Creates a requested spec carrying no identity restatement.
+    #[must_use]
+    pub fn new(reload: ReloadSpec, cert_group: Option<u32>) -> Self {
+        Self {
+            component: None,
+            service_name: None,
+            reload,
+            cert_group,
+        }
+    }
+
+    /// Returns this spec with `component` restated as `value`.
+    #[must_use]
+    pub fn with_component(mut self, value: &str) -> Self {
+        self.component = Some(value.to_string());
+        self
+    }
+
+    /// Returns this spec with `service_name` restated as `value`.
+    #[must_use]
+    pub fn with_service_name(mut self, value: &str) -> Self {
+        self.service_name = Some(value.to_string());
+        self
+    }
+}
+
+/// Everything the derivation produces for one request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivedIdentity {
+    /// The multiplicity class the component's entry declares.
+    pub multiplicity: Multiplicity,
+    /// The deployment-wide namespace key. Never a certificate field.
+    pub registration_id: String,
+    /// The certificate SAN, always four segments.
+    pub san: String,
+}
+
+/// Validates the wire `service_name` and `host` as single DNS labels.
+///
+/// This runs before anything else and before any derivation, so a
+/// refusal here carries no `registration_id` and none is computed as a
+/// side effect. `host` is validated for **every** multiplicity class,
+/// including the one-per-deployment class whose derivation arm ignores
+/// it: the SAN's third segment still needs it, so "not used by the id
+/// arm" is not "optional".
+///
+/// # Errors
+///
+/// Returns [`RegistrarError::InvalidServiceName`] or
+/// [`RegistrarError::InvalidHost`], each carrying the raw offending
+/// string for the caller to record.
+pub fn validate_request_labels(service_name: &str, host: &str) -> Result<(), RegistrarError> {
+    validate_dns_label(service_name).map_err(|kind| RegistrarError::InvalidServiceName {
+        value: service_name.to_string(),
+        kind,
+    })?;
+    validate_dns_label(host).map_err(|kind| RegistrarError::InvalidHost {
+        value: host.to_string(),
+        kind,
+    })?;
+    Ok(())
+}
+
+/// Refuses a spec that restates an identity other than the one the wire
+/// `service_name` selected.
+///
+/// Both `spec.component` and `spec.service_name` are checked, and both
+/// produce the **same** variant — they are one refusal semantically —
+/// with [`SpecIdentityField`] recording which one disagreed. Run this
+/// before the safe-set check and before any derivation, so the refusal
+/// is unambiguous.
+///
+/// The comparison is strict equality against the post-split contract:
+/// the spec's identity fields carry the plain keyword, never a composed
+/// name. A `spec.service_name` of `roxyd-h1` against a wire
+/// `service_name` of `roxyd` is a disagreement like any other; there is
+/// no compatibility path that strips a host suffix.
+///
+/// # Errors
+///
+/// Returns [`RegistrarError::SpecIdentityDisagreement`].
+pub fn check_spec_identity(service_name: &str, spec: &RequestedSpec) -> Result<(), RegistrarError> {
+    let component_disagrees = spec
+        .component
+        .as_deref()
+        .is_some_and(|value| value != service_name);
+    let service_name_disagrees = spec
+        .service_name
+        .as_deref()
+        .is_some_and(|value| value != service_name);
+    let field = match (component_disagrees, service_name_disagrees) {
+        (false, false) => return Ok(()),
+        (true, false) => SpecIdentityField::Component,
+        (false, true) => SpecIdentityField::ServiceName,
+        (true, true) => SpecIdentityField::Both,
+    };
+    Err(RegistrarError::SpecIdentityDisagreement {
+        field,
+        expected: service_name.to_string(),
+        spec_component: spec.component.clone(),
+        spec_service_name: spec.service_name.clone(),
+    })
+}
+
+/// Refuses a registration whose `instance` presence contradicts the
+/// component's multiplicity class.
+///
+/// This is the identity **shape** check. It is reachable without
+/// deriving anything, so a refusal here carries no `registration_id`.
+///
+/// # Errors
+///
+/// Returns [`RegistrarError::ServiceInstanceMismatch`] when `instance`
+/// is present for a one-per-host or one-per-deployment component, or
+/// absent for a many-per-host one.
+pub fn check_instance_shape(
+    component: &str,
+    multiplicity: Multiplicity,
+    instance: Option<u32>,
+) -> Result<(), RegistrarError> {
+    if multiplicity.takes_instance() == instance.is_some() {
+        return Ok(());
+    }
+    Err(RegistrarError::ServiceInstanceMismatch {
+        component: component.to_string(),
+        multiplicity,
+        instance_supplied: instance.is_some(),
+    })
+}
+
+/// Derives the `registration_id` from the identity's parts and the
+/// component's multiplicity class, per ecosystem RFC-A §4.
+///
+/// This is the **only** implementation of that rule in this repository.
+/// The three arms are:
+///
+/// | class | key |
+/// | --- | --- |
+/// | one-per-deployment | `<component>` |
+/// | one-per-host | `<host>-<component>` |
+/// | many-per-host | `<host>-<component>-<instance>` |
+///
+/// `instance` is rendered three digits zero-padded. `host` is required
+/// and validated for every class, but the one-per-deployment arm does
+/// not read it.
+///
+/// The derivation is **not injective in general**: component names and
+/// host labels both admit hyphens, so `web` on host `h1-aimer` and
+/// `aimer-web` on host `h1` derive the same key. A uniqueness check
+/// against durable state is therefore required, and it is the caller's —
+/// nothing here reads registration state.
+///
+/// # Errors
+///
+/// Returns [`RegistrarError::ServiceInstanceMismatch`] when `instance`
+/// contradicts `multiplicity`, and [`RegistrarError::DerivedKeyInvalid`]
+/// when the derived key is not path-safe — including the ≤131-octet
+/// bound, which is enforced on the derived string by the shared
+/// [`validate_registration_id`] rather than inferred from the inputs.
+pub fn derive_registration_id(
+    multiplicity: Multiplicity,
+    service_name: &str,
+    host: &str,
+    instance: Option<u32>,
+) -> Result<String, RegistrarError> {
+    check_instance_shape(service_name, multiplicity, instance)?;
+    let key = match (multiplicity, instance) {
+        (Multiplicity::OnePerDeployment, _) => service_name.to_string(),
+        (Multiplicity::OnePerHost, _) => format!("{host}-{service_name}"),
+        (Multiplicity::ManyPerHost, Some(instance)) => {
+            format!("{host}-{service_name}-{instance:03}")
+        }
+        // Unreachable: `check_instance_shape` above refuses a
+        // many-per-host request with no instance.
+        (Multiplicity::ManyPerHost, None) => {
+            return Err(RegistrarError::ServiceInstanceMismatch {
+                component: service_name.to_string(),
+                multiplicity,
+                instance_supplied: false,
+            });
+        }
+    };
+    validate_registration_id(&key).map_err(|kind| RegistrarError::DerivedKeyInvalid {
+        key: key.clone(),
+        kind,
+    })?;
+    Ok(key)
+}
+
+/// Composes the certificate SAN from the identity's four parts.
+///
+/// The shape is `<instance>.<service>.<host>.<domain>` and it always has
+/// four segments: a component whose class has no instance dimension
+/// carries no `instance` on the wire and takes the literal `001` here.
+/// `<service>` is the same wire `service_name` that selected the config
+/// entry — never the derived `registration_id`, which is a namespace key
+/// and not a certificate field. `domain` comes only from the rendered
+/// file.
+///
+/// This is the repository's third site composing this name, by necessity
+/// rather than choice: [`crate::config::profile_domain`] formats it from
+/// a `Settings` plus a `DaemonProfileSettings`, and
+/// `commands::verify::expected_dns_name` from a `ServiceEntry`, and
+/// neither takes bare parts. A test pins byte-identical agreement with
+/// the first; the second is private to the binary crate and is named
+/// here as the third site that must stay in step.
+#[must_use]
+pub fn compose_san(instance: Option<u32>, service_name: &str, host: &str, domain: &str) -> String {
+    let instance = instance.unwrap_or(DEFAULT_SAN_INSTANCE);
+    format!("{instance:03}.{service_name}.{host}.{domain}")
+}
+
+/// Returns whether a requested spec is the component's single rendered
+/// spec.
+///
+/// Both `cert_group` and `reload` must be equal. It is not a per-field
+/// allow-list: independent per-field sets would admit cross-products no
+/// component ever declares. An omitted `cert_group` in the rendered spec
+/// means the component's registrations must carry none, so a request
+/// that supplies one is outside the safe-set.
+fn spec_matches(rendered: &RegistrationSpec, requested: &RequestedSpec) -> bool {
+    rendered.cert_group == requested.cert_group && rendered.reload == requested.reload
+}
+
+impl RegistrarConfig {
+    /// Resolves the component's class and runs the identity-shape check
+    /// against it, without deriving anything.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistrarError::ComponentNotConfigured`] when the
+    /// component has no entry, and
+    /// [`RegistrarError::ServiceInstanceMismatch`] when `instance`
+    /// contradicts its class. These are two distinct variants: the
+    /// endpoint collapses both onto one caller-facing identifier, but
+    /// the audit record stores the internal one, and a single variant
+    /// would erase the difference between a caller sending the wrong
+    /// `instance` shape and a caller probing component names that do not
+    /// exist.
+    pub fn check_identity_shape(
+        &self,
+        service_name: &str,
+        instance: Option<u32>,
+    ) -> Result<Multiplicity, RegistrarError> {
+        let multiplicity = self.multiplicity(service_name)?;
+        check_instance_shape(service_name, multiplicity, instance)?;
+        Ok(multiplicity)
+    }
+
+    /// Composes the SAN for a request, taking the domain from this
+    /// loaded file.
+    ///
+    /// Prefer this over [`compose_san`] wherever a loaded config is in
+    /// hand: it is what makes it structurally impossible for a verb to
+    /// compose a name under a domain that arrived on the wire, which is
+    /// the whole reason the domain is not a request field.
+    #[must_use]
+    pub fn san_for(&self, instance: Option<u32>, service_name: &str, host: &str) -> String {
+        compose_san(instance, service_name, host, self.domain())
+    }
+
+    /// Validates a requested spec against the component's single
+    /// rendered spec.
+    ///
+    /// Callable on its own, after the caller has derived the key and
+    /// consulted its durable binding — that ordering is a correctness
+    /// requirement, not a preference. Comparison is equality on parsed
+    /// values and nothing else: a rendered `reload` target that looks
+    /// like a placeholder is a literal string and is not expanded.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistrarError::ComponentNotConfigured`] when the
+    /// component has no entry, and
+    /// [`RegistrarError::ServiceSpecOutsideSafeSet`] when the request
+    /// differs from the rendered spec in `cert_group` or `reload`.
+    ///
+    /// Never returns anything about a *stored* spec — this library has
+    /// no access to registration state, and a request that disagrees
+    /// with what already exists is the verb layer's `ServiceSpecConflict`
+    /// rather than a refusal here.
+    pub fn validate_spec(
+        &self,
+        service_name: &str,
+        spec: &RequestedSpec,
+    ) -> Result<(), RegistrarError> {
+        let entry = self.component(service_name)?;
+        if spec_matches(entry.spec(), spec) {
+            return Ok(());
+        }
+        Err(RegistrarError::ServiceSpecOutsideSafeSet {
+            component: service_name.to_string(),
+        })
+    }
+
+    /// Runs every step this library owns, in order, for one request.
+    ///
+    /// **For tests and callers with no durable state to consult.** The
+    /// verb layer must not use it: the per-identity mutex and the
+    /// durable-binding collision check belong between the derivation and
+    /// the safe-set comparison, and there is nowhere to put them here.
+    ///
+    /// # Errors
+    ///
+    /// Returns any variant the individual steps produce.
+    pub fn resolve_end_to_end(
+        &self,
+        service_name: &str,
+        host: &str,
+        instance: Option<u32>,
+        spec: Option<&RequestedSpec>,
+    ) -> Result<DerivedIdentity, RegistrarError> {
+        validate_request_labels(service_name, host)?;
+        if let Some(spec) = spec {
+            check_spec_identity(service_name, spec)?;
+        }
+        let multiplicity = self.check_identity_shape(service_name, instance)?;
+        let registration_id = derive_registration_id(multiplicity, service_name, host, instance)?;
+        if let Some(spec) = spec {
+            self.validate_spec(service_name, spec)?;
+        }
+        Ok(DerivedIdentity {
+            multiplicity,
+            registration_id,
+            san: self.san_for(instance, service_name, host),
+        })
+    }
+}

--- a/src/registrar/tests.rs
+++ b/src/registrar/tests.rs
@@ -1,0 +1,1248 @@
+//! Tests for the registrar config loader and the derivation library.
+//!
+//! The three derived literals asserted in [`derives_the_three_arms`] are
+//! a contract with the `registration_id` split, whose own fixtures use
+//! the same namespace keys. They are written out rather than
+//! round-tripped against the derivation, because a derivation that
+//! round-trips against itself agrees with itself no matter what it
+//! emits.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use crate::config::{
+    AcmeSettings, DaemonProfileSettings, DaemonRuntimeSettings, HookSettings, Paths, RetrySettings,
+    SchedulerSettings, Settings, TrustSettings, profile_domain,
+};
+use crate::input_validation::ValidationError;
+use crate::registrar::config::{
+    CONFIG_FILE_NAME, DEFAULT_CONFIG_PATH, Multiplicity, RegistrarConfig, RegistrationSpec,
+    ReloadKind, ReloadSpec, SUPPORTED_SCHEMA_VERSION,
+};
+use crate::registrar::error::{RegistrarError, SpecIdentityField};
+use crate::registrar::fixture::{ComponentFixture, FIXTURE_DOMAIN, RegistrarConfigFixture};
+use crate::registrar::identity::{
+    RequestedSpec, check_instance_shape, check_spec_identity, compose_san, derive_registration_id,
+    validate_request_labels,
+};
+
+const EXAMPLE_FILE: &str = "docs/reference/provisioning.toml.example";
+const SCHEMA_DOC_FILE: &str = "docs/reference/registrar-provisioning-config.md";
+/// The structural maximum of a derived key, per `input_validation`.
+const REGISTRATION_ID_MAX_LEN: usize = 131;
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+/// Writes `contents` verbatim as the rendered config inside a fresh
+/// temporary directory, so no test ever touches [`DEFAULT_CONFIG_PATH`].
+fn write_raw(contents: &str) -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join(CONFIG_FILE_NAME);
+    std::fs::write(&path, contents).expect("the fixture file must be writable");
+    (dir, path)
+}
+
+fn load_fixture(
+    fixture: &RegistrarConfigFixture,
+) -> (TempDir, Result<RegistrarConfig, RegistrarError>) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = fixture
+        .write_to(dir.path())
+        .expect("the fixture must write");
+    let loaded = RegistrarConfig::load(&path);
+    (dir, loaded)
+}
+
+fn loaded_default() -> (TempDir, RegistrarConfig) {
+    let (dir, loaded) = load_fixture(&RegistrarConfigFixture::new());
+    (dir, loaded.expect("the default fixture must load"))
+}
+
+fn piglet_spec() -> RequestedSpec {
+    RequestedSpec::new(
+        ReloadSpec::new(ReloadKind::DockerRestart, "piglet"),
+        Some(3001),
+    )
+}
+
+// ---------------------------------------------------------------------
+// The documented example and the shipped documentation
+// ---------------------------------------------------------------------
+
+#[test]
+fn loads_the_shipped_example_through_the_production_loader() {
+    let config = RegistrarConfig::load(&repo_path(EXAMPLE_FILE))
+        .expect("the shipped example must load through the production loader");
+
+    assert_eq!(config.domain(), "trusted.domain");
+    assert_eq!(config.schema_version(), SUPPORTED_SCHEMA_VERSION);
+    assert_eq!(
+        config.component_names().collect::<Vec<_>>(),
+        vec!["piglet", "review", "roxyd"]
+    );
+
+    let review = config.component("review").expect("review resolves");
+    assert_eq!(review.multiplicity(), Multiplicity::OnePerDeployment);
+    assert_eq!(review.spec().cert_group, Some(3000));
+    assert_eq!(
+        review.spec().reload,
+        ReloadSpec::new(ReloadKind::DockerRestart, "review")
+    );
+
+    let roxyd = config.component("roxyd").expect("roxyd resolves");
+    assert_eq!(roxyd.multiplicity(), Multiplicity::OnePerHost);
+    assert_eq!(roxyd.spec().cert_group, None);
+    assert_eq!(
+        roxyd.spec().reload,
+        ReloadSpec::new(ReloadKind::Systemd, "roxyd.service")
+    );
+
+    let piglet = config.component("piglet").expect("piglet resolves");
+    assert_eq!(piglet.multiplicity(), Multiplicity::ManyPerHost);
+    assert_eq!(piglet.spec().cert_group, Some(3001));
+    assert_eq!(
+        piglet.spec().reload,
+        ReloadSpec::new(ReloadKind::DockerRestart, "piglet")
+    );
+}
+
+/// The schema description quotes the example file. Quoting it is only
+/// worth anything while the quote is the file.
+#[test]
+fn schema_documentation_quotes_the_example_verbatim() {
+    let example = std::fs::read_to_string(repo_path(EXAMPLE_FILE)).expect("the example is shipped");
+    let doc =
+        std::fs::read_to_string(repo_path(SCHEMA_DOC_FILE)).expect("the schema doc is shipped");
+    assert!(
+        doc.contains(&example),
+        "{SCHEMA_DOC_FILE} no longer quotes {EXAMPLE_FILE} verbatim"
+    );
+}
+
+#[test]
+fn default_path_is_the_writers_product_namespaced_one() {
+    assert_eq!(
+        DEFAULT_CONFIG_PATH,
+        "/etc/clumit-security/provisioning.toml"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Loader: hard failures
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_missing_file_is_a_hard_failure() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let err = RegistrarConfig::load(&dir.path().join("absent.toml"))
+        .expect_err("a missing config must not load");
+    assert!(
+        matches!(err, RegistrarError::ConfigUnreadable { .. }),
+        "{err:?}"
+    );
+}
+
+/// A directory standing where the file should be is unreadable for the
+/// same reason a mode-000 file is, and stays unreadable when the test
+/// suite happens to run as root.
+#[test]
+fn an_unreadable_file_is_a_hard_failure() {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join(CONFIG_FILE_NAME);
+    std::fs::create_dir(&path).expect("the placeholder directory must be creatable");
+    let err = RegistrarConfig::load(&path).expect_err("an unreadable config must not load");
+    assert!(
+        matches!(err, RegistrarError::ConfigUnreadable { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn a_malformed_body_is_a_typed_failure() {
+    let body = "this is not toml\n";
+    let (_dir, path) = write_raw(&format!(
+        "fingerprint = \"{}\"\n{body}",
+        crate::tls::sha256_hex(body.as_bytes())
+    ));
+    let err = RegistrarConfig::load(&path).expect_err("a malformed body must not load");
+    assert!(
+        matches!(err, RegistrarError::ConfigMalformed { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn a_missing_domain_is_a_typed_failure() {
+    let body = "schema_version = 1\n";
+    let (_dir, path) = write_raw(&format!(
+        "fingerprint = \"{}\"\n{body}",
+        crate::tls::sha256_hex(body.as_bytes())
+    ));
+    let err = RegistrarConfig::load(&path).expect_err("a config with no domain must not load");
+    assert!(
+        matches!(err, RegistrarError::ConfigMalformed { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn an_invalid_domain_is_a_typed_failure() {
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::new().with_domain("trusted_domain"));
+    let err = loaded.expect_err("an invalid domain must not load");
+    assert!(
+        matches!(err, RegistrarError::InvalidDomain { ref domain, .. } if domain == "trusted_domain"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn an_unrecognised_multiplicity_carries_the_offending_value() {
+    let fixture = RegistrarConfigFixture::new().with_raw_component(
+        "piglet",
+        ComponentFixture {
+            multiplicity: "sometimes".to_string(),
+            cert_group: Some(3001),
+            reload_kind: "docker-restart".to_string(),
+            reload_target: Some("piglet".to_string()),
+        },
+    );
+    let (_dir, loaded) = load_fixture(&fixture);
+    let err = loaded.expect_err("an unrecognised multiplicity must not load");
+    match err {
+        RegistrarError::UnknownMultiplicity { component, value } => {
+            assert_eq!(component, "piglet");
+            assert_eq!(value, "sometimes");
+        }
+        other => panic!("expected UnknownMultiplicity, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unrecognised_reload_kind_carries_the_offending_value() {
+    let fixture = RegistrarConfigFixture::new().with_raw_component(
+        "piglet",
+        ComponentFixture {
+            multiplicity: "many-per-host".to_string(),
+            cert_group: Some(3001),
+            reload_kind: "container-restart".to_string(),
+            reload_target: Some("piglet".to_string()),
+        },
+    );
+    let (_dir, loaded) = load_fixture(&fixture);
+    let err = loaded.expect_err("an unrecognised reload kind must not load");
+    match err {
+        RegistrarError::UnknownReloadKind { component, value } => {
+            assert_eq!(component, "piglet");
+            // The infrastructure-certificate vocabulary is not this
+            // file's, and reaching for it is a load failure rather than
+            // a silently accepted synonym.
+            assert_eq!(value, "container-restart");
+        }
+        other => panic!("expected UnknownReloadKind, got {other:?}"),
+    }
+}
+
+#[test]
+fn every_reload_kind_the_writer_renders_is_accepted() {
+    for (kind, target) in [
+        (ReloadKind::Sighup, Some("roxyd")),
+        (ReloadKind::Systemd, Some("roxyd.service")),
+        (ReloadKind::DockerRestart, Some("roxyd")),
+        (ReloadKind::None, None),
+    ] {
+        let reload = match target {
+            Some(target) => ReloadSpec::new(kind, target),
+            None => ReloadSpec::none(),
+        };
+        let fixture = RegistrarConfigFixture::new().with_component(
+            "roxyd",
+            Multiplicity::OnePerHost,
+            &RegistrationSpec {
+                cert_group: None,
+                reload: reload.clone(),
+            },
+        );
+        let (_dir, loaded) = load_fixture(&fixture);
+        let config = loaded.unwrap_or_else(|err| panic!("{kind} must load: {err:?}"));
+        assert_eq!(
+            config
+                .component("roxyd")
+                .expect("roxyd resolves")
+                .spec()
+                .reload,
+            reload
+        );
+    }
+}
+
+#[test]
+fn a_reload_target_that_contradicts_its_kind_is_refused() {
+    for (kind, target) in [("none", Some("roxyd")), ("systemd", None)] {
+        let fixture = RegistrarConfigFixture::new().with_raw_component(
+            "roxyd",
+            ComponentFixture {
+                multiplicity: "one-per-host".to_string(),
+                cert_group: None,
+                reload_kind: kind.to_string(),
+                reload_target: target.map(str::to_string),
+            },
+        );
+        let (_dir, loaded) = load_fixture(&fixture);
+        let err = loaded.expect_err("a contradictory reload target must not load");
+        assert!(
+            matches!(err, RegistrarError::InvalidReloadTarget { .. }),
+            "{kind}: {err:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Loader: the two integrity gates
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_first_line_must_be_the_exact_fingerprint_form() {
+    let digest = "a".repeat(64);
+    for contents in [
+        // No newline at all.
+        format!("fingerprint = \"{digest}\""),
+        // The key is not the fingerprint.
+        "schema_version = 1\ndomain = \"trusted.domain\"\n".to_string(),
+        // Too short.
+        format!("fingerprint = \"{}\"\n", "a".repeat(63)),
+        // Too long.
+        format!("fingerprint = \"{}\"\n", "a".repeat(65)),
+        // Uppercase hex.
+        format!("fingerprint = \"{}\"\n", "A".repeat(64)),
+        // Not hex.
+        format!("fingerprint = \"{}\"\n", "z".repeat(64)),
+        // Unquoted.
+        format!("fingerprint = {digest}\n"),
+        // Extra whitespace around the assignment.
+        format!("fingerprint  =  \"{digest}\"\n"),
+        // A trailing comment on the fingerprint line.
+        format!("fingerprint = \"{digest}\" # rendered\n"),
+        // An empty file.
+        String::new(),
+    ] {
+        let (_dir, path) = write_raw(&contents);
+        let err = RegistrarConfig::load(&path).expect_err("a malformed first line must not load");
+        assert!(
+            matches!(err, RegistrarError::FingerprintLineMalformed { .. }),
+            "{contents:?}: {err:?}"
+        );
+    }
+}
+
+#[test]
+fn a_digest_that_does_not_match_the_body_is_refused() {
+    let declared = "0".repeat(64);
+    let fixture = RegistrarConfigFixture::new().with_fingerprint(&declared);
+    let (_dir, loaded) = load_fixture(&fixture);
+    let err = loaded.expect_err("a mismatched digest must not load");
+    match err {
+        RegistrarError::FingerprintMismatch {
+            declared: found,
+            computed,
+            ..
+        } => {
+            assert_eq!(found, declared);
+            assert_eq!(
+                computed,
+                crate::tls::sha256_hex(fixture.render_body().as_bytes())
+            );
+        }
+        other => panic!("expected FingerprintMismatch, got {other:?}"),
+    }
+}
+
+/// The regression the digest gate exists for: a body cut at a
+/// `[components.*]` boundary is still valid TOML with entries missing,
+/// so without the gate the load would succeed and the dropped components
+/// would be refused one request at a time — a silent per-component
+/// enrollment outage indistinguishable from a component that was never
+/// provisioned.
+#[test]
+fn a_body_truncated_at_a_component_boundary_fails_on_the_digest() {
+    let fixture = RegistrarConfigFixture::new();
+    let whole = fixture.render();
+    let cut = whole
+        .find("\n[components.review]")
+        .expect("the rendered file has a review table");
+    let truncated = whole.get(..cut + 1).expect("the cut is on a char boundary");
+
+    // The truncated body really does still parse, so the digest is the
+    // only thing standing between it and a short component table.
+    assert!(truncated.parse::<toml_edit::DocumentMut>().is_ok());
+
+    let (_dir, path) = write_raw(truncated);
+    let err = RegistrarConfig::load(&path).expect_err("a truncated config must not load");
+    assert!(
+        matches!(err, RegistrarError::FingerprintMismatch { .. }),
+        "expected the digest failure rather than a per-component refusal, got {err:?}"
+    );
+}
+
+/// The declared fingerprint has no reader outside a validated load: the
+/// field is private and `load` is the only constructor, so a caller
+/// holding a `RegistrarConfig` holds a digest that was checked.
+#[test]
+fn the_declared_fingerprint_is_reachable_only_from_a_validated_load() {
+    let fixture = RegistrarConfigFixture::new();
+    let (_dir, config) = {
+        let (dir, loaded) = load_fixture(&fixture);
+        (dir, loaded.expect("the fixture must load"))
+    };
+    assert_eq!(
+        config.fingerprint(),
+        crate::tls::sha256_hex(fixture.render_body().as_bytes())
+    );
+}
+
+#[test]
+fn an_unsupported_schema_version_carries_both_versions() {
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::new().with_schema_version(2));
+    let err = loaded.expect_err("a newer schema must not load");
+    match err {
+        RegistrarError::UnsupportedSchemaVersion {
+            found, supported, ..
+        } => {
+            assert_eq!(found, 2);
+            assert_eq!(supported, SUPPORTED_SCHEMA_VERSION);
+        }
+        other => panic!("expected UnsupportedSchemaVersion, got {other:?}"),
+    }
+}
+
+/// The body's shape is closed. An extra key means the file was written
+/// against a shape this build does not implement, and a `schema_version`
+/// that failed to say so is not a reason to read it anyway.
+#[test]
+fn an_unknown_key_in_the_body_is_refused() {
+    for body in [
+        "schema_version = 1\ndomain = \"trusted.domain\"\nregion = \"eu\"\n",
+        // A second fingerprint, inside the digested body this time.
+        "schema_version = 1\ndomain = \"trusted.domain\"\nfingerprint = \"x\"\n",
+        "schema_version = 1\ndomain = \"trusted.domain\"\n\n[components.review]\nmultiplicity = \"one-per-deployment\"\nreload = { kind = \"none\" }\nprivilege = \"root\"\n",
+    ] {
+        let (_dir, path) = write_raw(&format!(
+            "fingerprint = \"{}\"\n{body}",
+            crate::tls::sha256_hex(body.as_bytes())
+        ));
+        let err = RegistrarConfig::load(&path).expect_err("an unknown key must not load");
+        assert!(
+            matches!(err, RegistrarError::ConfigMalformed { .. }),
+            "{body:?}: {err:?}"
+        );
+    }
+}
+
+/// A `[components.<key>]` that no wire `service_name` could ever select
+/// is a rendering error, not an entry to carry around unreachable.
+#[test]
+fn a_component_key_that_is_not_a_dns_label_is_refused() {
+    let fixture = RegistrarConfigFixture::empty().with_raw_component(
+        "review_eu",
+        ComponentFixture {
+            multiplicity: "one-per-deployment".to_string(),
+            cert_group: None,
+            reload_kind: "none".to_string(),
+            reload_target: None,
+        },
+    );
+    let (_dir, loaded) = load_fixture(&fixture);
+    let err = loaded.expect_err("an unselectable component key must not load");
+    assert!(
+        matches!(err, RegistrarError::InvalidComponentKey { ref component, .. } if component == "review_eu"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn an_absent_schema_version_is_refused_rather_than_defaulted() {
+    let body = "domain = \"trusted.domain\"\n\n[components.review]\nmultiplicity = \"one-per-deployment\"\nreload = { kind = \"none\" }\n";
+    let (_dir, path) = write_raw(&format!(
+        "fingerprint = \"{}\"\n{body}",
+        crate::tls::sha256_hex(body.as_bytes())
+    ));
+    let err = RegistrarConfig::load(&path).expect_err("an absent schema_version must not load");
+    assert!(
+        matches!(err, RegistrarError::ConfigMalformed { .. }),
+        "{err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Derivation
+// ---------------------------------------------------------------------
+
+/// These three literals are a contract with the `registration_id` split
+/// issue, which asserts the same strings as namespace keys in its own
+/// fixtures.
+#[test]
+fn derives_the_three_arms() {
+    let cases: [(Multiplicity, &str, &str, Option<u32>, &str); 7] = [
+        (
+            Multiplicity::ManyPerHost,
+            "piglet",
+            "h1",
+            Some(1),
+            "h1-piglet-001",
+        ),
+        (Multiplicity::OnePerHost, "roxyd", "h1", None, "h1-roxyd"),
+        (
+            Multiplicity::OnePerDeployment,
+            "review",
+            "h1",
+            None,
+            "review",
+        ),
+        // Hyphenated component and host names.
+        (
+            Multiplicity::OnePerDeployment,
+            "aice-web-next",
+            "edge-01",
+            None,
+            "aice-web-next",
+        ),
+        (
+            Multiplicity::OnePerHost,
+            "aice-web-next",
+            "edge-01",
+            None,
+            "edge-01-aice-web-next",
+        ),
+        (
+            Multiplicity::ManyPerHost,
+            "aice-web-next",
+            "edge-01",
+            Some(12),
+            "edge-01-aice-web-next-012",
+        ),
+        (
+            Multiplicity::ManyPerHost,
+            "piglet",
+            "h1",
+            Some(999),
+            "h1-piglet-999",
+        ),
+    ];
+    for (multiplicity, service_name, host, instance, expected) in cases {
+        let derived = derive_registration_id(multiplicity, service_name, host, instance)
+            .unwrap_or_else(|err| panic!("{expected} must derive: {err:?}"));
+        assert_eq!(derived, expected);
+    }
+}
+
+/// The derivation is not injective in general: component names and host
+/// labels both admit hyphens. A uniqueness check against durable state
+/// is therefore required, and it is the caller's — nothing in this
+/// library reads registration state.
+#[test]
+fn the_derivation_is_not_injective() {
+    let web_on_h1_aimer =
+        derive_registration_id(Multiplicity::ManyPerHost, "web", "h1-aimer", Some(1))
+            .expect("web on h1-aimer derives");
+    let aimer_web_on_h1 =
+        derive_registration_id(Multiplicity::ManyPerHost, "aimer-web", "h1", Some(1))
+            .expect("aimer-web on h1 derives");
+    assert_eq!(web_on_h1_aimer, "h1-aimer-web-001");
+    assert_eq!(aimer_web_on_h1, "h1-aimer-web-001");
+}
+
+#[test]
+fn the_derived_key_is_bounded_at_the_structural_maximum() {
+    let host = "h".repeat(63);
+    let component = "c".repeat(63);
+
+    let at_limit = derive_registration_id(Multiplicity::ManyPerHost, &component, &host, Some(1))
+        .expect("the structural maximum is legal");
+    assert_eq!(at_limit.len(), REGISTRATION_ID_MAX_LEN);
+
+    // One octet past it, reached the only way the derivation can: an
+    // instance whose three-digit rendering needs a fourth digit.
+    let err = derive_registration_id(Multiplicity::ManyPerHost, &component, &host, Some(1000))
+        .expect_err("one octet past the maximum is refused");
+    match err {
+        RegistrarError::DerivedKeyInvalid { key, kind } => {
+            assert_eq!(key.len(), REGISTRATION_ID_MAX_LEN + 1);
+            // The refusal comes from the shared validator, not from a
+            // length check written locally in this library.
+            assert_eq!(kind, ValidationError::InvalidRegistrationId);
+        }
+        other => panic!("expected DerivedKeyInvalid, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// SAN composition
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_san_always_has_four_segments() {
+    assert_eq!(
+        compose_san(None, "roxyd", "h1", FIXTURE_DOMAIN),
+        "001.roxyd.h1.trusted.domain"
+    );
+    assert_eq!(
+        compose_san(None, "review", "h1", FIXTURE_DOMAIN),
+        "001.review.h1.trusted.domain"
+    );
+    assert_eq!(
+        compose_san(Some(1), "piglet", "h1", FIXTURE_DOMAIN),
+        "001.piglet.h1.trusted.domain"
+    );
+    assert_eq!(
+        compose_san(Some(12), "piglet", "h1", FIXTURE_DOMAIN),
+        "012.piglet.h1.trusted.domain"
+    );
+}
+
+/// The `001` default is SAN-only. Applying it before the derivation arm
+/// is selected would collapse the two-part/three-part distinction the
+/// identity-shape check exists to enforce.
+#[test]
+fn the_default_instance_reaches_the_san_and_never_the_id() {
+    let (_dir, config) = loaded_default();
+    let cases: [(&str, Option<u32>, &str, &str); 3] = [
+        ("review", None, "review", "001.review.h1.trusted.domain"),
+        ("roxyd", None, "h1-roxyd", "001.roxyd.h1.trusted.domain"),
+        (
+            "piglet",
+            Some(1),
+            "h1-piglet-001",
+            "001.piglet.h1.trusted.domain",
+        ),
+    ];
+    for (service_name, instance, expected_id, expected_san) in cases {
+        let derived = config
+            .resolve_end_to_end(service_name, "h1", instance, None)
+            .unwrap_or_else(|err| panic!("{service_name} must resolve: {err:?}"));
+        assert_eq!(derived.registration_id, expected_id);
+        assert_eq!(derived.san, expected_san);
+    }
+    // Spelled out, because it is the regression that would catch the
+    // default being applied before arm selection.
+    let roxyd = config
+        .resolve_end_to_end("roxyd", "h1", None, None)
+        .expect("roxyd resolves");
+    assert!(!roxyd.registration_id.contains("001"));
+    let review = config
+        .resolve_end_to_end("review", "h1", None, None)
+        .expect("review resolves");
+    assert!(!review.registration_id.contains("001"));
+}
+
+/// The three sites that compose `<instance>.<service>.<host>.<domain>`
+/// must agree byte for byte. This pins the two that a test in this crate
+/// can reach; `commands::verify::expected_dns_name` is private to the
+/// binary crate and is named in the schema documentation instead.
+/// A loaded config composes under its own domain, never one a caller
+/// could have supplied.
+#[test]
+fn san_for_takes_the_domain_from_the_loaded_file() {
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::new().with_domain("other.domain"));
+    let config = loaded.expect("the fixture must load");
+    assert_eq!(
+        config.san_for(Some(1), "piglet", "h1"),
+        "001.piglet.h1.other.domain"
+    );
+    assert_eq!(
+        config.san_for(None, "roxyd", "h1"),
+        compose_san(None, "roxyd", "h1", config.domain())
+    );
+}
+
+#[test]
+fn the_composer_agrees_with_profile_domain() {
+    for (instance, service_name, host) in [
+        (Some(1), "piglet", "h1"),
+        (Some(12), "piglet", "h1"),
+        (None, "roxyd", "h1"),
+        (None, "review", "h1"),
+    ] {
+        let settings = settings_with_domain(FIXTURE_DOMAIN);
+        let rendered_instance = format!("{:03}", instance.unwrap_or(1));
+        let profile = profile_with(&rendered_instance, service_name, host);
+        assert_eq!(
+            compose_san(instance, service_name, host, FIXTURE_DOMAIN),
+            profile_domain(&settings, &profile),
+            "{service_name} on {host} instance {instance:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Label validation and the identity-shape check
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_label_that_is_not_a_single_dns_label_is_refused_with_its_raw_value() {
+    let err = validate_request_labels("piglet.h1", "h1").expect_err("a dotted service_name");
+    match err {
+        RegistrarError::InvalidServiceName { value, kind } => {
+            assert_eq!(value, "piglet.h1");
+            assert_eq!(kind, ValidationError::InvalidDnsLabel);
+        }
+        other => panic!("expected InvalidServiceName, got {other:?}"),
+    }
+
+    let err = validate_request_labels("piglet", "h1_a").expect_err("an underscored host");
+    match err {
+        RegistrarError::InvalidHost { value, kind } => {
+            assert_eq!(value, "h1_a");
+            assert_eq!(kind, ValidationError::InvalidDnsLabel);
+        }
+        other => panic!("expected InvalidHost, got {other:?}"),
+    }
+
+    assert!(validate_request_labels("piglet", "h1").is_ok());
+}
+
+/// The one-per-deployment arm ignores `host`, but the SAN's third
+/// segment does not, so "not used by the id arm" is not "optional".
+#[test]
+fn a_one_per_deployment_request_still_needs_a_valid_host() {
+    let (_dir, config) = loaded_default();
+    for host in ["", "h1.example", "-h1"] {
+        let err = config
+            .resolve_end_to_end("review", host, None, None)
+            .expect_err("a one-per-deployment request with a bad host must be refused");
+        assert!(
+            matches!(err, RegistrarError::InvalidHost { .. }),
+            "{host:?}: {err:?}"
+        );
+    }
+}
+
+#[test]
+fn the_identity_shape_check_refuses_both_directions() {
+    let (_dir, config) = loaded_default();
+
+    // An instance for a class with no instance dimension.
+    for service_name in ["review", "roxyd"] {
+        let err = config
+            .check_identity_shape(service_name, Some(1))
+            .expect_err("a supplied instance must be refused");
+        assert!(
+            matches!(
+                err,
+                RegistrarError::ServiceInstanceMismatch {
+                    instance_supplied: true,
+                    ..
+                }
+            ),
+            "{service_name}: {err:?}"
+        );
+    }
+
+    // No instance for the class that has one.
+    let err = config
+        .check_identity_shape("piglet", None)
+        .expect_err("an omitted instance must be refused");
+    assert!(
+        matches!(
+            err,
+            RegistrarError::ServiceInstanceMismatch {
+                instance_supplied: false,
+                ..
+            }
+        ),
+        "{err:?}"
+    );
+
+    // The matching shapes.
+    assert_eq!(
+        config.check_identity_shape("review", None).expect("review"),
+        Multiplicity::OnePerDeployment
+    );
+    assert_eq!(
+        config.check_identity_shape("roxyd", None).expect("roxyd"),
+        Multiplicity::OnePerHost
+    );
+    assert_eq!(
+        config
+            .check_identity_shape("piglet", Some(1))
+            .expect("piglet"),
+        Multiplicity::ManyPerHost
+    );
+}
+
+/// The endpoint maps both onto one caller-facing identifier, but the
+/// audit record stores the internal variant, so collapsing them here
+/// would erase the difference between a wrong `instance` shape and a
+/// caller probing component names that do not exist.
+#[test]
+fn an_absent_component_is_a_distinct_variant_from_an_instance_mismatch() {
+    let (_dir, config) = loaded_default();
+    let absent = config
+        .check_identity_shape("giganto", None)
+        .expect_err("an unconfigured component must be refused");
+    let mismatch = config
+        .check_identity_shape("piglet", None)
+        .expect_err("an omitted instance must be refused");
+
+    assert!(
+        matches!(absent, RegistrarError::ComponentNotConfigured { ref component } if component == "giganto"),
+        "{absent:?}"
+    );
+    assert!(
+        matches!(mismatch, RegistrarError::ServiceInstanceMismatch { .. }),
+        "{mismatch:?}"
+    );
+    assert_ne!(
+        std::mem::discriminant(&absent),
+        std::mem::discriminant(&mismatch)
+    );
+}
+
+#[test]
+fn a_component_removed_from_the_config_is_refused_rather_than_defaulted() {
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::new().without_component("piglet"));
+    let config = loaded.expect("the fixture must load");
+    let err = config
+        .resolve_end_to_end("piglet", "h1", Some(1), None)
+        .expect_err("an absent component must be refused");
+    assert!(
+        matches!(err, RegistrarError::ComponentNotConfigured { .. }),
+        "{err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Safe-set validation
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_safe_set_accepts_only_the_single_rendered_spec() {
+    let (_dir, config) = loaded_default();
+    assert!(config.validate_spec("piglet", &piglet_spec()).is_ok());
+
+    let rejected = [
+        // Differs only in cert_group.
+        RequestedSpec::new(
+            ReloadSpec::new(ReloadKind::DockerRestart, "piglet"),
+            Some(0),
+        ),
+        // Differs only in reload.kind.
+        RequestedSpec::new(ReloadSpec::new(ReloadKind::Systemd, "piglet"), Some(3001)),
+        // Differs only in reload.target.
+        RequestedSpec::new(
+            ReloadSpec::new(ReloadKind::DockerRestart, "piglet-attacker"),
+            Some(3001),
+        ),
+        // Omits the cert_group the component's spec renders.
+        RequestedSpec::new(ReloadSpec::new(ReloadKind::DockerRestart, "piglet"), None),
+    ];
+    for spec in rejected {
+        let err = config
+            .validate_spec("piglet", &spec)
+            .expect_err("a spec outside the safe-set must be refused");
+        assert!(
+            matches!(err, RegistrarError::ServiceSpecOutsideSafeSet { ref component } if component == "piglet"),
+            "{spec:?}: {err:?}"
+        );
+    }
+}
+
+/// An omitted `cert_group` in the rendered spec means the component's
+/// registrations must carry none — not that any gid is allowed.
+#[test]
+fn a_component_rendering_no_cert_group_refuses_a_request_that_supplies_one() {
+    let (_dir, config) = loaded_default();
+    let reload = ReloadSpec::new(ReloadKind::Systemd, "roxyd.service");
+
+    assert!(
+        config
+            .validate_spec("roxyd", &RequestedSpec::new(reload.clone(), None))
+            .is_ok()
+    );
+    let err = config
+        .validate_spec("roxyd", &RequestedSpec::new(reload, Some(3000)))
+        .expect_err("a supplied cert_group must be refused");
+    assert!(
+        matches!(err, RegistrarError::ServiceSpecOutsideSafeSet { .. }),
+        "{err:?}"
+    );
+}
+
+/// There is no template language. A rendered token that looks like a
+/// placeholder is a literal string, and a matcher that tolerated a
+/// varying segment would silently widen what one rendered line
+/// authorises.
+#[test]
+fn a_placeholder_looking_token_is_not_expanded() {
+    let spec = RegistrationSpec {
+        cert_group: Some(3001),
+        reload: ReloadSpec::new(ReloadKind::DockerRestart, "piglet-{instance}"),
+    };
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::new().with_spec("piglet", &spec));
+    let config = loaded.expect("the fixture must load");
+
+    let err = config
+        .validate_spec(
+            "piglet",
+            &RequestedSpec::new(
+                ReloadSpec::new(ReloadKind::DockerRestart, "piglet-001"),
+                Some(3001),
+            ),
+        )
+        .expect_err("the expanded form must be refused");
+    assert!(
+        matches!(err, RegistrarError::ServiceSpecOutsideSafeSet { .. }),
+        "{err:?}"
+    );
+
+    assert!(
+        config
+            .validate_spec(
+                "piglet",
+                &RequestedSpec::new(
+                    ReloadSpec::new(ReloadKind::DockerRestart, "piglet-{instance}"),
+                    Some(3001),
+                ),
+            )
+            .is_ok()
+    );
+}
+
+// ---------------------------------------------------------------------
+// Spec identity agreement
+// ---------------------------------------------------------------------
+
+#[test]
+fn a_spec_component_that_disagrees_is_refused_before_anything_else() {
+    let (_dir, config) = loaded_default();
+    // The spec is otherwise inside the safe-set, and the component it
+    // names is itself configured — so nothing but the identity check
+    // stops it being validated against `review`'s rendered entry.
+    let spec = piglet_spec().with_component("review");
+
+    let err = config
+        .resolve_end_to_end("piglet", "h1", Some(1), Some(&spec))
+        .expect_err("a disagreeing spec.component must be refused");
+    match err {
+        RegistrarError::SpecIdentityDisagreement {
+            field,
+            expected,
+            spec_component,
+            spec_service_name,
+        } => {
+            assert_eq!(field, SpecIdentityField::Component);
+            assert_eq!(expected, "piglet");
+            assert_eq!(spec_component.as_deref(), Some("review"));
+            assert_eq!(spec_service_name, None);
+        }
+        other => panic!("expected SpecIdentityDisagreement, got {other:?}"),
+    }
+
+    // An unrelated string is refused the same way.
+    let err = check_spec_identity("piglet", &piglet_spec().with_component("not-a-component"))
+        .expect_err("an unrelated spec.component must be refused");
+    assert!(
+        matches!(err, RegistrarError::SpecIdentityDisagreement { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn a_spec_service_name_that_disagrees_is_refused_even_inside_the_safe_set() {
+    let (_dir, config) = loaded_default();
+    for name in ["review", "not-a-component", "roxyd-h1"] {
+        let spec = piglet_spec().with_service_name(name);
+        let err = config
+            .resolve_end_to_end("piglet", "h1", Some(1), Some(&spec))
+            .expect_err("a disagreeing spec.service_name must be refused");
+        match err {
+            RegistrarError::SpecIdentityDisagreement {
+                field,
+                spec_service_name,
+                ..
+            } => {
+                assert_eq!(field, SpecIdentityField::ServiceName);
+                assert_eq!(spec_service_name.as_deref(), Some(name));
+            }
+            other => panic!("{name}: expected SpecIdentityDisagreement, got {other:?}"),
+        }
+    }
+}
+
+/// The post-split contract: the spec's identity fields carry the plain
+/// keyword, never a composed name. There is no compatibility path that
+/// strips a host suffix — and the derivation never reads the field, so
+/// the id and the SAN a matching request produces are the wire's alone.
+#[test]
+fn a_composed_name_in_the_spec_is_refused_and_never_read() {
+    let (_dir, config) = loaded_default();
+    let err = check_spec_identity(
+        "roxyd",
+        &RequestedSpec::new(ReloadSpec::new(ReloadKind::Systemd, "roxyd.service"), None)
+            .with_service_name("roxyd-h1"),
+    )
+    .expect_err("a composed spec.service_name must be refused");
+    assert!(
+        matches!(err, RegistrarError::SpecIdentityDisagreement { .. }),
+        "{err:?}"
+    );
+
+    // The same request with the spec's identity fields absent, and with
+    // them agreeing, derives the same id and SAN — so neither is a
+    // source for either.
+    let plain = RequestedSpec::new(ReloadSpec::new(ReloadKind::Systemd, "roxyd.service"), None);
+    let restated = plain
+        .clone()
+        .with_component("roxyd")
+        .with_service_name("roxyd");
+    let from_plain = config
+        .resolve_end_to_end("roxyd", "h1", None, Some(&plain))
+        .expect("the plain spec resolves");
+    let from_restated = config
+        .resolve_end_to_end("roxyd", "h1", None, Some(&restated))
+        .expect("the restated spec resolves");
+    assert_eq!(from_plain, from_restated);
+    assert_eq!(from_plain.registration_id, "h1-roxyd");
+    assert_eq!(from_plain.san, "001.roxyd.h1.trusted.domain");
+}
+
+#[test]
+fn the_disagreeing_field_is_recorded_behind_the_single_variant() {
+    let base = piglet_spec();
+    let cases = [
+        (
+            base.clone().with_component("review"),
+            SpecIdentityField::Component,
+        ),
+        (
+            base.clone().with_service_name("review"),
+            SpecIdentityField::ServiceName,
+        ),
+        (
+            base.clone()
+                .with_component("review")
+                .with_service_name("roxyd"),
+            SpecIdentityField::Both,
+        ),
+    ];
+    for (spec, expected) in cases {
+        let err = check_spec_identity("piglet", &spec).expect_err("a disagreement");
+        match err {
+            RegistrarError::SpecIdentityDisagreement { field, .. } => assert_eq!(field, expected),
+            other => panic!("expected SpecIdentityDisagreement, got {other:?}"),
+        }
+    }
+
+    // Absent and equal both pass.
+    assert!(check_spec_identity("piglet", &base).is_ok());
+    assert!(
+        check_spec_identity(
+            "piglet",
+            &base.with_component("piglet").with_service_name("piglet")
+        )
+        .is_ok()
+    );
+}
+
+// ---------------------------------------------------------------------
+// One keyword, and separately callable steps
+// ---------------------------------------------------------------------
+
+/// One and the same wire `service_name` selects the config entry,
+/// supplies the `<component>` segment of the id and supplies the
+/// `<service>` segment of the SAN. Asserted together rather than each in
+/// isolation, because a second selector would only show up as a
+/// disagreement between them.
+#[test]
+fn one_service_name_does_all_three_jobs() {
+    let (_dir, config) = loaded_default();
+    let service_name = "piglet";
+
+    let entry = config
+        .component(service_name)
+        .expect("the entry is selected");
+    assert_eq!(entry.multiplicity(), Multiplicity::ManyPerHost);
+
+    let derived = config
+        .resolve_end_to_end(service_name, "h1", Some(1), Some(&piglet_spec()))
+        .expect("the request resolves");
+    assert_eq!(derived.registration_id, "h1-piglet-001");
+    assert_eq!(derived.san, "001.piglet.h1.trusted.domain");
+
+    // The one keyword is literally present in all three places.
+    assert!(config.component_names().any(|name| name == service_name));
+    assert!(derived.registration_id.contains(service_name));
+    assert!(derived.san.contains(&format!(".{service_name}.")));
+}
+
+/// The pre-derivation arm is reachable without deriving anything, so a
+/// refusal there has no `registration_id` to report and none is computed
+/// as a side effect.
+#[test]
+fn the_pre_derivation_steps_are_callable_without_deriving() {
+    let (_dir, config) = loaded_default();
+
+    // Labels, on their own.
+    assert!(validate_request_labels("piglet", "h1").is_ok());
+
+    // Class resolution, on its own.
+    assert_eq!(
+        config.multiplicity("piglet").expect("piglet is configured"),
+        Multiplicity::ManyPerHost
+    );
+
+    // The shape check, on its own — and its refusal is an error with no
+    // id field at all, because the derivation was never reached.
+    let err = check_instance_shape("piglet", Multiplicity::ManyPerHost, None)
+        .expect_err("an omitted instance must be refused");
+    match err {
+        RegistrarError::ServiceInstanceMismatch {
+            component,
+            multiplicity,
+            instance_supplied,
+        } => {
+            assert_eq!(component, "piglet");
+            assert_eq!(multiplicity, Multiplicity::ManyPerHost);
+            assert!(!instance_supplied);
+        }
+        other => panic!("expected ServiceInstanceMismatch, got {other:?}"),
+    }
+}
+
+/// Derivation and safe-set validation are two calls with the caller's
+/// own collision check between them. Neither takes, reads or requires
+/// registration state.
+#[test]
+fn derivation_and_safe_set_validation_are_separate_calls() {
+    let (_dir, config) = loaded_default();
+
+    let multiplicity = config
+        .check_identity_shape("piglet", Some(1))
+        .expect("the shape is valid");
+    let registration_id =
+        derive_registration_id(multiplicity, "piglet", "h1", Some(1)).expect("the key derives");
+    assert_eq!(registration_id, "h1-piglet-001");
+
+    // Here is where the verb layer takes its per-identity mutex and
+    // consults its durable binding. This library has nothing to
+    // contribute, which is the point.
+
+    config
+        .validate_spec("piglet", &piglet_spec())
+        .expect("the spec is inside the safe-set");
+}
+
+// ---------------------------------------------------------------------
+// The fixture builder
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_fixture_builder_produces_a_config_the_loader_accepts() {
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::new());
+    let config = loaded.expect("the default fixture must load");
+    assert_eq!(config.domain(), FIXTURE_DOMAIN);
+    assert_eq!(config.component_names().count(), 3);
+}
+
+#[test]
+fn every_fixture_override_takes_effect() {
+    let spec = RegistrationSpec {
+        cert_group: Some(4242),
+        reload: ReloadSpec::new(ReloadKind::Sighup, "hog"),
+    };
+    let fixture = RegistrarConfigFixture::new()
+        .with_domain("other.domain")
+        .with_multiplicity("review", Multiplicity::OnePerHost)
+        .with_spec("piglet", &spec)
+        .with_component("hog", Multiplicity::ManyPerHost, &spec)
+        .without_component("roxyd");
+    let (_dir, loaded) = load_fixture(&fixture);
+    let config = loaded.expect("the overridden fixture must load");
+
+    assert_eq!(config.domain(), "other.domain");
+    assert_eq!(
+        config.multiplicity("review").expect("review is configured"),
+        Multiplicity::OnePerHost
+    );
+    assert_eq!(
+        config
+            .component("piglet")
+            .expect("piglet is configured")
+            .spec(),
+        &spec
+    );
+    assert_eq!(
+        config
+            .component("hog")
+            .expect("hog is configured")
+            .multiplicity(),
+        Multiplicity::ManyPerHost
+    );
+    assert!(matches!(
+        config.multiplicity("roxyd"),
+        Err(RegistrarError::ComponentNotConfigured { .. })
+    ));
+
+    // An empty fixture still loads: it is a config with no components,
+    // and every request against it is refused individually.
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::empty());
+    let config = loaded.expect("an empty fixture must load");
+    assert_eq!(config.component_names().count(), 0);
+}
+
+// ---------------------------------------------------------------------
+// Helpers for the composer-agreement test
+// ---------------------------------------------------------------------
+
+fn settings_with_domain(domain: &str) -> Settings {
+    Settings {
+        email: "ops@example.invalid".to_string(),
+        server: "https://ca.example.invalid/acme/directory".to_string(),
+        domain: domain.to_string(),
+        eab: None,
+        acme: AcmeSettings {
+            http_responder_url: "http://127.0.0.1:0".to_string(),
+            http_responder_hmac: "hmac".to_string(),
+            http_responder_timeout_secs: 5,
+            http_responder_token_ttl_secs: 5,
+            directory_fetch_attempts: 1,
+            directory_fetch_base_delay_secs: 1,
+            directory_fetch_max_delay_secs: 1,
+            poll_attempts: 1,
+            poll_interval_secs: 1,
+        },
+        retry: RetrySettings {
+            backoff_secs: vec![1],
+        },
+        trust: TrustSettings::default(),
+        scheduler: SchedulerSettings::default(),
+        profiles: Vec::new(),
+        openbao: None,
+    }
+}
+
+fn profile_with(instance_id: &str, service_name: &str, hostname: &str) -> DaemonProfileSettings {
+    DaemonProfileSettings {
+        // `profile_domain` never reads this field, and this test is the
+        // one place that must not look like a second derivation site.
+        registration_id: "unread-by-profile-domain".to_string(),
+        service_name: service_name.to_string(),
+        instance_id: instance_id.to_string(),
+        hostname: hostname.to_string(),
+        paths: Paths {
+            cert: PathBuf::from("/tmp/cert.pem"),
+            key: PathBuf::from("/tmp/key.pem"),
+        },
+        daemon: DaemonRuntimeSettings {
+            check_interval: Duration::from_secs(1),
+            renew_before: Duration::from_secs(1),
+            check_jitter: Duration::from_secs(0),
+        },
+        retry: None,
+        hooks: HookSettings::default(),
+        eab: None,
+        cert_group_gid: None,
+    }
+}

--- a/src/registrar/tests.rs
+++ b/src/registrar/tests.rs
@@ -694,10 +694,6 @@ fn the_default_instance_reaches_the_san_and_never_the_id() {
     assert!(!review.registration_id.contains("001"));
 }
 
-/// The three sites that compose `<instance>.<service>.<host>.<domain>`
-/// must agree byte for byte. This pins the two that a test in this crate
-/// can reach; `commands::verify::expected_dns_name` is private to the
-/// binary crate and is named in the schema documentation instead.
 /// A loaded config composes under its own domain, never one a caller
 /// could have supplied.
 #[test]
@@ -714,6 +710,11 @@ fn san_for_takes_the_domain_from_the_loaded_file() {
     );
 }
 
+/// The four sites that compose `<instance>.<service>.<host>.<domain>`
+/// must agree byte for byte. This pins the two a test in this crate can
+/// reach; `commands::verify::expected_dns_name` and
+/// `commands::dns_alias::dns_alias_for_entry` are private to the binary
+/// crate and are named in the schema documentation instead.
 #[test]
 fn the_composer_agrees_with_profile_domain() {
     for (instance, service_name, host) in [

--- a/src/registrar/tests.rs
+++ b/src/registrar/tests.rs
@@ -479,25 +479,44 @@ fn an_unknown_key_in_the_body_is_refused() {
     }
 }
 
-/// A `[components.<key>]` that no wire `service_name` could ever select
-/// is a rendering error, not an entry to carry around unreachable.
+/// A `[components.<key>]` that no registration could ever use is a
+/// rendering error, not an entry to carry around unreachable. The key is
+/// spent twice — a wire `service_name` selects the entry, and the same
+/// value is the `<component>` segment of every derived id — so both
+/// rules apply. `Review` is the case only the second rule catches: it is
+/// a legal DNS label, so it *is* selectable, but it is not path-safe, so
+/// every enrollment of it would be refused at the derivation step one
+/// request at a time rather than the file refused once.
 #[test]
-fn a_component_key_that_is_not_a_dns_label_is_refused() {
-    let fixture = RegistrarConfigFixture::empty().with_raw_component(
-        "review_eu",
-        ComponentFixture {
-            multiplicity: "one-per-deployment".to_string(),
-            cert_group: None,
-            reload_kind: "none".to_string(),
-            reload_target: None,
-        },
-    );
-    let (_dir, loaded) = load_fixture(&fixture);
-    let err = loaded.expect_err("an unselectable component key must not load");
-    assert!(
-        matches!(err, RegistrarError::InvalidComponentKey { ref component, .. } if component == "review_eu"),
-        "{err:?}"
-    );
+fn a_component_key_no_registration_could_use_is_refused() {
+    for (key, kind) in [
+        ("review_eu", ValidationError::InvalidDnsLabel),
+        ("-review", ValidationError::InvalidDnsLabel),
+        ("review-", ValidationError::InvalidDnsLabel),
+        ("Review", ValidationError::InvalidRegistrationId),
+    ] {
+        let fixture = RegistrarConfigFixture::empty().with_raw_component(
+            key,
+            ComponentFixture {
+                multiplicity: "one-per-deployment".to_string(),
+                cert_group: None,
+                reload_kind: "none".to_string(),
+                reload_target: None,
+            },
+        );
+        let (_dir, loaded) = load_fixture(&fixture);
+        let err = loaded.expect_err("an unusable component key must not load");
+        match err {
+            RegistrarError::InvalidComponentKey {
+                component,
+                kind: found,
+            } => {
+                assert_eq!(component, key);
+                assert_eq!(found, kind, "{key}");
+            }
+            other => panic!("{key}: expected InvalidComponentKey, got {other:?}"),
+        }
+    }
 }
 
 #[test]

--- a/src/registrar/tests.rs
+++ b/src/registrar/tests.rs
@@ -279,9 +279,20 @@ fn every_reload_kind_the_writer_renders_is_accepted() {
     }
 }
 
+/// `target` must be absent for `none` and non-empty for the other three.
+/// An empty string is still `Some`, so accepting one would leave a `none`
+/// component holding `Some("")` — a spec no request built from
+/// [`ReloadSpec::none`] can equal, and therefore every registration of
+/// that component refused one at a time rather than the file refused
+/// once.
 #[test]
 fn a_reload_target_that_contradicts_its_kind_is_refused() {
-    for (kind, target) in [("none", Some("roxyd")), ("systemd", None)] {
+    for (kind, target) in [
+        ("none", Some("roxyd")),
+        ("none", Some("")),
+        ("systemd", None),
+        ("systemd", Some("")),
+    ] {
         let fixture = RegistrarConfigFixture::new().with_raw_component(
             "roxyd",
             ComponentFixture {
@@ -295,9 +306,36 @@ fn a_reload_target_that_contradicts_its_kind_is_refused() {
         let err = loaded.expect_err("a contradictory reload target must not load");
         assert!(
             matches!(err, RegistrarError::InvalidReloadTarget { .. }),
-            "{kind}: {err:?}"
+            "{kind} with {target:?}: {err:?}"
         );
     }
+}
+
+/// The `none` style's whole safe-set is [`ReloadSpec::none`], so a
+/// component the writer renders it for must accept exactly that value
+/// and nothing else.
+#[test]
+fn a_none_reload_component_matches_the_target_free_spec() {
+    let spec = RegistrationSpec {
+        cert_group: None,
+        reload: ReloadSpec::none(),
+    };
+    let (_dir, loaded) = load_fixture(&RegistrarConfigFixture::new().with_spec("roxyd", &spec));
+    let config = loaded.expect("the fixture must load");
+
+    assert_eq!(
+        config
+            .component("roxyd")
+            .expect("roxyd is configured")
+            .spec()
+            .reload,
+        ReloadSpec::none()
+    );
+    assert!(
+        config
+            .validate_spec("roxyd", &RequestedSpec::new(ReloadSpec::none(), None))
+            .is_ok()
+    );
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
Closes #757.

Adds `bootroot::registrar`: the reader for the bootler-rendered provisioning file, and the registration-identity derivation the registrar verbs will run against it. Pure library plus file I/O — no OpenBao calls, no listener, no daemon wiring, and nothing here reads registration state.

## The file

`/etc/clumit-security/provisioning.toml`, implemented verbatim from the shape settled with `aicers/bootler` #200. One TOML file, envelope of `fingerprint` / `schema_version` / `domain`, one `[components.<package-id>]` table per component carrying `multiplicity`, an optional bare-`u32` `cert_group`, and a `{ kind, target }` `reload` whose `kind` mirrors `ReloadStyle` (not the infrastructure-certificate `ReloadStrategy`). `multiplicity` and `reload.kind` are enums; an unrecognised value is a typed load failure carrying the offending string, and neither is stored as a `String`.

Both integrity gates run before anything downstream:

- The first line must be exactly `fingerprint = "<64 lowercase hex>"` followed by one `\n`, and the SHA-256 of the remaining bytes — verbatim as written, as a byte range, never re-serialized — must equal it. A body truncated at a `[components.*]` boundary still parses as valid TOML with entries missing, and those components would then be refused individually; the digest turns that into one loud failure. A test cuts a valid file exactly there and asserts the refusal is the digest one.
- `schema_version` is refused when it is not this build's, with its own variant carrying both versions, and refused when absent rather than defaulted.

The declared fingerprint is reachable only through `RegistrarConfig::load`, so no caller can report a digest it did not check. A missing or unreadable file is a hard failure. The loader takes the path as a parameter, so no test reads the real one.

Two shapes are refused at load rather than left to fail every one of a component's enrollments individually — the same silent per-component outage the digest gate exists to close. A `reload` whose `target` contradicts its `kind` (missing, empty, or present under `none`) is one; a `[components.<key>]` no registration could ever use is the other, since the key is spent twice and must satisfy both the DNS-label rule that lets a wire `service_name` select it and the `registration_id` rule that lets an id derived from it pass.

## The derivation

One rule, one place. `<component>` / `<host>-<component>` / `<host>-<component>-<instance>` by multiplicity class, instances three digits zero-padded. `("piglet", h1, 1)` → `h1-piglet-001`, `("roxyd", h1, none)` → `h1-roxyd`, `("review", h1, none)` → `review`, asserted as literals rather than round-tripped. The ≤131-octet bound is enforced on the derived string by the shared `input_validation::validate_registration_id`, not by a second check written here.

The SAN takes the four parts and always has four segments: a request that correctly omits `instance` takes the literal `001` there, and that default never reaches the id. A test asserts this composer's output is byte-identical to `config::profile_domain`'s for the same four values across all three classes; neither `profile_domain` nor the ACME issuance path was touched. `commands::verify::expected_dns_name` and `commands::dns_alias::dns_alias_for_entry` are private to the binary crate and cannot be called from that test, so both are named in the documentation's table of composition sites that must stay in step. `RegistrarConfig::san_for` supplies the domain from the loaded file, so a verb cannot compose under one that arrived on the wire.

One keyword does all three jobs — the wire `service_name` selects the config entry, is the `<component>` segment of the id and the `<service>` segment of the SAN. There is no second selector, and a test asserts all three for one request.

## Refusals

`RegistrarError` is the definition of these refusals for the repository. `ServiceInstanceMismatch` and the component-absent refusal are **distinct** variants even though the endpoint will map both onto one caller-facing identifier: the audit record stores the internal one, and collapsing them there would erase the difference between a wrong `instance` shape and a caller probing names that do not exist. The spec-identity disagreement is **one** variant covering `spec.component` and `spec.service_name`, carrying which field disagreed (and both, when both do), in a typed field rather than a message string. Nothing refers to a stored or previously applied spec — that is the verb layer's `ServiceSpecConflict`.

Safe-set validation is equality on both `cert_group` and `reload` against the component's single rendered spec: not a per-field allow-list, not a list of pairs, no template language. A rendered `piglet-{instance}` is a literal, and a request presenting `piglet-001` is refused.

## Separately callable steps

Label validation, class resolution, the shape check, derivation, SAN composition and safe-set validation are each invocable on their own, because the verb layer interleaves its per-identity mutex and durable-binding collision check between the derivation and the spec comparison. Two tests pin it: one runs the pre-derivation arm and asserts no `registration_id` is produced on a refusal there, another derives and then validates the spec as a separate call. `resolve_end_to_end` exists for tests and is documented as not for the verb layer.

## Docs and fixture

`docs/reference/registrar-provisioning-config.md` documents the schema, and `docs/reference/provisioning.toml.example` is the shipped example with a real digest of its own body. One test loads the example through the production loader; another asserts the documentation still quotes it verbatim. Both sit outside the mirrored `docs/en/` + `docs/ko/` pair on the precedent of `registrar-wire-contract.md`.

`RegistrarConfigFixture` renders the file for tests, with overrides for the domain, a component's multiplicity class, a component's safe-set, the schema version, the fingerprint and a raw entry for the values the loader must refuse.

## Deviations from the issue, stated

- **The fingerprint line is first, and the example's commentary follows it.** The issue's example block puts its comment header above `fingerprint`, while the same block's own comment — and the digest rule — say the first line *is* the fingerprint. The rule is the load-bearing half, so the shipped example carries the fingerprint on line 1 and every comment verbatim after it.
- **The library is `pub`, not `pub(crate)`.** Nothing inside the library crate calls it yet, so `pub(crate)` items fail the dead-code lint under `-D warnings`; and the verb, endpoint and acceptance-suite code that will consume it lives in the binary crate and under `tests/`, neither of which can see a `pub(crate)` item here. The fixture builder is exported unconditionally for the same reason: `#[cfg(any(test, feature = "test-support"))]` is invisible to both of those consumers, which are exactly the siblings it exists to keep from hand-writing their own. It contains no panics and no production code path reaches it.
- **`multiplicity` and `reload.kind` are converted from strings by a private parse layer** rather than by `#[derive(Deserialize)]` on the enums, because the refusal has to carry the offending value in a typed field and a serde error can only carry it inside a message. Neither field is *stored* as a string; the public model holds enums.

## Test plan

- [x] All three derivation arms yield the contract literals: `h1-piglet-001`, `h1-roxyd`, `review` — asserted as literals, including hyphenated component and host names.
- [x] The example shipped under `docs/` loads through the production loader and its components resolve, so the documented contract and the parser cannot drift.
- [x] An unrecognised `multiplicity` or `reload.kind` is a typed load failure carrying the offending value; all four of `sighup`, `systemd`, `docker-restart`, `none` are accepted; `cert_group` reads as a bare `u32` or absent.
- [x] A missing, unreadable or malformed file fails with a distinct typed error — never a default domain, never an assumed class.
- [x] A body truncated at a `[components.*]` boundary — still valid TOML, entries missing — is refused with the fingerprint mismatch, not a per-component refusal.
- [x] The declared fingerprint is reachable only from a validated load.
- [x] An unsupported `schema_version` is refused with its own variant carrying both versions; an absent one is refused, not defaulted.
- [x] A first line that is not the exact fingerprint form, and a digest that does not match the body, are each refused.
- [x] A `reload` whose `target` contradicts its `kind`, and a `[components.<key>]` no registration could use, are refused at load.
- [x] The default path constant is `/etc/clumit-security/provisioning.toml`, and the loader still takes the path as a parameter.
- [x] A `service_name` or `host` that is not a single DNS label is refused before any derivation, carrying the raw offending string.
- [x] The identity-shape check refuses both mismatch directions with `ServiceInstanceMismatch`, refuses an absent component with a distinct variant, and a test asserts the two are not the same variant.
- [x] A request omitting `instance` composes `001.roxyd.h1.<domain>` and `001.review.h1.<domain>` while deriving `h1-roxyd` and `review` — no `001` in either id.
- [x] A supplied `instance` renders zero-padded in both: SAN `001.piglet.h1.<domain>`, id `h1-piglet-001`.
- [x] A one-per-deployment request with a missing or malformed `host` is refused.
- [x] A derived id at and just past 131 octets is refused by the shared `validate_registration_id`, not a local length check.
- [x] Safe-set validation accepts only the single rendered spec and refuses one differing in `cert_group` alone, `reload.kind` alone, or `reload.target` alone, with `ServiceSpecOutsideSafeSet`.
- [x] For a component rendering no `cert_group`, a request supplying one is refused and a request omitting it is accepted.
- [x] A `spec.component` disagreement is refused before the safe-set check and before any derivation, including when it names a different *configured* component.
- [x] A `spec.service_name` disagreement is refused with the same variant even when `cert_group` and `reload` match exactly; absent or equal is accepted; a composed `roxyd-h1` against wire `roxyd` is refused, and no derivation or SAN segment reads the field.
- [x] The variant records which field disagreed — component-only, service-name-only and both-disagree are distinguishable behind the single variant.
- [x] One wire `service_name` selects the entry, supplies the id's `<component>` and the SAN's `<service>`, asserted together for one request.
- [x] The SAN composer's output is byte-identical to `config::profile_domain`'s across all three classes, and neither `profile_domain` nor the ACME issuance path was modified.
- [x] A rendered `{instance}`-looking token is a literal: a request carrying the expanded form is refused with `ServiceSpecOutsideSafeSet`.
- [x] No error variant refers to a stored or previously applied spec, and nothing here reads registration state.
- [x] The derivation rule appears in exactly one place in the repository.
- [x] The steps are individually callable: one test runs the pre-derivation arm and asserts no id is produced on a refusal, another derives and then validates the spec separately.
- [x] The colliding pair (`web` on `h1-aimer`, `aimer-web` on `h1`) both derive `h1-aimer-web-001`, documenting that the derivation is not injective.
- [x] The fixture builder produces a config the loader accepts, and each override takes effect.
- [x] Tests use `tempfile::tempdir()`; no fixed paths.
- [x] `cargo clippy` is warning-free and `cargo fmt --check` passes.

## Testing

- `cargo test` — full suite green across all targets, including 45 tests in `registrar::tests`.
- `scripts/preflight/ci/check.sh` — `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, rustdoc with `-D warnings`, ruff, biome, markdownlint, `scripts/check-docs.sh` (`mkdocs build --strict` plus the theme verification), and `cargo audit` (one pre-existing allowed warning for the unmaintained `rustls-pemfile`).
- The Docker E2E preflights (`e2e-matrix.sh`, `e2e-extended.sh`) were not run. This change adds a library nothing calls yet plus two documentation files; it touches no Docker lifecycle, no E2E script and no code path those suites exercise.

