### PR TITLE
Add the registrar client and endpoint identities (#760)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
 
           cargo run --bin bootroot -- service add \
             --registration-id bootroot-agent \
-            --service-name bootroot-agent \
+            --service-name agent-selftest \
             --hostname bootroot-agent \
             --domain trusted.domain \
             --agent-config "$(pwd)/tmp/agent-bootroot-agent.toml" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ service host. For a component installed once per deployment, reusing its
 old `service_name` as the key reproduces every previous path and name
 byte for byte.
 
+### Security
+
+- Bumped `h2` from 0.4.15 to 0.4.16 to address RUSTSEC-2026-0258
+  (unbounded buffering of empty HTTP/2 DATA frames, which lets a peer
+  drive a connection's memory use without bound).
+
 ## [0.3.0] - 2026-08-17
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- `bootroot service add` and `bootroot-remote bootstrap` refuse a
+  `--service-name` whose lowercased form starts with `bootroot-`, with
+  its own message rather than the DNS-label one. The prefix is reserved
+  for bootroot's own certificate identities, so a name a bootroot
+  component treats as one of its own cannot be obtained by registering
+  an ordinary service — including through a bootstrap run that supplies
+  the name on the command line instead of through an artifact. Ordinary
+  component keywords are unaffected, and so is the bare name `bootroot` —
+  the reserved prefix includes the hyphen. The `agent.toml.compose` smoke
+  profile that shipped with `service_name = "bootroot-agent"` now uses
+  `agent-selftest`; its `registration_id`, `hostname` and certificate
+  paths are unchanged, since only the SAN's second label is reserved.
 - A registration is now keyed by a new required `registration_id`,
   separate from `service_name`. `service_name` used to do two
   incompatible jobs: it was the certificate SAN's second label, so it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,12 @@ webpki-root-certs = "1"
 x509-parser = { version = "0.18", features = ["verify"] }
 
 [dev-dependencies]
+# `x509-parser` lets `rcgen` parse a CSR back and sign it, which is how
+# the issuance tests take a `build_csr_params` CSR through a local CA and
+# read the SAN off the leaf. It pulls in nothing new: the feature turns
+# on `x509-parser` 0.18 with `verify`, the exact dependency and feature
+# this crate already declares above.
+rcgen = { version = "0.14", features = ["x509-parser"] }
 tokio = { version = "1", features = ["test-util"] }
 wiremock = "0.6"
 

--- a/agent.toml.compose
+++ b/agent.toml.compose
@@ -31,7 +31,11 @@ backoff_secs = [5, 10, 30]
 
 [[profiles]]
 registration_id = "bootroot-agent"
-service_name = "bootroot-agent"
+# The SAN's second label may not sit under the reserved `bootroot-`
+# prefix, which names bootroot's own certificate identities and which
+# `service add` refuses. `registration_id` and `hostname` are not the
+# SAN label and keep naming the agent.
+service_name = "agent-selftest"
 instance_id = "001"
 hostname = "bootroot-agent"
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,6 +3,6 @@ services:
     networks:
       default:
         aliases:
-          - 001.bootroot-agent.bootroot-agent.trusted.domain
+          - 001.agent-selftest.bootroot-agent.trusted.domain
           - 001.edge-proxy.edge-node-01.trusted.domain
           - 001.web-app.web-01.trusted.domain

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -1126,6 +1126,12 @@ Input priority is **CLI flags > environment variables > prompts/defaults**.
 - `--service-name`: service name identifier, used as the SAN's second label
   - Must be a single DNS label: letters, digits, and hyphens only, max 63
     characters, no dots or underscores
+  - Must not start with `bootroot-` (compared case-insensitively). That
+    prefix is reserved for bootroot's own certificate identities, so that
+    a name a bootroot component recognizes as one of its own cannot be
+    minted through `service add`. Ordinary component keywords such as
+    `roxyd`, `piglet` and `edge-proxy` are unaffected, as is the bare name
+    `bootroot`.
 - `--delivery-mode`: delivery mode (`local-file` or `remote-bootstrap`).
   Note: `remote-bootstrap` is a mode value, not an executable binary, and the
   executable used for this mode is `bootroot-remote`.
@@ -2696,6 +2702,12 @@ Key inputs:
     letter or digit, max 131 characters
 - `--service-name`: required unless `--artifact` is provided.
   - Must follow the same single-label DNS rule as `bootroot service add`
+  - Must not start with `bootroot-` either (compared case-insensitively),
+    for the same reason and with its own error. This flag becomes
+    `[[profiles]].service_name`, hence the second label of the SAN the
+    agent orders, and a run without `--artifact` takes it straight from
+    the command line rather than from an artifact `service add` already
+    vetted.
 - `--role-id-path`, `--secret-id-path`, `--eab-file-path`: required
   unless `--artifact` is provided.
 - `--agent-config-path`: required unless `--artifact` is provided.

--- a/docs/ko/cli.md
+++ b/docs/ko/cli.md
@@ -1099,6 +1099,11 @@ post-renew 훅이 컨테이너를 리로드합니다
 - `--service-name`: SAN의 두 번째 label로 쓰이는 서비스 이름 식별자
   - 단일 DNS label이어야 합니다. 영문자/숫자/하이픈만 허용하며, 최대 63자,
     점(`.`)과 밑줄(`_`)은 허용되지 않습니다.
+  - `bootroot-`로 시작할 수 없습니다(대소문자 구분 없이 비교). 이 접두사는
+    bootroot 자체 인증서 identity 전용으로 예약되어 있으며, bootroot 컴포넌트가
+    자기 것으로 인식하는 이름을 `service add`로 발급받지 못하게 막습니다.
+    `roxyd`, `piglet`, `edge-proxy` 같은 일반 컴포넌트 키워드와 `bootroot`
+    자체는 영향을 받지 않습니다.
 - `--delivery-mode`: 전달 모드 (`local-file` 또는 `remote-bootstrap`).
   참고: `remote-bootstrap`은 실행 파일이 아니라 모드 값이며, 이 모드에서
   사용하는 실행 파일은 `bootroot-remote`입니다.
@@ -2559,6 +2564,11 @@ fast-poll 루프로 trust와 `secret_id`를 최신 상태로 유지하며,
     하고, 최대 131자입니다.
 - `--service-name`: `--artifact` 미지정 시 필수.
   - `bootroot service add`와 같은 단일 DNS label 규칙을 따릅니다.
+  - 마찬가지로 `bootroot-`로 시작할 수 없으며(대소문자 구분 없이 비교),
+    같은 이유로 별도의 오류 메시지를 냅니다. 이 값은
+    `[[profiles]].service_name`이 되어 agent가 요청하는 SAN의 두 번째
+    label이 되며, `--artifact` 없이 실행하면 `service add`가 이미 검증한
+    artifact가 아니라 명령줄 값이 그대로 쓰입니다.
 - `--role-id-path`, `--secret-id-path`, `--eab-file-path`:
   `--artifact` 미지정 시 필수.
 - `--agent-config-path`: `--artifact` 미지정 시 필수.

--- a/docs/reference/registrar-client-identity.md
+++ b/docs/reference/registrar-client-identity.md
@@ -1,0 +1,268 @@
+<!-- markdownlint-configure-file {
+  "MD013": { "tables": false, "code_blocks": false }
+} -->
+
+# Registrar client identity, endpoint identity, and the endpoint pin file
+
+This file is the contract between bootroot and the provisioning tool that
+installs a registrar. bootroot **consumes** the pin file described here; it does
+not write it. It is checked in outside the mirrored `docs/en/` + `docs/ko/`
+operator pair, on the precedent of `docs/rfcs/` and
+`docs/reference/registrar-wire-contract.md`: it is a cross-repository contract
+rather than operator documentation, so `mkdocs.yml` lists it in neither locale's
+nav and there is no `docs/ko/` counterpart.
+
+## 1. The two reserved identities
+
+bootroot issues one certificate shape for ordinary services: a single DNS SAN
+`<instance>.<service_name>.<host>.<domain>`, repeated as the common name, with no
+extended key usage requested (`src/acme/flow.rs::build_csr_params`). The
+registrar surface needs two names that an ordinary `bootroot service add` cannot
+produce. They reuse that composition exactly and differ in the **second label
+only**:
+
+| Identity | Name | Defined as |
+| --- | --- | --- |
+| Registrar client — the leaf the registrar authenticates to the host-local endpoint with | `<instance>.bootroot-registrar.<host>.<domain>` | `bootroot::registrar::REGISTRAR_CLIENT_LABEL` |
+| Endpoint server — the leaf the daemon's endpoint presents, and the name a client pins | `<instance>.bootroot-registrar-endpoint.<host>.<domain>` | `bootroot::registrar::REGISTRAR_ENDPOINT_LABEL` |
+
+For the v1 single registrar per bootroot host, `<instance>` is `001` and
+`<host>` is that host's single DNS label. With `domain = example.internal` the
+two names are:
+
+```text
+001.bootroot-registrar.h1.example.internal
+001.bootroot-registrar-endpoint.h1.example.internal
+```
+
+**`<domain>` is a suffix, not a label.** It is the configured `network.domain`,
+and `validate_domain_name` accepts any number of labels — `internal` is one,
+`example.internal` is two, `corp.example.internal` is three. Both names are
+therefore *three fixed leading labels followed by the configured domain suffix*,
+and their total label count is `3 + <label count of the configured domain>`.
+Never hard-code a total label count and never treat the domain as a single
+trailing label.
+
+Both names carry **exactly one** SAN, of type DNS, and no SAN of any other type,
+and repeat the SAN string as the common name — exactly like today's service
+leaves.
+
+How this differs from an ordinary service leaf on the same host: roxyd's leaf
+there is `001.roxyd.h1.example.internal`, its plain component keyword in the
+second label. The `registration_id` split keys bootroot's namespaces and does
+not change the SAN label. The registrar client identity differs in the second
+label alone.
+
+## 2. The reserved-prefix guard on operator-supplied service names
+
+`bootroot service add` refuses a `--service-name` whose ASCII-lowercased form
+starts with **`bootroot-`** (`bootroot::registrar::RESERVED_SERVICE_NAME_PREFIX`),
+alongside the existing DNS-label check, with its own error rather than the
+DNS-label one. The comparison is case-insensitive because `validate_dns_label`
+admits mixed case and DNS labels compare case-insensitively, so
+`BOOTROOT-Registrar` is refused too.
+
+`bootroot-remote bootstrap --service-name` is held to the same rule, through the
+same predicate. That flag becomes `[[profiles]].service_name` in the `agent.toml`
+the bootstrap writes, and therefore the second label of the SAN the agent orders;
+a run without `--artifact` takes it straight from the command line rather than
+from an artifact `service add` already vetted, so it is a second way into the
+same name. Both call
+`bootroot::registrar::is_reserved_service_name` — one predicate, so there is no
+second list of reserved names to drift.
+
+Ordinary component keywords — `roxyd`, `piglet`, `edge-proxy` — are unaffected,
+as is the bare name `bootroot`: the prefix includes the hyphen.
+
+**Where the guard is deliberately not applied.** It sits on the two operator
+inputs that create a registration, not on `[[profiles]].service_name` as the
+daemon loads it: `src/config/validation.rs` still holds that field to the
+DNS-label rule alone. Every writer of a `[[profiles]]` block is one of the two
+guarded commands, so only a hand-edited `agent.toml` can reach the daemon with a
+reserved label — and that config belongs to the host's own root, which already
+holds the agent's credentials. Guarding it there would also stand in the way of
+bootroot's own identities, which are ordered under this very prefix. So the
+guard's claim is precise: a name under the prefix cannot be obtained by
+*registering a service*. It is not a claim that no ACME order for such a name can
+ever be placed by a host against itself, and an endpoint that scopes
+authorization by the `host` label recognition returns (§3) is the layer that
+decides what a recognized identity may then do.
+
+This guard is what makes recognition (§3) sound. Without it anyone able to call
+`service add` could mint the registrar's own name. The **whole `bootroot-`
+namespace** is reserved rather than the two labels above, so a later
+bootroot-internal identity picks a name under the same prefix and is covered by
+this one guard — there is deliberately no second list of reserved names that
+could drift from it. `bootroot-` was already bootroot's own namespace prefix
+(`bootroot-service-`, `bootroot-runtime-`), and the product is pre-release, so
+nothing needs migrating. One fixture did sit under it: the agent's own
+self-test registration in CI and in the `agent.toml.compose` smoke profile
+registered `service_name = "bootroot-agent"`. Its SAN label is now
+`agent-selftest`; its `registration_id`, `hostname` and certificate paths are
+unchanged, since only the second label is reserved.
+`tests/reserved_service_name_fixtures.rs` keeps that from drifting back —
+a workflow, script or example config that registers a reserved name fails
+`cargo test` rather than a Docker E2E job.
+
+## 3. The recognition rule
+
+`bootroot::registrar::recognize_registrar_client(end_entity_der, domain)` is the
+single implementation a server-side verifier calls. Given an **already-verified**
+peer certificate and the locally configured `domain`, it accepts only when all
+of the following hold:
+
+1. the certificate carries **exactly one** SAN, of type DNS;
+2. that name ends with the configured `domain` **on a label boundary** — the name
+   equals `<something>.<domain>`, never a bare string suffix, so the domain
+   `example.internal` does not accept `…​.evil-example.internal`;
+3. stripping the domain suffix leaves **exactly three** labels (equivalently:
+   the total label count is `3 + <label count of domain>`, derived from the
+   configured value);
+4. of those three, the **second** is `bootroot-registrar`;
+5. the **first** is a numeric instance label and the **third** a valid DNS label.
+
+Every label and suffix comparison is ASCII-case-insensitive. The common name is
+**not** consulted: today's leaves mirror the SAN into the CN, but recognition is
+SAN-only.
+
+On success the rule returns the parsed `instance`, `host` and `domain`, each
+ASCII-lowercased, so the endpoint can scope authorization by host. **Which**
+recognized identity may invoke **which** operation is the endpoint's decision,
+not this rule's. Every failure is its own typed rejection
+(`RegistrarIdentityError`).
+
+The rule performs no chain building and no time validation — it is a name rule
+applied to a peer certificate something else has already verified. It also
+**never consults the extended key usage**, for the reason recorded in §5: every
+leaf this CA issues carries the same EKU set, so that attribute cannot
+discriminate. Recognition is by name.
+
+## 4. The endpoint pin file
+
+### 4.1 What is pinned
+
+**Trust anchors, plus an exact expected SAN on the presented leaf.** Not the
+endpoint leaf's DER and not its SPKI: every bootroot issuance generates a fresh
+key pair, so a leaf-shaped pin goes stale at the next daemon renewal, while the
+writer of this file runs once at install and lives in another repository. Anchor
+pinning is also the one pinning idiom this tree already has
+(`trust.trusted_ca_sha256`, `tls::ca_bundle_fingerprints`), so the existing
+`PinnedCertVerifier` semantics are reused rather than a second scheme grown
+beside them.
+
+Pinning the anchor alone would admit any leaf that CA ever issued, so the anchor
+pin is paired with a **mandatory** check that the presented end-entity
+certificate's single DNS SAN is exactly the endpoint server identity name from
+§1 — a name the §2 guard makes unmintable through `service add`.
+
+### 4.2 Where the file lives
+
+bootroot has **no fixed certificate directory**: every certificate and key path
+is configured per profile (`[[profiles]].paths`). This contract therefore fixes
+the **basename** and a **derivation rule**, and no absolute directory:
+
+- basename: **`registrar-endpoint-anchors.sha256`**
+  (`bootroot::registrar::endpoint_pin::REGISTRAR_ENDPOINT_ANCHORS_FILE`);
+- location: the **parent directory of the registrar client certificate**, joined
+  with that basename —
+  `bootroot::registrar::endpoint_pin::anchor_pin_path_for_client_certificate`
+  computes exactly this and touches no filesystem and no configuration.
+
+So the file's absolute directory **follows the configured registrar client
+certificate path** and is not fixed here; it is settled by whatever provisions
+that certificate. bootroot's own pinning helper takes the pin-file path as an
+explicit argument, with no built-in default and no configuration lookup.
+
+### 4.3 Format
+
+UTF-8 text, LF-separated lines.
+
+- Each significant line is exactly **64 ASCII hex characters** — the SHA-256 of
+  one trust anchor certificate's **DER**, i.e. the value
+  `tls::ca_bundle_fingerprints` produces and `trust.trusted_ca_sha256` carries.
+- Leading and trailing ASCII whitespace on a line is trimmed before
+  interpretation.
+- Blank lines, and lines whose first non-whitespace character is `#`, are
+  ignored.
+- Uppercase hex is accepted and normalized to lowercase on read; entries are
+  written lowercase.
+- Order is irrelevant and duplicates collapse.
+- **Multiple entries must be supported.** CA rotation
+  (`RotationMode::IntermediateOnly` / `Full`) means the old and the new anchor
+  have to be pinnable at the same time.
+- At least one valid entry must be present, and **any** non-ignored line that is
+  not 64 hex characters rejects the **whole file**. There is no partial
+  acceptance.
+
+Worked example:
+
+```text
+# bootrootd registrar endpoint — pinned trust anchors (SHA-256 of certificate DER)
+# written by the provisioning tool at install; one anchor per line
+3b1f0c9a5d2e47b8c6a1f0e93d7b425c8e6a09f31d4b7c25e8a06f93b1d4c72e
+# second entry present only during a CA rotation
+9d4c72e1b0a538f6c2e94b7d051a63f8c4b29e0d75a1f386c0b9e24d7f513a6b
+```
+
+### 4.4 Writer-side contract
+
+The **provisioning tool writes this file at install**; nothing in this
+repository writes it. bootroot only reads it.
+
+Pin the digests of certificates the endpoint actually **presents**. The pin file
+carries digests and no certificate material, so a pinned anchor has to arrive on
+the wire for a chain to be built to it — in a bootroot deployment that is the CA
+bundle the server sends alongside its leaf, whose fingerprints are exactly what
+`tls::ca_bundle_fingerprints` returns for `trust.ca_bundle_path`. During a CA
+rotation, keep both generations in the file until the endpoint's leaf has been
+reissued under the new anchor.
+
+## 5. Observed extended key usage on issued certificates
+
+The CSR is where this repository's decision ends. On the CSR
+(`rcgen::CertificateParams`) the two shapes differ exactly as intended, and this
+is asserted by unit tests with no CA involved:
+
+| Shape | `subject_alt_names` | `extended_key_usages` |
+| --- | --- | --- |
+| ordinary service | one DNS SAN, `<instance>.<service_name>.<host>.<domain>` | **empty** |
+| registrar client | one DNS SAN, `<instance>.bootroot-registrar.<host>.<domain>` | `ClientAuth` |
+
+What the **issued** leaf carries is decided by step-ca's certificate template,
+not by this repository: there is no `extKeyUsage` string and no x509 template
+anywhere in this tree, so issuance runs on step-ca's defaults.
+
+**Observed**, against `smallstep/step-ca:0.30.2` — the image
+`docker-compose.yml` pins — with the default configuration (`"template": {}` in
+`ca.json`, empty `templates/` directory):
+
+| Shape | How it was issued | Issued `X509v3 Extended Key Usage` | Issued `X509v3 Key Usage` | Issued SAN |
+| --- | --- | --- | --- | --- |
+| ordinary service | bootroot's own ACME path — `scripts/impl/run-local-lifecycle.sh`, reading `edge-proxy.crt` and `web-app.crt` out of the run's workspace | `TLS Web Server Authentication, TLS Web Client Authentication` | `Digital Signature` (critical) | the requested DNS SAN, unchanged |
+| ordinary service | `step ca sign` of the CSR `build_csr_params` produces, ACME and JWK provisioners on one CA | `Server Authentication, Client Authentication` | `Digital Signature` (critical) | the requested DNS SAN, unchanged |
+| registrar client | `step ca sign` of the CSR `build_registrar_client_csr_params` produces | `Server Authentication, Client Authentication` | `Digital Signature` (critical) | the requested DNS SAN, unchanged |
+
+The first row is the real path — bootroot's agent ordering a certificate over
+ACME from the step-ca the compose stack runs. The other two exist because no
+ACME order can be placed for the registrar client name until the issue that
+provisions that certificate lands, so the two shapes were put through the same
+CA side by side to compare them; the ACME and JWK provisioners on that CA
+returned the same extensions, which is expected when neither carries a template
+of its own.
+
+Two things follow, and both are why no test in this repository asserts an issued
+EKU set:
+
+- step-ca's default leaf template **ignores the EKU the CSR requests**. The
+  service CSR requests none and comes back with both usages; the client CSR
+  requests `clientAuth` and comes back with both. Requesting `ClientAuth` is
+  correct and cost-free — it is what the CSR should say, and it is what a
+  template-carrying CA would honour — but it is not what makes the issued leaf
+  usable as a client certificate here.
+- **An ordinary service leaf is `clientAuth`-capable too.** An EKU set every leaf
+  carries cannot distinguish the registrar from any other service, which is why
+  §3's rule is a name rule and consults no EKU at all.
+
+Asserting a particular issued EKU set would be asserting an upstream default
+this repository does not pin, and would fail the day that default moves. The
+**SAN** is asserted on an issued certificate; the EKU is only observed, here.

--- a/scripts/preflight/ci/test-core.sh
+++ b/scripts/preflight/ci/test-core.sh
@@ -186,7 +186,7 @@ cargo run --bin bootroot -- service add \
 
 cargo run --bin bootroot -- service add \
   --registration-id bootroot-agent \
-  --service-name bootroot-agent \
+  --service-name agent-selftest \
   --hostname bootroot-agent \
   --domain trusted.domain \
   --agent-config "$(pwd)/tmp/agent-bootroot-agent.toml" \

--- a/scripts/preflight/extra/agent-scenarios.sh
+++ b/scripts/preflight/extra/agent-scenarios.sh
@@ -349,7 +349,7 @@ backoff_secs = [1, 2, 3]
 
 [[profiles]]
 registration_id = "bootroot-agent"
-service_name = "bootroot-agent"
+service_name = "agent-selftest"
 instance_id = "001"
 hostname = "bootroot-agent"
 
@@ -660,7 +660,7 @@ backoff_secs = [1, 2, 3]
 
 [[profiles]]
 registration_id = "bootroot-agent"
-service_name = "bootroot-agent"
+service_name = "agent-selftest"
 instance_id = "001"
 hostname = "bootroot-agent"
 
@@ -707,7 +707,7 @@ backoff_secs = [1, 2, 3]
 
 [[profiles]]
 registration_id = "bootroot-agent"
-service_name = "bootroot-agent"
+service_name = "agent-selftest"
 instance_id = "001"
 hostname = "bootroot-agent"
 
@@ -756,7 +756,7 @@ backoff_secs = [1, 2, 3]
 
 [[profiles]]
 registration_id = "bootroot-agent"
-service_name = "bootroot-agent"
+service_name = "agent-selftest"
 instance_id = "001"
 hostname = "bootroot-agent"
 
@@ -832,7 +832,7 @@ backoff_secs = [1, 2, 3]
 
 [[profiles]]
 registration_id = "bootroot-agent"
-service_name = "bootroot-agent"
+service_name = "agent-selftest"
 instance_id = "001"
 hostname = "bootroot-agent"
 

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -4,4 +4,4 @@ pub mod http01_protocol;
 pub mod responder_client;
 pub(crate) mod types;
 
-pub use flow::issue_certificate;
+pub use flow::{build_registrar_client_csr_params, issue_certificate};

--- a/src/acme/flow.rs
+++ b/src/acme/flow.rs
@@ -25,14 +25,63 @@ fn build_csr_params(
     settings: &crate::config::Settings,
     profile: &crate::config::DaemonProfileSettings,
 ) -> Result<rcgen::CertificateParams> {
-    let primary_domain = crate::config::profile_domain(settings, profile);
+    // The ordinary service leaf requests no extended key usage at all,
+    // exactly as it always has. The registrar client identity is an
+    // additive shape beside it, never a widening of this one.
+    build_named_csr_params(crate::config::profile_domain(settings, profile), &[])
+}
+
+/// Builds the CSR parameters for the registrar's client identity,
+/// `<instance>.bootroot-registrar.<host>.<domain>`.
+///
+/// The name is composed exactly like an ordinary service leaf's and
+/// differs in the second label only, which
+/// [`crate::registrar::is_reserved_service_name`] keeps `service add`
+/// from minting. `domain` is the configured `network.domain` and is a
+/// suffix of whatever label count it carries, not a single label.
+///
+/// Unlike the service shape these params request
+/// [`rcgen::ExtendedKeyUsagePurpose::ClientAuth`]. What the *issued*
+/// leaf ends up carrying is step-ca's template's decision, not this
+/// repository's, so nothing here or downstream asserts an issued EKU
+/// set.
+///
+/// # Errors
+///
+/// Returns an error when `instance` is not numeric, `host` is not a DNS
+/// label, `domain` is not a DNS name, or the composed name is not a
+/// valid `rcgen` DNS SAN.
+pub fn build_registrar_client_csr_params(
+    instance: &str,
+    host: &str,
+    domain: &str,
+) -> Result<rcgen::CertificateParams> {
+    crate::input_validation::validate_numeric_instance_id(instance)
+        .map_err(|err| anyhow::anyhow!("registrar client instance label is invalid: {err:?}"))?;
+    crate::input_validation::validate_dns_label(host)
+        .map_err(|err| anyhow::anyhow!("registrar client host label is invalid: {err:?}"))?;
+    crate::input_validation::validate_domain_name(domain)
+        .map_err(|err| anyhow::anyhow!("registrar client domain is invalid: {err:?}"))?;
+    build_named_csr_params(
+        crate::registrar::registrar_client_identity(instance, host, domain),
+        &[rcgen::ExtendedKeyUsagePurpose::ClientAuth],
+    )
+}
+
+/// Builds CSR parameters carrying `dns_name` as the sole DNS SAN and as
+/// the common name, requesting `extended_key_usages`.
+fn build_named_csr_params(
+    dns_name: String,
+    extended_key_usages: &[rcgen::ExtendedKeyUsagePurpose],
+) -> Result<rcgen::CertificateParams> {
     let mut params = rcgen::CertificateParams::default();
     params
         .distinguished_name
-        .push(rcgen::DnType::CommonName, primary_domain.clone());
+        .push(rcgen::DnType::CommonName, dns_name.clone());
 
-    let dns_name = primary_domain.try_into()?;
+    let dns_name = dns_name.try_into()?;
     params.subject_alt_names = vec![rcgen::SanType::DnsName(dns_name)];
+    params.extended_key_usages = extended_key_usages.to_vec();
     Ok(params)
 }
 
@@ -571,6 +620,188 @@ mod tests {
             None => panic!("Common name missing"),
         };
         assert_eq!(common_name, expected_domain());
+    }
+
+    /// The service path is unchanged by the client path's arrival: one
+    /// DNS SAN, the CN mirroring it, and no extended key usage
+    /// requested at all.
+    #[test]
+    fn test_build_csr_params_requests_no_extended_key_usage() {
+        let settings = test_settings();
+        let profile = test_profile();
+        let params = build_csr_params(&settings, &profile).unwrap();
+        assert_eq!(params.subject_alt_names.len(), 1);
+        assert!(
+            params.extended_key_usages.is_empty(),
+            "the ordinary service shape must request no EKU: {:?}",
+            params.extended_key_usages
+        );
+    }
+
+    /// Every current caller of the service path goes through
+    /// `profile_domain`, so asserting the params for a profile whose
+    /// labels differ from the fixture's is what shows the shape did not
+    /// move for any of them.
+    #[test]
+    fn test_build_csr_params_is_unchanged_for_every_service_caller() {
+        let settings = test_settings();
+        for (service_name, instance_id, hostname) in [
+            ("edge-proxy", "001", "edge-node-01"),
+            ("roxyd", "002", "h1"),
+            ("piglet", "010", "node-7"),
+        ] {
+            let mut profile = test_profile();
+            profile.service_name = service_name.to_string();
+            profile.instance_id = instance_id.to_string();
+            profile.hostname = hostname.to_string();
+            let params = build_csr_params(&settings, &profile).unwrap();
+            let expected = format!("{instance_id}.{service_name}.{hostname}.{TEST_DOMAIN}");
+            assert_eq!(
+                dns_sans(&params),
+                vec![expected.clone()],
+                "{expected} SAN moved"
+            );
+            assert_eq!(common_name(&params), expected);
+            assert!(
+                params.extended_key_usages.is_empty(),
+                "{expected} gained an EKU"
+            );
+        }
+    }
+
+    /// The client path differs from the service path in the second
+    /// label and in requesting `clientAuth`, and in nothing else. No CA
+    /// is in the loop: this is what the CSR asks for, which is the half
+    /// this repository decides.
+    #[test]
+    fn test_build_registrar_client_csr_params_carries_the_reserved_label_and_client_auth() {
+        let params = build_registrar_client_csr_params("001", "h1", TEST_DOMAIN).unwrap();
+        assert_eq!(
+            dns_sans(&params),
+            vec![format!("001.bootroot-registrar.h1.{TEST_DOMAIN}")]
+        );
+        assert_eq!(
+            common_name(&params),
+            format!("001.bootroot-registrar.h1.{TEST_DOMAIN}")
+        );
+        assert_eq!(
+            params.extended_key_usages,
+            vec![rcgen::ExtendedKeyUsagePurpose::ClientAuth]
+        );
+    }
+
+    /// The domain is a suffix of whatever label count it was configured
+    /// with, never a single trailing label, so the composed name has to
+    /// grow with it.
+    #[test]
+    fn test_build_registrar_client_csr_params_treats_the_domain_as_a_suffix() {
+        for domain in ["internal", "example.internal", "corp.example.internal"] {
+            let params = build_registrar_client_csr_params("001", "h1", domain).unwrap();
+            let expected = format!("001.bootroot-registrar.h1.{domain}");
+            assert_eq!(dns_sans(&params), vec![expected.clone()]);
+            assert_eq!(
+                expected.split('.').count(),
+                3 + domain.split('.').count(),
+                "label count must be derived from the configured domain"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_registrar_client_csr_params_rejects_invalid_parts() {
+        assert!(build_registrar_client_csr_params("abc", "h1", TEST_DOMAIN).is_err());
+        assert!(build_registrar_client_csr_params("001", "-h1", TEST_DOMAIN).is_err());
+        assert!(build_registrar_client_csr_params("001", "h1", "bad_domain").is_err());
+    }
+
+    /// A client certificate can be issued from the client path's CSR,
+    /// and the reserved-label name survives issuance: the CSR is
+    /// serialized exactly as `issue_certificate` serializes it, parsed
+    /// back the way a CA does, signed, and the leaf's single DNS SAN
+    /// read off the issued certificate.
+    ///
+    /// The issued **EKU set is deliberately not asserted**. Which
+    /// extended key usages a leaf comes back with is decided by the
+    /// issuing CA's certificate template — step-ca's, in every real
+    /// deployment — and this repository pins no template, so an
+    /// assertion here would be asserting a local test CA's behaviour and
+    /// would say nothing about what step-ca returns. The observed
+    /// step-ca result for both shapes is recorded in
+    /// `docs/reference/registrar-client-identity.md` instead.
+    #[test]
+    fn test_registrar_client_certificate_can_be_issued_with_the_reserved_label_san() {
+        let params = build_registrar_client_csr_params("001", "h1", TEST_DOMAIN).unwrap();
+        let issued = issue_from_csr(&params);
+        assert_eq!(
+            bootroot_single_dns_san(&issued),
+            format!("001.bootroot-registrar.h1.{TEST_DOMAIN}")
+        );
+    }
+
+    /// The same route for the ordinary service shape, so the two are
+    /// compared under one procedure rather than one being asserted and
+    /// the other assumed.
+    #[test]
+    fn test_service_certificate_issued_from_the_unchanged_path_keeps_its_san() {
+        let settings = test_settings();
+        let profile = test_profile();
+        let params = build_csr_params(&settings, &profile).unwrap();
+        let issued = issue_from_csr(&params);
+        assert_eq!(
+            bootroot_single_dns_san(&issued),
+            format!("001.edge-proxy.edge-node-01.{TEST_DOMAIN}")
+        );
+    }
+
+    /// Serializes `params` into a CSR with a fresh key pair — exactly
+    /// what `issue_certificate` does — then parses and signs it with a
+    /// throwaway CA, returning the issued certificate's DER.
+    fn issue_from_csr(params: &rcgen::CertificateParams) -> Vec<u8> {
+        let subject_key = rcgen::KeyPair::generate().expect("generate subject key");
+        let csr_der = params
+            .serialize_request(&subject_key)
+            .expect("serialize CSR");
+
+        let ca_key = rcgen::KeyPair::generate().expect("generate CA key");
+        let mut ca_params = rcgen::CertificateParams::new(Vec::new()).expect("CA params");
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![
+            rcgen::KeyUsagePurpose::KeyCertSign,
+            rcgen::KeyUsagePurpose::CrlSign,
+        ];
+        let ca = rcgen::CertifiedIssuer::self_signed(ca_params, ca_key).expect("self-signed CA");
+
+        let request = rcgen::CertificateSigningRequestParams::from_der(csr_der.der())
+            .expect("parse CSR the way a CA does");
+        request
+            .signed_by(&ca)
+            .expect("issue certificate")
+            .der()
+            .to_vec()
+    }
+
+    /// Reads the issued leaf's single DNS SAN through the same library
+    /// helper the registrar's verifiers use.
+    fn bootroot_single_dns_san(der: &[u8]) -> String {
+        crate::registrar::single_dns_san(der).expect("issued leaf carries one DNS SAN")
+    }
+
+    fn dns_sans(params: &rcgen::CertificateParams) -> Vec<String> {
+        params
+            .subject_alt_names
+            .iter()
+            .filter_map(|san| match san {
+                rcgen::SanType::DnsName(dns) => Some(dns.as_str().to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn common_name(params: &rcgen::CertificateParams) -> String {
+        match params.distinguished_name.get(&rcgen::DnType::CommonName) {
+            Some(rcgen::DnValue::Utf8String(value)) => value.as_str().to_string(),
+            other => panic!("Unexpected common name value: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/bin/bootroot-remote/validation.rs
+++ b/src/bin/bootroot-remote/validation.rs
@@ -3,6 +3,7 @@ use bootroot::input_validation::{
     ValidationError, validate_dns_label, validate_domain_name, validate_numeric_instance_id,
     validate_registration_id,
 };
+use bootroot::registrar::{RESERVED_SERVICE_NAME_PREFIX, is_reserved_service_name};
 
 use super::{Locale, localized};
 
@@ -14,8 +15,28 @@ pub(super) fn validate_registration_id_arg(value: &str, lang: Locale) -> Result<
     validate_registration_id(value).map_err(|err| registration_id_error(err, lang))
 }
 
+/// Validates the `--service-name` this bootstrap writes into the
+/// profile: a DNS label that is not inside bootroot's own reserved
+/// namespace.
+///
+/// The reserved half is the library's shared predicate
+/// ([`bootroot::registrar::is_reserved_service_name`]), the same one
+/// `bootroot service add` applies, because this flag lands in the same
+/// place: it becomes `[[profiles]].service_name`, which is the second
+/// label of the SAN the agent then orders. A bootstrap run without
+/// `--artifact` takes the value straight from the command line rather
+/// than from a control-plane artifact `service add` already vetted, so
+/// leaving the check out here would let a reserved name be minted
+/// around that guard.
 pub(super) fn validate_service_name(value: &str, lang: Locale) -> Result<()> {
-    validate_dns_label(value).map_err(|err| service_name_error(err, lang))
+    validate_dns_label(value).map_err(|err| service_name_error(err, lang))?;
+    if is_reserved_service_name(value) {
+        return Err(service_name_error(
+            ValidationError::ReservedServiceName,
+            lang,
+        ));
+    }
+    Ok(())
 }
 
 pub(super) fn validate_profile_hostname(value: &str, lang: Locale) -> Result<()> {
@@ -46,7 +67,8 @@ fn registration_id_error(err: ValidationError, lang: Locale) -> anyhow::Error {
         | ValidationError::InvalidDomainName
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
-        | ValidationError::NonNumeric => anyhow::anyhow!(
+        | ValidationError::NonNumeric
+        | ValidationError::ReservedServiceName => anyhow::anyhow!(
             "{}",
             localized(
                 lang,
@@ -67,6 +89,23 @@ fn service_name_error(err: ValidationError, lang: Locale) -> anyhow::Error {
                 lang,
                 "--service-name must not be empty",
                 "--service-name 값은 비어 있으면 안 됩니다",
+            )
+        ),
+        // Its own message, not the DNS-label one: `bootroot-registrar`
+        // is a perfectly well-formed label, and an operator told it is
+        // not one would go looking for the wrong problem.
+        ValidationError::ReservedServiceName => anyhow::anyhow!(
+            "{}",
+            localized(
+                lang,
+                &format!(
+                    "--service-name must not start with `{RESERVED_SERVICE_NAME_PREFIX}`: \
+                     that prefix is reserved for bootroot's own certificate identities",
+                ),
+                &format!(
+                    "--service-name은 `{RESERVED_SERVICE_NAME_PREFIX}`로 시작할 수 없습니다. \
+                     해당 접두사는 bootroot 자체 인증서 identity 전용으로 예약되어 있습니다",
+                ),
             )
         ),
         ValidationError::InvalidDnsLabel
@@ -100,7 +139,8 @@ fn profile_hostname_error(err: ValidationError, lang: Locale) -> anyhow::Error {
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
         | ValidationError::NonNumeric
-        | ValidationError::InvalidRegistrationId => anyhow::anyhow!(
+        | ValidationError::InvalidRegistrationId
+        | ValidationError::ReservedServiceName => anyhow::anyhow!(
             "{}",
             localized(
                 lang,
@@ -126,7 +166,8 @@ fn agent_domain_error(err: ValidationError, lang: Locale) -> anyhow::Error {
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
         | ValidationError::NonNumeric
-        | ValidationError::InvalidRegistrationId => anyhow::anyhow!(
+        | ValidationError::InvalidRegistrationId
+        | ValidationError::ReservedServiceName => anyhow::anyhow!(
             "{}",
             localized(
                 lang,
@@ -145,7 +186,8 @@ fn profile_instance_id_error(err: ValidationError, lang: Locale) -> anyhow::Erro
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
         | ValidationError::NonNumeric
-        | ValidationError::InvalidRegistrationId => anyhow::anyhow!(
+        | ValidationError::InvalidRegistrationId
+        | ValidationError::ReservedServiceName => anyhow::anyhow!(
             "{}",
             localized(
                 lang,
@@ -153,5 +195,57 @@ fn profile_instance_id_error(err: ValidationError, lang: Locale) -> anyhow::Erro
                 "--profile-instance-id는 숫자만 허용됩니다",
             )
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A bootstrap run without `--artifact` takes `--service-name`
+    /// straight from the command line, so the reserved-namespace guard
+    /// has to hold here as well as on `bootroot service add`. The rule
+    /// reached is the library's shared predicate — this file defines no
+    /// reserved name of its own, so there is no second list to drift
+    /// from `bootroot::registrar::RESERVED_SERVICE_NAME_PREFIX`.
+    #[test]
+    fn service_name_refuses_the_reserved_bootroot_prefix() {
+        for value in [
+            "bootroot-registrar",
+            "BOOTROOT-Registrar",
+            "bootroot-registrar-endpoint",
+            "bootroot-anything",
+        ] {
+            for lang in [Locale::En, Locale::Ko] {
+                let err = validate_service_name(value, lang)
+                    .expect_err(&format!("{value} must be refused"));
+                assert!(
+                    err.to_string().contains(RESERVED_SERVICE_NAME_PREFIX),
+                    "{value}: {err}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn service_name_accepts_ordinary_component_keywords() {
+        for value in ["roxyd", "piglet", "edge-proxy", "bootroot"] {
+            assert!(validate_service_name(value, Locale::En).is_ok(), "{value}");
+        }
+    }
+
+    /// The reserved refusal is its own message, not the DNS-label one:
+    /// `bootroot-registrar` is a well-formed label, and an operator told
+    /// it is not one would go looking for the wrong problem.
+    #[test]
+    fn reserved_and_malformed_service_names_are_refused_differently() {
+        let reserved = validate_service_name("bootroot-registrar", Locale::En)
+            .expect_err("reserved name")
+            .to_string();
+        let malformed = validate_service_name("edge_proxy", Locale::En)
+            .expect_err("malformed label")
+            .to_string();
+        assert_ne!(reserved, malformed);
+        assert!(!reserved.contains("must be a DNS label"), "{reserved}");
     }
 }

--- a/src/commands/service/resolve.rs
+++ b/src/commands/service/resolve.rs
@@ -5,6 +5,7 @@ use bootroot::input_validation::{
     ValidationError, validate_cidr_list, validate_dns_label, validate_domain_name,
     validate_numeric_instance_id, validate_registration_id,
 };
+use bootroot::registrar::{RESERVED_SERVICE_NAME_PREFIX, is_reserved_service_name};
 
 use crate::cli::args::{HookFailurePolicyArg, ReloadStyle, ServiceAddArgs};
 use crate::cli::prompt::Prompt;
@@ -367,8 +368,26 @@ fn validate_registration_id_input(value: &str, messages: &Messages) -> Result<St
     Ok(value.to_string())
 }
 
+/// Validates an operator-supplied `service_name`: a DNS label that is
+/// not inside bootroot's own reserved namespace.
+///
+/// The reserved-prefix half is the library's shared predicate
+/// ([`bootroot::registrar::is_reserved_service_name`]), not a list
+/// restated here. It is what makes the registrar identities
+/// unmintable — anyone able to call `service add` could otherwise
+/// produce `<instance>.bootroot-registrar.<host>.<domain>` and be
+/// recognized as the registrar. Reserving the whole `bootroot-` prefix
+/// rather than the individual labels means a later bootroot-internal
+/// identity is covered by this one guard instead of a second list that
+/// can drift from it.
 fn validate_service_name(value: &str, messages: &Messages) -> Result<String> {
     validate_dns_label(value).map_err(|err| service_name_error(err, messages))?;
+    if is_reserved_service_name(value) {
+        return Err(service_name_error(
+            ValidationError::ReservedServiceName,
+            messages,
+        ));
+    }
     Ok(value.to_string())
 }
 
@@ -395,7 +414,8 @@ fn registration_id_error(err: ValidationError, messages: &Messages) -> anyhow::E
         | ValidationError::InvalidDomainName
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
-        | ValidationError::NonNumeric => {
+        | ValidationError::NonNumeric
+        | ValidationError::ReservedServiceName => {
             anyhow::anyhow!(messages.error_registration_id_invalid())
         }
     }
@@ -404,6 +424,9 @@ fn registration_id_error(err: ValidationError, messages: &Messages) -> anyhow::E
 fn service_name_error(err: ValidationError, messages: &Messages) -> anyhow::Error {
     match err {
         ValidationError::Empty => anyhow::anyhow!(messages.error_value_required()),
+        ValidationError::ReservedServiceName => {
+            anyhow::anyhow!(messages.error_service_name_reserved(RESERVED_SERVICE_NAME_PREFIX))
+        }
         ValidationError::InvalidDnsLabel
         | ValidationError::InvalidDomainName
         | ValidationError::InvalidCidr
@@ -423,7 +446,8 @@ fn hostname_error(err: ValidationError, messages: &Messages) -> anyhow::Error {
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
         | ValidationError::NonNumeric
-        | ValidationError::InvalidRegistrationId => {
+        | ValidationError::InvalidRegistrationId
+        | ValidationError::ReservedServiceName => {
             anyhow::anyhow!(messages.error_hostname_invalid())
         }
     }
@@ -437,7 +461,8 @@ fn domain_error(err: ValidationError, messages: &Messages) -> anyhow::Error {
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
         | ValidationError::NonNumeric
-        | ValidationError::InvalidRegistrationId => {
+        | ValidationError::InvalidRegistrationId
+        | ValidationError::ReservedServiceName => {
             anyhow::anyhow!(messages.error_domain_invalid())
         }
     }
@@ -451,7 +476,8 @@ fn instance_id_error(err: ValidationError, messages: &Messages) -> anyhow::Error
         | ValidationError::InvalidCidr
         | ValidationError::CidrClearConflict
         | ValidationError::NonNumeric
-        | ValidationError::InvalidRegistrationId => {
+        | ValidationError::InvalidRegistrationId
+        | ValidationError::ReservedServiceName => {
             anyhow::anyhow!(messages.error_instance_id_invalid())
         }
     }
@@ -696,6 +722,58 @@ mod tests {
 
     use super::*;
     use crate::cli::args::{AuthMode, RuntimeAuthArgs};
+
+    /// `service add` refuses every name inside bootroot's reserved
+    /// namespace, whatever its case, and leaves ordinary component
+    /// keywords alone. The rule reached here is the library's shared
+    /// predicate — this module defines no reserved name of its own, so
+    /// there is no second list to drift from
+    /// `bootroot::registrar::RESERVED_SERVICE_NAME_PREFIX`.
+    #[test]
+    fn validate_service_name_refuses_the_reserved_bootroot_prefix() {
+        let messages = crate::i18n::test_messages();
+        for value in [
+            "bootroot-registrar",
+            "BOOTROOT-Registrar",
+            "bootroot-registrar-endpoint",
+            "bootroot-anything",
+        ] {
+            let err = validate_service_name(value, &messages)
+                .expect_err(&format!("{value} must be refused"));
+            assert!(
+                err.to_string().contains(RESERVED_SERVICE_NAME_PREFIX),
+                "{value}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_service_name_accepts_ordinary_component_keywords() {
+        let messages = crate::i18n::test_messages();
+        for value in ["roxyd", "piglet", "edge-proxy"] {
+            assert_eq!(
+                validate_service_name(value, &messages).expect(value),
+                value.to_string()
+            );
+        }
+    }
+
+    /// The reserved-name refusal is its own message, not the DNS-label
+    /// one: `bootroot-registrar` is a perfectly well-formed label and an
+    /// operator told it is not one would go looking for the wrong
+    /// problem.
+    #[test]
+    fn reserved_and_malformed_service_names_are_refused_differently() {
+        let messages = crate::i18n::test_messages();
+        let reserved = validate_service_name("bootroot-registrar", &messages)
+            .expect_err("reserved name")
+            .to_string();
+        let malformed = validate_service_name("edge_proxy", &messages)
+            .expect_err("malformed label")
+            .to_string();
+        assert_ne!(reserved, malformed);
+        assert_eq!(validate_dns_label("bootroot-registrar"), Ok(()));
+    }
 
     fn empty_args() -> ServiceAddArgs {
         ServiceAddArgs {

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -115,6 +115,7 @@ pub(crate) struct Strings {
     pub(crate) error_service_instance_id_required: &'static str,
     pub(crate) error_value_required: &'static str,
     pub(crate) error_service_name_invalid: &'static str,
+    pub(crate) error_service_name_reserved: &'static str,
     pub(crate) error_registration_id_invalid: &'static str,
     pub(crate) error_hostname_invalid: &'static str,
     pub(crate) error_domain_invalid: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -94,6 +94,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_service_instance_id_required: "instance_id is required for all services",
     error_value_required: "Value is required",
     error_service_name_invalid: "service_name must be a DNS label (letters, digits, hyphens only; max 63 chars)",
+    error_service_name_reserved: "service_name must not start with `{value}`: that prefix is reserved for bootroot's own certificate identities",
     error_registration_id_invalid: "registration_id must be lowercase letters, digits and hyphens, starting and ending with a letter or digit (max 131 chars)",
     error_hostname_invalid: "hostname must be a DNS label (letters, digits, hyphens only; max 63 chars)",
     error_domain_invalid: "domain must be a DNS name with dot-separated labels (letters, digits, hyphens only)",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -94,6 +94,7 @@ pub(super) static STRINGS: Strings = Strings {
     error_service_instance_id_required: "모든 서비스에는 instance_id가 필요합니다",
     error_value_required: "값을 입력해야 합니다",
     error_service_name_invalid: "service_name은 DNS label이어야 합니다(영문자, 숫자, 하이픈만 허용, 최대 63자)",
+    error_service_name_reserved: "service_name은 `{value}`로 시작할 수 없습니다. 해당 접두사는 bootroot 자체 인증서 identity 전용으로 예약되어 있습니다",
     error_registration_id_invalid: "registration_id는 영소문자, 숫자, 하이픈만 허용되며 영숫자로 시작하고 끝나야 합니다(최대 131자)",
     error_hostname_invalid: "hostname은 DNS label이어야 합니다(영문자, 숫자, 하이픈만 허용, 최대 63자)",
     error_domain_invalid: "domain은 점으로 구분된 DNS label들로 구성된 DNS 이름이어야 합니다(영문자, 숫자, 하이픈만 허용)",

--- a/src/i18n/service.rs
+++ b/src/i18n/service.rs
@@ -88,6 +88,13 @@ impl Messages {
         self.strings().error_service_name_invalid
     }
 
+    pub(crate) fn error_service_name_reserved(&self, prefix: &str) -> String {
+        format_template(
+            self.strings().error_service_name_reserved,
+            &[("value", prefix)],
+        )
+    }
+
     pub(crate) fn error_registration_id_invalid(&self) -> &'static str {
         self.strings().error_registration_id_invalid
     }

--- a/src/input_validation.rs
+++ b/src/input_validation.rs
@@ -25,6 +25,12 @@ pub enum ValidationError {
     /// Distinct from [`ValidationError::InvalidDnsLabel`] because a
     /// registration key may legitimately be longer than a DNS label.
     InvalidRegistrationId,
+    /// The value is a well-formed DNS label but falls inside bootroot's
+    /// own reserved namespace
+    /// ([`crate::registrar::RESERVED_SERVICE_NAME_PREFIX`]).
+    /// Distinct from [`ValidationError::InvalidDnsLabel`] because the
+    /// value is refused for what it names, not for how it is spelled.
+    ReservedServiceName,
 }
 
 /// Validates a DNS label used for service names and hostnames.

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -20,8 +20,32 @@
 //! the durable-binding collision check the caller's step rather than a
 //! missing one here, and it is why no variant in [`error`] refers to a
 //! stored or previously applied spec.
+//!
+//! Alongside that library, this module owns the two names the registrar
+//! surface itself is known by, and the primitives that recognize them.
+//! bootroot issues one certificate shape for ordinary services:
+//! `<instance>.<service_name>.<host>.<domain>` as a single DNS SAN
+//! ([`crate::config::profile_domain`]). The registrar surface needs two
+//! names that an ordinary `service add` cannot mint, so it reuses that
+//! composition and distinguishes itself by a reserved second label under
+//! the [`RESERVED_SERVICE_NAME_PREFIX`] namespace:
+//!
+//! - the **registrar client identity**, [`REGISTRAR_CLIENT_LABEL`], is
+//!   the leaf the registrar authenticates to the host-local endpoint
+//!   with;
+//! - the **endpoint server identity**, [`REGISTRAR_ENDPOINT_LABEL`], is
+//!   the leaf the daemon's endpoint presents, and the name a client pins
+//!   ([`endpoint_pin`]).
+//!
+//! Those items are `pub` on purpose. `service add` lives in the binary
+//! crate and reaches the reserved-prefix guard through
+//! `bootroot::registrar::…`, while the endpoint's verifier is
+//! library-side; a `pub(crate)` item would be invisible to one of them
+//! and the sibling that cannot reach it would grow a second list of
+//! reserved names.
 
 pub mod config;
+pub mod endpoint_pin;
 pub mod error;
 pub mod fixture;
 pub mod identity;
@@ -38,3 +62,526 @@ pub use identity::{
     DerivedIdentity, RequestedSpec, check_instance_shape, check_spec_identity, compose_san,
     derive_registration_id, validate_request_labels,
 };
+use x509_parser::certificate::X509Certificate;
+use x509_parser::extensions::{GeneralName, ParsedExtension};
+use x509_parser::prelude::FromDer;
+
+use crate::input_validation::{
+    validate_dns_label, validate_domain_name, validate_numeric_instance_id,
+};
+
+/// The namespace prefix bootroot reserves for its own certificate
+/// identities. A `service_name` whose ASCII-lowercased form starts with
+/// it is refused by `service add`, which is what makes
+/// [`recognize_registrar_client`] sound: no operator-driven issuance can
+/// produce a name under this prefix.
+pub const RESERVED_SERVICE_NAME_PREFIX: &str = "bootroot-";
+
+/// The reserved second label of the registrar's own client identity.
+pub const REGISTRAR_CLIENT_LABEL: &str = "bootroot-registrar";
+
+/// The reserved second label of the host-local endpoint's server
+/// identity.
+pub const REGISTRAR_ENDPOINT_LABEL: &str = "bootroot-registrar-endpoint";
+
+/// Number of labels a registrar identity carries in front of the
+/// configured domain suffix: instance, reserved service label, host.
+/// The domain itself is a suffix of *any* label count
+/// ([`validate_domain_name`] accepts one label or five), so a total
+/// label count is never hard-coded — it is always this plus the label
+/// count of the configured domain.
+const IDENTITY_LEADING_LABELS: usize = 3;
+
+/// Reports whether `value` falls inside bootroot's reserved
+/// [`RESERVED_SERVICE_NAME_PREFIX`] namespace.
+///
+/// The comparison is ASCII-case-insensitive because
+/// [`validate_dns_label`] admits mixed case and DNS labels compare
+/// case-insensitively, so `BOOTROOT-Registrar` is the same name as
+/// `bootroot-registrar`.
+///
+/// This is the single predicate every bootroot-internal identity is
+/// protected by. Callers add reserved names *under* the prefix rather
+/// than adding a second guard, so there is only ever one list to
+/// consult.
+#[must_use]
+pub fn is_reserved_service_name(value: &str) -> bool {
+    value
+        .as_bytes()
+        .get(..RESERVED_SERVICE_NAME_PREFIX.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(RESERVED_SERVICE_NAME_PREFIX.as_bytes()))
+}
+
+/// Composes the registrar client identity name
+/// `<instance>.bootroot-registrar.<host>.<domain>`.
+///
+/// `domain` is the configured `network.domain` and is a *suffix* of
+/// whatever label count it was configured with, not a single label.
+#[must_use]
+pub fn registrar_client_identity(instance: &str, host: &str, domain: &str) -> String {
+    format!("{instance}.{REGISTRAR_CLIENT_LABEL}.{host}.{domain}")
+}
+
+/// Composes the endpoint server identity name
+/// `<instance>.bootroot-registrar-endpoint.<host>.<domain>`.
+///
+/// `domain` is the configured `network.domain` and is a *suffix* of
+/// whatever label count it was configured with, not a single label.
+#[must_use]
+pub fn registrar_endpoint_identity(instance: &str, host: &str, domain: &str) -> String {
+    format!("{instance}.{REGISTRAR_ENDPOINT_LABEL}.{host}.{domain}")
+}
+
+/// Why a presented certificate does not carry the one DNS SAN both
+/// registrar name rules require.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum SanShapeError {
+    /// The DER did not parse as an X.509 certificate.
+    #[error("certificate could not be parsed")]
+    Malformed,
+    /// The certificate carries no subject alternative name at all.
+    #[error("certificate carries no subject alternative name")]
+    Missing,
+    /// The certificate carries more than one subject alternative name.
+    #[error("certificate carries more than one subject alternative name")]
+    Multiple,
+    /// The certificate's only subject alternative name is not a DNS
+    /// name.
+    #[error("certificate's only subject alternative name is not a DNS name")]
+    NotDns,
+}
+
+/// Returns the single DNS subject alternative name of an end-entity
+/// certificate, ASCII-lowercased.
+///
+/// Both registrar name rules require *exactly one* SAN, of type DNS: a
+/// certificate carrying a second name could satisfy the rule under one
+/// of its names and be used under another, so more than one is a
+/// rejection rather than a search.
+///
+/// The common name is never consulted. Today's leaves mirror the SAN
+/// into the CN, but the CN is not a name a verifier may act on.
+///
+/// # Errors
+///
+/// Returns [`SanShapeError`] when the DER does not parse, when the
+/// certificate carries no SAN, when it carries more than one, or when
+/// its only SAN is not a DNS name.
+pub fn single_dns_san(end_entity_der: &[u8]) -> Result<String, SanShapeError> {
+    let (_, cert) =
+        X509Certificate::from_der(end_entity_der).map_err(|_| SanShapeError::Malformed)?;
+    single_dns_san_of(&cert)
+}
+
+fn single_dns_san_of(cert: &X509Certificate<'_>) -> Result<String, SanShapeError> {
+    let mut names = Vec::new();
+    for extension in cert.extensions() {
+        if let ParsedExtension::SubjectAlternativeName(san) = extension.parsed_extension() {
+            names.extend(san.general_names.iter());
+        }
+    }
+    let mut names = names.into_iter();
+    let Some(first) = names.next() else {
+        return Err(SanShapeError::Missing);
+    };
+    if names.next().is_some() {
+        return Err(SanShapeError::Multiple);
+    }
+    match first {
+        GeneralName::DNSName(dns) => Ok(dns.to_ascii_lowercase()),
+        _ => Err(SanShapeError::NotDns),
+    }
+}
+
+/// The parsed parts of a recognized registrar client identity, each
+/// ASCII-lowercased.
+///
+/// Recognition establishes *which* identity presented itself, never what
+/// it may do: scoping an operation by `host` is the endpoint's decision,
+/// not this module's.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistrarClientIdentity {
+    /// The leading instance label, e.g. `001`.
+    pub instance: String,
+    /// The host label the registrar runs on.
+    pub host: String,
+    /// The configured domain suffix the name was matched against.
+    pub domain: String,
+}
+
+/// Why a presented certificate is not a registrar client identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RegistrarIdentityError {
+    /// The locally configured domain is not a valid DNS name, so no
+    /// name could be matched against it.
+    #[error("the configured domain is not a valid DNS name")]
+    InvalidConfiguredDomain,
+    /// The certificate does not carry exactly one DNS SAN.
+    #[error(transparent)]
+    San(#[from] SanShapeError),
+    /// The SAN does not end in the configured domain on a label
+    /// boundary.
+    #[error("subject alternative name does not end in the configured domain")]
+    DomainMismatch,
+    /// The SAN does not carry exactly three labels in front of the
+    /// configured domain suffix.
+    #[error("subject alternative name does not carry exactly three labels before the domain")]
+    LabelCount,
+    /// The SAN's second label is not [`REGISTRAR_CLIENT_LABEL`].
+    #[error("subject alternative name's service label is not the registrar client label")]
+    NotRegistrarClient,
+    /// The SAN's first label is not a numeric instance identifier.
+    #[error("subject alternative name's instance label is not numeric")]
+    InvalidInstanceLabel,
+    /// The SAN's third label is not a valid DNS label.
+    #[error("subject alternative name's host label is not a valid DNS label")]
+    InvalidHostLabel,
+}
+
+/// Recognizes the registrar client identity on an already-verified peer
+/// certificate.
+///
+/// This is a *name* rule and nothing more. It builds no chain, checks no
+/// validity window and consults no extended key usage — step-ca's
+/// template decides the EKU set of every leaf it issues, so an attribute
+/// an ordinary service leaf may also carry cannot discriminate.
+/// Recognition is by name, and the name is unmintable through
+/// `service add` because of [`is_reserved_service_name`].
+///
+/// Accepts only when the certificate carries exactly one DNS SAN, that
+/// name ends in `domain` on a label boundary, exactly three labels
+/// precede the suffix, the second of them is [`REGISTRAR_CLIENT_LABEL`],
+/// the first is a numeric instance label and the third a valid DNS
+/// label. Every comparison is ASCII-case-insensitive.
+///
+/// # Errors
+///
+/// Returns the [`RegistrarIdentityError`] naming the first rule the
+/// certificate failed.
+pub fn recognize_registrar_client(
+    end_entity_der: &[u8],
+    domain: &str,
+) -> Result<RegistrarClientIdentity, RegistrarIdentityError> {
+    let dns_name = single_dns_san(end_entity_der)?;
+    recognize_registrar_client_name(&dns_name, domain)
+}
+
+/// Applies the registrar client name rule to an already-extracted DNS
+/// name.
+///
+/// Split out from [`recognize_registrar_client`] so the rule can be
+/// exercised — and reused — without a certificate in hand.
+///
+/// # Errors
+///
+/// Returns the [`RegistrarIdentityError`] naming the first rule the name
+/// failed.
+pub fn recognize_registrar_client_name(
+    dns_name: &str,
+    domain: &str,
+) -> Result<RegistrarClientIdentity, RegistrarIdentityError> {
+    if validate_domain_name(domain).is_err() {
+        return Err(RegistrarIdentityError::InvalidConfiguredDomain);
+    }
+    if !dns_name.is_ascii() {
+        // A non-ASCII name can match neither an ASCII domain suffix nor
+        // `validate_dns_label`, and byte offsets into it are not char
+        // boundaries, so it is rejected before any slicing happens.
+        return Err(RegistrarIdentityError::DomainMismatch);
+    }
+    let name = dns_name.to_ascii_lowercase();
+    let domain = domain.to_ascii_lowercase();
+
+    // A label-boundary suffix match, never a bare string suffix: the
+    // domain `example.internal` must not accept a name ending in
+    // `evil-example.internal`.
+    let boundary = name
+        .len()
+        .checked_sub(domain.len() + 1)
+        .ok_or(RegistrarIdentityError::DomainMismatch)?;
+    let (leading, suffix) = name.split_at(boundary);
+    if suffix.strip_prefix('.') != Some(domain.as_str()) {
+        return Err(RegistrarIdentityError::DomainMismatch);
+    }
+
+    let labels: Vec<&str> = leading.split('.').collect();
+    if labels.len() != IDENTITY_LEADING_LABELS {
+        return Err(RegistrarIdentityError::LabelCount);
+    }
+    let (Some(instance), Some(service), Some(host)) =
+        (labels.first(), labels.get(1), labels.get(2))
+    else {
+        return Err(RegistrarIdentityError::LabelCount);
+    };
+    if !service.eq_ignore_ascii_case(REGISTRAR_CLIENT_LABEL) {
+        return Err(RegistrarIdentityError::NotRegistrarClient);
+    }
+    if validate_numeric_instance_id(instance).is_err() {
+        return Err(RegistrarIdentityError::InvalidInstanceLabel);
+    }
+    if validate_dns_label(host).is_err() {
+        return Err(RegistrarIdentityError::InvalidHostLabel);
+    }
+    Ok(RegistrarClientIdentity {
+        instance: (*instance).to_string(),
+        host: (*host).to_string(),
+        domain,
+    })
+}
+
+/// Tests for the reserved-prefix guard and the registrar name rules.
+/// The config loader and the derivation library are covered by the
+/// sibling [`tests`] module.
+#[cfg(test)]
+mod recognition_tests {
+    use rcgen::{CertificateParams, IsCa, KeyPair, SanType};
+
+    use super::*;
+
+    const TWO_LABEL_DOMAIN: &str = "example.internal";
+    const ONE_LABEL_DOMAIN: &str = "internal";
+    const THREE_LABEL_DOMAIN: &str = "corp.example.internal";
+
+    /// Self-signs a leaf carrying exactly the given subject alternative
+    /// names, and returns its DER.
+    fn certificate_with_sans(sans: Vec<SanType>) -> Vec<u8> {
+        let key = KeyPair::generate().expect("generate key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params.is_ca = IsCa::NoCa;
+        params.subject_alt_names = sans;
+        params
+            .self_signed(&key)
+            .expect("self-signed certificate")
+            .der()
+            .to_vec()
+    }
+
+    fn certificate_with_dns_san(name: &str) -> Vec<u8> {
+        certificate_with_sans(vec![SanType::DnsName(
+            name.to_string().try_into().expect("valid DNS SAN"),
+        )])
+    }
+
+    #[test]
+    fn reserved_prefix_covers_the_whole_bootroot_namespace() {
+        for value in [
+            "bootroot-registrar",
+            "BOOTROOT-Registrar",
+            "bootroot-registrar-endpoint",
+            "bootroot-anything",
+            "bootroot-",
+        ] {
+            assert!(is_reserved_service_name(value), "{value}");
+        }
+    }
+
+    /// Ordinary component keywords are unaffected, including the ones
+    /// that merely start with the letters of the prefix but do not carry
+    /// the hyphen that makes it a namespace.
+    #[test]
+    fn reserved_prefix_leaves_ordinary_service_names_alone() {
+        for value in ["roxyd", "piglet", "edge-proxy", "bootroot", "bootrootish"] {
+            assert!(!is_reserved_service_name(value), "{value}");
+        }
+    }
+
+    #[test]
+    fn identity_names_compose_the_reserved_labels() {
+        assert_eq!(
+            registrar_client_identity("001", "h1", TWO_LABEL_DOMAIN),
+            "001.bootroot-registrar.h1.example.internal"
+        );
+        assert_eq!(
+            registrar_endpoint_identity("001", "h1", TWO_LABEL_DOMAIN),
+            "001.bootroot-registrar-endpoint.h1.example.internal"
+        );
+    }
+
+    /// Both reserved labels must stay usable as single DNS labels, since
+    /// they occupy one label of the SAN.
+    #[test]
+    fn reserved_labels_are_valid_dns_labels() {
+        assert_eq!(validate_dns_label(REGISTRAR_CLIENT_LABEL), Ok(()));
+        assert_eq!(validate_dns_label(REGISTRAR_ENDPOINT_LABEL), Ok(()));
+    }
+
+    /// The expected label count is derived from the configured domain,
+    /// never hard-coded: the same name shape is accepted under a
+    /// one-, two- and three-label domain.
+    #[test]
+    fn recognizes_the_registrar_under_domains_of_differing_label_counts() {
+        for domain in [ONE_LABEL_DOMAIN, TWO_LABEL_DOMAIN, THREE_LABEL_DOMAIN] {
+            let name = registrar_client_identity("001", "h1", domain);
+            let der = certificate_with_dns_san(&name);
+            let identity = recognize_registrar_client(&der, domain)
+                .unwrap_or_else(|err| panic!("{domain} should be recognized: {err}"));
+            assert_eq!(
+                identity,
+                RegistrarClientIdentity {
+                    instance: "001".to_string(),
+                    host: "h1".to_string(),
+                    domain: domain.to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn recognition_returns_the_parsed_parts() {
+        let der = certificate_with_dns_san("007.bootroot-registrar.edge-node-01.example.internal");
+        let identity = recognize_registrar_client(&der, TWO_LABEL_DOMAIN).expect("recognized");
+        assert_eq!(identity.instance, "007");
+        assert_eq!(identity.host, "edge-node-01");
+        assert_eq!(identity.domain, TWO_LABEL_DOMAIN);
+    }
+
+    #[test]
+    fn recognition_is_ascii_case_insensitive() {
+        let der = certificate_with_dns_san("001.BOOTROOT-Registrar.H1.Example.Internal");
+        let identity = recognize_registrar_client(&der, "EXAMPLE.internal").expect("recognized");
+        assert_eq!(identity.host, "h1");
+        assert_eq!(identity.domain, TWO_LABEL_DOMAIN);
+    }
+
+    /// Each rejection is distinguishable, so a caller can tell "not the
+    /// registrar" from "malformed certificate".
+    #[test]
+    fn recognition_rejects_each_near_miss_distinguishably() {
+        for (name, expected) in [
+            // An ordinary service leaf, including the registrar host's
+            // own: same host, same domain, ordinary second label.
+            (
+                "001.roxyd.h1.example.internal",
+                RegistrarIdentityError::NotRegistrarClient,
+            ),
+            // The right reserved label, the wrong number of labels in
+            // front of the domain suffix.
+            (
+                "bootroot-registrar.h1.example.internal",
+                RegistrarIdentityError::LabelCount,
+            ),
+            (
+                "001.extra.bootroot-registrar.h1.example.internal",
+                RegistrarIdentityError::LabelCount,
+            ),
+            // The endpoint's own server identity is not a client
+            // identity.
+            (
+                "001.bootroot-registrar-endpoint.h1.example.internal",
+                RegistrarIdentityError::NotRegistrarClient,
+            ),
+            // A suffix that is not the configured domain, including the
+            // non-boundary near-miss.
+            (
+                "001.bootroot-registrar.h1.evil-example.internal",
+                RegistrarIdentityError::DomainMismatch,
+            ),
+            (
+                "001.bootroot-registrar.h1.example.public",
+                RegistrarIdentityError::DomainMismatch,
+            ),
+            (
+                "001.bootroot-registrar.h1.internal",
+                RegistrarIdentityError::DomainMismatch,
+            ),
+            // A non-numeric instance label, and a host label that is not
+            // a DNS label.
+            (
+                "abc.bootroot-registrar.h1.example.internal",
+                RegistrarIdentityError::InvalidInstanceLabel,
+            ),
+            (
+                "001.bootroot-registrar.-h1.example.internal",
+                RegistrarIdentityError::InvalidHostLabel,
+            ),
+        ] {
+            let der = certificate_with_dns_san(name);
+            assert_eq!(
+                recognize_registrar_client(&der, TWO_LABEL_DOMAIN),
+                Err(expected),
+                "{name}"
+            );
+        }
+    }
+
+    /// `evil-example.internal` shares a string suffix with the
+    /// configured `example.internal` but not a label boundary — and it
+    /// carries the *same* total label count as the name that would be
+    /// accepted, so nothing but the boundary rule stands between it and
+    /// acceptance. A bare `ends_with` would let it through.
+    #[test]
+    fn recognition_never_matches_a_non_boundary_domain_suffix() {
+        let accepted = registrar_client_identity("001", "h1", TWO_LABEL_DOMAIN);
+        let near_miss = registrar_client_identity("001", "h1", "evil-example.internal");
+        assert_eq!(
+            accepted.split('.').count(),
+            near_miss.split('.').count(),
+            "the near miss must differ from the accepted name only in the suffix"
+        );
+        assert!(near_miss.ends_with(TWO_LABEL_DOMAIN));
+
+        let der = certificate_with_dns_san(&near_miss);
+        assert_eq!(
+            recognize_registrar_client(&der, TWO_LABEL_DOMAIN),
+            Err(RegistrarIdentityError::DomainMismatch)
+        );
+        assert!(recognize_registrar_client_name(&accepted, TWO_LABEL_DOMAIN).is_ok());
+    }
+
+    #[test]
+    fn recognition_rejects_a_certificate_with_more_than_one_san() {
+        let der = certificate_with_sans(vec![
+            SanType::DnsName(
+                registrar_client_identity("001", "h1", TWO_LABEL_DOMAIN)
+                    .try_into()
+                    .expect("valid DNS SAN"),
+            ),
+            SanType::DnsName(
+                "other.example.internal"
+                    .to_string()
+                    .try_into()
+                    .expect("san"),
+            ),
+        ]);
+        assert_eq!(
+            recognize_registrar_client(&der, TWO_LABEL_DOMAIN),
+            Err(RegistrarIdentityError::San(SanShapeError::Multiple))
+        );
+    }
+
+    #[test]
+    fn recognition_rejects_a_certificate_whose_only_san_is_not_a_dns_name() {
+        let der = certificate_with_sans(vec![SanType::IpAddress(std::net::IpAddr::from([
+            10, 0, 0, 1,
+        ]))]);
+        assert_eq!(
+            recognize_registrar_client(&der, TWO_LABEL_DOMAIN),
+            Err(RegistrarIdentityError::San(SanShapeError::NotDns))
+        );
+    }
+
+    #[test]
+    fn recognition_rejects_a_certificate_with_no_san() {
+        let der = certificate_with_sans(Vec::new());
+        assert_eq!(
+            recognize_registrar_client(&der, TWO_LABEL_DOMAIN),
+            Err(RegistrarIdentityError::San(SanShapeError::Missing))
+        );
+    }
+
+    #[test]
+    fn recognition_rejects_unparseable_der() {
+        assert_eq!(
+            recognize_registrar_client(b"not a certificate", TWO_LABEL_DOMAIN),
+            Err(RegistrarIdentityError::San(SanShapeError::Malformed))
+        );
+    }
+
+    #[test]
+    fn recognition_rejects_an_invalid_configured_domain() {
+        assert_eq!(
+            recognize_registrar_client_name("001.bootroot-registrar.h1.bad_domain", "bad_domain"),
+            Err(RegistrarIdentityError::InvalidConfiguredDomain)
+        );
+    }
+}

--- a/src/registrar/endpoint_pin.rs
+++ b/src/registrar/endpoint_pin.rs
@@ -1,0 +1,1104 @@
+//! The registrar endpoint's pin file and the TLS verification it backs.
+//!
+//! A TLS handshake to the host-local endpoint has no hostname to match a
+//! server certificate against, and the operation the endpoint serves
+//! hands back a CA anchor that becomes a newly onboarded host's trust
+//! root — so "accept whatever was presented" would let anything that can
+//! impersonate the endpoint inject a CA of its choosing. The answer is
+//! not a permissive verifier but a pin file plus an exact expected name:
+//!
+//! - the file pins **trust anchors** by the SHA-256 of their DER, the
+//!   one pinning idiom this tree already has
+//!   ([`crate::tls::ca_bundle_fingerprints`],
+//!   `trust.trusted_ca_sha256`). A leaf-shaped pin is not an option:
+//!   every issuance generates a fresh key pair, so a leaf or SPKI digest
+//!   goes stale at the next renewal while the file's writer — the
+//!   provisioning tool — runs once at install;
+//! - pinning the anchor alone would admit any leaf that CA ever issued,
+//!   so it is paired with a mandatory check that the presented
+//!   end-entity certificate's single DNS SAN is exactly the endpoint
+//!   server identity name, which `service add`'s reserved-prefix guard
+//!   makes unmintable.
+//!
+//! Nothing here discovers a path. bootroot has no fixed certificate
+//! directory — every cert and key path is per-profile configuration
+//! ([`crate::config::Paths`]) — so the pin file's basename is fixed here
+//! ([`REGISTRAR_ENDPOINT_ANCHORS_FILE`]) and its directory follows the
+//! registrar client certificate's, via
+//! [`anchor_pin_path_for_client_certificate`]. The verifier is handed an
+//! explicit path and reads no configuration.
+
+use std::collections::{BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rustls::ClientConfig;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{WebPkiSupportedAlgorithms, verify_tls12_signature, verify_tls13_signature};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use x509_parser::certificate::X509Certificate;
+use x509_parser::prelude::{ASN1Time, FromDer};
+
+use crate::registrar::{SanShapeError, single_dns_san};
+use crate::tls;
+
+/// Basename of the file a registrar client reads the endpoint's pinned
+/// trust anchors from. Only the basename is fixed here; see
+/// [`anchor_pin_path_for_client_certificate`] for the directory rule.
+pub const REGISTRAR_ENDPOINT_ANCHORS_FILE: &str = "registrar-endpoint-anchors.sha256";
+
+/// Length of a SHA-256 digest written as lowercase hex, the only shape a
+/// significant line of the pin file may take. Mirrors the
+/// `trusted_ca_sha256` rule in [`crate::kv_payload`].
+const FINGERPRINT_HEX_LEN: usize = 64;
+
+/// A line whose first non-whitespace character is this is a comment.
+const COMMENT_PREFIX: char = '#';
+
+/// Why the *content* of a pin file is not usable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PinContentError {
+    /// A non-ignored line is not 64 ASCII hex characters. The whole file
+    /// is rejected: there is no partial acceptance.
+    #[error("line {line} is not a {FINGERPRINT_HEX_LEN}-character hex SHA-256 digest")]
+    MalformedEntry {
+        /// 1-based line number of the offending line.
+        line: usize,
+    },
+    /// The file holds no anchor digest at all.
+    #[error("no trust anchor digest present")]
+    NoEntries,
+}
+
+/// Why a pinned endpoint TLS configuration could not be built.
+///
+/// Every variant is a refusal. None of them falls back to trusting
+/// whatever the peer presents.
+#[derive(Debug, thiserror::Error)]
+pub enum EndpointPinError {
+    /// The pin file does not exist.
+    #[error("registrar endpoint pin file {} does not exist", .path.display())]
+    Missing {
+        /// The path that was handed to the helper.
+        path: PathBuf,
+    },
+    /// The pin file exists but could not be read.
+    #[error("registrar endpoint pin file {} could not be read", .path.display())]
+    Unreadable {
+        /// The path that was handed to the helper.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The pin file was read but its content is not usable.
+    #[error("registrar endpoint pin file {}: {source}", .path.display())]
+    Content {
+        /// The path that was handed to the helper.
+        path: PathBuf,
+        /// Which content rule the file broke.
+        #[source]
+        source: PinContentError,
+    },
+    /// The expected endpoint identity name is not a usable DNS name.
+    #[error("expected endpoint identity name {name} is not a valid DNS name")]
+    InvalidEndpointName {
+        /// The name that was handed to the helper.
+        name: String,
+    },
+}
+
+/// Why a presented server certificate was refused by
+/// [`RegistrarEndpointVerifier`].
+///
+/// Each variant is a distinct refusal, and none of them is a fallback to
+/// trusting the certificate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum EndpointVerifyRejection {
+    /// The presented end-entity certificate does not carry exactly one
+    /// DNS SAN.
+    #[error(transparent)]
+    San(#[from] SanShapeError),
+    /// The presented end-entity certificate's single DNS SAN is not the
+    /// expected endpoint identity name. Applied under both arms: a
+    /// directly pinned certificate is refused here too, rather than
+    /// accepted because its digest is in the pin set.
+    #[error("presented certificate's DNS SAN is not the expected endpoint identity name")]
+    SanMismatch,
+    /// No presented certificate's DER SHA-256 is in the pin set.
+    #[error("no presented certificate matches a pinned trust anchor")]
+    AnchorMismatch,
+    /// A pinned certificate did not parse as X.509, so it cannot be
+    /// checked for CA capability or validity.
+    #[error("the pinned certificate could not be parsed")]
+    AnchorMalformed,
+    /// The pinned certificate the chain would rest on is not CA-capable.
+    #[error("the pinned certificate is not a CA certificate")]
+    AnchorNotCa,
+    /// The pinned anchor's validity window has passed.
+    #[error("the pinned trust anchor has expired")]
+    AnchorExpired,
+    /// The pinned anchor's validity window has not started.
+    #[error("the pinned trust anchor is not yet valid")]
+    AnchorNotYetValid,
+    /// A pinned anchor matched, but the presented chain does not build
+    /// to it.
+    #[error("the presented chain does not build to a pinned trust anchor")]
+    ChainVerificationFailed,
+}
+
+impl From<EndpointVerifyRejection> for rustls::Error {
+    fn from(rejection: EndpointVerifyRejection) -> Self {
+        let error = match rejection {
+            EndpointVerifyRejection::San(SanShapeError::Malformed)
+            | EndpointVerifyRejection::AnchorMalformed => rustls::CertificateError::BadEncoding,
+            EndpointVerifyRejection::San(_) | EndpointVerifyRejection::SanMismatch => {
+                rustls::CertificateError::NotValidForName
+            }
+            EndpointVerifyRejection::AnchorMismatch
+            | EndpointVerifyRejection::ChainVerificationFailed => {
+                rustls::CertificateError::UnknownIssuer
+            }
+            EndpointVerifyRejection::AnchorNotCa => {
+                rustls::CertificateError::ApplicationVerificationFailure
+            }
+            EndpointVerifyRejection::AnchorExpired => rustls::CertificateError::Expired,
+            EndpointVerifyRejection::AnchorNotYetValid => rustls::CertificateError::NotValidYet,
+        };
+        Self::InvalidCertificate(error)
+    }
+}
+
+/// Derives the conventional pin-file path from a registrar client
+/// certificate path: that path's parent directory joined with
+/// [`REGISTRAR_ENDPOINT_ANCHORS_FILE`].
+///
+/// Pure — it touches no filesystem and reads no configuration. bootroot
+/// fixes no certificate directory, so the pin file's absolute directory
+/// follows wherever the registrar client certificate was configured to
+/// live; only the basename and this beside-the-certificate rule are
+/// fixed. A path with no parent yields the bare basename, relative to
+/// the caller's working directory.
+#[must_use]
+pub fn anchor_pin_path_for_client_certificate(client_certificate_path: &Path) -> PathBuf {
+    client_certificate_path
+        .parent()
+        .map_or_else(PathBuf::new, Path::to_path_buf)
+        .join(REGISTRAR_ENDPOINT_ANCHORS_FILE)
+}
+
+/// Parses pin-file content into the set of pinned anchor digests,
+/// lowercased and deduplicated.
+///
+/// The format is UTF-8 text, LF-separated. Leading and trailing ASCII
+/// whitespace is trimmed off each line; blank lines and lines whose
+/// first non-whitespace character is `#` are ignored; uppercase hex is
+/// accepted and normalized; order is irrelevant and duplicates collapse.
+/// Every other line must be exactly 64 ASCII hex characters — the
+/// SHA-256 of one trust anchor certificate's DER, the value
+/// [`crate::tls::ca_bundle_fingerprints`] produces.
+///
+/// # Errors
+///
+/// Returns [`PinContentError::MalformedEntry`] for the first non-ignored
+/// line that is not 64 hex characters — the whole file is rejected,
+/// never partially accepted — and [`PinContentError::NoEntries`] when no
+/// digest is present.
+pub fn parse_anchor_pins(contents: &str) -> Result<BTreeSet<String>, PinContentError> {
+    let mut pins = BTreeSet::new();
+    for (index, raw) in contents.lines().enumerate() {
+        let line = raw.trim_matches(|ch: char| ch.is_ascii_whitespace());
+        if line.is_empty() || line.starts_with(COMMENT_PREFIX) {
+            continue;
+        }
+        if line.len() != FINGERPRINT_HEX_LEN || !line.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            return Err(PinContentError::MalformedEntry { line: index + 1 });
+        }
+        pins.insert(line.to_ascii_lowercase());
+    }
+    if pins.is_empty() {
+        return Err(PinContentError::NoEntries);
+    }
+    Ok(pins)
+}
+
+/// Reads and parses the pin file at an explicitly supplied path.
+///
+/// Performs no path discovery and reads no configuration; see
+/// [`anchor_pin_path_for_client_certificate`] for the conventional
+/// location a caller may derive.
+///
+/// # Errors
+///
+/// Returns [`EndpointPinError::Missing`] when the file does not exist,
+/// [`EndpointPinError::Unreadable`] when it exists but cannot be read,
+/// and [`EndpointPinError::Content`] when its content breaks the format.
+pub fn load_anchor_pins(path: &Path) -> Result<BTreeSet<String>, EndpointPinError> {
+    let contents = std::fs::read_to_string(path).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            EndpointPinError::Missing {
+                path: path.to_path_buf(),
+            }
+        } else {
+            EndpointPinError::Unreadable {
+                path: path.to_path_buf(),
+                source,
+            }
+        }
+    })?;
+    parse_anchor_pins(&contents).map_err(|source| EndpointPinError::Content {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Builds the server-certificate verifier a registrar client uses
+/// against the host-local endpoint, from an explicitly supplied pin-file
+/// path and the exact endpoint identity name it must present.
+///
+/// # Errors
+///
+/// Returns [`EndpointPinError`] when the pin file is missing,
+/// unreadable, or malformed, or when `expected_endpoint_name` is not a
+/// valid DNS name.
+pub fn endpoint_server_verifier(
+    pin_file: &Path,
+    expected_endpoint_name: &str,
+) -> Result<Arc<dyn ServerCertVerifier>, EndpointPinError> {
+    let pins = load_anchor_pins(pin_file)?;
+    Ok(Arc::new(RegistrarEndpointVerifier::new(
+        pins.into_iter().collect(),
+        expected_endpoint_name,
+    )?))
+}
+
+/// Builds a [`ClientConfig`] whose only trust decision is the pinned
+/// anchor set plus the exact endpoint SAN.
+///
+/// A convenience over [`endpoint_server_verifier`] for a caller that
+/// presents no client certificate. A caller that authenticates with the
+/// registrar client identity builds its own config from the same
+/// verifier and finishes with
+/// [`rustls::ConfigBuilder::with_client_auth_cert`] instead — the
+/// verification semantics are identical either way.
+///
+/// # Errors
+///
+/// Returns [`EndpointPinError`] when the pin file is missing,
+/// unreadable, or malformed, or when `expected_endpoint_name` is not a
+/// valid DNS name.
+pub fn build_endpoint_client_config(
+    pin_file: &Path,
+    expected_endpoint_name: &str,
+) -> Result<ClientConfig, EndpointPinError> {
+    let verifier = endpoint_server_verifier(pin_file, expected_endpoint_name)?;
+    Ok(ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth())
+}
+
+/// Anchor-pinning server verifier for the registrar endpoint.
+///
+/// Wraps [`crate::tls`]'s existing `PinnedCertVerifier` rather than
+/// growing a second verification path, and adds the unconditional
+/// exact-SAN check on the presented end-entity certificate.
+///
+/// The trust anchors are taken from the certificates the peer presents,
+/// keeping only those whose DER SHA-256 is pinned: a pin file carries
+/// digests and no certificate material, so there is nothing else for an
+/// anchor to come from. A pin therefore has to name a certificate the
+/// endpoint actually sends — in a bootroot deployment, the CA bundle
+/// fingerprints the server presents alongside its leaf.
+#[derive(Debug)]
+pub struct RegistrarEndpointVerifier {
+    pins: HashSet<String>,
+    expected_name: String,
+    /// The expected name again, as the [`ServerName`] handed to the
+    /// inner webpki verifier. The name the caller dialed with is
+    /// deliberately ignored: over `AF_UNIX` there is no meaningful one,
+    /// and the name that matters is the pinned one.
+    expected_server_name: ServerName<'static>,
+    supported_algs: WebPkiSupportedAlgorithms,
+}
+
+impl RegistrarEndpointVerifier {
+    /// Builds a verifier over an already-parsed pin set.
+    ///
+    /// `pins` are normalized to lowercase hex, the form `tls::sha256_hex`
+    /// produces and the only form a digest is ever compared in.
+    /// [`parse_anchor_pins`] already normalizes, but a caller assembling
+    /// a pin set some other way would otherwise get a verifier that
+    /// refuses every handshake — a fail-closed footgun with no error to
+    /// read.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EndpointPinError::InvalidEndpointName`] when
+    /// `expected_endpoint_name` is not a valid DNS name.
+    pub fn new(
+        pins: HashSet<String>,
+        expected_endpoint_name: &str,
+    ) -> Result<Self, EndpointPinError> {
+        tls::install_crypto_provider();
+        let pins = pins
+            .into_iter()
+            .map(|pin| pin.to_ascii_lowercase())
+            .collect();
+        let expected_name = expected_endpoint_name.to_ascii_lowercase();
+        let expected_server_name = ServerName::try_from(expected_name.clone()).map_err(|_| {
+            EndpointPinError::InvalidEndpointName {
+                name: expected_endpoint_name.to_string(),
+            }
+        })?;
+        Ok(Self {
+            pins,
+            expected_name,
+            expected_server_name,
+            supported_algs: rustls::crypto::ring::default_provider()
+                .signature_verification_algorithms,
+        })
+    }
+
+    /// Applies the pinned-anchor and exact-SAN rules, returning the
+    /// typed refusal rather than a [`rustls::Error`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`EndpointVerifyRejection`] naming the first rule the
+    /// presented material failed.
+    pub fn verify(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: UnixTime,
+    ) -> Result<(), EndpointVerifyRejection> {
+        // The exact-SAN check runs first and unconditionally, so a SAN
+        // mismatch is reported as one instead of being masked by the
+        // chain failure it would also cause.
+        let presented_name = single_dns_san(end_entity.as_ref())?;
+        if presented_name != self.expected_name {
+            return Err(EndpointVerifyRejection::SanMismatch);
+        }
+
+        let anchors = self.pinned_anchors(end_entity, intermediates, now)?;
+        let verifier = tls::build_pinned_verifier(&anchors, &self.pins)
+            .map_err(|_| EndpointVerifyRejection::ChainVerificationFailed)?;
+        verifier
+            .verify_server_cert(
+                end_entity,
+                intermediates,
+                &self.expected_server_name,
+                &[],
+                now,
+            )
+            .map_err(|_| EndpointVerifyRejection::ChainVerificationFailed)?;
+        Ok(())
+    }
+
+    /// Selects the presented certificates whose DER SHA-256 is pinned
+    /// and that are usable as a trust anchor — CA-capable and
+    /// time-valid.
+    fn pinned_anchors(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: UnixTime,
+    ) -> Result<Vec<CertificateDer<'static>>, EndpointVerifyRejection> {
+        let mut anchors = Vec::new();
+        let mut matched = false;
+        let mut rejection = None;
+        for candidate in std::iter::once(end_entity).chain(intermediates) {
+            if !self.pins.contains(&tls::sha256_hex(candidate.as_ref())) {
+                continue;
+            }
+            matched = true;
+            match anchor_usability(candidate, now) {
+                Ok(()) => anchors.push(CertificateDer::from(candidate.as_ref().to_vec())),
+                Err(err) => {
+                    rejection.get_or_insert(err);
+                }
+            }
+        }
+        if !matched {
+            return Err(EndpointVerifyRejection::AnchorMismatch);
+        }
+        if anchors.is_empty() {
+            return Err(rejection.unwrap_or(EndpointVerifyRejection::AnchorMismatch));
+        }
+        Ok(anchors)
+    }
+}
+
+impl ServerCertVerifier for RegistrarEndpointVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        self.verify(end_entity, intermediates, now)?;
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls12_signature(message, cert, dss, &self.supported_algs)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(message, cert, dss, &self.supported_algs)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.supported_algs.supported_schemes()
+    }
+}
+
+/// Reports whether a pinned certificate may serve as a trust anchor:
+/// CA-capable and inside its validity window. Mirrors what
+/// `PinnedCertVerifier`'s direct-pin arm demands, so the two arms agree
+/// about what a pinned certificate has to be.
+fn anchor_usability(
+    certificate: &CertificateDer<'_>,
+    now: UnixTime,
+) -> Result<(), EndpointVerifyRejection> {
+    let (_, cert) = X509Certificate::from_der(certificate.as_ref())
+        .map_err(|_| EndpointVerifyRejection::AnchorMalformed)?;
+    let is_ca = cert
+        .basic_constraints()
+        .map_err(|_| EndpointVerifyRejection::AnchorMalformed)?
+        .is_some_and(|constraints| constraints.value.ca);
+    if !is_ca {
+        return Err(EndpointVerifyRejection::AnchorNotCa);
+    }
+    validate_anchor_time(&cert, now)
+}
+
+fn validate_anchor_time(
+    cert: &X509Certificate<'_>,
+    now: UnixTime,
+) -> Result<(), EndpointVerifyRejection> {
+    let seconds = i64::try_from(now.as_secs())
+        .map_err(|_| EndpointVerifyRejection::ChainVerificationFailed)?;
+    let now = ASN1Time::from_timestamp(seconds)
+        .map_err(|_| EndpointVerifyRejection::ChainVerificationFailed)?;
+    let validity = cert.validity();
+    if now < validity.not_before {
+        Err(EndpointVerifyRejection::AnchorNotYetValid)
+    } else if now > validity.not_after {
+        Err(EndpointVerifyRejection::AnchorExpired)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rcgen::{
+        BasicConstraints, CertificateParams, CertifiedIssuer, DnType, KeyPair, KeyUsagePurpose,
+        SanType, date_time_ymd,
+    };
+    use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::registrar::registrar_endpoint_identity;
+
+    const TEST_NOW_SECS: u64 = 1_700_000_000;
+    const TEST_DOMAIN: &str = "example.internal";
+
+    fn test_now() -> UnixTime {
+        UnixTime::since_unix_epoch(Duration::from_secs(TEST_NOW_SECS))
+    }
+
+    fn endpoint_name() -> String {
+        registrar_endpoint_identity("001", "h1", TEST_DOMAIN)
+    }
+
+    type TestCa = CertifiedIssuer<'static, KeyPair>;
+
+    /// Generates a self-signed CA whose validity window is
+    /// `(not_before, not_after)`.
+    fn generate_ca(not_before: (i32, u8, u8), not_after: (i32, u8, u8)) -> TestCa {
+        let key = KeyPair::generate().expect("generate key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Bootroot Test CA");
+        params.is_ca = rcgen::IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![
+            KeyUsagePurpose::DigitalSignature,
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+        ];
+        params.not_before = date_time_ymd(not_before.0, not_before.1, not_before.2);
+        params.not_after = date_time_ymd(not_after.0, not_after.1, not_after.2);
+        CertifiedIssuer::self_signed(params, key).expect("self-signed CA")
+    }
+
+    fn valid_ca() -> TestCa {
+        generate_ca((2020, 1, 1), (2099, 1, 1))
+    }
+
+    fn ca_der(ca: &TestCa) -> CertificateDer<'static> {
+        CertificateDer::from(ca.der().to_vec())
+    }
+
+    /// Issues a leaf carrying `name` as its single DNS SAN, signed by
+    /// `ca`.
+    fn issue_leaf(ca: &TestCa, name: &str) -> CertificateDer<'static> {
+        issue_leaf_with_sans(
+            ca,
+            vec![SanType::DnsName(
+                name.to_string().try_into().expect("valid DNS SAN"),
+            )],
+        )
+    }
+
+    fn issue_leaf_with_sans(ca: &TestCa, sans: Vec<SanType>) -> CertificateDer<'static> {
+        issue_leaf_with_sans_and_key(ca, sans).0
+    }
+
+    /// The same issuance, keeping the leaf's private key: a server that
+    /// has to complete a handshake needs it, and the validity window is
+    /// wide open because that handshake is verified against the real
+    /// clock rather than [`test_now`].
+    fn issue_leaf_with_sans_and_key(
+        ca: &TestCa,
+        sans: Vec<SanType>,
+    ) -> (CertificateDer<'static>, PrivateKeyDer<'static>) {
+        let key = KeyPair::generate().expect("generate key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params.is_ca = rcgen::IsCa::NoCa;
+        params.not_before = date_time_ymd(2020, 1, 1);
+        params.not_after = date_time_ymd(2099, 1, 1);
+        params.subject_alt_names = sans;
+        let leaf = params.signed_by(&key, ca).expect("issued leaf");
+        (
+            CertificateDer::from(leaf.der().to_vec()),
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.serialize_der())),
+        )
+    }
+
+    fn issue_leaf_and_key(
+        ca: &TestCa,
+        name: &str,
+    ) -> (CertificateDer<'static>, PrivateKeyDer<'static>) {
+        issue_leaf_with_sans_and_key(
+            ca,
+            vec![SanType::DnsName(
+                name.to_string().try_into().expect("valid DNS SAN"),
+            )],
+        )
+    }
+
+    /// Runs a TLS handshake between a server presenting `chain` and a
+    /// client configured by `client_config`, entirely in memory — no
+    /// socket, no port, no timing.
+    fn handshake(
+        client_config: ClientConfig,
+        chain: Vec<CertificateDer<'static>>,
+        key: PrivateKeyDer<'static>,
+    ) -> Result<(), rustls::Error> {
+        let server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(chain, key)
+            .expect("server config");
+        let mut server =
+            rustls::ServerConnection::new(Arc::new(server_config)).expect("server connection");
+        let mut client = rustls::ClientConnection::new(
+            Arc::new(client_config),
+            // Deliberately not the endpoint identity name: over
+            // `AF_UNIX` there is no meaningful name to dial with, and
+            // the verifier decides on the pinned one instead.
+            ServerName::try_from("localhost").expect("valid server name"),
+        )
+        .expect("client connection");
+
+        // Bounded rather than `loop`, so a handshake that stops making
+        // progress fails the test instead of hanging it.
+        for _ in 0..16 {
+            let mut to_server = Vec::new();
+            while client.wants_write() {
+                client.write_tls(&mut to_server).expect("client write");
+            }
+            let mut pending = to_server.as_slice();
+            while !pending.is_empty() {
+                server.read_tls(&mut pending).expect("server read");
+            }
+            server.process_new_packets()?;
+
+            let mut to_client = Vec::new();
+            while server.wants_write() {
+                server.write_tls(&mut to_client).expect("server write");
+            }
+            let mut pending = to_client.as_slice();
+            while !pending.is_empty() {
+                client.read_tls(&mut pending).expect("client read");
+            }
+            client.process_new_packets()?;
+
+            if !client.is_handshaking() && !server.is_handshaking() {
+                return Ok(());
+            }
+        }
+        panic!("handshake made no progress");
+    }
+
+    /// Writes a pin file holding `pins` and returns the client
+    /// configuration the helper builds from it, together with the
+    /// temporary directory whose drop removes the file.
+    fn client_config_over(pins: &[String], expected: &str) -> (tempfile::TempDir, ClientConfig) {
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join(REGISTRAR_ENDPOINT_ANCHORS_FILE);
+        let mut contents = String::new();
+        for pin in pins {
+            contents.push_str(pin);
+            contents.push('\n');
+        }
+        std::fs::write(&path, contents).expect("write pin file");
+        let config = build_endpoint_client_config(&path, expected).expect("client config");
+        (dir, config)
+    }
+
+    /// Self-signs a CA-capable certificate that carries `name` as its
+    /// single DNS SAN — the shape the direct-pin arm is exercised with.
+    fn self_signed_ca_with_san(name: &str, validity: ((i32, u8, u8), (i32, u8, u8))) -> Vec<u8> {
+        let key = KeyPair::generate().expect("generate key");
+        let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+        params.is_ca = rcgen::IsCa::Ca(BasicConstraints::Unconstrained);
+        params.not_before = date_time_ymd(validity.0.0, validity.0.1, validity.0.2);
+        params.not_after = date_time_ymd(validity.1.0, validity.1.1, validity.1.2);
+        params.subject_alt_names = vec![SanType::DnsName(
+            name.to_string().try_into().expect("valid DNS SAN"),
+        )];
+        params
+            .self_signed(&key)
+            .expect("self-signed CA")
+            .der()
+            .to_vec()
+    }
+
+    fn verifier_over(pins: &[String], expected: &str) -> RegistrarEndpointVerifier {
+        RegistrarEndpointVerifier::new(pins.iter().cloned().collect(), expected)
+            .expect("valid endpoint name")
+    }
+
+    #[test]
+    fn pin_path_is_derived_beside_the_client_certificate() {
+        assert_eq!(
+            anchor_pin_path_for_client_certificate(Path::new("/etc/bootroot/registrar/client.crt")),
+            PathBuf::from("/etc/bootroot/registrar/registrar-endpoint-anchors.sha256")
+        );
+        assert_eq!(
+            anchor_pin_path_for_client_certificate(Path::new("/var/lib/roxyd/tls/registrar.pem")),
+            PathBuf::from("/var/lib/roxyd/tls/registrar-endpoint-anchors.sha256")
+        );
+    }
+
+    #[test]
+    fn pin_path_of_a_bare_filename_is_the_bare_basename() {
+        assert_eq!(
+            anchor_pin_path_for_client_certificate(Path::new("client.crt")),
+            PathBuf::from(REGISTRAR_ENDPOINT_ANCHORS_FILE)
+        );
+    }
+
+    #[test]
+    fn parser_accepts_a_single_anchor() {
+        let pins = parse_anchor_pins(&format!("{}\n", "ab".repeat(32))).expect("valid file");
+        assert_eq!(pins.len(), 1);
+        assert!(pins.contains(&"ab".repeat(32)));
+    }
+
+    /// CA rotation keeps the old and the new anchor pinnable at once, so
+    /// several entries are required to work — and the documented
+    /// niceties (comments, blank lines, surrounding whitespace,
+    /// uppercase hex, duplicates) all have to survive in one file.
+    #[test]
+    fn parser_accepts_the_documented_format() {
+        let first = "3b".repeat(32);
+        let second = "9d".repeat(32);
+        let contents = format!(
+            "# bootrootd registrar endpoint — pinned trust anchors\n\
+             \n\
+             {first}\n\
+             \t  {}  \n\
+             \n\
+             \t# second entry present only during a CA rotation\n\
+             {second}\n\
+             {first}\n",
+            first.to_ascii_uppercase()
+        );
+        let pins = parse_anchor_pins(&contents).expect("valid file");
+        assert_eq!(pins.len(), 2, "duplicates and case must collapse");
+        assert!(pins.contains(&first));
+        assert!(pins.contains(&second));
+    }
+
+    #[test]
+    fn parser_rejects_a_malformed_line_and_names_it() {
+        let good = "ab".repeat(32);
+        for (contents, line) in [
+            (format!("{good}\n{}\n", "ab".repeat(31) + "a"), 2),
+            (format!("{good}\nnot-a-digest\n"), 2),
+            (format!("{}\n{good}\n", "zz".repeat(32)), 1),
+        ] {
+            assert_eq!(
+                parse_anchor_pins(&contents),
+                Err(PinContentError::MalformedEntry { line }),
+                "{contents}"
+            );
+        }
+    }
+
+    #[test]
+    fn parser_rejects_a_file_with_no_entry() {
+        for contents in ["", "\n\n", "# only a comment\n", "   \n\t\n"] {
+            assert_eq!(
+                parse_anchor_pins(contents),
+                Err(PinContentError::NoEntries),
+                "{contents:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn loading_a_missing_pin_file_is_its_own_refusal() {
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join(REGISTRAR_ENDPOINT_ANCHORS_FILE);
+        let err = load_anchor_pins(&path).expect_err("missing file");
+        assert!(matches!(err, EndpointPinError::Missing { .. }), "{err:?}");
+    }
+
+    /// A directory stands in for an unreadable file: reading it fails
+    /// with something other than `NotFound`, which is the distinction
+    /// the two refusals rest on. A permission-denied file would need the
+    /// test to run as a non-owner.
+    #[test]
+    fn loading_an_unreadable_pin_file_is_its_own_refusal() {
+        let dir = tempdir().expect("temp dir");
+        let err = load_anchor_pins(dir.path()).expect_err("unreadable file");
+        assert!(
+            matches!(err, EndpointPinError::Unreadable { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn loading_a_malformed_pin_file_is_its_own_refusal() {
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join(REGISTRAR_ENDPOINT_ANCHORS_FILE);
+        std::fs::write(&path, "# nothing but a comment\n").expect("write pin file");
+        let err = load_anchor_pins(&path).expect_err("no entries");
+        assert!(
+            matches!(
+                err,
+                EndpointPinError::Content {
+                    source: PinContentError::NoEntries,
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn building_a_config_rejects_an_endpoint_name_that_is_not_a_dns_name() {
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join(REGISTRAR_ENDPOINT_ANCHORS_FILE);
+        std::fs::write(&path, format!("{}\n", "ab".repeat(32))).expect("write pin file");
+        let err = build_endpoint_client_config(&path, "not a dns name")
+            .expect_err("invalid endpoint name");
+        assert!(
+            matches!(err, EndpointPinError::InvalidEndpointName { .. }),
+            "{err:?}"
+        );
+    }
+
+    /// The end-to-end shape a real deployment takes: the endpoint's leaf
+    /// is CA-issued, the server presents the issuing anchor alongside
+    /// it, and the pin file names that anchor.
+    #[test]
+    fn accepts_a_chained_leaf_whose_anchor_is_pinned_and_whose_san_matches() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf(&ca, &endpoint_name());
+        let pin = tls::sha256_hex(anchor.as_ref());
+        let verifier = verifier_over(&[pin], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Ok(())
+        );
+    }
+
+    /// A pin set assembled outside [`parse_anchor_pins`] — uppercase
+    /// hex, say — still matches, rather than silently refusing every
+    /// handshake.
+    #[test]
+    fn an_uppercase_pin_still_matches_the_anchor() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf(&ca, &endpoint_name());
+        let pin = tls::sha256_hex(anchor.as_ref()).to_ascii_uppercase();
+        let verifier = verifier_over(&[pin], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn refuses_a_chain_whose_anchor_is_not_pinned() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf(&ca, &endpoint_name());
+        let other = valid_ca();
+        let verifier = verifier_over(
+            &[tls::sha256_hex(ca_der(&other).as_ref())],
+            &endpoint_name(),
+        );
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Err(EndpointVerifyRejection::AnchorMismatch)
+        );
+    }
+
+    /// The refusal that stands between a pinned anchor and an
+    /// impersonator: the leaf carries the expected name and the pin file
+    /// names a certificate the peer really did present, but that
+    /// certificate did not issue the leaf. A pinned anchor arriving on
+    /// the wire must not be enough on its own — the chain has to build
+    /// to it.
+    #[test]
+    fn refuses_a_leaf_that_does_not_chain_to_the_pinned_anchor_it_ships_with() {
+        let pinned = valid_ca();
+        let anchor = ca_der(&pinned);
+        let rogue = valid_ca();
+        let leaf = issue_leaf(&rogue, &endpoint_name());
+        let verifier = verifier_over(&[tls::sha256_hex(anchor.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Err(EndpointVerifyRejection::ChainVerificationFailed)
+        );
+    }
+
+    #[test]
+    fn refuses_a_leaf_whose_san_is_not_the_endpoint_identity() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf(&ca, "001.roxyd.h1.example.internal");
+        let verifier = verifier_over(&[tls::sha256_hex(anchor.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Err(EndpointVerifyRejection::SanMismatch)
+        );
+    }
+
+    #[test]
+    fn refuses_a_leaf_carrying_more_than_one_san() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf_with_sans(
+            &ca,
+            vec![
+                SanType::DnsName(endpoint_name().try_into().expect("valid DNS SAN")),
+                SanType::DnsName(
+                    "other.example.internal"
+                        .to_string()
+                        .try_into()
+                        .expect("san"),
+                ),
+            ],
+        );
+        let verifier = verifier_over(&[tls::sha256_hex(anchor.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Err(EndpointVerifyRejection::San(SanShapeError::Multiple))
+        );
+    }
+
+    #[test]
+    fn refuses_an_expired_pinned_anchor() {
+        let ca = generate_ca((1999, 1, 1), (2000, 1, 1));
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf(&ca, &endpoint_name());
+        let verifier = verifier_over(&[tls::sha256_hex(anchor.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Err(EndpointVerifyRejection::AnchorExpired)
+        );
+    }
+
+    #[test]
+    fn refuses_a_not_yet_valid_pinned_anchor() {
+        let ca = generate_ca((2100, 1, 1), (2101, 1, 1));
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf(&ca, &endpoint_name());
+        let verifier = verifier_over(&[tls::sha256_hex(anchor.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, std::slice::from_ref(&anchor), test_now()),
+            Err(EndpointVerifyRejection::AnchorNotYetValid)
+        );
+    }
+
+    /// The direct-pin arm is inherited from `PinnedCertVerifier`, not a
+    /// deployment shape: a correctly provisioned endpoint always takes
+    /// the chained arm. It is pinned down here so the reuse has a
+    /// defined behaviour — a pinned non-CA certificate is refused.
+    #[test]
+    fn refuses_a_directly_pinned_certificate_that_is_not_a_ca() {
+        let ca = valid_ca();
+        let leaf = issue_leaf(&ca, &endpoint_name());
+        let verifier = verifier_over(&[tls::sha256_hex(leaf.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&leaf, &[], test_now()),
+            Err(EndpointVerifyRejection::AnchorNotCa)
+        );
+    }
+
+    #[test]
+    fn accepts_a_directly_pinned_ca_certificate_carrying_the_endpoint_identity() {
+        let der = self_signed_ca_with_san(&endpoint_name(), ((2020, 1, 1), (2099, 1, 1)));
+        let certificate = CertificateDer::from(der);
+        let verifier = verifier_over(&[tls::sha256_hex(certificate.as_ref())], &endpoint_name());
+        assert_eq!(verifier.verify(&certificate, &[], test_now()), Ok(()));
+    }
+
+    /// The exact-SAN check is unconditional. A pinned, CA-capable,
+    /// time-valid certificate carrying any other name is refused with
+    /// the SAN-mismatch refusal rather than accepted because its digest
+    /// is in the pin set.
+    #[test]
+    fn refuses_a_directly_pinned_ca_certificate_carrying_another_name() {
+        let der = self_signed_ca_with_san(
+            "001.bootroot-registrar-endpoint.h2.example.internal",
+            ((2020, 1, 1), (2099, 1, 1)),
+        );
+        let certificate = CertificateDer::from(der);
+        let verifier = verifier_over(&[tls::sha256_hex(certificate.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&certificate, &[], test_now()),
+            Err(EndpointVerifyRejection::SanMismatch)
+        );
+    }
+
+    #[test]
+    fn refuses_an_expired_directly_pinned_ca_certificate() {
+        let der = self_signed_ca_with_san(&endpoint_name(), ((1999, 1, 1), (2000, 1, 1)));
+        let certificate = CertificateDer::from(der);
+        let verifier = verifier_over(&[tls::sha256_hex(certificate.as_ref())], &endpoint_name());
+        assert_eq!(
+            verifier.verify(&certificate, &[], test_now()),
+            Err(EndpointVerifyRejection::AnchorExpired)
+        );
+    }
+
+    /// Every refusal reaches rustls as a certificate error. None of them
+    /// is an acceptance, which is the property that matters more than
+    /// which variant each maps to.
+    #[test]
+    fn every_rejection_reaches_rustls_as_a_certificate_error() {
+        for rejection in [
+            EndpointVerifyRejection::San(SanShapeError::Malformed),
+            EndpointVerifyRejection::San(SanShapeError::Missing),
+            EndpointVerifyRejection::SanMismatch,
+            EndpointVerifyRejection::AnchorMalformed,
+            EndpointVerifyRejection::AnchorMismatch,
+            EndpointVerifyRejection::AnchorNotCa,
+            EndpointVerifyRejection::AnchorExpired,
+            EndpointVerifyRejection::AnchorNotYetValid,
+            EndpointVerifyRejection::ChainVerificationFailed,
+        ] {
+            assert!(
+                matches!(
+                    rustls::Error::from(rejection),
+                    rustls::Error::InvalidCertificate(_)
+                ),
+                "{rejection:?}"
+            );
+        }
+    }
+
+    /// The verifier ignores whatever `ServerName` the caller dialed
+    /// with: over `AF_UNIX` there is no meaningful one, and the name
+    /// that decides the handshake is the pinned expected name.
+    #[test]
+    fn the_dialed_server_name_does_not_affect_the_decision() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let leaf = issue_leaf(&ca, &endpoint_name());
+        let verifier = verifier_over(&[tls::sha256_hex(anchor.as_ref())], &endpoint_name());
+        let result = ServerCertVerifier::verify_server_cert(
+            &verifier,
+            &leaf,
+            std::slice::from_ref(&anchor),
+            &ServerName::try_from("localhost").expect("valid server name"),
+            &[],
+            test_now(),
+        );
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    /// The helper's deliverable is a `ClientConfig`, and every
+    /// assertion above stops at `verify`. A `ServerCertVerifier` also
+    /// carries `supported_verify_schemes` and the TLS 1.2/1.3 signature
+    /// verification, which no direct call to `verify` touches: get
+    /// those wrong and every real handshake fails while the whole suite
+    /// above still passes. So one handshake is run end to end, from the
+    /// pin file on disk through to a completed session.
+    #[test]
+    fn a_pinned_client_completes_a_handshake_with_the_endpoint_it_pins() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let (leaf, key) = issue_leaf_and_key(&ca, &endpoint_name());
+        let (_dir, config) =
+            client_config_over(&[tls::sha256_hex(anchor.as_ref())], &endpoint_name());
+        let result = handshake(config, vec![leaf, anchor], key);
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    /// And the refusal really refuses: it aborts the handshake rather
+    /// than only being returned from a helper the handshake ignores.
+    #[test]
+    fn a_pinned_client_aborts_the_handshake_when_the_anchor_is_not_pinned() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let (leaf, key) = issue_leaf_and_key(&ca, &endpoint_name());
+        let unrelated = valid_ca();
+        let (_dir, config) = client_config_over(
+            &[tls::sha256_hex(ca_der(&unrelated).as_ref())],
+            &endpoint_name(),
+        );
+        let err = handshake(config, vec![leaf, anchor], key).expect_err("unpinned anchor");
+        assert!(
+            matches!(err, rustls::Error::InvalidCertificate(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_pinned_configuration_can_be_built_from_a_file_on_disk() {
+        let ca = valid_ca();
+        let anchor = ca_der(&ca);
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join(REGISTRAR_ENDPOINT_ANCHORS_FILE);
+        std::fs::write(&path, format!("{}\n", tls::sha256_hex(anchor.as_ref())))
+            .expect("write pin file");
+        assert!(build_endpoint_client_config(&path, &endpoint_name()).is_ok());
+    }
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -170,7 +170,7 @@ pub fn build_http_client_with_local_and_webpki_roots(pem_content: &str) -> Resul
         .context("Failed to build HTTP client with local+webpki roots")
 }
 
-fn install_crypto_provider() {
+pub(crate) fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
@@ -271,7 +271,7 @@ fn certs_to_root_store(certs: &[CertificateDer<'static>]) -> Result<rustls::Root
 /// accepted as long as its issuer is pinned. When no bundle certificate
 /// matches a pin the verifier is direct-pin only: it accepts a handshake
 /// solely when the server presents a directly pinned CA certificate.
-fn build_pinned_verifier(
+pub(crate) fn build_pinned_verifier(
     certs: &[CertificateDer<'static>],
     pins: &HashSet<String>,
 ) -> Result<Arc<dyn ServerCertVerifier>> {

--- a/tests/bootroot_service.rs
+++ b/tests/bootroot_service.rs
@@ -1540,6 +1540,119 @@ async fn test_app_add_rejects_invalid_registration_id_in_both_locales() {
     }
 }
 
+/// `service add` refuses the whole `bootroot-` namespace, whatever the
+/// case, and leaves ordinary component keywords alone.
+///
+/// This is what makes the registrar's certificate identity unmintable:
+/// without it, anyone able to run `service add` could register
+/// `--service-name bootroot-registrar` and be handed a leaf that
+/// `bootroot::registrar::recognize_registrar_client` accepts. The whole
+/// prefix is reserved rather than the two labels the registrar surface
+/// uses today, so a later bootroot-internal identity needs no second
+/// guard that could drift from this one.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_app_add_refuses_the_reserved_bootroot_service_name_prefix() {
+    for value in [
+        "bootroot-registrar",
+        "BOOTROOT-Registrar",
+        "bootroot-registrar-endpoint",
+        "bootroot-anything",
+    ] {
+        let temp_dir = tempdir().expect("create temp dir");
+        let agent_config = temp_dir.path().join("agent.toml");
+        let cert_dir = temp_dir.path().join("certs");
+        fs::create_dir_all(&cert_dir).expect("create cert dir");
+
+        write_state_file(temp_dir.path(), "http://localhost:8200").expect("write state.json");
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+            .current_dir(temp_dir.path())
+            .args([
+                "service",
+                "add",
+                "--print-only",
+                "--registration-id",
+                "h1-probe-001",
+                "--service-name",
+                value,
+                "--hostname",
+                "h1",
+                "--domain",
+                "trusted.domain",
+                "--agent-config",
+                agent_config.to_string_lossy().as_ref(),
+                "--cert-path",
+                cert_dir.join("probe.crt").to_string_lossy().as_ref(),
+                "--key-path",
+                cert_dir.join("probe.key").to_string_lossy().as_ref(),
+                "--instance-id",
+                "001",
+            ])
+            .output()
+            .expect("run service add");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "{value} must be refused");
+        assert!(
+            stderr.contains("bootroot-"),
+            "{value} must be refused for the reserved prefix, got: {stderr}"
+        );
+        // A well-formed label refused for what it names, not for how it
+        // is spelled — the DNS-label message would send an operator
+        // after the wrong problem.
+        assert!(!stderr.contains("must be a DNS label"), "{value}: {stderr}");
+    }
+}
+
+/// The guard above must not catch an ordinary component keyword. These
+/// names get past validation and fail later (or not at all), so the
+/// assertion is on the reserved-prefix message never appearing.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_app_add_accepts_ordinary_service_names_beside_the_reserved_prefix() {
+    for value in ["roxyd", "piglet", "edge-proxy", "bootroot"] {
+        let temp_dir = tempdir().expect("create temp dir");
+        let agent_config = temp_dir.path().join("agent.toml");
+        let cert_dir = temp_dir.path().join("certs");
+        fs::create_dir_all(&cert_dir).expect("create cert dir");
+
+        write_state_file(temp_dir.path(), "http://localhost:8200").expect("write state.json");
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_bootroot"))
+            .current_dir(temp_dir.path())
+            .args([
+                "service",
+                "add",
+                "--print-only",
+                "--registration-id",
+                "h1-probe-001",
+                "--service-name",
+                value,
+                "--hostname",
+                "h1",
+                "--domain",
+                "trusted.domain",
+                "--agent-config",
+                agent_config.to_string_lossy().as_ref(),
+                "--cert-path",
+                cert_dir.join("probe.crt").to_string_lossy().as_ref(),
+                "--key-path",
+                cert_dir.join("probe.key").to_string_lossy().as_ref(),
+                "--instance-id",
+                "001",
+            ])
+            .output()
+            .expect("run service add");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("reserved"),
+            "{value} must not be caught by the reserved-prefix guard, got: {stderr}"
+        );
+    }
+}
+
 /// Issue #691: the containerized-consumer story is the consumer-reload
 /// hook, not a per-service agent sidecar. `service add` must keep
 /// accepting `--reload-style docker-restart --reload-target <container>`

--- a/tests/reserved_service_name_fixtures.rs
+++ b/tests/reserved_service_name_fixtures.rs
@@ -1,0 +1,174 @@
+//! The repository's own fixtures must stay outside the reserved
+//! `bootroot-` service-name namespace.
+//!
+//! `bootroot service add` and `bootroot-remote bootstrap` refuse a
+//! `service_name` under that prefix, because it is the SAN's second
+//! label and the registrar's identities are recognized by it. A CI
+//! workflow, preflight script or shipped example config that registers
+//! such a name is not caught by any unit test — it fails much later, in
+//! a Docker E2E job, as a `service add` that suddenly exits non-zero.
+//! This test is that check, and it runs in `cargo test`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use bootroot::registrar::{RESERVED_SERVICE_NAME_PREFIX, is_reserved_service_name};
+
+/// Roots walked in full. Everything under them that names a
+/// `service_name` names one bootroot itself will register.
+const SCANNED_DIRS: [&str; 2] = [".github/workflows", "scripts"];
+
+/// Individual files outside those roots that carry the same values.
+const SCANNED_FILES: [&str; 3] = [
+    "agent.toml.compose",
+    "agent.toml.example",
+    "docker-compose.test.yml",
+];
+
+/// `tests/` is deliberately not scanned: the guard's own tests pass
+/// reserved names on purpose.
+fn scanned_paths() -> Vec<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut paths: Vec<PathBuf> = SCANNED_FILES.iter().map(|name| root.join(name)).collect();
+    for dir in SCANNED_DIRS {
+        collect_files(&root.join(dir), &mut paths);
+    }
+    paths
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, out);
+        } else {
+            out.push(path);
+        }
+    }
+}
+
+/// A value spelled as a shell or template expansion names nothing here;
+/// whatever it expands to is set elsewhere in the same file.
+fn is_literal(value: &str) -> bool {
+    !value.is_empty() && !value.starts_with('$') && !value.starts_with('{')
+}
+
+/// Pulls every literal `--service-name <value>` and `service_name =
+/// "<value>"` out of one file.
+fn service_names(contents: &str) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut tokens = contents.split_whitespace().peekable();
+    while let Some(token) = tokens.next() {
+        if let Some(value) = token.strip_prefix("--service-name=") {
+            found.push(value.trim_matches('"').to_string());
+        } else if token == "--service-name" {
+            // A shell line continuation between the flag and its value
+            // would otherwise make the scan read `\` as the name and
+            // skip the real one in silence -- the one failure mode a
+            // guard-against-drift test must not have.
+            while tokens.peek().is_some_and(|next| *next == "\\") {
+                tokens.next();
+            }
+            if let Some(value) = tokens.peek() {
+                found.push(value.trim_matches('"').to_string());
+            }
+        }
+    }
+    for line in contents.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("service_name") else {
+            continue;
+        };
+        let Some(rest) = rest.trim_start().strip_prefix('=') else {
+            continue;
+        };
+        let mut quoted = rest.trim().split('"');
+        if quoted.next().is_some_and(str::is_empty)
+            && let Some(value) = quoted.next()
+        {
+            found.push(value.to_string());
+        }
+    }
+    found.retain(|value| is_literal(value));
+    found
+}
+
+/// The scan has to see the value in every spelling the fixtures use, or
+/// it reports a clean sweep of names it never read. The line-continuation
+/// form is the one that fails silently: without the skip above, `\` is
+/// recorded as the name and the real one is never examined.
+#[test]
+fn the_scan_reads_a_service_name_in_every_spelling() {
+    assert_eq!(
+        service_names("  --service-name agent-selftest \\\n  --hostname h1\n"),
+        vec!["agent-selftest".to_string()]
+    );
+    assert_eq!(
+        service_names("  --service-name \\\n    agent-selftest \\\n"),
+        vec!["agent-selftest".to_string()]
+    );
+    assert_eq!(
+        service_names("--service-name=agent-selftest\n"),
+        vec!["agent-selftest".to_string()]
+    );
+    assert_eq!(
+        service_names("service_name = \"agent-selftest\"\n"),
+        vec!["agent-selftest".to_string()]
+    );
+    // A value the shell expands names nothing here.
+    assert!(service_names("--service-name \"$SERVICE_NAME\"\n").is_empty());
+}
+
+#[test]
+fn no_shipped_fixture_registers_a_reserved_service_name() {
+    let mut checked = 0_usize;
+    for path in scanned_paths() {
+        let Ok(contents) = fs::read_to_string(&path) else {
+            // Binary or unreadable files carry no service name.
+            continue;
+        };
+        for value in service_names(&contents) {
+            checked += 1;
+            assert!(
+                !is_reserved_service_name(&value),
+                "{}: service_name `{value}` is inside the reserved \
+                 `{RESERVED_SERVICE_NAME_PREFIX}` namespace, so the \
+                 `service add` that registers it is refused",
+                path.display()
+            );
+        }
+    }
+    assert!(
+        checked > 0,
+        "the scan found no service name at all — it stopped matching \
+         what the fixtures spell, and would no longer catch a reserved one"
+    );
+}
+
+/// The HTTP-01 responder's compose aliases are the names step-ca
+/// resolves during a challenge, so each mirrors one registration's SAN.
+/// Their second label is that registration's `service_name`.
+#[test]
+fn no_compose_alias_carries_a_reserved_service_label() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docker-compose.test.yml");
+    let contents = fs::read_to_string(&path).expect("read docker-compose.test.yml");
+    let mut checked = 0_usize;
+    for line in contents.lines() {
+        let Some(alias) = line.trim().strip_prefix("- ") else {
+            continue;
+        };
+        let Some(label) = alias.split('.').nth(1) else {
+            continue;
+        };
+        checked += 1;
+        assert!(
+            !is_reserved_service_name(label),
+            "{alias}: the SAN's second label is inside the reserved \
+             `{RESERVED_SERVICE_NAME_PREFIX}` namespace"
+        );
+    }
+    assert!(checked > 0, "no alias was examined");
+}


### PR DESCRIPTION
Closes #760.

Delivers both certificate-side primitives the host-local registrar endpoint needs, ahead of the endpoint itself. No listener, wire protocol or authorization logic comes with them.

## The two identities and the guard that protects them

`src/registrar.rs` (new, `pub mod registrar` from `src/lib.rs`) owns the reserved labels, the prefix constant and the recognition predicate. They are `pub` because their consumers sit on both sides of the crate boundary: `service add` is in the binary crate and reaches them through `bootroot::registrar::…`, while the endpoint's verifier is library-side.

- Client identity: `<instance>.bootroot-registrar.<host>.<domain>`. Endpoint server identity: `<instance>.bootroot-registrar-endpoint.<host>.<domain>`. `<domain>` is the configured suffix of whatever label count it carries — nothing hard-codes a total label count, and the tests run under one-, two- and three-label domains.
- `service add` refuses a `--service-name` whose lowercased form starts with `bootroot-`, with its own typed error rather than the DNS-label one. The whole prefix is reserved rather than the two labels in use, so a later bootroot-internal identity is covered by this one guard. The check lands in `src/commands/service/resolve.rs::validate_service_name`, the single choke point every `service add` path (flag, prompt, and the final `validate_service_add`) already goes through for the DNS-label rule — the issue points at `src/commands/service.rs`, and this is that module's validation file rather than a second guard beside it.
- `bootroot-remote bootstrap --service-name` calls the same shared predicate. It is the second way an operator-supplied name becomes the SAN's second label: the flag lands in `[[profiles]].service_name`, and a run without `--artifact` takes it straight from the command line rather than from an artifact `service add` already vetted. One predicate rather than two lists that drift.
- `recognize_registrar_client` accepts only a certificate with exactly one DNS SAN, ending in the configured domain **on a label boundary**, with exactly three labels before it, the second being `bootroot-registrar`, the first numeric and the third a valid DNS label — all ASCII-case-insensitive, CN never consulted. It returns the parsed `instance`, `host` and `domain` and decides no authorization. Every failure is its own variant.

`build_registrar_client_csr_params` is the additive CSR shape: the same single DNS SAN and CN mirror, plus `ClientAuth`. The service path is refactored through a shared helper and is byte-for-byte what it was, with an empty `extended_key_usages` — asserted for three different profile shapes.

The one fixture that sat under the reserved prefix moved with the guard: the agent's self-test registration carried `service_name = "bootroot-agent"` in CI, the preflight scripts and the shipped compose profile, and its SAN label is now `agent-selftest`. Its `registration_id`, `hostname` and certificate paths are unchanged, since only the second label is reserved. A `cargo test` regression scan keeps the next such fixture from being caught only by a Docker E2E job twenty minutes in.

## The pin file and the pinning helper

`src/registrar/endpoint_pin.rs` owns the basename `registrar-endpoint-anchors.sha256`, the format (64-hex lines, `#` comments, blank lines, surrounding whitespace, uppercase hex, duplicates collapsing, multiple anchors required, whole-file rejection on any malformed line), the parser, and the verifier.

The verifier wraps `tls::PinnedCertVerifier` with its behaviour unmodified — the only change to `src/tls.rs` is widening `build_pinned_verifier` and `install_crypto_provider` to `pub(crate)` — and adds the unconditional exact-SAN check on the presented leaf, applied **first** so a SAN mismatch is reported as one instead of being masked by the chain failure it would also cause. It takes the pin-file path as an explicit argument and reads no configuration; `anchor_pin_path_for_client_certificate` derives the conventional path from a supplied client-certificate path with no filesystem access.

One consequence worth calling out, because it is a design decision the issue's inputs force rather than an obvious reading: **the trust anchors are taken from the certificates the peer presents**, keeping only those whose DER SHA-256 is pinned. The helper's only inputs are the pin-file path and the expected SAN, and a pin file carries digests and no certificate material — and the endpoint's caller is precisely the party that does *not* yet have the CA bundle, since fetching that anchor is what the endpoint is for. So a pin has to name a certificate the endpoint actually sends: in a bootroot deployment, the CA bundle fingerprints the server presents alongside its leaf, which is exactly what `tls::ca_bundle_fingerprints` returns. The docs state this as the writer-side contract.

The inherited direct-pin arm is kept and pinned down: a pinned, CA-capable, time-valid certificate is accepted only if its single DNS SAN is the endpoint identity name, and refused with the SAN-mismatch refusal otherwise.

## The observed EKU

Recorded in `docs/reference/registrar-client-identity.md` — which also carries the two identity names, the guard, the recognition rule and the pin-file contract with its worked example — from three runs against `smallstep/step-ca:0.30.2` (the image `docker-compose.yml` pins) with its default configuration:

| Shape | How | Issued EKU |
| --- | --- | --- |
| ordinary service | bootroot's own ACME path, reading `edge-proxy.crt` / `web-app.crt` out of a `run-local-lifecycle.sh` workspace | `TLS Web Server Authentication, TLS Web Client Authentication` |
| ordinary service | `step ca sign` of this repo's CSR, ACME and JWK provisioners | `Server Authentication, Client Authentication` |
| registrar client | `step ca sign` of this repo's CSR | `Server Authentication, Client Authentication` |

step-ca's default leaf template ignores the EKU the CSR requests — the service CSR requests none and gets both; the client CSR requests `clientAuth` and gets both. So an ordinary service leaf is `clientAuth`-capable too, which is why recognition is a name rule that consults no EKU, and why nothing here asserts an issued EKU set.

`docs/en/cli.md` and `docs/ko/cli.md` note the refusal under both `--service-name` flags, and `CHANGELOG.md` records it under `### Changed`.

## What the guard does and does not prove

The guard covers the two CLI routes that let an operator name a service — `service add` and `bootroot-remote bootstrap` — which is the issue's scope, and the issue is explicit that no sibling adds a third. Worth stating plainly all the same: a host that already holds a valid registration can edit its own `agent.toml`'s `service_name` and order any name step-ca's ACME provisioner will validate, so the CLI guards are not by themselves a proof that no `bootroot-registrar` leaf can exist. Closing that would mean constraining ACME/EAB issuance, which this issue puts out of scope.

## Dependency note

`rcgen` gains the `x509-parser` feature under `[dev-dependencies]`, so the issuance tests can parse a CSR back and sign it the way a CA does. That feature adds nothing to `Cargo.lock`: it turns on `x509-parser` 0.18 with `verify`, the exact dependency and feature this crate already declares.

The one `Cargo.lock` change on this branch is unrelated to the work above. RUSTSEC-2026-0258 was published on 2026-08-17 against `h2` 0.4.15 — a peer can make it buffer empty HTTP/2 DATA frames without bound — and `h2` is pinned transitively here through `hyper`, `reqwest` and `poem`, so `cargo audit` in the `Quality Check` job went red on every commit of this branch. Bumped to 0.4.16, which is a patch release with no API to adapt to, and recorded under `### Security` in `[Unreleased]` following the `rustls-webpki` entry in 0.3.0. The bump is hand-applied to the two `h2` lines rather than taken from `cargo update`, which also rewrote a dozen unrelated `windows-sys` dependency edges; `cargo metadata --locked` accepts the result.

## Test plan

- [x] CSR params, client path: the params carry the reserved-label SAN and `ClientAuth`, asserted directly on the params with no CA involved.
- [x] CSR params, service path unchanged: today's single DNS SAN and an **empty** `extended_key_usages`, asserted for every current caller shape.
- [x] Issued certificate: the issued client leaf's parsed single DNS SAN is the reserved-label name; no assertion on the issued EKU set.
- [x] Guard: `service add` refuses `bootroot-registrar`, `BOOTROOT-Registrar` and `bootroot-anything`, and accepts `roxyd` / `piglet` / `edge-proxy`; `bootroot-remote bootstrap --service-name` refuses the same through the same predicate.
- [x] Reachability: the prefix constant and the predicate are `pub` items in the library named through `bootroot::…` from the binary crate, so no second guard has to be written.
- [x] Fixture drift: a `cargo test` scan finds no workflow, preflight script or shipped example config registering a `service_name` under the reserved prefix, and reads the flag across a line continuation, an `=` join and a TOML assignment.
- [x] Predicate, under domains of one, two and three labels: accepted registrar identity; rejected ordinary service leaf, the registrar host's own service leaf, wrong label count before the domain suffix, the non-boundary near-miss (`evil-example.internal` against domain `example.internal`), a multi-SAN certificate and a non-DNS SAN — each distinguishably. Mixed-case reserved label accepted; parsed parts returned.
- [x] Pin-file parser: single and multi-anchor files, comments, blank lines, surrounding whitespace, uppercase hex and duplicates accepted; a 63-hex line, a non-hex line and an entries-free file each reject the whole file.
- [x] Pin-path derivation: the parent directory of a supplied client-certificate path joined with `registrar-endpoint-anchors.sha256`, asserted for two unrelated inputs with no filesystem access.
- [x] Pinning: anchor match plus SAN match accepted, including through an in-memory handshake; anchor mismatch, SAN mismatch, expired anchor, not-yet-valid anchor, non-CA direct pin, unreadable file and missing file each refused with a distinguishable error and no permissive fallback.
- [x] Direct-pin edge cases: a pinned, CA-capable, time-valid certificate carrying the endpoint identity name is accepted; the same shape carrying another SAN is refused with the SAN-mismatch refusal.
- [x] Tests use `tempfile::tempdir()` for certificate and pin-file material; no fixed paths.
- [x] `cargo test --all-features`: 1918 passing, 0 failing.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --check -- --config group_imports=StdExternalCrate` clean.
- [x] `scripts/check-docs.sh`: `mkdocs build --strict` green, theme assets verified.
- [x] `scripts/preflight/ci/e2e-matrix.sh` and `e2e-extended.sh` — **not runnable on the author's host** (no passwordless `sudo`, so the matrix aborts at the OpenBao TLS re-own step; the extended suite needs a DNS-label hostname this machine does not have), so both were confirmed on CI instead. All ten Docker E2E matrix scenarios pass on the head commit, and a dispatched `E2E Extended` run over this branch ([32112778197](https://github.com/aicers/bootroot/actions/runs/32112778197)) reports `overall_status: pass` with all seven cases green — `scale-contention`, `failure-recovery`, `runner-timer`, `runner-cron`, `ca-key-recovery`, `reinit-recovery`, `infra-lifecycle` — which carries the renamed `agent-selftest` fixture through the Docker lifecycle.
- [x] `run-local-lifecycle.sh` `verify-after-ca-key` phase: it fails on the author's machine with `Untrusted CA fingerprint` for `web-app`, reproducible on `origin/main` and unrelated to this branch. Confirmed on CI, where `Docker E2E (local-hosts)` and `(local-no-hosts)` run the script end to end on the head commit and both pass.



