### PR TITLE
Add the registrar mint and deregister verbs (#758)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,10 @@ jobs:
             script: run-two-instance-isolation.sh
             resolution: ""
             artifact: ci-two-instance
+          - label: registrar-verbs
+            script: run-registrar-verbs-e2e.sh
+            resolution: ""
+            artifact: ci-registrar-verbs
     steps:
       - uses: actions/checkout@v7
 
@@ -486,7 +490,7 @@ jobs:
         run: cargo build --bin bootroot --bin bootroot-remote --bin bootroot-agent
 
       - name: Run E2E scenario (lifecycle)
-        if: matrix.scenario.label != 'rotation' && matrix.scenario.label != 'reinit-recovery' && matrix.scenario.label != 'stepca-san' && matrix.scenario.label != 'openbao-tls-no-delta' && matrix.scenario.label != 'openbao-tls-reown' && matrix.scenario.label != 'two-instance'
+        if: matrix.scenario.label != 'rotation' && matrix.scenario.label != 'reinit-recovery' && matrix.scenario.label != 'stepca-san' && matrix.scenario.label != 'openbao-tls-no-delta' && matrix.scenario.label != 'openbao-tls-reown' && matrix.scenario.label != 'two-instance' && matrix.scenario.label != 'registrar-verbs'
         run: |
           ARTIFACT_DIR="$(pwd)/tmp/e2e/${{ matrix.scenario.artifact }}-${GITHUB_RUN_ID}"
           # Local arms run the daemon-only model: every service agent is
@@ -639,6 +643,24 @@ jobs:
             for f in "$ARTIFACT_DIR"/snapshots/*.diff; do
               [ -f "$f" ] && { echo "--- $(basename "$f") ---"; cat "$f"; } || true
             done
+            exit 1
+          }
+
+      - name: Run E2E scenario (registrar verbs)
+        if: matrix.scenario.label == 'registrar-verbs'
+        # This scenario stands its own single OpenBao up on a free
+        # loopback port, so it needs no compose project, no secrets
+        # wiring and none of the bootroot binaries. It is the gate for
+        # the ignored `registrar::verbs::tests` library tests.
+        run: |
+          ARTIFACT_DIR="$(pwd)/tmp/e2e/${{ matrix.scenario.artifact }}-${GITHUB_RUN_ID}"
+          ARTIFACT_DIR="$ARTIFACT_DIR" \
+          ./scripts/impl/run-registrar-verbs-e2e.sh || {
+            echo "registrar-verbs failed"
+            [ -f "$ARTIFACT_DIR/phases.log" ] && cat "$ARTIFACT_DIR/phases.log" || true
+            [ -f "$ARTIFACT_DIR/run.log" ] && tail -n 200 "$ARTIFACT_DIR/run.log" || true
+            [ -f "$ARTIFACT_DIR/cargo-test.log" ] && tail -n 200 "$ARTIFACT_DIR/cargo-test.log" || true
+            [ -f "$ARTIFACT_DIR/openbao.log" ] && tail -n 200 "$ARTIFACT_DIR/openbao.log" || true
             exit 1
           }
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -77,6 +77,9 @@ PR-critical Docker test set validates:
 - OpenBao TLS re-issuance after `secrets/` is re-owned
 - two co-located instances stay independent (install, containers, volumes,
   published ports and HTTP-01 responder DNS aliases)
+- the registrar's mint and deregister verbs against a live OpenBao (durable
+  bindings, the KV v2 compare-and-set claim, re-mint, wrong-host refusal, the
+  absent-binding sweep and both concurrency properties)
 
 Primary scripts:
 
@@ -88,6 +91,7 @@ Primary scripts:
 - `scripts/impl/run-openbao-tls-no-delta.sh`
 - `scripts/impl/run-openbao-tls-reown.sh`
 - `scripts/impl/run-two-instance-isolation.sh`
+- `scripts/impl/run-registrar-verbs-e2e.sh`
 
 Three of those scripts are handed no project name at all, and derive their
 own instead. `run-two-instance-isolation.sh` installs two instances into two
@@ -99,6 +103,13 @@ All three pick run-scoped `--instance-name` values and free host ports
 themselves, and every teardown and leftover check is scoped to those exact
 names — they are safe to run on a host that already has a default `bootroot`
 install.
+
+`run-registrar-verbs-e2e.sh` is outside that discussion entirely: it stands a
+single OpenBao container up on a free loopback port and needs no compose
+project, no secrets wiring and none of the bootroot binaries. It is the gate
+for the `#[ignore]`d `registrar::verbs::tests` library tests, which it runs
+with the container's URL, token and KV mount passed in on the child process's
+environment.
 
 ### Two lifecycle runs can share a host
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -13,7 +13,7 @@ PR-critical CI (`.github/workflows/ci.yml`) runs:
 
 - `test-core`: unit/integration smoke path
 - `test-docker-e2e-matrix`: Docker E2E test set for end-to-end flow +
-  rotation/recovery (10 scenarios run in parallel via matrix strategy)
+  rotation/recovery (11 scenarios run in parallel via matrix strategy)
 
 Extended E2E (`.github/workflows/e2e-extended.yml`) runs separately:
 

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -75,6 +75,9 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 - `secrets/` 소유자 변경 이후 OpenBao TLS 인증서 재발급
 - 같은 호스트의 두 인스턴스가 서로 독립적으로 유지되는지(설치,
   컨테이너, 볼륨, 게시 포트, HTTP-01 리스폰더 DNS 별칭)
+- 실제 OpenBao를 상대로 한 registrar의 mint/deregister 동사(영속 바인딩,
+  KV v2 compare-and-set 클레임, 재발급, 호스트 불일치 거부, 바인딩 없는
+  정리, 두 가지 동시성 속성)
 
 주요 스크립트:
 
@@ -86,6 +89,7 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 - `scripts/impl/run-openbao-tls-no-delta.sh`
 - `scripts/impl/run-openbao-tls-reown.sh`
 - `scripts/impl/run-two-instance-isolation.sh`
+- `scripts/impl/run-registrar-verbs-e2e.sh`
 
 위 스크립트 가운데 셋은 프로젝트 이름을 전혀 전달받지 **않고** 스스로
 만들어 씁니다. `run-two-instance-isolation.sh`는 basename이 같은
@@ -97,6 +101,12 @@ PR 필수 Docker 조합 검증은 다음을 검증합니다.
 스스로 만들고 비어 있는 호스트 포트도 직접 고르며, 모든 정리와 잔여물
 확인이 그 이름들로만 한정되므로 기본 `bootroot` 설치본이 이미 있는
 호스트에서도 안전하게 실행할 수 있습니다.
+
+`run-registrar-verbs-e2e.sh`는 이 논의 바깥에 있습니다. 비어 있는 루프백
+포트에 OpenBao 컨테이너 하나만 띄우므로 compose 프로젝트도, secrets 배선도,
+bootroot 바이너리도 전혀 필요하지 않습니다. 이 스크립트는 `#[ignore]`가 붙은
+`registrar::verbs::tests` 라이브러리 테스트의 게이트이며, 컨테이너의 URL과
+토큰, KV 마운트를 자식 프로세스의 환경 변수로 넘겨 그 테스트들을 실행합니다.
 
 ### 라이프사이클 실행 두 개는 한 호스트를 공유할 수 있습니다
 

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -13,7 +13,7 @@ PR 필수 CI(`.github/workflows/ci.yml`)는 다음을 실행합니다.
 
 - `test-core`: 단위/통합 스모크 경로
 - `test-docker-e2e-matrix`: 전체 흐름 + 회전/복구 Docker E2E 조합 검증
-  (10개 시나리오가 matrix 전략으로 병렬 실행)
+  (11개 시나리오가 matrix 전략으로 병렬 실행)
 
 확장 E2E(`.github/workflows/e2e-extended.yml`)는 별도 실행됩니다.
 

--- a/scripts/impl/run-registrar-verbs-e2e.sh
+++ b/scripts/impl/run-registrar-verbs-e2e.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docker-backed scenario for the registrar mint/deregister verbs (#758).
+#
+# The verbs' write-dependent behaviour — durable bindings, the KV v2
+# compare-and-set claim, re-mint, wrong-host refusal, the absent-binding
+# sweep, teardown-before-unbind ordering, and both concurrency properties
+# — cannot be asserted against a canned-response mock without building a
+# second implementation of OpenBao's CAS semantics, which is exactly the
+# thing a bug in the first one would then agree with.  So they live as
+# `#[ignore]`d library tests in `src/registrar/verbs/tests.rs` and this
+# scenario is what runs them:
+#
+#   1. stand a single OpenBao container up on a free loopback port, at
+#      the image tag `docker-compose.yml` already pins;
+#   2. enable the AppRole auth method the verbs provision into;
+#   3. hand the child `cargo test` the URL, the token and the KV mount
+#      through the environment, and run the ignored tests.
+#
+# The connection details travel as environment variables on the child
+# process only.  The tests read them and never write them: mutating the
+# process environment from a test is unsound in Rust 2024, and there is
+# no reason to here.
+#
+# This is a self-contained OpenBao rather than the full compose stack.
+# The verbs touch no step-ca, no PostgreSQL and no responder, and a
+# scenario that stood them up anyway would be slower and would fail for
+# reasons that have nothing to do with what it is testing.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+RUN_ID="${GITHUB_RUN_ID:-local-$(date +%s)-$$}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT_DIR/tmp/e2e/registrar-verbs-${RUN_ID}}"
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd)"
+
+PHASE_LOG="$ARTIFACT_DIR/phases.log"
+RUN_LOG="$ARTIFACT_DIR/run.log"
+TEST_LOG="$ARTIFACT_DIR/cargo-test.log"
+OPENBAO_LOG="$ARTIFACT_DIR/openbao.log"
+
+CURRENT_PHASE="startup"
+CONTAINER_NAME="bootroot-registrar-verbs-${RUN_ID}"
+KV_MOUNT="${KV_MOUNT:-secret}"
+READY_ATTEMPTS="${READY_ATTEMPTS:-60}"
+READY_DELAY_SECS="${READY_DELAY_SECS:-1}"
+
+log_phase() {
+  CURRENT_PHASE="$1"
+  printf '{"ts":"%s","phase":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >>"$PHASE_LOG"
+  echo "[registrar-verbs][$1]"
+}
+
+fail() {
+  printf '[fatal][%s] %s\n' "$CURRENT_PHASE" "$1" >>"$RUN_LOG" 2>/dev/null || true
+  echo "[registrar-verbs][${CURRENT_PHASE}] $1" >&2
+  exit 1
+}
+
+# shellcheck source=lib/ports.sh
+. "$SCRIPT_DIR/lib/ports.sh"
+
+cleanup() {
+  # Best effort, but the logs are collected first: a container removed
+  # before its output was read leaves a failure with nothing to read.
+  if docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+    docker logs "$CONTAINER_NAME" >>"$OPENBAO_LOG" 2>&1 || true
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+command -v cargo >/dev/null 2>&1 || fail "cargo is required"
+
+# One pinned image for the whole repository: read it out of the compose
+# file rather than restating it here, so a bump lands in both places at
+# once.
+OPENBAO_IMAGE="$(awk '/^  openbao:/{found=1} found && /image: openbao\//{print $2; exit}' \
+  "$ROOT_DIR/docker-compose.yml")"
+[ -n "$OPENBAO_IMAGE" ] || fail "could not read the OpenBao image tag from docker-compose.yml"
+
+log_phase "allocate-port"
+pick_free_port
+OPENBAO_HOST_PORT="$PICKED_PORT"
+OPENBAO_URL="http://127.0.0.1:${OPENBAO_HOST_PORT}"
+
+# A throwaway root token for a throwaway container published on loopback
+# only.  Drawn from the system CSPRNG all the same, because a predictable
+# one would be a habit worth not forming.
+if command -v openssl >/dev/null 2>&1; then
+  OPENBAO_TOKEN="root-$(openssl rand -hex 16)"
+else
+  OPENBAO_TOKEN="root-$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+fi
+[ -n "${OPENBAO_TOKEN#root-}" ] || fail "could not generate a dev root token"
+
+log_phase "openbao-up"
+echo "[registrar-verbs] image=$OPENBAO_IMAGE port=$OPENBAO_HOST_PORT" >>"$RUN_LOG"
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -p "127.0.0.1:${OPENBAO_HOST_PORT}:8200" \
+  -e "BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_TOKEN}" \
+  -e "BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200" \
+  "$OPENBAO_IMAGE" server -dev >>"$RUN_LOG" 2>&1 ||
+  fail "could not start $OPENBAO_IMAGE"
+
+log_phase "openbao-ready"
+ready=0
+for _ in $(seq 1 "$READY_ATTEMPTS"); do
+  if curl -fsS "${OPENBAO_URL}/v1/sys/health" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep "$READY_DELAY_SECS"
+done
+[ "$ready" -eq 1 ] || {
+  docker logs "$CONTAINER_NAME" >>"$OPENBAO_LOG" 2>&1 || true
+  fail "OpenBao did not become ready on ${OPENBAO_URL}"
+}
+
+# Dev mode mounts KV v2 at `secret/` already; AppRole is not enabled by
+# default and the verbs provision roles into it.  Enabling it twice is a
+# 400, so an already-enabled mount is not a failure.
+log_phase "enable-approle"
+enable_status="$(curl -sS -o "$ARTIFACT_DIR/enable-approle.json" -w '%{http_code}' \
+  -X POST \
+  -H "X-Vault-Token: ${OPENBAO_TOKEN}" \
+  -d '{"type":"approle"}' \
+  "${OPENBAO_URL}/v1/sys/auth/approle" || true)"
+case "$enable_status" in
+  2*) ;;
+  400)
+    grep -q "path is already in use" "$ARTIFACT_DIR/enable-approle.json" ||
+      fail "could not enable the AppRole auth method (HTTP $enable_status)"
+    ;;
+  *) fail "could not enable the AppRole auth method (HTTP $enable_status)" ;;
+esac
+
+# Assert the mount the tests are told to use really is KV v2, so a
+# misconfiguration surfaces here rather than as a puzzling 400 inside a
+# compare-and-set assertion.
+log_phase "verify-kv-mount"
+curl -fsS -H "X-Vault-Token: ${OPENBAO_TOKEN}" \
+  "${OPENBAO_URL}/v1/sys/mounts/${KV_MOUNT}" >"$ARTIFACT_DIR/kv-mount.json" 2>>"$RUN_LOG" ||
+  fail "KV mount ${KV_MOUNT} is not present"
+grep -q '"version": *"2"' "$ARTIFACT_DIR/kv-mount.json" ||
+  fail "KV mount ${KV_MOUNT} is not version 2"
+
+log_phase "run-ignored-library-tests"
+set +e
+BOOTROOT_REGISTRAR_TEST_OPENBAO_URL="$OPENBAO_URL" \
+BOOTROOT_REGISTRAR_TEST_OPENBAO_TOKEN="$OPENBAO_TOKEN" \
+BOOTROOT_REGISTRAR_TEST_KV_MOUNT="$KV_MOUNT" \
+  cargo test --lib registrar::verbs::tests -- --ignored 2>&1 | tee "$TEST_LOG"
+status="${PIPESTATUS[0]}"
+set -e
+[ "$status" -eq 0 ] || fail "the ignored registrar verb tests failed (see $TEST_LOG)"
+
+log_phase "done"
+echo "[registrar-verbs] artifacts: $ARTIFACT_DIR"

--- a/scripts/impl/run-registrar-verbs-e2e.sh
+++ b/scripts/impl/run-registrar-verbs-e2e.sh
@@ -63,11 +63,21 @@ fail() {
 # shellcheck source=lib/ports.sh
 . "$SCRIPT_DIR/lib/ports.sh"
 
+# Collects the container's output, with the dev root token redacted.
+# `server -dev` prints "Root Token: <value>" on startup, and this log is
+# uploaded as a CI artifact; the token dies with the container a moment
+# later, but a live credential does not belong in a build artifact on the
+# way there.
+collect_openbao_log() {
+  docker logs "$CONTAINER_NAME" 2>&1 |
+    sed "s|${OPENBAO_TOKEN}|<redacted>|g" >>"$OPENBAO_LOG" || true
+}
+
 cleanup() {
   # Best effort, but the logs are collected first: a container removed
   # before its output was read leaves a failure with nothing to read.
   if docker inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
-    docker logs "$CONTAINER_NAME" >>"$OPENBAO_LOG" 2>&1 || true
+    collect_openbao_log
     docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
   fi
 }
@@ -91,12 +101,12 @@ OPENBAO_URL="http://127.0.0.1:${OPENBAO_HOST_PORT}"
 
 # A throwaway root token for a throwaway container published on loopback
 # only.  Drawn from the system CSPRNG all the same, because a predictable
-# one would be a habit worth not forming.
-if command -v openssl >/dev/null 2>&1; then
-  OPENBAO_TOKEN="root-$(openssl rand -hex 16)"
-else
-  OPENBAO_TOKEN="root-$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
-fi
+# one would be a habit worth not forming.  Read straight from
+# /dev/urandom rather than through `openssl rand`: this scenario needs no
+# openssl, and a `command -v openssl` here would be the bare
+# existence check `validate-e2e-openssl-compat.sh` exists to keep out of
+# scripts/impl.
+OPENBAO_TOKEN="root-$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
 [ -n "${OPENBAO_TOKEN#root-}" ] || fail "could not generate a dev root token"
 
 log_phase "openbao-up"
@@ -120,7 +130,7 @@ for _ in $(seq 1 "$READY_ATTEMPTS"); do
   sleep "$READY_DELAY_SECS"
 done
 [ "$ready" -eq 1 ] || {
-  docker logs "$CONTAINER_NAME" >>"$OPENBAO_LOG" 2>&1 || true
+  collect_openbao_log
   fail "OpenBao did not become ready on ${OPENBAO_URL}"
 }
 

--- a/scripts/preflight/ci/e2e-matrix.sh
+++ b/scripts/preflight/ci/e2e-matrix.sh
@@ -24,6 +24,7 @@ Runs the same Docker E2E matrix steps used in CI:
 8) OpenBao TLS transition with no compose delta
 9) OpenBao TLS re-issuance after secrets/ is re-owned
 10) two co-located instances stay independent
+11) registrar mint/deregister verbs against a live OpenBao
 
 Options:
   --skip-hosts  Skip hosts steps (useful when sudo -n is unavailable locally)
@@ -196,6 +197,14 @@ ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-two-instance-${RUN_ID}" \
 BOOTROOT_BIN="$ROOT_DIR/target/debug/bootroot" \
 "$ROOT_DIR/scripts/impl/run-two-instance-isolation.sh"
 
+# The registrar verbs' write-dependent behaviour lives in ignored library
+# tests; this scenario is their only gate. It stands its own OpenBao up on
+# a free loopback port and needs no compose project, no secrets wiring and
+# no bootroot binaries.
+echo "[ci-local-e2e] run registrar verbs (issue #758)"
+ARTIFACT_DIR="$ROOT_DIR/tmp/e2e/ci-registrar-verbs-${RUN_ID}" \
+"$ROOT_DIR/scripts/impl/run-registrar-verbs-e2e.sh"
+
 echo "[ci-local-e2e] done"
 echo "[ci-local-e2e] artifacts:"
 echo "  - $ROOT_DIR/tmp/e2e/ci-local-no-hosts-${RUN_ID}"
@@ -208,3 +217,4 @@ echo "  - $ROOT_DIR/tmp/e2e/ci-stepca-san-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-openbao-tls-no-delta-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-openbao-tls-reown-${RUN_ID}"
 echo "  - $ROOT_DIR/tmp/e2e/ci-two-instance-${RUN_ID}"
+echo "  - $ROOT_DIR/tmp/e2e/ci-registrar-verbs-${RUN_ID}"

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -24,7 +24,6 @@ use crate::commands::openbao_auth::authenticate_openbao_client;
 use crate::i18n::Messages;
 use crate::state::{DeliveryMode, ServiceEntry, ServiceRoleEntry, StateFile};
 
-pub(super) const SERVICE_ROLE_PREFIX: &str = "bootroot-service-";
 pub(super) const SERVICE_SECRET_DIR: &str = "services";
 pub(super) const SERVICE_ROLE_ID_FILENAME: &str = "role_id";
 pub(super) const SERVICE_SECRET_ID_FILENAME: &str = "secret_id";
@@ -626,7 +625,7 @@ async fn create_artifact_wrap_info(
     let Some(ttl) = wrap_ttl else {
         return Ok(None);
     };
-    let role_name = approle::service_role_name(&resolved.registration_id);
+    let role_name = bootroot::service_material::service_role_name(&resolved.registration_id);
     let secret_id_options = build_secret_id_options(resolved);
     let wrap_info = client
         .create_secret_id_wrap_only(&role_name, &secret_id_options, ttl)
@@ -1232,10 +1231,10 @@ fn build_preview_service_entry(resolved: &ResolvedServiceAdd, state: &StateFile)
     build_service_entry_from_role(
         resolved,
         ServiceRoleEntry {
-            role_name: approle::service_role_name(&resolved.registration_id),
+            role_name: bootroot::service_material::service_role_name(&resolved.registration_id),
             role_id: "dry-run".to_string(),
             secret_id_path: preview_secret_id_path,
-            policy_name: approle::service_policy_name(&resolved.registration_id),
+            policy_name: bootroot::service_material::service_policy_name(&resolved.registration_id),
             secret_id_ttl: resolved.secret_id_ttl.clone(),
             secret_id_wrap_ttl: resolved.secret_id_wrap_ttl.clone(),
             token_bound_cidrs: resolved.token_bound_cidrs.clone(),

--- a/src/commands/service/approle.rs
+++ b/src/commands/service/approle.rs
@@ -3,13 +3,26 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use bootroot::fs_util;
 use bootroot::openbao::{OpenBaoClient, SecretIdOptions};
-use bootroot::trust_bootstrap::SERVICE_REISSUE_KV_SUFFIX;
+use bootroot::service_material::{
+    ProvisionedServiceRole, ServiceProvisionError, ServiceProvisionStep, ServiceRoleTtls,
+    build_service_policy, provision_service_role, service_policy_name,
+};
 
-use super::{SERVICE_ROLE_PREFIX, ServiceAppRoleMaterialized};
-use crate::commands::constants::SERVICE_KV_BASE;
+use super::ServiceAppRoleMaterialized;
 use crate::commands::init::{SECRET_ID_TTL, TOKEN_TTL};
 use crate::i18n::Messages;
 use crate::state::StateFile;
+
+/// Renders the step-specific diagnostic the CLI reported for each of the
+/// three provisioning calls before that sequence was shared with the
+/// registrar.
+fn provision_message(err: &ServiceProvisionError, messages: &Messages) -> &'static str {
+    match err.step {
+        ServiceProvisionStep::Policy => messages.error_openbao_policy_write_failed(),
+        ServiceProvisionStep::AppRole => messages.error_openbao_approle_create_failed(),
+        ServiceProvisionStep::RoleId => messages.error_openbao_role_id_failed(),
+    }
+}
 
 pub(super) async fn ensure_service_approle(
     client: &OpenBaoClient,
@@ -19,28 +32,30 @@ pub(super) async fn ensure_service_approle(
     wrap_ttl: Option<&str>,
     messages: &Messages,
 ) -> Result<ServiceAppRoleMaterialized> {
-    let policy_name = service_policy_name(registration_id);
-    let policy = build_service_policy(&state.kv_mount, registration_id);
-    client
-        .write_policy(&policy_name, &policy)
-        .await
-        .with_context(|| messages.error_openbao_policy_write_failed())?;
-
-    let role_name = service_role_name(registration_id);
-    client
-        .create_approle(
-            &role_name,
-            &[policy_name.as_str()],
-            TOKEN_TTL,
-            SECRET_ID_TTL,
-            true,
-        )
-        .await
-        .with_context(|| messages.error_openbao_approle_create_failed())?;
-    let role_id = client
-        .read_role_id(&role_name)
-        .await
-        .with_context(|| messages.error_openbao_role_id_failed())?;
+    // The CLI keeps its own role-level TTLs: the shared helper declares
+    // none, so `init`'s constants stay this caller's decision.
+    let provisioned = provision_service_role(
+        client,
+        &state.kv_mount,
+        registration_id,
+        ServiceRoleTtls {
+            token_ttl: TOKEN_TTL,
+            secret_id_ttl: SECRET_ID_TTL,
+        },
+    )
+    .await
+    .map_err(|err| {
+        let message = provision_message(&err, messages);
+        anyhow::Error::new(err).context(message)
+    })?;
+    let ProvisionedServiceRole {
+        role_name,
+        policy_name,
+        role_id,
+    } = provisioned;
+    // Issuance stays here, not in the shared helper: `service add`
+    // delivers the raw `secret_id` to a local file, wrapping only as a
+    // transport hop it immediately unwraps.
     let secret_id = match wrap_ttl {
         Some(ttl) => {
             client
@@ -77,37 +92,6 @@ pub(super) async fn reapply_service_policy(
         .await
         .with_context(|| messages.error_openbao_policy_write_failed())?;
     Ok(())
-}
-
-/// Builds the service `AppRole` policy body. Every path is scoped to the
-/// registration's own KV subtree, so two registrations of one component
-/// on one host never see each other's material.
-fn build_service_policy(kv_mount: &str, registration_id: &str) -> String {
-    let base = format!("{SERVICE_KV_BASE}/{registration_id}");
-    // The service subtree is read-only except for its own reissue object: the
-    // fast-poll loop must write `completed_at`/`completed_version` back so the
-    // control plane's `rotate force-reissue --wait` can observe completion.
-    // Narrowly grant create/update on exactly that one path.
-    format!(
-        r#"path "{kv_mount}/data/{base}/{SERVICE_REISSUE_KV_SUFFIX}" {{
-  capabilities = ["read", "create", "update"]
-}}
-path "{kv_mount}/data/{base}/*" {{
-  capabilities = ["read"]
-}}
-path "{kv_mount}/metadata/{base}/*" {{
-  capabilities = ["list"]
-}}
-"#
-    )
-}
-
-pub(super) fn service_role_name(registration_id: &str) -> String {
-    format!("{SERVICE_ROLE_PREFIX}{registration_id}")
-}
-
-pub(super) fn service_policy_name(registration_id: &str) -> String {
-    format!("{SERVICE_ROLE_PREFIX}{registration_id}")
 }
 
 pub(super) async fn write_secret_id_file(
@@ -239,77 +223,5 @@ mod tests {
             format!("{err:#}").contains("Refusing to overwrite"),
             "override role_id write must be no-clobber, got: {err:#}"
         );
-    }
-
-    #[test]
-    fn service_policy_grants_write_only_on_reissue_path() {
-        let policy = build_service_policy("secret", "edge-proxy");
-
-        assert!(
-            policy.contains(
-                "path \"secret/data/bootroot/services/edge-proxy/reissue\" {\n  capabilities = [\"read\", \"create\", \"update\"]"
-            ),
-            "reissue path must carry create/update, got:\n{policy}"
-        );
-        assert!(
-            policy.contains(
-                "path \"secret/data/bootroot/services/edge-proxy/*\" {\n  capabilities = [\"read\"]"
-            ),
-            "rest of data subtree must stay read-only, got:\n{policy}"
-        );
-        assert!(
-            policy.contains(
-                "path \"secret/metadata/bootroot/services/edge-proxy/*\" {\n  capabilities = [\"list\"]"
-            ),
-            "metadata subtree must stay list-only, got:\n{policy}"
-        );
-    }
-
-    /// The policy body is keyed on `registration_id`, so two
-    /// registrations of one component on one host get disjoint KV
-    /// subtrees even though their `service_name` is identical.
-    #[test]
-    fn service_policy_paths_derive_from_registration_id() {
-        let first = build_service_policy("secret", "h1-piglet-001");
-        let second = build_service_policy("secret", "h1-piglet-002");
-
-        assert!(first.contains("secret/data/bootroot/services/h1-piglet-001/"));
-        assert!(second.contains("secret/data/bootroot/services/h1-piglet-002/"));
-        assert!(!first.contains("h1-piglet-002"));
-        assert!(!second.contains("h1-piglet-001"));
-    }
-
-    /// The role and policy names are one and the same derivation off
-    /// `registration_id`, and a one-per-deployment singleton whose key is
-    /// still the bare component name keeps the exact names it had before
-    /// the split.
-    #[test]
-    fn role_and_policy_names_derive_from_registration_id() {
-        assert_eq!(service_role_name("review"), "bootroot-service-review");
-        assert_eq!(service_policy_name("review"), "bootroot-service-review");
-        assert_eq!(
-            service_role_name("h1-piglet-001"),
-            "bootroot-service-h1-piglet-001"
-        );
-        assert_ne!(
-            service_role_name("h1-piglet-001"),
-            service_role_name("h1-piglet-002")
-        );
-    }
-
-    #[test]
-    fn service_policy_grants_no_broader_write_scope() {
-        let policy = build_service_policy("secret", "edge-proxy");
-
-        // Only the reissue rule may carry create/update; no other rule may.
-        for block in policy.split("path ").filter(|b| !b.is_empty()) {
-            let has_write = block.contains("create") || block.contains("update");
-            let is_reissue =
-                block.starts_with("\"secret/data/bootroot/services/edge-proxy/reissue\"");
-            assert!(
-                !has_write || is_reissue,
-                "unexpected write capability outside the reissue path:\n{block}"
-            );
-        }
     }
 }

--- a/src/commands/service/remove.rs
+++ b/src/commands/service/remove.rs
@@ -4,7 +4,13 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use bootroot::fs_util;
 use bootroot::openbao::OpenBaoClient;
-use bootroot::trust_bootstrap::remove_managed_service_profile;
+use bootroot::service_material::{
+    ResourceOutcome, ServiceResource, service_kv_path, teardown_service_material,
+};
+use bootroot::trust_bootstrap::{
+    SERVICE_EAB_KV_SUFFIX, SERVICE_RESPONDER_HMAC_KV_SUFFIX, SERVICE_SECRET_ID_KV_SUFFIX,
+    SERVICE_TRUST_KV_SUFFIX, remove_managed_service_profile,
+};
 
 use super::{
     REMOTE_BOOTSTRAP_DIR, SERVICE_ROLE_ID_FILENAME, SERVICE_SECRET_DIR, service_eab_file_path,
@@ -12,21 +18,10 @@ use super::{
 use crate::cli::args::ServiceRemoveArgs;
 use crate::cli::prompt::Prompt;
 use crate::commands::compose_project::ComposeIdentity;
-use crate::commands::constants::SERVICE_KV_BASE;
 use crate::commands::dns_alias::reconcile_dns_aliases;
 use crate::commands::openbao_auth::{authenticate_openbao_client, resolve_runtime_auth};
-use crate::commands::trust::SERVICE_TRUST_KV_SUFFIX;
 use crate::i18n::Messages;
 use crate::state::{DeliveryMode, ServiceEntry, StateFile};
-
-/// KV path suffix for the per-service EAB material. Mirrors
-/// `write_service_kv_secrets` in `service/secrets.rs`.
-const KV_EAB_SUFFIX: &str = "eab";
-/// KV path suffix for the per-service HTTP-01 responder HMAC.
-const KV_HTTP_RESPONDER_HMAC_SUFFIX: &str = "http_responder_hmac";
-/// KV path suffix for the per-service `secret_id` (written only for
-/// `remote-bootstrap` services by `sync_service_kv_bundle`).
-const KV_SECRET_ID_SUFFIX: &str = "secret_id";
 
 /// On-disk artifacts eligible for deletion under `--delete-artifacts`.
 struct ArtifactPlan {
@@ -61,6 +56,34 @@ impl TeardownReport {
             }
         }
     }
+
+    /// Prints and records one attempt made by the shared `OpenBao`
+    /// teardown, preserving the labels and the retention rule this
+    /// command reported before that sequence was shared.
+    fn record_resource(
+        &mut self,
+        resource: &ServiceResource,
+        outcome: &ResourceOutcome,
+        messages: &Messages,
+    ) {
+        let label = match resource {
+            ServiceResource::Kv(path) => format!("KV {path}"),
+            ServiceResource::AppRole(name) => format!("AppRole {name}"),
+            ServiceResource::Policy(name) => format!("policy {name}"),
+        };
+        match outcome {
+            ResourceOutcome::Removed => {
+                println!("{}", messages.service_remove_resource_removed(&label));
+            }
+            ResourceOutcome::AlreadyAbsent => {
+                println!("{}", messages.service_remove_resource_absent(&label));
+            }
+            ResourceOutcome::Failed(err) => {
+                eprintln!("{}", messages.service_remove_resource_failed(&label, err));
+                self.any_failed = true;
+            }
+        }
+    }
 }
 
 /// Deregisters a service: tears down its `OpenBao` `AppRole`, policy, and
@@ -74,7 +97,11 @@ pub(crate) async fn run_service_remove(
     let mut state = load_state_or_missing(&state_path, messages)?;
     let entry = require_service_entry(&state, &args.registration_id, messages)?;
 
-    let kv_paths = service_kv_paths(&entry);
+    let kv_suffixes = service_kv_suffixes(&entry);
+    let kv_paths: Vec<String> = kv_suffixes
+        .iter()
+        .map(|suffix| service_kv_path(&entry.registration_id, suffix))
+        .collect();
     let artifacts = if args.delete_artifacts {
         Some(build_artifact_plan(&state, &entry))
     } else {
@@ -113,23 +140,24 @@ pub(crate) async fn run_service_remove(
 
     // Remote cleanup FIRST — the AppRole, policy, and KV deletions must
     // all complete before the state.json entry is dropped, so a partial
-    // failure leaves the stored role/policy names available for a re-run.
-    for path in &kv_paths {
-        let result = delete_kv_if_present(&client, &state.kv_mount, path).await;
-        report.record(&format!("KV {path}"), result, messages);
+    // failure leaves the entry available for a re-run.
+    //
+    // The shared teardown derives the role and policy names from the
+    // registration id, which is exactly what `service add` persisted into
+    // `entry.approle`, so the plan printed above names the same two
+    // resources this deletes. It attempts every resource and never
+    // short-circuits; this adapter turns the per-resource outcomes back
+    // into the operator-facing lines this command has always printed.
+    let shared = teardown_service_material(
+        &client,
+        &state.kv_mount,
+        &entry.registration_id,
+        &kv_suffixes,
+    )
+    .await;
+    for attempt in shared.attempts() {
+        report.record_resource(&attempt.resource, &attempt.outcome, messages);
     }
-    let approle_result = delete_approle_if_present(&client, &entry.approle.role_name).await;
-    report.record(
-        &format!("AppRole {}", entry.approle.role_name),
-        approle_result,
-        messages,
-    );
-    let policy_result = delete_policy_if_present(&client, &entry.approle.policy_name).await;
-    report.record(
-        &format!("policy {}", entry.approle.policy_name),
-        policy_result,
-        messages,
-    );
 
     // On-disk artifacts (opt-in). These are local, but a failure here
     // also keeps the entry so a re-run can retry.
@@ -244,18 +272,25 @@ async fn finalize_removal(
         .with_context(|| messages.error_serialize_state_failed())
 }
 
-/// Builds the exact per-registration KV paths written by `service add`.
-fn service_kv_paths(entry: &ServiceEntry) -> Vec<String> {
-    let base = format!("{SERVICE_KV_BASE}/{}", entry.registration_id);
-    let mut paths = vec![
-        format!("{base}/{KV_EAB_SUFFIX}"),
-        format!("{base}/{KV_HTTP_RESPONDER_HMAC_SUFFIX}"),
-        format!("{base}/{SERVICE_TRUST_KV_SUFFIX}"),
+/// Returns the exact per-registration KV suffixes `service add` wrote,
+/// as this command's `state.json` entry records them.
+///
+/// This set is deliberately narrower than the registrar's: it is derived
+/// from what the CLI wrote, and it intentionally omits `reissue`, which
+/// this command has never deleted. Widening it here would change what
+/// `service remove` does to an operator's installation; the registrar's
+/// deregister verb, which owns the identities it minted end to end,
+/// sweeps the full set instead.
+fn service_kv_suffixes(entry: &ServiceEntry) -> Vec<&'static str> {
+    let mut suffixes = vec![
+        SERVICE_EAB_KV_SUFFIX,
+        SERVICE_RESPONDER_HMAC_KV_SUFFIX,
+        SERVICE_TRUST_KV_SUFFIX,
     ];
     if matches!(entry.delivery_mode, DeliveryMode::RemoteBootstrap) {
-        paths.push(format!("{base}/{KV_SECRET_ID_SUFFIX}"));
+        suffixes.push(SERVICE_SECRET_ID_KV_SUFFIX);
     }
-    paths
+    suffixes
 }
 
 fn build_artifact_plan(state: &StateFile, entry: &ServiceEntry) -> ArtifactPlan {
@@ -355,33 +390,6 @@ fn confirm_removal(registration_id: &str, messages: &Messages) -> Result<bool> {
         answer.trim().to_ascii_lowercase().as_str(),
         "y" | "yes"
     ))
-}
-
-async fn delete_kv_if_present(client: &OpenBaoClient, mount: &str, path: &str) -> Result<bool> {
-    if client.kv_exists(mount, path).await? {
-        client.delete_kv(mount, path).await?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
-async fn delete_approle_if_present(client: &OpenBaoClient, role_name: &str) -> Result<bool> {
-    if client.approle_exists(role_name).await? {
-        client.delete_approle(role_name).await?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
-async fn delete_policy_if_present(client: &OpenBaoClient, policy_name: &str) -> Result<bool> {
-    if client.policy_exists(policy_name).await? {
-        client.delete_policy(policy_name).await?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
 }
 
 fn delete_dir_if_present(path: &Path) -> Result<bool> {
@@ -654,12 +662,18 @@ mod tests {
         assert!(!plan.dirs.contains(&agent_dir));
     }
 
+    fn kv_paths_for(entry: &ServiceEntry) -> Vec<String> {
+        service_kv_suffixes(entry)
+            .iter()
+            .map(|suffix| service_kv_path(&entry.registration_id, suffix))
+            .collect()
+    }
+
     #[test]
     fn service_kv_paths_local_file_omits_secret_id() {
         let entry = sample_entry("svc", DeliveryMode::LocalFile);
-        let paths = service_kv_paths(&entry);
         assert_eq!(
-            paths,
+            kv_paths_for(&entry),
             vec![
                 "bootroot/services/svc/eab".to_string(),
                 "bootroot/services/svc/http_responder_hmac".to_string(),
@@ -671,9 +685,22 @@ mod tests {
     #[test]
     fn service_kv_paths_remote_bootstrap_includes_secret_id() {
         let entry = sample_entry("svc", DeliveryMode::RemoteBootstrap);
-        let paths = service_kv_paths(&entry);
+        let paths = kv_paths_for(&entry);
         assert!(paths.contains(&"bootroot/services/svc/secret_id".to_string()));
         assert_eq!(paths.len(), 4);
+    }
+
+    /// The CLI's set intentionally continues not to delete `reissue`:
+    /// widening it here would change what `service remove` does to an
+    /// operator's installation.
+    #[test]
+    fn service_kv_suffixes_intentionally_exclude_reissue_and_the_binding() {
+        for mode in [DeliveryMode::LocalFile, DeliveryMode::RemoteBootstrap] {
+            let entry = sample_entry("svc", mode);
+            let suffixes = service_kv_suffixes(&entry);
+            assert!(!suffixes.contains(&bootroot::trust_bootstrap::SERVICE_REISSUE_KV_SUFFIX));
+            assert!(!suffixes.contains(&"registrar_binding"));
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod locale;
 pub mod openbao;
 pub mod profile;
 pub mod registrar;
+pub mod service_material;
 pub mod tls;
 pub mod toml_util;
 pub mod trust_bootstrap;

--- a/src/openbao.rs
+++ b/src/openbao.rs
@@ -8,6 +8,13 @@ use serde::{Deserialize, Serialize};
 const VAULT_TOKEN_HEADER: &str = "X-Vault-Token";
 const VAULT_WRAP_TTL_HEADER: &str = "X-Vault-Wrap-TTL";
 const ROOT_POLICY: &str = "root";
+/// The KV v2 `cas` value that admits a write only when the path carries
+/// no version yet.
+const KV_CREATE_IF_ABSENT_CAS: u64 = 0;
+/// The exact substring `OpenBao` puts in the 400 body when a
+/// check-and-set write loses. Matching it — rather than the bare status
+/// — is what keeps an unrelated 400 an error.
+const KV_CAS_MISMATCH_MESSAGE: &str = "check-and-set parameter did not match the current version";
 
 #[derive(Debug, Clone)]
 pub struct OpenBaoClient {
@@ -150,6 +157,25 @@ pub struct RootRotationUpdateResponse {
 #[derive(Debug, Deserialize)]
 struct DataEnvelope<T> {
     data: T,
+}
+
+/// Outcome of an absent-only KV v2 create
+/// ([`OpenBaoClient::create_kv_if_absent`]).
+///
+/// The two arms are the whole result surface: either this call created
+/// the path's first version, or some other writer had already created
+/// one. Everything else — transport, protocol, a 400 that is not the
+/// documented CAS mismatch — stays an `anyhow` error, so a caller that
+/// treats `AlreadyExists` as "another writer won the race" can never
+/// reach that arm through a misconfigured mount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvCreateIfAbsent {
+    /// This call wrote the path's first version. Carries the version the
+    /// write produced, or `None` when the response body did not report
+    /// one (older `OpenBao`, or a proxy that stripped it).
+    Created(Option<u64>),
+    /// The path already carried a version, so nothing was written.
+    AlreadyExists,
 }
 
 /// Versioned KV v2 read result.
@@ -852,6 +878,80 @@ impl OpenBaoClient {
         Ok(parsed.data.version)
     }
 
+    /// Creates a KV v2 secret **only if the path carries no version
+    /// yet**, using the KV v2 check-and-set option `cas: 0`.
+    ///
+    /// This is the cross-process claim primitive: two writers racing to
+    /// create the same path both send `{"options":{"cas":0}}`, `OpenBao`
+    /// admits exactly one, and the loser is told so rather than
+    /// overwriting. An in-process mutex cannot provide that guarantee,
+    /// because another process — another registrar instance, an
+    /// operator's CLI — can write the same namespace.
+    ///
+    /// Only the documented CAS-mismatch 400 response is reported as
+    /// [`KvCreateIfAbsent::AlreadyExists`]. Every other 400, and every
+    /// transport, protocol or parse failure, stays an error: a
+    /// misconfigured mount and a lost race must not look alike to a
+    /// caller that treats one of them as "somebody else won".
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails, if the response is not the
+    /// documented CAS-mismatch body for a 400, or if a successful
+    /// response body is not valid JSON.
+    pub async fn create_kv_if_absent(
+        &self,
+        mount: &str,
+        path: &str,
+        data: serde_json::Value,
+    ) -> Result<KvCreateIfAbsent> {
+        #[derive(Serialize)]
+        struct KvCasRequest {
+            options: KvCasOptions,
+            data: serde_json::Value,
+        }
+        #[derive(Serialize)]
+        struct KvCasOptions {
+            cas: u64,
+        }
+        #[derive(Deserialize)]
+        struct KvWriteResponse {
+            data: KvWriteResponseData,
+        }
+        #[derive(Deserialize)]
+        struct KvWriteResponseData {
+            #[serde(default)]
+            version: Option<u64>,
+        }
+        let full_path = format!("{mount}/data/{path}");
+        let body = KvCasRequest {
+            options: KvCasOptions {
+                cas: KV_CREATE_IF_ABSENT_CAS,
+            },
+            data,
+        };
+        let response = self
+            .send_authed_json(Method::POST, &full_path, &body, None)
+            .await?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .context("Failed to read OpenBao response body")?;
+        if status == StatusCode::BAD_REQUEST && text.contains(KV_CAS_MISMATCH_MESSAGE) {
+            return Ok(KvCreateIfAbsent::AlreadyExists);
+        }
+        if !status.is_success() {
+            anyhow::bail!("OpenBao API error ({status}): {text}");
+        }
+        if text.trim().is_empty() {
+            return Ok(KvCreateIfAbsent::Created(None));
+        }
+        let parsed: KvWriteResponse = serde_json::from_str(&text)
+            .context("Failed to parse OpenBao KV create-if-absent response")?;
+        Ok(KvCreateIfAbsent::Created(parsed.data.version))
+    }
+
     /// Reads a KV v2 secret.
     ///
     /// # Errors
@@ -1409,6 +1509,127 @@ mod wrap_tests {
             .await
             .expect("create_secret_id_wrapped should succeed");
         assert_eq!(secret_id, "unwrapped-secret-abc");
+    }
+}
+
+/// Canned-response coverage for the absent-only KV v2 create. Wiremock
+/// keeps no `OpenBao` state here — each mock returns one fixed body, so
+/// what is under test is the request envelope and the classification of
+/// the reply, never a simulated CAS engine.
+#[cfg(test)]
+mod create_if_absent_tests {
+    use serde_json::json;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn client_with_token(server: &MockServer) -> OpenBaoClient {
+        let mut client = OpenBaoClient::new(&server.uri()).expect("client init");
+        client.set_token("root-token".to_string());
+        client
+    }
+
+    #[tokio::test]
+    async fn create_if_absent_sends_cas_zero_envelope_and_reports_the_version() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path(
+                "/v1/secret/data/bootroot/services/h1-piglet-001/registrar_binding",
+            ))
+            .and(header("X-Vault-Token", "root-token"))
+            .and(body_json(json!({
+                "options": { "cas": 0 },
+                "data": { "host": "h1" }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "version": 1 }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_with_token(&server);
+        let outcome = client
+            .create_kv_if_absent(
+                "secret",
+                "bootroot/services/h1-piglet-001/registrar_binding",
+                json!({ "host": "h1" }),
+            )
+            .await
+            .expect("an absent-only create should succeed");
+        assert_eq!(outcome, KvCreateIfAbsent::Created(Some(1)));
+    }
+
+    /// A success whose body carries no `data.version` is still a
+    /// creation; the version is simply unknown.
+    #[tokio::test]
+    async fn create_if_absent_reports_created_without_a_version() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/secret/data/claim"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_with_token(&server);
+        let outcome = client
+            .create_kv_if_absent("secret", "claim", json!({}))
+            .await
+            .expect("an empty success body should still be a creation");
+        assert_eq!(outcome, KvCreateIfAbsent::Created(None));
+    }
+
+    #[tokio::test]
+    async fn create_if_absent_classifies_the_exact_cas_mismatch_as_already_exists() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/secret/data/claim"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "errors": ["check-and-set parameter did not match the current version"]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_with_token(&server);
+        let outcome = client
+            .create_kv_if_absent("secret", "claim", json!({ "host": "h1" }))
+            .await
+            .expect("a CAS mismatch is a result, not an error");
+        assert_eq!(outcome, KvCreateIfAbsent::AlreadyExists);
+    }
+
+    /// Every other 400 stays an error. A mount that is not KV v2 answers
+    /// 400 too, and reading that as "another writer won" would hand a
+    /// caller a claim it never made.
+    #[tokio::test]
+    async fn create_if_absent_preserves_a_different_bad_request_as_an_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/secret/data/claim"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "errors": ["check-and-set parameter required for this call"]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_with_token(&server);
+        let err = client
+            .create_kv_if_absent("secret", "claim", json!({}))
+            .await
+            .expect_err("a non-CAS 400 must not be swallowed");
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("check-and-set parameter required"),
+            "the underlying 400 must survive, got: {rendered}"
+        );
     }
 }
 

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -16,6 +16,14 @@
 //! - [`error`] declares every refusal the two produce.
 //! - [`fixture`] builds a rendered config for tests.
 //!
+//! The crate-private `verbs` sibling is the layer above: the
+//! transport-free mint and deregister control plane that calls those
+//! steps in the one order they are correct in, interleaving its own
+//! durable-binding checks between them. It is deliberately not part of
+//! the library's public surface — the endpoint that drives it lives in
+//! this crate — so no consumer can reach a verb without going through
+//! the endpoint's authentication.
+//!
 //! Nothing here reads or requires registration state. That is what makes
 //! the durable-binding collision check the caller's step rather than a
 //! missing one here, and it is why no variant in [`error`] refers to a
@@ -49,6 +57,7 @@ pub mod endpoint_pin;
 pub mod error;
 pub mod fixture;
 pub mod identity;
+pub(crate) mod verbs;
 
 #[cfg(test)]
 mod tests;

--- a/src/registrar/verbs.rs
+++ b/src/registrar/verbs.rs
@@ -1,0 +1,989 @@
+//! The registrar's two restricted verbs: mint an identity, and
+//! deregister one.
+//!
+//! This is a **transport-free** control plane. There is no socket, no
+//! codec, no peer authentication and no serialization here — the
+//! endpoint owns all of that. What is here is the decision procedure,
+//! expressed over in-process types, so it can be tested without a
+//! transport and so the transport cannot quietly acquire a decision of
+//! its own.
+//!
+//! # What a caller may and may not influence
+//!
+//! A request carries an opaque caller identity and the identity's
+//! **parts**: `service_name`, `host`, an optional numeric `instance`,
+//! and — for a mint — the requested spec and a requested `wrap_ttl`. It
+//! carries no composed name, no `registration_id`, no domain, no policy
+//! body, no role definition, no policy list and no credential. The
+//! privileged `OpenBao` client, the KV mount, the loaded config, the
+//! fixed [`SecretIdOptions`], the role-level TTLs and the bounded
+//! wrap-TTL policy are **construction** dependencies, so no request can
+//! select any of them.
+//!
+//! The caller identity is carried into every outcome unchanged and is
+//! used for nothing else: it is never parsed, never authenticated, never
+//! used to pick a client, and no part of the derived identity comes from
+//! it.
+//!
+//! # The fixed order
+//!
+//! Both verbs run the same three stages, and the order is a correctness
+//! requirement rather than a preference:
+//!
+//! 1. **Pre-derivation**, under a process-wide [`tokio::sync::Mutex`]
+//!    released before any `.await`: validate the two labels, refuse a
+//!    reserved `service_name`, resolve the component's multiplicity from
+//!    the rendered config, and check the instance shape. Mint also checks
+//!    the spec's identity restatement here. Every refusal on this arm
+//!    carries **no** `registration_id`, because none has been computed.
+//! 2. **Derivation** of the `registration_id` and the SAN. Fallible even
+//!    after the labels validated — the ≤131-octet bound is enforced on
+//!    the derived string — and a derivation failure takes no per-id lock
+//!    and performs no `OpenBao` or binding operation at all.
+//! 3. **Per-id work**, under the `registration_id`'s own
+//!    [`tokio::sync::Mutex`], shared by both verbs so a mint and a
+//!    deregister for one identity can never interleave.
+//!
+//! Inside stage 3 the binding is consulted **before** the safe-set:
+//! a different stored host is a collision, a same-host different spec is
+//! a conflict, and only after both does the requested spec get compared
+//! against the rendered safe-set. The rendered spec is host-agnostic, so
+//! a safe-set-first flow would match for a second host and re-wrap the
+//! first host's identity for it.
+//!
+//! # Why compare-and-set, and why the claim is never rolled back
+//!
+//! The per-id mutex is a *process* lock. Another process — a second
+//! registrar, an operator's CLI — can write the same `OpenBao` namespace,
+//! so a new binding is claimed with the absent-only
+//! [`OpenBaoClient::create_kv_if_absent`] and the loser is told so rather
+//! than overwriting. Once that claim wins, it is **retained** through any
+//! subsequent failure: a `creating` binding whose convergence died is
+//! what keeps whatever role or policy did get created covered by a
+//! durable claim. Rolling it back would manufacture exactly the unbound
+//! orphan the binding exists to prevent. The matching host recovers
+//! through a mint re-drive or through deregister; every other host stays
+//! refused.
+//!
+//! # The accepted hazard
+//!
+//! A deregister with **no** binding still sweeps the full service-material
+//! set and reports already-absent. That is deliberate — it is how an
+//! identity whose binding was lost gets cleaned up — and it means a
+//! manually deleted binding, or an identity created through the direct
+//! CLI, can leave live material sweepable by a registrar deregister for
+//! the same derived id. The alternative is an intent marker or a second
+//! state store, and both were rejected: a second store has the same
+//! divergence problem one layer up. The hazard is documented rather than
+//! masked.
+
+// The endpoint that drives these verbs is separate work — this issue is
+// deliberately transport-free — so no production code path reaches them
+// yet and every item here would be reported dead. The alternatives are
+// worse: publishing the module would put a privileged control plane on
+// the library's public surface, and sprinkling per-item allows would
+// have to be undone item by item when the endpoint lands.
+#![allow(dead_code)]
+
+pub(crate) mod binding;
+pub(crate) mod outcome;
+pub(crate) mod wrap_ttl;
+
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, PoisonError, Weak};
+
+use anyhow::Context as _;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use tokio::sync::{Mutex as TokioMutex, OwnedMutexGuard};
+
+use self::binding::{BindingRecord, BindingSpec, BindingState, REGISTRAR_BINDING_KV_SUFFIX};
+use self::outcome::{
+    CallerIdentity, DeregisterKind, DeregisterOutcome, DeregisterResult, MintKind, MintOutcome,
+    MintResult, ProducingArm, RequestId, VerbContext, VerbError, VerbRefusal, WrappedSecretIdToken,
+};
+use self::wrap_ttl::{GrantedWrapTtl, WrapTtlPolicy};
+use crate::openbao::{KvCreateIfAbsent, OpenBaoClient, SecretIdOptions, WrapInfo};
+use crate::registrar::config::{Multiplicity, RegistrarConfig};
+use crate::registrar::identity::{RequestedSpec, check_instance_shape, derive_registration_id};
+use crate::registrar::{check_spec_identity, is_reserved_service_name, validate_request_labels};
+use crate::service_material::{
+    ProvisionedServiceRole, ServiceRoleTtls, provision_service_role, service_kv_path,
+    service_role_name, teardown_service_material,
+};
+use crate::trust_bootstrap::{
+    SERVICE_EAB_KV_SUFFIX, SERVICE_REISSUE_KV_SUFFIX, SERVICE_RESPONDER_HMAC_KV_SUFFIX,
+    SERVICE_SECRET_ID_KV_SUFFIX, SERVICE_TRUST_KV_SUFFIX,
+};
+
+/// Every service-material suffix a registrar-managed identity owns.
+///
+/// The registrar always sweeps all five, `reissue` included. The CLI's
+/// `service remove` intentionally keeps its narrower state-derived set
+/// and continues not to delete `reissue`, which leaves its reissue
+/// inheritance hazard in place for CLI-managed identities; removing it
+/// here is what keeps that hazard off registrar-managed ones.
+///
+/// The registrar binding is **not** in this set. It outlives the material
+/// and is deleted separately, only after this sweep reports aggregate
+/// success.
+pub(crate) const REGISTRAR_TEARDOWN_KV_SUFFIXES: [&str; 5] = [
+    SERVICE_EAB_KV_SUFFIX,
+    SERVICE_RESPONDER_HMAC_KV_SUFFIX,
+    SERVICE_TRUST_KV_SUFFIX,
+    SERVICE_SECRET_ID_KV_SUFFIX,
+    SERVICE_REISSUE_KV_SUFFIX,
+];
+
+/// How many times a mint re-reads the binding after losing the
+/// compare-and-set race before giving up as unavailable.
+///
+/// Losing the race means somebody else wrote the binding, so the re-read
+/// finds one and the loop ends. A second lost race can only mean that
+/// binding was deleted between the read and the claim, which is a
+/// deregister racing this mint from another process; a bound retry keeps
+/// a pathological pair of processes from spinning here forever.
+const MAX_CLAIM_ATTEMPTS: usize = 3;
+
+/// The fixed dependencies a [`RegistrarVerbs`] is constructed with.
+///
+/// Every one of these is chosen once, by whatever provisions the
+/// registrar, and none of them is reachable from a request.
+pub(crate) struct RegistrarVerbsConfig {
+    /// A privileged `OpenBao` client. Its provisioning and renewal are
+    /// somebody else's problem; this module only uses it.
+    pub(crate) client: OpenBaoClient,
+    /// The KV v2 mount every path is written under.
+    pub(crate) kv_mount: String,
+    /// The loaded, digest-verified registrar config.
+    pub(crate) config: RegistrarConfig,
+    /// The fixed per-issuance `secret_id` options. No request selects
+    /// TTL, use count, metadata or token-bound CIDRs.
+    pub(crate) secret_id_options: SecretIdOptions,
+    /// Role-level `token_ttl`.
+    pub(crate) token_ttl: String,
+    /// Role-level `secret_id_ttl`.
+    pub(crate) secret_id_ttl: String,
+    /// The bounded wrap-TTL policy: the maximum, and the rules a
+    /// requested value is validated under.
+    pub(crate) wrap_ttl_policy: WrapTtlPolicy,
+}
+
+/// A mint request: an opaque caller plus the identity's parts.
+#[derive(Debug, Clone)]
+pub(crate) struct MintRequest {
+    /// Carried into the outcome unchanged; used for nothing else.
+    pub(crate) caller: CallerIdentity,
+    /// The component's plain keyword, a single DNS label.
+    pub(crate) service_name: String,
+    /// The target host's single DNS label.
+    pub(crate) host: String,
+    /// The instance number, present exactly for a many-per-host
+    /// component.
+    pub(crate) instance: Option<u32>,
+    /// The requested registration spec.
+    pub(crate) spec: RequestedSpec,
+    /// The *requested* wrapped-material lifetime. The registrar clamps
+    /// it to its own maximum and the granted deadline is computed, never
+    /// echoed.
+    pub(crate) wrap_ttl: time::Duration,
+}
+
+/// A deregister request: an opaque caller plus the identity's parts.
+#[derive(Debug, Clone)]
+pub(crate) struct DeregisterRequest {
+    /// Carried into the outcome unchanged; used for nothing else.
+    pub(crate) caller: CallerIdentity,
+    /// The component's plain keyword, a single DNS label.
+    pub(crate) service_name: String,
+    /// The host the caller claims the identity is bound to.
+    pub(crate) host: String,
+    /// The instance number, present exactly for a many-per-host
+    /// component.
+    pub(crate) instance: Option<u32>,
+}
+
+/// The registrar's restricted verb service.
+pub(crate) struct RegistrarVerbs {
+    client: OpenBaoClient,
+    kv_mount: String,
+    config: RegistrarConfig,
+    secret_id_options: SecretIdOptions,
+    token_ttl: String,
+    secret_id_ttl: String,
+    wrap_ttl_policy: WrapTtlPolicy,
+    /// Serializes the pre-derivation stage of every invocation. Held
+    /// across no `.await`.
+    entry_lock: TokioMutex<()>,
+    /// The per-`registration_id` locks.
+    id_locks: IdLocks,
+}
+
+impl RegistrarVerbs {
+    /// Creates the verb service from its fixed dependencies.
+    pub(crate) fn new(config: RegistrarVerbsConfig) -> Self {
+        Self {
+            client: config.client,
+            kv_mount: config.kv_mount,
+            config: config.config,
+            secret_id_options: config.secret_id_options,
+            token_ttl: config.token_ttl,
+            secret_id_ttl: config.secret_id_ttl,
+            wrap_ttl_policy: config.wrap_ttl_policy,
+            entry_lock: TokioMutex::new(()),
+            id_locks: IdLocks::default(),
+        }
+    }
+
+    /// Mints — or idempotently re-mints — one service identity and
+    /// returns fresh wrap-only material for it.
+    pub(crate) async fn mint(&self, request: &MintRequest) -> MintResult {
+        let request_id = RequestId::generate();
+        let caller = request.caller.clone();
+        let refuse = |arm: ProducingArm, registration_id: Option<String>, error: VerbError| {
+            VerbRefusal::new(
+                VerbContext::new(request_id.clone(), caller.clone(), registration_id, arm),
+                error,
+            )
+        };
+
+        // Stage 1. No `.await` inside the guard's scope.
+        let multiplicity = {
+            let _entry = self.entry_lock.lock().await;
+            self.pre_derivation(
+                &request.service_name,
+                &request.host,
+                request.instance,
+                Some(&request.spec),
+            )
+        }
+        .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
+
+        // Still stage 1: the wrap TTL is a purely local property of the
+        // request, checked under the construction-supplied policy well
+        // before any OpenBao call, so an unusable request never creates
+        // material that would then have to be revoked.
+        let granted = self
+            .wrap_ttl_policy
+            .grant(request.wrap_ttl)
+            .map_err(|err| {
+                refuse(
+                    ProducingArm::PreDerivation,
+                    None,
+                    VerbError::InvalidWrapTtl(err),
+                )
+            })?;
+
+        // Stage 2. Derivation is fallible even after the labels
+        // validated, and a failure here takes no per-id lock.
+        let registration_id = derive_registration_id(
+            multiplicity,
+            &request.service_name,
+            &request.host,
+            request.instance,
+        )
+        .map_err(|err| refuse(ProducingArm::Derivation, None, VerbError::Registrar(err)))?;
+        let san = self
+            .config
+            .san_for(request.instance, &request.service_name, &request.host);
+
+        // Stage 3.
+        let _id_guard = self.id_locks.acquire(&registration_id).await;
+        self.mint_locked(request, &request_id, &registration_id, &san, &granted)
+            .await
+    }
+
+    /// Tears one service identity down and removes its durable binding.
+    pub(crate) async fn deregister(&self, request: &DeregisterRequest) -> DeregisterResult {
+        let request_id = RequestId::generate();
+        let caller = request.caller.clone();
+        let refuse = |arm: ProducingArm, registration_id: Option<String>, error: VerbError| {
+            VerbRefusal::new(
+                VerbContext::new(request_id.clone(), caller.clone(), registration_id, arm),
+                error,
+            )
+        };
+
+        let multiplicity = {
+            let _entry = self.entry_lock.lock().await;
+            self.pre_derivation(&request.service_name, &request.host, request.instance, None)
+        }
+        .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
+
+        let registration_id = derive_registration_id(
+            multiplicity,
+            &request.service_name,
+            &request.host,
+            request.instance,
+        )
+        .map_err(|err| refuse(ProducingArm::Derivation, None, VerbError::Registrar(err)))?;
+
+        let _id_guard = self.id_locks.acquire(&registration_id).await;
+        self.deregister_locked(request, &request_id, &registration_id)
+            .await
+    }
+
+    /// Stage 1, shared by both verbs. Entirely synchronous, so the
+    /// process-wide guard around it is never held across an `.await`.
+    ///
+    /// `spec` is `Some` only for a mint: the spec's identity restatement
+    /// is a mint-only pre-derivation refusal, because a deregister
+    /// carries no spec to restate anything with.
+    fn pre_derivation(
+        &self,
+        service_name: &str,
+        host: &str,
+        instance: Option<u32>,
+        spec: Option<&RequestedSpec>,
+    ) -> Result<Multiplicity, VerbError> {
+        validate_request_labels(service_name, host)?;
+        // Before the component lookup, so no operator configuration can
+        // make ordinary issuance mint a registrar identity by declaring
+        // a component under the reserved prefix.
+        if is_reserved_service_name(service_name) {
+            return Err(VerbError::ReservedServiceName {
+                service_name: service_name.to_string(),
+            });
+        }
+        if let Some(spec) = spec {
+            check_spec_identity(service_name, spec)?;
+        }
+        let multiplicity = self.config.multiplicity(service_name)?;
+        check_instance_shape(service_name, multiplicity, instance)?;
+        Ok(multiplicity)
+    }
+
+    async fn mint_locked(
+        &self,
+        request: &MintRequest,
+        request_id: &RequestId,
+        registration_id: &str,
+        san: &str,
+        granted: &GrantedWrapTtl,
+    ) -> MintResult {
+        let refuse = |arm: ProducingArm, error: VerbError| {
+            VerbRefusal::new(
+                VerbContext::new(
+                    request_id.clone(),
+                    request.caller.clone(),
+                    Some(registration_id.to_string()),
+                    arm,
+                ),
+                error,
+            )
+        };
+
+        for _ in 0..MAX_CLAIM_ATTEMPTS {
+            let existing = self
+                .read_binding(registration_id)
+                .await
+                .map_err(|err| refuse(ProducingArm::Binding, err))?;
+
+            let Some(record) = existing else {
+                match self
+                    .claim_and_mint(request, request_id, registration_id, san, granted)
+                    .await?
+                {
+                    Some(outcome) => return Ok(outcome),
+                    // Another writer won the claim. Re-read and repeat
+                    // the same host-first order against whatever it
+                    // wrote.
+                    None => continue,
+                }
+            };
+
+            return self
+                .mint_against_binding(request, request_id, registration_id, san, granted, &record)
+                .await;
+        }
+
+        Err(refuse(
+            ProducingArm::Binding,
+            VerbError::unavailable(
+                "claiming the durable binding",
+                anyhow::anyhow!(
+                    "the binding for {registration_id} was created and removed by another writer \
+                     on every attempt"
+                ),
+            ),
+        ))
+    }
+
+    /// The no-binding arm: validate the safe-set, claim the binding with
+    /// the absent-only compare-and-set, then converge and issue.
+    ///
+    /// Returns `Ok(None)` when the claim lost the race, which is the
+    /// caller's signal to re-read and start the host-first order over.
+    async fn claim_and_mint(
+        &self,
+        request: &MintRequest,
+        request_id: &RequestId,
+        registration_id: &str,
+        san: &str,
+        granted: &GrantedWrapTtl,
+    ) -> Result<Option<MintOutcome>, VerbRefusal> {
+        let refuse = |arm: ProducingArm, error: VerbError| {
+            VerbRefusal::new(
+                VerbContext::new(
+                    request_id.clone(),
+                    request.caller.clone(),
+                    Some(registration_id.to_string()),
+                    arm,
+                ),
+                error,
+            )
+        };
+
+        // The safe-set is checked before anything is claimed, so a
+        // request outside it writes nothing at all.
+        self.config
+            .validate_spec(&request.service_name, &request.spec)
+            .map_err(|err| refuse(ProducingArm::SafeSet, VerbError::Registrar(err)))?;
+
+        let claim = BindingRecord::creating(&request.host, &request.spec);
+        let claimed = self
+            .claim_binding(registration_id, &claim)
+            .await
+            .map_err(|err| refuse(ProducingArm::Binding, err))?;
+        if claimed == KvCreateIfAbsent::AlreadyExists {
+            return Ok(None);
+        }
+        self.converge_and_issue(
+            request,
+            request_id,
+            registration_id,
+            san,
+            granted,
+            &claim,
+            MintKind::FirstMint,
+        )
+        .await
+        .map(Some)
+    }
+
+    /// The existing-binding arm, in its required order: host, then the
+    /// stored spec, then the rendered safe-set.
+    async fn mint_against_binding(
+        &self,
+        request: &MintRequest,
+        request_id: &RequestId,
+        registration_id: &str,
+        san: &str,
+        granted: &GrantedWrapTtl,
+        record: &BindingRecord,
+    ) -> MintResult {
+        let refuse = |arm: ProducingArm, error: VerbError| {
+            VerbRefusal::new(
+                VerbContext::new(
+                    request_id.clone(),
+                    request.caller.clone(),
+                    Some(registration_id.to_string()),
+                    arm,
+                ),
+                error,
+            )
+        };
+
+        // Host first, always. The rendered spec is host-agnostic, so a
+        // spec comparison here would match for the wrong host and re-wrap
+        // the bound host's identity for the requesting one.
+        if record.host != request.host {
+            return Err(refuse(
+                ProducingArm::Binding,
+                VerbError::RegistrationIdCollision {
+                    registration_id: registration_id.to_string(),
+                    stored_host: record.host.clone(),
+                    requested_host: request.host.clone(),
+                },
+            ));
+        }
+
+        let requested_spec = BindingSpec::from_requested(&request.spec);
+        // An active binding is compared against what it applied; a
+        // `creating` one against what its claim requested. A `creating`
+        // record carrying no requested spec — which this build never
+        // writes — has nothing to disagree with, so the re-drive
+        // proceeds and the activation records the request's spec.
+        let stored = match record.state {
+            BindingState::Active => {
+                let Some(applied) = record.applied_spec.as_ref() else {
+                    return Err(refuse(
+                        ProducingArm::Binding,
+                        VerbError::unavailable(
+                            "reading an active binding",
+                            anyhow::anyhow!(
+                                "active binding for {registration_id} carries no applied_spec"
+                            ),
+                        ),
+                    ));
+                };
+                Some(applied)
+            }
+            BindingState::Creating => record.requested_spec.as_ref(),
+        };
+        if stored.is_some_and(|stored| *stored != requested_spec) {
+            return Err(refuse(
+                ProducingArm::Binding,
+                VerbError::StoredSpecConflict {
+                    registration_id: registration_id.to_string(),
+                },
+            ));
+        }
+
+        // Only after both binding checks.
+        self.config
+            .validate_spec(&request.service_name, &request.spec)
+            .map_err(|err| refuse(ProducingArm::SafeSet, VerbError::Registrar(err)))?;
+
+        match record.state {
+            BindingState::Active => {
+                // The role and policy are reused untouched; only the
+                // credential is fresh.
+                let role_name = service_role_name(registration_id);
+                let role_id = self
+                    .client
+                    .read_role_id(&role_name)
+                    .await
+                    .with_context(|| format!("reading role_id for {role_name}"))
+                    .map_err(|err| {
+                        refuse(
+                            ProducingArm::Issuance,
+                            VerbError::unavailable("reusing the derived role", err),
+                        )
+                    })?;
+                self.issue(
+                    request,
+                    request_id,
+                    registration_id,
+                    san,
+                    granted,
+                    &role_name,
+                    role_id,
+                    MintKind::IdempotentReMint,
+                )
+                .await
+            }
+            // A claim whose convergence failed or was interrupted. The
+            // matching host re-drives exactly the path the claimant
+            // would have taken.
+            BindingState::Creating => {
+                self.converge_and_issue(
+                    request,
+                    request_id,
+                    registration_id,
+                    san,
+                    granted,
+                    record,
+                    MintKind::FirstMint,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Converges role and policy, flips the binding to active, and only
+    /// then issues.
+    ///
+    /// Every failure in here leaves the `creating` binding exactly where
+    /// it is. That is the point: whatever half of the role material got
+    /// created stays covered by a durable claim, and the matching host
+    /// recovers through a re-drive of this same path or through
+    /// deregister's teardown-before-unbind sequence.
+    #[allow(clippy::too_many_arguments)]
+    async fn converge_and_issue(
+        &self,
+        request: &MintRequest,
+        request_id: &RequestId,
+        registration_id: &str,
+        san: &str,
+        granted: &GrantedWrapTtl,
+        claim: &BindingRecord,
+        kind: MintKind,
+    ) -> MintResult {
+        let refuse = |arm: ProducingArm, error: VerbError| {
+            VerbRefusal::new(
+                VerbContext::new(
+                    request_id.clone(),
+                    request.caller.clone(),
+                    Some(registration_id.to_string()),
+                    arm,
+                ),
+                error,
+            )
+        };
+
+        let ProvisionedServiceRole {
+            role_name, role_id, ..
+        } = provision_service_role(
+            &self.client,
+            &self.kv_mount,
+            registration_id,
+            ServiceRoleTtls {
+                token_ttl: &self.token_ttl,
+                secret_id_ttl: &self.secret_id_ttl,
+            },
+        )
+        .await
+        .map_err(|err| {
+            refuse(
+                ProducingArm::Provisioning,
+                VerbError::unavailable("converging the derived role and policy", err.into()),
+            )
+        })?;
+
+        let active = claim.activated(&request.spec);
+        self.write_binding(registration_id, &active)
+            .await
+            .map_err(|err| refuse(ProducingArm::Binding, err))?;
+
+        self.issue(
+            request,
+            request_id,
+            registration_id,
+            san,
+            granted,
+            &role_name,
+            role_id,
+            kind,
+        )
+        .await
+    }
+
+    /// Issues wrap-only material and computes the granted deadline.
+    ///
+    /// `create_secret_id_wrap_only`, never `create_secret_id_wrapped`:
+    /// the latter unwraps immediately and hands back the raw
+    /// `secret_id`, which is exactly the value no registrar path may
+    /// hold.
+    #[allow(clippy::too_many_arguments)]
+    async fn issue(
+        &self,
+        request: &MintRequest,
+        request_id: &RequestId,
+        registration_id: &str,
+        san: &str,
+        granted: &GrantedWrapTtl,
+        role_name: &str,
+        role_id: String,
+        kind: MintKind,
+    ) -> MintResult {
+        let refuse = |error: VerbError| {
+            VerbRefusal::new(
+                VerbContext::new(
+                    request_id.clone(),
+                    request.caller.clone(),
+                    Some(registration_id.to_string()),
+                    ProducingArm::Issuance,
+                ),
+                error,
+            )
+        };
+
+        let wrap_info = self
+            .client
+            .create_secret_id_wrap_only(
+                role_name,
+                &self.secret_id_options,
+                granted.as_openbao_str(),
+            )
+            .await
+            .with_context(|| format!("issuing wrap-only material for {role_name}"))
+            .map_err(|err| refuse(VerbError::unavailable("issuing wrapped material", err)))?;
+
+        let expires_at = granted_deadline(&wrap_info).map_err(|err| {
+            refuse(VerbError::unavailable(
+                "reading the wrap token's expiry",
+                err,
+            ))
+        })?;
+
+        Ok(MintOutcome::new(
+            VerbContext::new(
+                request_id.clone(),
+                request.caller.clone(),
+                Some(registration_id.to_string()),
+                ProducingArm::Issuance,
+            ),
+            kind,
+            san.to_string(),
+            role_id,
+            WrappedSecretIdToken::new(wrap_info.token),
+            expires_at,
+        ))
+    }
+
+    async fn deregister_locked(
+        &self,
+        request: &DeregisterRequest,
+        request_id: &RequestId,
+        registration_id: &str,
+    ) -> DeregisterResult {
+        let context = |arm: ProducingArm| {
+            VerbContext::new(
+                request_id.clone(),
+                request.caller.clone(),
+                Some(registration_id.to_string()),
+                arm,
+            )
+        };
+
+        let existing = self
+            .read_binding(registration_id)
+            .await
+            .map_err(|err| VerbRefusal::new(context(ProducingArm::Binding), err))?;
+
+        if let Some(record) = &existing
+            && record.host != request.host
+        {
+            // Neither lifecycle state lets a different host act. Nothing
+            // is touched.
+            return Err(VerbRefusal::new(
+                context(ProducingArm::Binding),
+                VerbError::HostMismatch {
+                    registration_id: registration_id.to_string(),
+                    stored_host: record.host.clone(),
+                    requested_host: request.host.clone(),
+                },
+            ));
+        }
+
+        // Teardown first, unbind after. A `creating` binding takes the
+        // same sequence as an `active` one: it is the durable
+        // registration claim, and removing it is what "identity removed"
+        // means whether or not the role material was ever completed.
+        let teardown = teardown_service_material(
+            &self.client,
+            &self.kv_mount,
+            registration_id,
+            &REGISTRAR_TEARDOWN_KV_SUFFIXES,
+        )
+        .await;
+
+        if !teardown.aggregate_success() {
+            return Err(VerbRefusal::new(
+                context(ProducingArm::Teardown),
+                VerbError::unavailable(
+                    "tearing down the identity's material",
+                    anyhow::anyhow!("one or more resources could not be deleted"),
+                ),
+            )
+            .with_teardown(teardown));
+        }
+
+        if existing.is_none() {
+            // The accepted hazard, stated in this module's header: with
+            // no binding the sweep still ran, so material left behind by
+            // a lost binding or by a direct-CLI registration of the same
+            // derived id is removed.
+            return Ok(DeregisterOutcome::new(
+                context(ProducingArm::Teardown),
+                DeregisterKind::AlreadyAbsent,
+                teardown,
+            ));
+        }
+
+        self.delete_binding(registration_id)
+            .await
+            .map_err(|err| VerbRefusal::new(context(ProducingArm::Binding), err))?;
+
+        Ok(DeregisterOutcome::new(
+            context(ProducingArm::Binding),
+            DeregisterKind::IdentityRemoved,
+            teardown,
+        ))
+    }
+
+    /// Returns how many per-id lock entries the map is currently
+    /// holding, so a test can assert that a refusal before stage 3 took
+    /// no lock at all.
+    #[cfg(test)]
+    fn tracked_lock_count(&self) -> usize {
+        self.id_locks.lock_entries().len()
+    }
+
+    fn binding_path(registration_id: &str) -> String {
+        service_kv_path(registration_id, REGISTRAR_BINDING_KV_SUFFIX)
+    }
+
+    async fn read_binding(
+        &self,
+        registration_id: &str,
+    ) -> Result<Option<BindingRecord>, VerbError> {
+        let path = Self::binding_path(registration_id);
+        let stored = self
+            .client
+            .try_read_kv(&self.kv_mount, &path)
+            .await
+            .with_context(|| format!("reading the registrar binding at {path}"))
+            .map_err(|err| VerbError::unavailable("reading the durable binding", err))?;
+        let Some(value) = stored else {
+            return Ok(None);
+        };
+        BindingRecord::decode(&value)
+            .map(Some)
+            // Fail closed and change nothing: a record this build cannot
+            // read may be a newer registrar's, and guessing at it is what
+            // would let a second host take an identity over.
+            .map_err(|err| {
+                VerbError::unavailable("reading the durable binding", anyhow::Error::new(err))
+            })
+    }
+
+    async fn claim_binding(
+        &self,
+        registration_id: &str,
+        record: &BindingRecord,
+    ) -> Result<KvCreateIfAbsent, VerbError> {
+        let path = Self::binding_path(registration_id);
+        let body = record
+            .encode()
+            .map_err(|err| VerbError::unavailable("encoding the durable binding", err.into()))?;
+        self.client
+            .create_kv_if_absent(&self.kv_mount, &path, body)
+            .await
+            .with_context(|| format!("claiming the registrar binding at {path}"))
+            .map_err(|err| VerbError::unavailable("claiming the durable binding", err))
+    }
+
+    async fn write_binding(
+        &self,
+        registration_id: &str,
+        record: &BindingRecord,
+    ) -> Result<(), VerbError> {
+        let path = Self::binding_path(registration_id);
+        let body = record
+            .encode()
+            .map_err(|err| VerbError::unavailable("encoding the durable binding", err.into()))?;
+        self.client
+            .write_kv(&self.kv_mount, &path, body)
+            .await
+            .with_context(|| format!("writing the registrar binding at {path}"))
+            .map_err(|err| VerbError::unavailable("activating the durable binding", err))
+    }
+
+    async fn delete_binding(&self, registration_id: &str) -> Result<(), VerbError> {
+        let path = Self::binding_path(registration_id);
+        self.client
+            .delete_kv(&self.kv_mount, &path)
+            .await
+            .with_context(|| format!("deleting the registrar binding at {path}"))
+            .map_err(|err| VerbError::unavailable("removing the durable binding", err))
+    }
+}
+
+/// Computes the granted absolute deadline from what `OpenBao` reported.
+///
+/// Both halves come from the response rather than from the request: the
+/// creation time is `OpenBao`'s, and the TTL is the one it actually
+/// applied, so a server-side clamp shows up here as well as the
+/// registrar's own. The conversion to [`time::Duration`] is checked —
+/// the reported TTL is a `u64` and the target is signed.
+fn granted_deadline(wrap_info: &WrapInfo) -> anyhow::Result<OffsetDateTime> {
+    let created = OffsetDateTime::parse(&wrap_info.creation_time, &Rfc3339).with_context(|| {
+        format!(
+            "parsing the wrap token's creation_time {:?} as RFC 3339",
+            wrap_info.creation_time
+        )
+    })?;
+    let seconds = i64::try_from(wrap_info.ttl).with_context(|| {
+        format!(
+            "the reported wrap ttl {} does not fit a duration",
+            wrap_info.ttl
+        )
+    })?;
+    let ttl = time::Duration::seconds(seconds);
+    created
+        .checked_add(ttl)
+        .with_context(|| format!("the wrap token's expiry overflows: {created} + {ttl}"))
+}
+
+/// The per-`registration_id` locks, keyed weakly so the map does not grow
+/// with every id a caller has ever named.
+///
+/// The locks themselves are [`tokio::sync::Mutex`] and are what mint and
+/// deregister serialize on. The map's own guard is a
+/// [`std::sync::Mutex`] deliberately: it is held across no `.await` at
+/// all, and reclaiming a dead entry has to happen in `Drop` — which runs
+/// when a verb's future is cancelled as well as when it returns, where an
+/// explicit async reclaim would not.
+#[derive(Default)]
+struct IdLocks {
+    entries: StdMutex<HashMap<String, Weak<TokioMutex<()>>>>,
+}
+
+impl IdLocks {
+    /// Returns a guard on `registration_id`'s lock, creating the lock if
+    /// no live one exists.
+    ///
+    /// The upgrade-or-insert happens under the map guard, so an
+    /// acquisition can never race a reclaim into handing two callers
+    /// different locks for one id.
+    async fn acquire(&self, registration_id: &str) -> IdGuard<'_> {
+        let lock = {
+            let mut entries = self.lock_entries();
+            if let Some(existing) = entries.get(registration_id).and_then(Weak::upgrade) {
+                existing
+            } else {
+                let fresh = Arc::new(TokioMutex::new(()));
+                entries.insert(registration_id.to_string(), Arc::downgrade(&fresh));
+                fresh
+            }
+        };
+        let entry = Arc::downgrade(&lock);
+        let guard = lock.lock_owned().await;
+        IdGuard {
+            guard: Some(guard),
+            locks: self,
+            registration_id: registration_id.to_string(),
+            entry,
+        }
+    }
+
+    /// Removes `registration_id`'s entry, but only when it is the
+    /// identical, now-dead `Weak` the releasing guard held.
+    ///
+    /// Both conditions matter. A live entry means another waiter already
+    /// upgraded it, and a different entry means the id was re-acquired
+    /// after this one died; removing either would drop a lock somebody
+    /// is using.
+    fn reclaim(&self, registration_id: &str, entry: &Weak<TokioMutex<()>>) {
+        let mut entries = self.lock_entries();
+        let is_dead_and_identical = entries
+            .get(registration_id)
+            .is_some_and(|stored| stored.strong_count() == 0 && Weak::ptr_eq(stored, entry));
+        if is_dead_and_identical {
+            entries.remove(registration_id);
+        }
+    }
+
+    /// Takes the map guard, recovering from a poisoned mutex.
+    ///
+    /// The critical sections here are a map lookup and an insert, so a
+    /// panic inside one cannot leave the map torn; treating the poison as
+    /// fatal would turn an unrelated panic elsewhere into a permanently
+    /// unusable registrar.
+    fn lock_entries(&self) -> std::sync::MutexGuard<'_, HashMap<String, Weak<TokioMutex<()>>>> {
+        self.entries.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Holds one `registration_id`'s lock, and reclaims its map entry on
+/// drop.
+struct IdGuard<'a> {
+    /// Dropped first, inside `Drop`, so the strong count the reclaim
+    /// checks is the one that excludes this guard.
+    guard: Option<OwnedMutexGuard<()>>,
+    locks: &'a IdLocks,
+    registration_id: String,
+    entry: Weak<TokioMutex<()>>,
+}
+
+impl Drop for IdGuard<'_> {
+    fn drop(&mut self) {
+        drop(self.guard.take());
+        self.locks.reclaim(&self.registration_id, &self.entry);
+    }
+}

--- a/src/registrar/verbs/binding.rs
+++ b/src/registrar/verbs/binding.rs
@@ -69,7 +69,7 @@ pub(crate) enum BindingState {
 /// The spellings are the same kebab-case words
 /// [`ReloadKind`] uses, and a test pins that.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum BindingReloadKind {
     /// `sighup`
     Sighup,

--- a/src/registrar/verbs/binding.rs
+++ b/src/registrar/verbs/binding.rs
@@ -1,0 +1,289 @@
+//! The durable record that binds a derived `registration_id` to the host
+//! that claimed it, and to the spec that identity was minted with.
+//!
+//! This record is the registrar's **only** authority for host collision,
+//! host mismatch and the re-mint decision. The derivation is not
+//! injective — `web` on `h1-aimer` and `aimer-web` on `h1` both derive
+//! `h1-aimer-web-001` — so "is this id already taken, and by whom" cannot
+//! be answered from the request's parts, and it has to survive a restart
+//! of the registrar to be answered at all.
+//!
+//! # Why the shape is local
+//!
+//! The JSON below is a **verb-local** shape, not a serialization of
+//! [`crate::registrar::RegistrationSpec`] /
+//! [`crate::registrar::ReloadSpec`] /
+//! [`crate::registrar::ReloadKind`]. Those three types are the
+//! parsed form of a file another repository renders, and putting serde
+//! derives on them would make this record's on-disk shape move whenever
+//! that file's parsed form did — a stored binding is read back months
+//! later by a build that has since re-read a re-rendered config, and the
+//! two must not be coupled. The conversion between the two vocabularies
+//! is explicit in both directions, and a test pins each local spelling
+//! against `ReloadKind::as_str` / `ReloadKind::from_str` so a variant
+//! added there cannot silently acquire a different spelling here.
+//!
+//! # Schema version
+//!
+//! The version is read on its own before the body is parsed against this
+//! build's shape. A record written by a newer registrar is refused
+//! **fail-closed and without touching the data**: guessing at its meaning
+//! is what would let a second host take over an identity the newer build
+//! bound, and deleting it is worse still.
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::registrar::config::{RegistrationSpec, ReloadKind, ReloadSpec};
+use crate::registrar::identity::RequestedSpec;
+
+/// KV path suffix, under `bootroot/services/<registration_id>/`, of the
+/// registrar's durable host binding.
+///
+/// Deliberately **not** in any teardown suffix set: the binding outlives
+/// the material it covers, and only the deregister verb deletes it, only
+/// after that material is aggregate-gone.
+pub(crate) const REGISTRAR_BINDING_KV_SUFFIX: &str = "registrar_binding";
+
+/// The schema version this build writes and reads.
+pub(crate) const BINDING_SCHEMA_VERSION: u32 = 1;
+
+/// Where a binding is in its two-step lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BindingState {
+    /// The claim won the compare-and-set, but the role, policy and the
+    /// active transition have not all completed yet. A binding left here
+    /// by a failed or interrupted convergence is **retained**, never
+    /// rolled back: it is what keeps whatever material did get created
+    /// covered by a durable claim instead of stranded as an orphan.
+    Creating,
+    /// Role and policy are converged and the identity is the requesting
+    /// host's. Only from here is a credential ever issued.
+    Active,
+}
+
+/// The post-renew hook style, in this record's own vocabulary.
+///
+/// The spellings are the same kebab-case words
+/// [`ReloadKind`] uses, and a test pins that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) enum BindingReloadKind {
+    /// `sighup`
+    Sighup,
+    /// `systemd`
+    Systemd,
+    /// `docker-restart`
+    DockerRestart,
+    /// `none`
+    None,
+}
+
+impl From<ReloadKind> for BindingReloadKind {
+    fn from(value: ReloadKind) -> Self {
+        match value {
+            ReloadKind::Sighup => Self::Sighup,
+            ReloadKind::Systemd => Self::Systemd,
+            ReloadKind::DockerRestart => Self::DockerRestart,
+            ReloadKind::None => Self::None,
+        }
+    }
+}
+
+impl From<BindingReloadKind> for ReloadKind {
+    fn from(value: BindingReloadKind) -> Self {
+        match value {
+            BindingReloadKind::Sighup => Self::Sighup,
+            BindingReloadKind::Systemd => Self::Systemd,
+            BindingReloadKind::DockerRestart => Self::DockerRestart,
+            BindingReloadKind::None => Self::None,
+        }
+    }
+}
+
+impl BindingReloadKind {
+    /// Returns the kebab-case word this variant serializes as, which is
+    /// the registrar vocabulary's own spelling for it.
+    pub(crate) fn as_str(self) -> &'static str {
+        ReloadKind::from(self).as_str()
+    }
+
+    /// Parses a kebab-case word through the registrar vocabulary, so
+    /// there is one parser rather than two.
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        ReloadKind::from_str(value).ok().map(Self::from)
+    }
+}
+
+/// The post-renew hook, in this record's own vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BindingReload {
+    /// The hook style.
+    pub(crate) kind: BindingReloadKind,
+    /// The process, unit or container the hook acts on; `null` exactly
+    /// when `kind` is `none`.
+    pub(crate) target: Option<String>,
+}
+
+/// The two per-registration spec fields, in this record's own
+/// vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BindingSpec {
+    /// The numeric gid the issued files are owned by, or `null`.
+    pub(crate) cert_group: Option<u32>,
+    /// The post-renew hook.
+    pub(crate) reload: BindingReload,
+}
+
+impl BindingSpec {
+    /// Converts a requested spec into the record's vocabulary. Only the
+    /// two safe-set fields are stored: the spec's identity-restating
+    /// `component` / `service_name` are checked against the wire
+    /// `service_name` before derivation and are not part of what a
+    /// re-mint compares.
+    pub(crate) fn from_requested(spec: &RequestedSpec) -> Self {
+        Self {
+            cert_group: spec.cert_group,
+            reload: BindingReload {
+                kind: spec.reload.kind.into(),
+                target: spec.reload.target.clone(),
+            },
+        }
+    }
+
+    /// Converts back into the registrar vocabulary.
+    pub(crate) fn to_registration_spec(&self) -> RegistrationSpec {
+        RegistrationSpec {
+            cert_group: self.cert_group,
+            reload: ReloadSpec {
+                kind: self.reload.kind.into(),
+                target: self.reload.target.clone(),
+            },
+        }
+    }
+}
+
+/// The stored binding record, schema version 1.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct BindingRecord {
+    /// The schema version this record was written under.
+    pub(crate) schema_version: u32,
+    /// The host that claimed this derived id. Every host-collision and
+    /// host-mismatch decision compares against this and nothing else.
+    pub(crate) host: String,
+    /// Where the binding is in its lifecycle.
+    pub(crate) state: BindingState,
+    /// The spec the claiming request asked for.
+    pub(crate) requested_spec: Option<BindingSpec>,
+    /// The spec the completed convergence applied — `null` until the
+    /// binding goes active, and then the same value `requested_spec`
+    /// carries.
+    pub(crate) applied_spec: Option<BindingSpec>,
+}
+
+/// Just the version, read before the body is parsed against this build's
+/// shape.
+///
+/// Deliberately **not** `deny_unknown_fields`: a record written by a
+/// newer build carries fields this one does not know, and it has to be
+/// recognisable as "a newer schema" rather than as "an unknown field".
+#[derive(Debug, Deserialize)]
+struct SchemaProbe {
+    schema_version: u32,
+}
+
+/// Why a stored binding could not be read as this build's record.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum BindingDecodeError {
+    /// The stored JSON does not even carry a readable `schema_version`.
+    #[error("stored binding does not declare a readable schema_version: {message}")]
+    NoSchemaVersion {
+        /// What the parser objected to.
+        message: String,
+    },
+    /// The record was written under a schema this build does not
+    /// implement.
+    #[error(
+        "stored binding declares schema_version {found}, but this build implements {supported}"
+    )]
+    UnsupportedSchemaVersion {
+        /// The version the record declares.
+        found: u32,
+        /// The version this build implements.
+        supported: u32,
+    },
+    /// The version matched but the body is not this build's shape —
+    /// including an unknown field, which is refused rather than ignored.
+    #[error("stored binding is not a schema-version-{BINDING_SCHEMA_VERSION} record: {message}")]
+    Malformed {
+        /// What the parser objected to.
+        message: String,
+    },
+}
+
+impl BindingRecord {
+    /// Builds the record a compare-and-set claim writes: the host is
+    /// bound, the requested spec is recorded so a same-host re-drive has
+    /// something to compare against, and nothing is applied yet.
+    pub(crate) fn creating(host: &str, spec: &RequestedSpec) -> Self {
+        Self {
+            schema_version: BINDING_SCHEMA_VERSION,
+            host: host.to_string(),
+            state: BindingState::Creating,
+            requested_spec: Some(BindingSpec::from_requested(spec)),
+            applied_spec: None,
+        }
+    }
+
+    /// Returns this record transitioned to active, with `applied_spec`
+    /// set to the same value `requested_spec` carries.
+    pub(crate) fn activated(&self, spec: &RequestedSpec) -> Self {
+        let stored = BindingSpec::from_requested(spec);
+        Self {
+            schema_version: BINDING_SCHEMA_VERSION,
+            host: self.host.clone(),
+            state: BindingState::Active,
+            requested_spec: Some(stored.clone()),
+            applied_spec: Some(stored),
+        }
+    }
+
+    /// Decodes a stored record, gating on the schema version first.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BindingDecodeError`] naming which of the three gates the
+    /// stored value failed. Every one of them is fail-closed: the caller
+    /// changes nothing on any of them.
+    pub(crate) fn decode(value: &serde_json::Value) -> Result<Self, BindingDecodeError> {
+        let probe: SchemaProbe = serde_json::from_value(value.clone()).map_err(|err| {
+            BindingDecodeError::NoSchemaVersion {
+                message: err.to_string(),
+            }
+        })?;
+        if probe.schema_version != BINDING_SCHEMA_VERSION {
+            return Err(BindingDecodeError::UnsupportedSchemaVersion {
+                found: probe.schema_version,
+                supported: BINDING_SCHEMA_VERSION,
+            });
+        }
+        serde_json::from_value(value.clone()).map_err(|err| BindingDecodeError::Malformed {
+            message: err.to_string(),
+        })
+    }
+
+    /// Encodes this record for the KV write.
+    ///
+    /// # Errors
+    ///
+    /// Returns the serializer's failure, which cannot arise for this
+    /// shape but is propagated rather than unwrapped.
+    pub(crate) fn encode(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}

--- a/src/registrar/verbs/outcome.rs
+++ b/src/registrar/verbs/outcome.rs
@@ -1,0 +1,461 @@
+//! What the two verbs return: the envelope every outcome carries, the
+//! typed refusals, and the redacting newtype the wrapped credential
+//! rides in.
+//!
+//! These are **in-process** types. The endpoint owns serialization and
+//! the caller-facing identifiers; nothing here maps onto a wire name, and
+//! several distinctions kept here — safe-set refusal versus stored-spec
+//! conflict, component absence versus instance-shape mismatch — are ones
+//! the wire contract deliberately groups. Keeping them apart internally
+//! is what lets an audit record say which of them happened after the wire
+//! has collapsed them.
+
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use time::OffsetDateTime;
+
+use crate::registrar::error::RegistrarError;
+use crate::registrar::verbs::wrap_ttl::WrapTtlRefusal;
+use crate::service_material::TeardownReport;
+
+/// Bytes of randomness in a generated request id.
+const REQUEST_ID_RANDOM_BYTES: usize = 9;
+
+/// Monotonic tail, so two ids minted in one process are distinct even if
+/// the system random source is unavailable.
+static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// A correlation handle for one verb invocation, generated at entry.
+///
+/// Not a secret and not an idempotency key: it correlates an audit
+/// record with a response, and nothing is cached under it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RequestId(String);
+
+impl RequestId {
+    /// Generates a fresh request id.
+    pub(crate) fn generate() -> Self {
+        let sequence = REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        match crate::utils::generate_secret(REQUEST_ID_RANDOM_BYTES) {
+            Ok(random) => Self(format!("{random}.{sequence}")),
+            // A correlation handle is still useful without the random
+            // half, and refusing the whole request because the system
+            // random source hiccuped would be a worse outcome than a
+            // handle that is unique only within this process.
+            Err(_) => Self(format!("seq.{sequence}")),
+        }
+    }
+
+    /// Returns the handle.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The caller's identity, carried through a verb **unchanged**.
+///
+/// Opaque on purpose. The verbs never parse it, never authenticate it,
+/// never select an `OpenBao` client from it and never derive any part of
+/// an identity from it — the derived `registration_id` and the SAN come
+/// from the request's parts and the rendered config alone. It exists so
+/// an outcome says who asked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallerIdentity(String);
+
+impl CallerIdentity {
+    /// Wraps a caller identity verbatim.
+    pub(crate) fn new(value: &str) -> Self {
+        Self(value.to_string())
+    }
+
+    /// Returns the identity exactly as it was supplied.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Which arm of a verb produced an outcome.
+///
+/// The arms are ordered as the verbs run them, so an outcome records how
+/// far a request got before it stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProducingArm {
+    /// Label validation, the reserved-name guard, component lookup and
+    /// the instance-shape check — everything that runs before any id
+    /// exists.
+    PreDerivation,
+    /// Deriving the `registration_id` and the SAN.
+    Derivation,
+    /// Reading, claiming or comparing the durable binding.
+    Binding,
+    /// Comparing the requested spec against the rendered safe-set.
+    SafeSet,
+    /// Converging the derived role and policy.
+    Provisioning,
+    /// Issuing the wrap-only credential.
+    Issuance,
+    /// Deleting the identity's material.
+    Teardown,
+}
+
+/// The envelope every outcome of either verb carries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerbContext {
+    request_id: RequestId,
+    caller: CallerIdentity,
+    registration_id: Option<String>,
+    arm: ProducingArm,
+}
+
+impl VerbContext {
+    pub(crate) fn new(
+        request_id: RequestId,
+        caller: CallerIdentity,
+        registration_id: Option<String>,
+        arm: ProducingArm,
+    ) -> Self {
+        Self {
+            request_id,
+            caller,
+            registration_id,
+            arm,
+        }
+    }
+
+    /// Returns the invocation's correlation handle.
+    pub(crate) fn request_id(&self) -> &RequestId {
+        &self.request_id
+    }
+
+    /// Returns the caller identity, exactly as it arrived.
+    pub(crate) fn caller(&self) -> &CallerIdentity {
+        &self.caller
+    }
+
+    /// Returns the derived `registration_id`, which is `None` for every
+    /// outcome produced before derivation.
+    pub(crate) fn registration_id(&self) -> Option<&str> {
+        self.registration_id.as_deref()
+    }
+
+    /// Returns the arm that produced this outcome.
+    pub(crate) fn arm(&self) -> ProducingArm {
+        self.arm
+    }
+}
+
+/// A response-wrapping token, held so it cannot be printed by accident.
+///
+/// The wrapped token is single-use material: whoever holds it can unwrap
+/// the `secret_id` once. `Debug` prints `<redacted>` by hand, so a
+/// `#[derive(Debug)]` on any enclosing outcome — which is how these
+/// values reach a log line — cannot leak it, and there is no `Display`
+/// at all.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct WrappedSecretIdToken(String);
+
+impl WrappedSecretIdToken {
+    pub(crate) fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Consumes the newtype and yields the raw token.
+    fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Debug for WrappedSecretIdToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+/// Which successful mint arm produced the material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MintKind {
+    /// The identity did not exist: this request claimed the binding,
+    /// converged the role and policy, activated the binding and issued.
+    FirstMint,
+    /// The identity already existed, bound to this host with a matching
+    /// spec. The role and policy were reused untouched and only fresh
+    /// wrap-only material was issued.
+    IdempotentReMint,
+}
+
+/// A successful mint.
+#[derive(Debug)]
+pub(crate) struct MintOutcome {
+    context: VerbContext,
+    kind: MintKind,
+    san: String,
+    role_id: String,
+    wrapped_secret_id: WrappedSecretIdToken,
+    expires_at: OffsetDateTime,
+}
+
+impl MintOutcome {
+    pub(crate) fn new(
+        context: VerbContext,
+        kind: MintKind,
+        san: String,
+        role_id: String,
+        wrapped_secret_id: WrappedSecretIdToken,
+        expires_at: OffsetDateTime,
+    ) -> Self {
+        Self {
+            context,
+            kind,
+            san,
+            role_id,
+            wrapped_secret_id,
+            expires_at,
+        }
+    }
+
+    /// Returns the outcome's envelope.
+    pub(crate) fn context(&self) -> &VerbContext {
+        &self.context
+    }
+
+    /// Returns which mint arm produced this material.
+    pub(crate) fn kind(&self) -> MintKind {
+        self.kind
+    }
+
+    /// Returns the composed certificate SAN for this identity.
+    pub(crate) fn san(&self) -> &str {
+        &self.san
+    }
+
+    /// Returns the service `AppRole`'s `role_id`.
+    pub(crate) fn role_id(&self) -> &str {
+        &self.role_id
+    }
+
+    /// Returns the **granted** absolute deadline: the wrap token's
+    /// creation time plus the TTL `OpenBao` actually reported, so an
+    /// `OpenBao`-side clamp is reflected here as well as the registrar's
+    /// own.
+    pub(crate) fn expires_at(&self) -> OffsetDateTime {
+        self.expires_at
+    }
+
+    /// Consumes the outcome and yields the wrapped token.
+    ///
+    /// Consuming on purpose, and on the outcome rather than on the
+    /// newtype: the token moves to the endpoint at its serialization
+    /// boundary and nowhere else, so no caller has to clone it, inspect
+    /// it, or hold a copy alongside the one it sent.
+    pub(crate) fn into_wrapped_secret_id(self) -> String {
+        self.wrapped_secret_id.into_inner()
+    }
+}
+
+/// Which successful deregister arm produced the outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeregisterKind {
+    /// A binding for this host existed and was removed, after its
+    /// material was torn down.
+    IdentityRemoved,
+    /// No binding existed. The material sweep still ran, and the result
+    /// is the idempotent re-drive the verb pair is built around.
+    AlreadyAbsent,
+}
+
+/// A successful deregister.
+#[derive(Debug)]
+pub(crate) struct DeregisterOutcome {
+    context: VerbContext,
+    kind: DeregisterKind,
+    teardown: TeardownReport,
+}
+
+impl DeregisterOutcome {
+    pub(crate) fn new(
+        context: VerbContext,
+        kind: DeregisterKind,
+        teardown: TeardownReport,
+    ) -> Self {
+        Self {
+            context,
+            kind,
+            teardown,
+        }
+    }
+
+    /// Returns the outcome's envelope.
+    pub(crate) fn context(&self) -> &VerbContext {
+        &self.context
+    }
+
+    /// Returns which deregister arm produced this outcome.
+    pub(crate) fn kind(&self) -> DeregisterKind {
+        self.kind
+    }
+
+    /// Returns the per-resource teardown report.
+    pub(crate) fn teardown(&self) -> &TeardownReport {
+        &self.teardown
+    }
+}
+
+/// Every refusal the two verbs produce.
+///
+/// The refusals the config loader and the derivation library already
+/// declare are **wrapped**, never redeclared: there is one definition of
+/// "this component has no entry" in the repository and this is not a
+/// second one. What is added here is only what those checks cannot see,
+/// because it depends on the reserved namespace, on durable state, or on
+/// the registrar's own bounded policy.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum VerbError {
+    /// The wire `service_name` is inside bootroot's reserved
+    /// `bootroot-` namespace. Refused case-insensitively, and refused
+    /// **before** the component lookup, so an operator configuration
+    /// that happened to declare a reserved key could still never make
+    /// ordinary issuance mint a registrar identity.
+    #[error("service_name {service_name:?} is inside bootroot's reserved namespace")]
+    ReservedServiceName {
+        /// The offending value, verbatim.
+        service_name: String,
+    },
+
+    /// A refusal the config loader or the derivation library produced:
+    /// an invalid label, an absent component, an instance-shape
+    /// mismatch, a spec-identity disagreement, a derivation failure, or
+    /// a safe-set refusal. Individually matchable through this one arm.
+    #[error(transparent)]
+    Registrar(#[from] RegistrarError),
+
+    /// The derived `registration_id` is already bound to a **different**
+    /// host. Raised before any spec comparison, because the rendered
+    /// spec is host-agnostic and a spec-first flow would match and
+    /// re-wrap the first host's identity for the second.
+    #[error(
+        "registration_id {registration_id} is bound to host {stored_host}, so host \
+         {requested_host} cannot claim it"
+    )]
+    RegistrationIdCollision {
+        /// The derived key both hosts arrived at.
+        registration_id: String,
+        /// The host the binding records.
+        stored_host: String,
+        /// The host that asked.
+        requested_host: String,
+    },
+
+    /// The identity exists, is bound to this host, and was minted with a
+    /// different spec. Distinct from a safe-set refusal: the request may
+    /// be inside the rendered safe-set and still disagree with what this
+    /// identity already carries.
+    #[error("registration_id {registration_id} is already bound with a different spec")]
+    StoredSpecConflict {
+        /// The identity whose stored spec disagreed.
+        registration_id: String,
+    },
+
+    /// A deregister whose `host` is not the identity's bound host.
+    /// Changes nothing at all.
+    #[error(
+        "registration_id {registration_id} is bound to host {stored_host}, not {requested_host}"
+    )]
+    HostMismatch {
+        /// The identity that was asked about.
+        registration_id: String,
+        /// The host the binding records.
+        stored_host: String,
+        /// The host that asked.
+        requested_host: String,
+    },
+
+    /// The requested `wrap_ttl` cannot produce a usable credential
+    /// lifetime.
+    ///
+    /// Not one of the durable-state refusals above, and deliberately its
+    /// own arm rather than folded into [`VerbError::Unavailable`]: it is
+    /// a permanent property of the request, not a transient property of
+    /// the registrar, and a caller that retried it unchanged would fail
+    /// identically forever.
+    #[error("requested wrap_ttl is not usable")]
+    InvalidWrapTtl(#[from] WrapTtlRefusal),
+
+    /// A fail-closed failure: `OpenBao` was unreachable or answered
+    /// unexpectedly, a stored binding could not be read, or a
+    /// convergence step failed. Nothing was rolled back — a binding this
+    /// request claimed is deliberately retained.
+    #[error("the registrar could not complete the request while {activity}")]
+    Unavailable {
+        /// What was being attempted, for the audit record.
+        activity: String,
+        /// The underlying failure.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl VerbError {
+    /// Builds an [`VerbError::Unavailable`] from an underlying failure.
+    pub(crate) fn unavailable(activity: &str, source: anyhow::Error) -> Self {
+        Self::Unavailable {
+            activity: activity.to_string(),
+            source,
+        }
+    }
+}
+
+/// A refused invocation: the envelope plus the typed refusal, and — for
+/// a deregister that got as far as tearing material down — whatever the
+/// teardown managed.
+#[derive(Debug)]
+pub(crate) struct VerbRefusal {
+    context: VerbContext,
+    error: VerbError,
+    teardown: Option<TeardownReport>,
+}
+
+impl VerbRefusal {
+    pub(crate) fn new(context: VerbContext, error: VerbError) -> Self {
+        Self {
+            context,
+            error,
+            teardown: None,
+        }
+    }
+
+    /// Attaches the teardown report a partially-completed deregister
+    /// produced, so the caller can see which resources are still there.
+    pub(crate) fn with_teardown(mut self, teardown: TeardownReport) -> Self {
+        self.teardown = Some(teardown);
+        self
+    }
+
+    /// Returns the refusal's envelope.
+    pub(crate) fn context(&self) -> &VerbContext {
+        &self.context
+    }
+
+    /// Returns the typed refusal.
+    pub(crate) fn error(&self) -> &VerbError {
+        &self.error
+    }
+
+    /// Returns the teardown report, when the refusal came from a
+    /// deregister that had already attempted one.
+    pub(crate) fn teardown(&self) -> Option<&TeardownReport> {
+        self.teardown.as_ref()
+    }
+}
+
+/// The mint verb's result.
+pub(crate) type MintResult = Result<MintOutcome, VerbRefusal>;
+
+/// The deregister verb's result.
+pub(crate) type DeregisterResult = Result<DeregisterOutcome, VerbRefusal>;

--- a/src/registrar/verbs/outcome.rs
+++ b/src/registrar/verbs/outcome.rs
@@ -158,7 +158,13 @@ impl VerbContext {
 /// `#[derive(Debug)]` on any enclosing outcome — which is how these
 /// values reach a log line — cannot leak it, and there is no `Display`
 /// at all.
-#[derive(Clone, PartialEq, Eq)]
+///
+/// It derives nothing else either. `Clone` would let a caller keep a
+/// copy alongside the one it sent, which is what the consuming accessor
+/// on [`MintOutcome`] exists to prevent, and a derived `PartialEq` on a
+/// secret-bearing type is a byte-at-a-time timing oracle. Neither is
+/// needed: the token is moved out once, at the endpoint's serialization
+/// boundary, and never compared.
 pub(crate) struct WrappedSecretIdToken(String);
 
 impl WrappedSecretIdToken {

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -22,7 +22,7 @@
 //! one would pass against it.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use serde_json::json;
 use tempfile::TempDir;
@@ -40,7 +40,7 @@ use super::outcome::{
 };
 use super::wrap_ttl::{WrapTtlPolicy, WrapTtlRefusal};
 use super::{
-    DeregisterRequest, MintRequest, REGISTRAR_TEARDOWN_KV_SUFFIXES, RegistrarVerbs,
+    DeregisterRequest, IdLocks, MintRequest, REGISTRAR_TEARDOWN_KV_SUFFIXES, RegistrarVerbs,
     RegistrarVerbsConfig, granted_deadline,
 };
 use crate::openbao::{OpenBaoClient, SecretIdOptions, WrapInfo};
@@ -633,6 +633,106 @@ async fn mint_refuses_an_unusable_wrap_ttl_before_touching_openbao() {
         );
     }
     assert_untouched(&server, &verbs).await;
+}
+
+// ---------------------------------------------------------------------
+// Fast tier: the per-id lock map
+// ---------------------------------------------------------------------
+
+/// A released guard reclaims its entry, so the map does not grow with
+/// every id a caller has ever named.
+///
+/// `assert_untouched` proves only that a refusal *before* stage 3 takes
+/// no lock. This is the other half: an id that did reach stage 3 leaves
+/// nothing behind once its guard is dropped.
+#[tokio::test]
+async fn a_released_id_lock_reclaims_its_map_entry() {
+    let locks = IdLocks::default();
+
+    for id in ["h1-roxyd", "h2-roxyd", "h1-piglet-001"] {
+        let guard = locks.acquire(id).await;
+        assert_eq!(locks.lock_entries().len(), 1, "one live id at a time");
+        drop(guard);
+        assert_eq!(
+            locks.lock_entries().len(),
+            0,
+            "dropping {id}'s guard must reclaim its entry"
+        );
+    }
+}
+
+/// A waiter keeps the entry alive and gets the *same* lock, so the two
+/// holders serialize rather than each taking a private mutex.
+///
+/// This is what makes a mint and a deregister for one id mutually
+/// exclusive, and it is also the case a careless reclaim would break by
+/// removing an entry another caller is queued on.
+#[tokio::test]
+async fn a_contended_id_lock_is_shared_and_survives_the_first_release() {
+    let locks = Arc::new(IdLocks::default());
+    let first = locks.acquire("h1-roxyd").await;
+
+    let acquired = Arc::new(AtomicBool::new(false));
+    let waiter = tokio::spawn({
+        let locks = Arc::clone(&locks);
+        let acquired = Arc::clone(&acquired);
+        async move {
+            let guard = locks.acquire("h1-roxyd").await;
+            acquired.store(true, Ordering::SeqCst);
+            assert_eq!(
+                locks.lock_entries().len(),
+                1,
+                "the waiter must hold the entry it woke on"
+            );
+            drop(guard);
+        }
+    });
+
+    // Give the waiter every chance to run. It cannot acquire, because
+    // the lock it found in the map is the one `first` is holding — had
+    // it been handed a private mutex instead, it would be through by
+    // now and the two verbs would not serialize.
+    for _ in 0..64 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !acquired.load(Ordering::SeqCst),
+        "a second holder of one id must block until the first releases"
+    );
+    assert_eq!(
+        locks.lock_entries().len(),
+        1,
+        "the waiter must be queued on the entry already in the map"
+    );
+
+    drop(first);
+    waiter.await.expect("the waiter must acquire and release");
+    assert!(acquired.load(Ordering::SeqCst));
+
+    assert_eq!(
+        locks.lock_entries().len(),
+        0,
+        "the last holder out reclaims the entry"
+    );
+}
+
+/// Re-acquiring a reclaimed id inserts a fresh entry rather than
+/// resurrecting a dead `Weak`.
+#[tokio::test]
+async fn a_reclaimed_id_is_re_acquirable() {
+    let locks = IdLocks::default();
+
+    drop(locks.acquire("h1-roxyd").await);
+    assert_eq!(locks.lock_entries().len(), 0);
+
+    let guard = locks.acquire("h1-roxyd").await;
+    assert_eq!(
+        locks.lock_entries().len(),
+        1,
+        "the id must be lockable again after its entry was reclaimed"
+    );
+    drop(guard);
+    assert_eq!(locks.lock_entries().len(), 0);
 }
 
 // ---------------------------------------------------------------------

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -543,6 +543,22 @@ fn wrap_ttl_policy_refuses_zero_negative_and_unrepresentable_requests() {
         policy.grant(Duration::milliseconds(500)),
         Err(WrapTtlRefusal::NotWholeSeconds)
     );
+    // One second past the largest value a Go `time.Duration` holds. It
+    // is a whole number of seconds and it is larger than the maximum,
+    // but it is refused rather than clamped: `OpenBao` cannot parse the
+    // string it would take to ask for it, so the request has no
+    // representation to grant a lesser share of.
+    assert_eq!(
+        policy.grant(Duration::seconds(9_223_372_037)),
+        Err(WrapTtlRefusal::ExceedsOpenBaoRange)
+    );
+    // The boundary itself is representable, so it clamps like any other
+    // over-long request.
+    let granted = policy
+        .grant(Duration::seconds(9_223_372_036))
+        .expect("the largest representable request is clamped, not refused");
+    assert_eq!(granted.duration(), Duration::minutes(30));
+    assert_eq!(granted.as_openbao_str(), "1800s");
 }
 
 #[test]
@@ -575,6 +591,10 @@ fn wrap_ttl_policy_holds_its_own_maximum_to_the_same_rules() {
     assert_eq!(
         WrapTtlPolicy::new(Duration::seconds(-30)),
         Err(WrapTtlRefusal::Negative)
+    );
+    assert_eq!(
+        WrapTtlPolicy::new(Duration::seconds(9_223_372_037)),
+        Err(WrapTtlRefusal::ExceedsOpenBaoRange)
     );
 }
 
@@ -618,6 +638,10 @@ async fn mint_refuses_an_unusable_wrap_ttl_before_touching_openbao() {
         (Duration::ZERO, WrapTtlRefusal::Zero),
         (Duration::seconds(-5), WrapTtlRefusal::Negative),
         (Duration::milliseconds(250), WrapTtlRefusal::NotWholeSeconds),
+        (
+            Duration::seconds(9_223_372_037),
+            WrapTtlRefusal::ExceedsOpenBaoRange,
+        ),
     ] {
         let mut request = mint_request("roxyd", "h1", None);
         request.wrap_ttl = requested;

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -1,0 +1,1628 @@
+//! Tests for the two verbs, split along one deliberate line.
+//!
+//! **Fast tier.** Everything that is decided before a stateful `OpenBao`
+//! interaction: the pre-derivation refusals, the derivation failures, the
+//! binding record's JSON, and the wrap-TTL policy. Where a client is
+//! needed at all it is a canned-response Wiremock, and the assertion is
+//! usually that *no request was made*.
+//!
+//! **Ignored tier.** Everything whose outcome depends on a prior
+//! `OpenBao` write: durable bindings, the compare-and-set, re-mint,
+//! wrong-host refusal, the absent-binding sweep, teardown-before-unbind
+//! ordering, and both concurrency properties. These are `#[ignore]`d
+//! library tests rather than integration tests under `tests/`, because
+//! they construct the crate-private verb service and assert crate-private
+//! outcomes. `scripts/impl/run-registrar-verbs-e2e.sh` brings up a live
+//! `OpenBao` and runs them, and the `test-docker-e2e-matrix` CI job is
+//! their gate.
+//!
+//! There is deliberately **no stateful `OpenBao` fake**. A fake that
+//! tracked KV versions would be a second implementation of the
+//! compare-and-set semantics the claim depends on, and a bug in the real
+//! one would pass against it.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::json;
+use tempfile::TempDir;
+use time::format_description::well_known::Rfc3339;
+use time::{Duration, OffsetDateTime};
+use wiremock::MockServer;
+
+use super::binding::{
+    BINDING_SCHEMA_VERSION, BindingRecord, BindingReloadKind, BindingSpec, BindingState,
+    REGISTRAR_BINDING_KV_SUFFIX,
+};
+use super::outcome::{
+    CallerIdentity, DeregisterKind, MintKind, MintOutcome, ProducingArm, RequestId, VerbContext,
+    VerbError, VerbRefusal, WrappedSecretIdToken,
+};
+use super::wrap_ttl::{WrapTtlPolicy, WrapTtlRefusal};
+use super::{
+    DeregisterRequest, MintRequest, REGISTRAR_TEARDOWN_KV_SUFFIXES, RegistrarVerbs,
+    RegistrarVerbsConfig, granted_deadline,
+};
+use crate::openbao::{OpenBaoClient, SecretIdOptions, WrapInfo};
+use crate::registrar::config::{
+    Multiplicity, RegistrarConfig, RegistrationSpec, ReloadKind, ReloadSpec,
+};
+use crate::registrar::error::{RegistrarError, SpecIdentityField};
+use crate::registrar::fixture::RegistrarConfigFixture;
+use crate::registrar::identity::RequestedSpec;
+use crate::service_material::{service_policy_name, service_role_name};
+
+/// Environment variable naming the live `OpenBao` the ignored tier runs
+/// against. Read, never written.
+const ENV_OPENBAO_URL: &str = "BOOTROOT_REGISTRAR_TEST_OPENBAO_URL";
+/// Environment variable carrying that `OpenBao`'s privileged token.
+const ENV_OPENBAO_TOKEN: &str = "BOOTROOT_REGISTRAR_TEST_OPENBAO_TOKEN";
+/// Environment variable naming the KV v2 mount to write under.
+const ENV_KV_MOUNT: &str = "BOOTROOT_REGISTRAR_TEST_KV_MOUNT";
+
+/// A distinctive caller identity, so a test can prove it survives into an
+/// outcome and reaches nothing else.
+const CALLER: &str = "spiffe://review/manager#7f3a";
+
+const TOKEN_TTL: &str = "1h";
+const SECRET_ID_TTL: &str = "24h";
+
+/// Discriminates one test run's identities from another's, so a live
+/// `OpenBao` that is reused across runs never has two tests writing one
+/// derived id.
+fn unique_label(prefix: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stamp = OffsetDateTime::now_utc().unix_timestamp().max(0);
+    format!("{prefix}{}x{stamp}x{n}", std::process::id())
+}
+
+fn sample_spec() -> RegistrationSpec {
+    RegistrationSpec {
+        cert_group: Some(3001),
+        reload: ReloadSpec::new(ReloadKind::DockerRestart, "piglet"),
+    }
+}
+
+/// The rendered spec of a component the base fixture declares, so a
+/// request built for it is inside its safe-set by default. Anything not
+/// named here is a component a test added itself with [`sample_spec`].
+fn spec_for(component: &str) -> RegistrationSpec {
+    match component {
+        "roxyd" => RegistrationSpec {
+            cert_group: None,
+            reload: ReloadSpec::new(ReloadKind::Systemd, "roxyd.service"),
+        },
+        "review" => RegistrationSpec {
+            cert_group: Some(3000),
+            reload: ReloadSpec::new(ReloadKind::DockerRestart, "review"),
+        },
+        _ => sample_spec(),
+    }
+}
+
+fn requested(spec: &RegistrationSpec) -> RequestedSpec {
+    RequestedSpec::new(spec.reload.clone(), spec.cert_group)
+}
+
+/// Writes a rendered config into a fresh temporary directory and loads it
+/// through the production loader.
+fn load_fixture(fixture: &RegistrarConfigFixture) -> (TempDir, RegistrarConfig) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = fixture.write_to(dir.path()).expect("write fixture");
+    let config = RegistrarConfig::load(&path).expect("the fixture must load");
+    (dir, config)
+}
+
+/// The fixture every test starts from: the three documented components,
+/// plus one under the reserved prefix so a test can prove the reserved
+/// guard runs *before* the component lookup.
+fn base_fixture() -> RegistrarConfigFixture {
+    RegistrarConfigFixture::new().with_component(
+        "bootroot-decoy",
+        Multiplicity::OnePerHost,
+        &RegistrationSpec {
+            cert_group: None,
+            reload: ReloadSpec::none(),
+        },
+    )
+}
+
+fn verbs_with(client: OpenBaoClient, kv_mount: &str, config: RegistrarConfig) -> RegistrarVerbs {
+    RegistrarVerbs::new(RegistrarVerbsConfig {
+        client,
+        kv_mount: kv_mount.to_string(),
+        config,
+        secret_id_options: SecretIdOptions {
+            ttl: Some("10m".to_string()),
+            num_uses: Some(1),
+            ..Default::default()
+        },
+        token_ttl: TOKEN_TTL.to_string(),
+        secret_id_ttl: SECRET_ID_TTL.to_string(),
+        wrap_ttl_policy: WrapTtlPolicy::new(Duration::minutes(30)).expect("policy maximum"),
+    })
+}
+
+fn mint_request(service_name: &str, host: &str, instance: Option<u32>) -> MintRequest {
+    MintRequest {
+        caller: CallerIdentity::new(CALLER),
+        service_name: service_name.to_string(),
+        host: host.to_string(),
+        instance,
+        spec: requested(&spec_for(service_name)),
+        wrap_ttl: Duration::minutes(5),
+    }
+}
+
+fn deregister_request(service_name: &str, host: &str, instance: Option<u32>) -> DeregisterRequest {
+    DeregisterRequest {
+        caller: CallerIdentity::new(CALLER),
+        service_name: service_name.to_string(),
+        host: host.to_string(),
+        instance,
+    }
+}
+
+/// Asserts that a refusal names the caller verbatim, carries the expected
+/// arm, and — for a pre-derivation or derivation arm — reports no
+/// `registration_id`.
+fn assert_envelope(refusal: &VerbRefusal, arm: ProducingArm) {
+    let context = refusal.context();
+    assert_eq!(context.caller().as_str(), CALLER);
+    assert!(!context.request_id().as_str().is_empty());
+    assert_eq!(context.arm(), arm);
+    if matches!(arm, ProducingArm::PreDerivation | ProducingArm::Derivation) {
+        assert_eq!(
+            context.registration_id(),
+            None,
+            "a refusal before derivation must carry no registration_id"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Fast tier: pre-derivation control flow
+// ---------------------------------------------------------------------
+
+/// A verb service over a Wiremock with **no** mounted responses: any
+/// request at all fails the mock, and the count is asserted directly.
+async fn refusal_harness(
+    fixture: &RegistrarConfigFixture,
+) -> (MockServer, TempDir, RegistrarVerbs) {
+    let server = MockServer::start().await;
+    let mut client = OpenBaoClient::new(&server.uri()).expect("client");
+    client.set_token("test-token".to_string());
+    let (dir, config) = load_fixture(fixture);
+    let verbs = verbs_with(client, "secret", config);
+    (server, dir, verbs)
+}
+
+async fn assert_untouched(server: &MockServer, verbs: &RegistrarVerbs) {
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert!(
+        requests.is_empty(),
+        "a pre-derivation refusal must reach OpenBao not at all, saw {} request(s)",
+        requests.len()
+    );
+    assert_eq!(
+        verbs.tracked_lock_count(),
+        0,
+        "a refusal before the per-id stage must take no per-id lock"
+    );
+}
+
+/// The reserved namespace is refused case-insensitively, and it is
+/// refused *before* the component lookup: the fixture declares
+/// `bootroot-decoy` as a perfectly ordinary component, and it is still
+/// unmintable.
+#[tokio::test]
+async fn both_verbs_refuse_a_reserved_service_name_before_the_component_lookup() {
+    let (server, _dir, verbs) = refusal_harness(&base_fixture()).await;
+
+    for name in ["bootroot-decoy", "BOOTROOT-Decoy", "bootroot-registrar"] {
+        let refusal = verbs
+            .mint(&mint_request(name, "h1", None))
+            .await
+            .expect_err("a reserved service_name must be refused");
+        assert_envelope(&refusal, ProducingArm::PreDerivation);
+        assert!(
+            matches!(refusal.error(), VerbError::ReservedServiceName { service_name } if service_name == name),
+            "expected a reserved-name refusal for {name}, got {:?}",
+            refusal.error()
+        );
+
+        let refusal = verbs
+            .deregister(&deregister_request(name, "h1", None))
+            .await
+            .expect_err("a reserved service_name must be refused");
+        assert_envelope(&refusal, ProducingArm::PreDerivation);
+        assert!(matches!(
+            refusal.error(),
+            VerbError::ReservedServiceName { .. }
+        ));
+    }
+    assert_untouched(&server, &verbs).await;
+}
+
+#[tokio::test]
+async fn both_verbs_refuse_an_invalid_label() {
+    let (server, _dir, verbs) = refusal_harness(&base_fixture()).await;
+
+    let refusal = verbs
+        .mint(&mint_request("bad_name", "h1", None))
+        .await
+        .expect_err("an invalid service_name must be refused");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::InvalidServiceName { .. })
+    ));
+
+    let refusal = verbs
+        .deregister(&deregister_request("roxyd", "-h1", None))
+        .await
+        .expect_err("an invalid host must be refused");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::InvalidHost { .. })
+    ));
+
+    assert_untouched(&server, &verbs).await;
+}
+
+#[tokio::test]
+async fn both_verbs_refuse_an_absent_component() {
+    let (server, _dir, verbs) = refusal_harness(&base_fixture().without_component("roxyd")).await;
+
+    let refusal = verbs
+        .mint(&mint_request("roxyd", "h1", None))
+        .await
+        .expect_err("an absent component must be refused");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::ComponentNotConfigured { .. })
+    ));
+
+    let refusal = verbs
+        .deregister(&deregister_request("roxyd", "h1", None))
+        .await
+        .expect_err("an absent component must be refused");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::ComponentNotConfigured { .. })
+    ));
+
+    assert_untouched(&server, &verbs).await;
+}
+
+#[tokio::test]
+async fn both_verbs_refuse_an_instance_shape_mismatch() {
+    let (server, _dir, verbs) = refusal_harness(&base_fixture()).await;
+
+    // `piglet` is many-per-host: an instance is required.
+    let refusal = verbs
+        .mint(&mint_request("piglet", "h1", None))
+        .await
+        .expect_err("a missing instance must be refused");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::ServiceInstanceMismatch { .. })
+    ));
+
+    // `roxyd` is one-per-host: an instance is forbidden.
+    let refusal = verbs
+        .deregister(&deregister_request("roxyd", "h1", Some(1)))
+        .await
+        .expect_err("a supplied instance must be refused");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::ServiceInstanceMismatch { .. })
+    ));
+
+    assert_untouched(&server, &verbs).await;
+}
+
+/// A mint-only refusal: a deregister carries no spec to restate an
+/// identity with.
+#[tokio::test]
+async fn mint_refuses_a_spec_identity_disagreement_before_derivation() {
+    let (server, _dir, verbs) = refusal_harness(&base_fixture()).await;
+
+    let mut request = mint_request("roxyd", "h1", None);
+    request.spec = requested(&sample_spec()).with_service_name("roxyd-h1");
+    let refusal = verbs
+        .mint(&request)
+        .await
+        .expect_err("a restated identity that disagrees must be refused");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::SpecIdentityDisagreement {
+            field: SpecIdentityField::ServiceName,
+            ..
+        })
+    ));
+
+    assert_untouched(&server, &verbs).await;
+}
+
+/// Both named derivation failures: the derived key exceeds the 131-octet
+/// bound, and an uppercase host makes it non-path-safe. Neither takes a
+/// per-id lock, and neither reaches `OpenBao`.
+#[tokio::test]
+async fn derivation_failures_take_no_lock_and_no_openbao_work() {
+    let long_component = "c".repeat(63);
+    let long_host = "h".repeat(63);
+    let fixture =
+        base_fixture().with_component(&long_component, Multiplicity::ManyPerHost, &sample_spec());
+    let (server, _dir, verbs) = refusal_harness(&fixture).await;
+
+    // 63 + 1 + 63 + 1 + 4 = 132 octets, one past the bound.
+    let refusal = verbs
+        .mint(&mint_request(&long_component, &long_host, Some(1000)))
+        .await
+        .expect_err("an over-long derived key must be refused");
+    assert_envelope(&refusal, ProducingArm::Derivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::DerivedKeyInvalid { .. })
+    ));
+
+    // The host label is a valid DNS label but not a path-safe key
+    // segment, so the failure is on the derived string.
+    let refusal = verbs
+        .deregister(&deregister_request("roxyd", "H1", None))
+        .await
+        .expect_err("an uppercase host must fail derivation");
+    assert_envelope(&refusal, ProducingArm::Derivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::DerivedKeyInvalid { .. })
+    ));
+
+    assert_untouched(&server, &verbs).await;
+}
+
+// ---------------------------------------------------------------------
+// Fast tier: the binding record
+// ---------------------------------------------------------------------
+
+fn binding_spec_for(kind: ReloadKind) -> BindingSpec {
+    let reload = if kind.takes_target() {
+        ReloadSpec::new(kind, "target-1")
+    } else {
+        ReloadSpec::none()
+    };
+    BindingSpec::from_requested(&RequestedSpec::new(reload, Some(3000)))
+}
+
+/// The record's version-1 JSON is pinned field by field, for a `creating`
+/// record and for the `active` one it becomes.
+#[test]
+fn binding_record_round_trips_its_version_one_json() {
+    let spec = requested(&sample_spec());
+    let creating = BindingRecord::creating("h1", &spec);
+    let encoded = creating.encode().expect("encode");
+    assert_eq!(
+        encoded,
+        json!({
+            "schema_version": 1,
+            "host": "h1",
+            "state": "creating",
+            "requested_spec": {
+                "cert_group": 3001,
+                "reload": { "kind": "docker-restart", "target": "piglet" }
+            },
+            "applied_spec": null
+        })
+    );
+    assert_eq!(BindingRecord::decode(&encoded).expect("decode"), creating);
+
+    let active = creating.activated(&spec);
+    let encoded = active.encode().expect("encode");
+    assert_eq!(encoded["state"], json!("active"));
+    assert_eq!(encoded["applied_spec"], encoded["requested_spec"]);
+    assert_eq!(BindingRecord::decode(&encoded).expect("decode"), active);
+    assert_eq!(active.state, BindingState::Active);
+}
+
+/// Every reload kind round-trips, and each local spelling is the one the
+/// registrar vocabulary uses — so a variant added to [`ReloadKind`]
+/// cannot silently acquire a different word here.
+#[test]
+fn binding_reload_kinds_round_trip_and_match_the_registrar_spellings() {
+    for kind in [
+        ReloadKind::Sighup,
+        ReloadKind::Systemd,
+        ReloadKind::DockerRestart,
+        ReloadKind::None,
+    ] {
+        let local = BindingReloadKind::from(kind);
+        assert_eq!(local.as_str(), kind.as_str());
+        assert_eq!(BindingReloadKind::parse(kind.as_str()), Some(local));
+        assert_eq!(ReloadKind::from(local), kind);
+
+        let spec = binding_spec_for(kind);
+        let record = BindingRecord {
+            schema_version: BINDING_SCHEMA_VERSION,
+            host: "h1".to_string(),
+            state: BindingState::Active,
+            requested_spec: Some(spec.clone()),
+            applied_spec: Some(spec.clone()),
+        };
+        let encoded = record.encode().expect("encode");
+        assert_eq!(
+            encoded["requested_spec"]["reload"]["kind"],
+            json!(kind.as_str())
+        );
+        assert_eq!(BindingRecord::decode(&encoded).expect("decode"), record);
+        assert_eq!(spec.to_registration_spec().reload.kind, kind);
+    }
+    assert_eq!(BindingReloadKind::parse("reboot"), None);
+}
+
+#[test]
+fn binding_record_rejects_an_unknown_field() {
+    let mut encoded = BindingRecord::creating("h1", &requested(&sample_spec()))
+        .encode()
+        .expect("encode");
+    encoded["intent"] = json!("mint");
+    let err = BindingRecord::decode(&encoded).expect_err("an unknown field must be refused");
+    assert!(
+        format!("{err}").contains("intent"),
+        "the refusal must name the unknown field, got: {err}"
+    );
+}
+
+#[test]
+fn binding_record_rejects_an_unknown_schema_version() {
+    let mut encoded = BindingRecord::creating("h1", &requested(&sample_spec()))
+        .encode()
+        .expect("encode");
+    encoded["schema_version"] = json!(2);
+    let err = BindingRecord::decode(&encoded).expect_err("a newer schema must be refused");
+    assert!(
+        format!("{err}").contains("schema_version 2"),
+        "the refusal must name the version it found, got: {err}"
+    );
+
+    // A record whose version is unreadable is refused too, and it is a
+    // distinguishable failure rather than a shape complaint.
+    let err = BindingRecord::decode(&json!({ "host": "h1" }))
+        .expect_err("a record with no version must be refused");
+    assert!(format!("{err}").contains("schema_version"), "got: {err}");
+}
+
+/// A newer record carrying fields this build does not know is refused as
+/// a *version* problem, not as an unknown field: the version gate reads
+/// its own shape before the body is parsed.
+#[test]
+fn binding_record_reads_the_version_of_a_newer_record_before_its_body() {
+    let err = BindingRecord::decode(&json!({
+        "schema_version": 7,
+        "host": "h1",
+        "lease": { "epoch": 3 }
+    }))
+    .expect_err("a newer record must be refused");
+    assert!(format!("{err}").contains("schema_version 7"), "got: {err}");
+}
+
+// ---------------------------------------------------------------------
+// Fast tier: the wrap-TTL policy and the granted deadline
+// ---------------------------------------------------------------------
+
+#[test]
+fn wrap_ttl_policy_refuses_zero_negative_and_unrepresentable_requests() {
+    let policy = WrapTtlPolicy::new(Duration::minutes(30)).expect("policy");
+    assert_eq!(policy.grant(Duration::ZERO), Err(WrapTtlRefusal::Zero));
+    assert_eq!(
+        policy.grant(Duration::seconds(-1)),
+        Err(WrapTtlRefusal::Negative)
+    );
+    assert_eq!(
+        policy.grant(Duration::milliseconds(-500)),
+        Err(WrapTtlRefusal::Negative)
+    );
+    assert_eq!(
+        policy.grant(Duration::milliseconds(1500)),
+        Err(WrapTtlRefusal::NotWholeSeconds)
+    );
+    // Below a whole second, which has no OpenBao spelling either.
+    assert_eq!(
+        policy.grant(Duration::milliseconds(500)),
+        Err(WrapTtlRefusal::NotWholeSeconds)
+    );
+}
+
+#[test]
+fn wrap_ttl_policy_grants_the_minimum_of_request_and_maximum() {
+    let policy = WrapTtlPolicy::new(Duration::minutes(30)).expect("policy");
+    assert_eq!(policy.maximum(), Duration::minutes(30));
+
+    let granted = policy
+        .grant(Duration::minutes(5))
+        .expect("within the maximum");
+    assert_eq!(granted.duration(), Duration::minutes(5));
+    assert_eq!(granted.as_openbao_str(), "300s");
+
+    let granted = policy.grant(Duration::hours(4)).expect("clamped");
+    assert_eq!(granted.duration(), Duration::minutes(30));
+    assert_eq!(granted.as_openbao_str(), "1800s");
+
+    let granted = policy
+        .grant(Duration::minutes(30))
+        .expect("exactly at the maximum");
+    assert_eq!(granted.duration(), Duration::minutes(30));
+}
+
+#[test]
+fn wrap_ttl_policy_holds_its_own_maximum_to_the_same_rules() {
+    assert_eq!(
+        WrapTtlPolicy::new(Duration::ZERO),
+        Err(WrapTtlRefusal::Zero)
+    );
+    assert_eq!(
+        WrapTtlPolicy::new(Duration::seconds(-30)),
+        Err(WrapTtlRefusal::Negative)
+    );
+}
+
+/// The granted deadline comes from what `OpenBao` reported, so a
+/// server-side clamp — a TTL smaller than the one asked for — is
+/// reflected rather than the request being echoed back.
+#[test]
+fn granted_deadline_reflects_the_reported_creation_time_and_ttl() {
+    let wrap_info = WrapInfo {
+        token: "wrap-token".to_string(),
+        ttl: 60,
+        creation_time: "2026-08-18T12:00:00Z".to_string(),
+        creation_path: "auth/approle/role/x/secret-id".to_string(),
+    };
+    let deadline = granted_deadline(&wrap_info).expect("a well-formed WrapInfo");
+    assert_eq!(
+        deadline,
+        OffsetDateTime::parse("2026-08-18T12:01:00Z", &Rfc3339).expect("expected deadline")
+    );
+}
+
+#[test]
+fn granted_deadline_refuses_a_creation_time_that_is_not_rfc3339() {
+    let wrap_info = WrapInfo {
+        token: "wrap-token".to_string(),
+        ttl: 60,
+        creation_time: "not a timestamp".to_string(),
+        creation_path: "auth/approle/role/x/secret-id".to_string(),
+    };
+    assert!(granted_deadline(&wrap_info).is_err());
+}
+
+/// A mint whose `wrap_ttl` cannot produce a usable lifetime is refused
+/// before any `OpenBao` call, so no credential and no binding is created
+/// that would then have to be revoked.
+#[tokio::test]
+async fn mint_refuses_an_unusable_wrap_ttl_before_touching_openbao() {
+    let (server, _dir, verbs) = refusal_harness(&base_fixture()).await;
+
+    for (requested, expected) in [
+        (Duration::ZERO, WrapTtlRefusal::Zero),
+        (Duration::seconds(-5), WrapTtlRefusal::Negative),
+        (Duration::milliseconds(250), WrapTtlRefusal::NotWholeSeconds),
+    ] {
+        let mut request = mint_request("roxyd", "h1", None);
+        request.wrap_ttl = requested;
+        let refusal = verbs
+            .mint(&request)
+            .await
+            .expect_err("an unusable wrap_ttl must be refused");
+        assert_envelope(&refusal, ProducingArm::PreDerivation);
+        assert!(
+            matches!(refusal.error(), VerbError::InvalidWrapTtl(err) if *err == expected),
+            "expected {expected:?}, got {:?}",
+            refusal.error()
+        );
+    }
+    assert_untouched(&server, &verbs).await;
+}
+
+// ---------------------------------------------------------------------
+// Fast tier: the outcome's redaction and the teardown suffix set
+// ---------------------------------------------------------------------
+
+/// No `Debug` on a successful mint may print the wrapped token, and the
+/// only way to get at it is the consuming accessor on the outcome.
+#[test]
+fn a_mint_outcome_redacts_its_wrapped_token_in_debug() {
+    const TOKEN: &str = "hvs.super-secret-wrap-token";
+    let outcome = MintOutcome::new(
+        VerbContext::new(
+            RequestId::generate(),
+            CallerIdentity::new(CALLER),
+            Some("h1-roxyd".to_string()),
+            ProducingArm::Issuance,
+        ),
+        MintKind::FirstMint,
+        "001.roxyd.h1.trusted.domain".to_string(),
+        "role-id".to_string(),
+        WrappedSecretIdToken::new(TOKEN.to_string()),
+        OffsetDateTime::now_utc(),
+    );
+
+    let rendered = format!("{outcome:?}");
+    assert!(
+        !rendered.contains(TOKEN),
+        "the wrapped token must never reach a Debug rendering: {rendered}"
+    );
+    assert!(
+        rendered.contains("<redacted>"),
+        "the redaction must be visible rather than the field being dropped: {rendered}"
+    );
+    assert!(
+        rendered.contains("role-id"),
+        "the rest of the outcome must still be legible: {rendered}"
+    );
+    assert_eq!(
+        format!("{:?}", WrappedSecretIdToken::new(TOKEN.to_string())),
+        "<redacted>"
+    );
+    assert_eq!(outcome.into_wrapped_secret_id(), TOKEN);
+}
+
+/// The registrar sweeps all five service-material suffixes, `reissue`
+/// included, and never the binding — which outlives the material and is
+/// deleted separately.
+#[test]
+fn the_registrar_teardown_set_is_the_five_material_suffixes_and_not_the_binding() {
+    use crate::trust_bootstrap::{
+        SERVICE_EAB_KV_SUFFIX, SERVICE_REISSUE_KV_SUFFIX, SERVICE_RESPONDER_HMAC_KV_SUFFIX,
+        SERVICE_SECRET_ID_KV_SUFFIX, SERVICE_TRUST_KV_SUFFIX,
+    };
+
+    assert_eq!(
+        REGISTRAR_TEARDOWN_KV_SUFFIXES,
+        [
+            SERVICE_EAB_KV_SUFFIX,
+            SERVICE_RESPONDER_HMAC_KV_SUFFIX,
+            SERVICE_TRUST_KV_SUFFIX,
+            SERVICE_SECRET_ID_KV_SUFFIX,
+            SERVICE_REISSUE_KV_SUFFIX,
+        ]
+    );
+    assert!(
+        !REGISTRAR_TEARDOWN_KV_SUFFIXES.contains(&REGISTRAR_BINDING_KV_SUFFIX),
+        "the binding must never be swept as material"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Ignored tier: everything that depends on a prior OpenBao write
+// ---------------------------------------------------------------------
+
+/// The live backend's connection details, read from the scenario-supplied
+/// environment. Nothing here writes the environment.
+struct LiveBackend {
+    url: String,
+    token: String,
+    kv_mount: String,
+}
+
+impl LiveBackend {
+    fn from_env() -> Self {
+        let read = |name: &str| {
+            std::env::var(name).unwrap_or_else(|_| {
+                panic!("{name} must be set; run scripts/impl/run-registrar-verbs-e2e.sh")
+            })
+        };
+        Self {
+            url: read(ENV_OPENBAO_URL),
+            token: read(ENV_OPENBAO_TOKEN),
+            kv_mount: read(ENV_KV_MOUNT),
+        }
+    }
+
+    fn client(&self) -> OpenBaoClient {
+        self.client_with_token(&self.token)
+    }
+
+    fn client_with_token(&self, token: &str) -> OpenBaoClient {
+        let mut client = OpenBaoClient::new(&self.url).expect("client");
+        client.set_token(token.to_string());
+        client
+    }
+
+    fn verbs(&self, config: RegistrarConfig) -> RegistrarVerbs {
+        verbs_with(self.client(), &self.kv_mount, config)
+    }
+
+    /// Issues a token carrying exactly `policies`, so a test can drive a
+    /// verb whose privileges are deliberately incomplete.
+    async fn scoped_token(&self, policies: &[&str]) -> String {
+        let response = reqwest::Client::new()
+            .post(format!("{}/v1/auth/token/create", self.url))
+            .header("X-Vault-Token", &self.token)
+            .json(&json!({ "policies": policies, "ttl": "30m", "no_default_policy": true }))
+            .send()
+            .await
+            .expect("token create");
+        let body: serde_json::Value = response.json().await.expect("token create body");
+        body["auth"]["client_token"]
+            .as_str()
+            .expect("a client token")
+            .to_string()
+    }
+
+    async fn read_role(&self, role_name: &str) -> Option<serde_json::Value> {
+        let response = reqwest::Client::new()
+            .get(format!("{}/v1/auth/approle/role/{role_name}", self.url))
+            .header("X-Vault-Token", &self.token)
+            .send()
+            .await
+            .expect("role read");
+        if !response.status().is_success() {
+            return None;
+        }
+        let body: serde_json::Value = response.json().await.expect("role body");
+        Some(body["data"].clone())
+    }
+
+    async fn lookup_secret_id(&self, role_name: &str, secret_id: &str) -> serde_json::Value {
+        let response = reqwest::Client::new()
+            .post(format!(
+                "{}/v1/auth/approle/role/{role_name}/secret-id/lookup",
+                self.url
+            ))
+            .header("X-Vault-Token", &self.token)
+            .json(&json!({ "secret_id": secret_id }))
+            .send()
+            .await
+            .expect("secret-id lookup");
+        let body: serde_json::Value = response.json().await.expect("lookup body");
+        body["data"].clone()
+    }
+
+    async fn binding_of(&self, registration_id: &str) -> Option<serde_json::Value> {
+        self.client()
+            .try_read_kv(
+                &self.kv_mount,
+                &format!("bootroot/services/{registration_id}/{REGISTRAR_BINDING_KV_SUFFIX}"),
+            )
+            .await
+            .expect("binding read")
+    }
+
+    async fn plant(&self, registration_id: &str, suffix: &str) {
+        self.client()
+            .write_kv(
+                &self.kv_mount,
+                &format!("bootroot/services/{registration_id}/{suffix}"),
+                json!({ "planted": true }),
+            )
+            .await
+            .expect("plant a record");
+    }
+
+    async fn kv_exists(&self, registration_id: &str, suffix: &str) -> bool {
+        self.client()
+            .kv_exists(
+                &self.kv_mount,
+                &format!("bootroot/services/{registration_id}/{suffix}"),
+            )
+            .await
+            .expect("kv exists")
+    }
+}
+
+/// Grants exactly what a verb needs to read and claim a binding, and
+/// nothing that would let it write a policy — so a mint's compare-and-set
+/// wins and its convergence then fails.
+async fn install_binding_only_policy(backend: &LiveBackend, name: &str) {
+    let mount = &backend.kv_mount;
+    let policy = format!(
+        r#"path "{mount}/data/bootroot/services/*" {{
+  capabilities = ["create", "read", "update"]
+}}
+path "{mount}/metadata/bootroot/services/*" {{
+  capabilities = ["read", "list", "delete"]
+}}
+"#
+    );
+    backend
+        .client()
+        .write_policy(name, &policy)
+        .await
+        .expect("write the restricted policy");
+}
+
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn first_mint_creates_exactly_the_derived_role_and_policy() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+
+    let outcome = verbs
+        .mint(&mint_request("piglet", &host, Some(1)))
+        .await
+        .expect("the first mint must succeed");
+    let registration_id = format!("{host}-piglet-001");
+
+    assert_eq!(outcome.kind(), MintKind::FirstMint);
+    assert_eq!(outcome.context().caller().as_str(), CALLER);
+    assert_eq!(
+        outcome.context().registration_id(),
+        Some(registration_id.as_str())
+    );
+    assert_eq!(
+        outcome.san(),
+        format!("001.piglet.{host}.trusted.domain"),
+        "the SAN is composed from the parts and the rendered domain"
+    );
+
+    let role_name = service_role_name(&registration_id);
+    let role = backend
+        .read_role(&role_name)
+        .await
+        .expect("the derived role must exist");
+    assert_eq!(
+        role["token_policies"],
+        json!([service_policy_name(&registration_id)]),
+        "the role must carry exactly the derived policy"
+    );
+    assert_eq!(role["token_ttl"], json!(3600));
+    assert_eq!(role["secret_id_ttl"], json!(86400));
+
+    // The binding is active before any material was returned.
+    let binding = backend
+        .binding_of(&registration_id)
+        .await
+        .expect("a binding must exist");
+    assert_eq!(binding["state"], json!("active"));
+    assert_eq!(binding["host"], json!(host));
+    assert_eq!(binding["applied_spec"], binding["requested_spec"]);
+
+    // The material is wrap-only: unwrapping it here is the first and only
+    // unwrap, which is what proves the verb did not unwrap it itself.
+    let expires_at = outcome.expires_at();
+    let now = OffsetDateTime::now_utc();
+    assert!(expires_at > now && expires_at <= now + Duration::minutes(6));
+    let token = outcome.into_wrapped_secret_id();
+    let secret_id = backend
+        .client()
+        .unwrap_secret_id(&token)
+        .await
+        .expect("the wrap token must still be unused");
+    let lookup = backend.lookup_secret_id(&role_name, &secret_id).await;
+    assert_eq!(
+        lookup["secret_id_num_uses"],
+        json!(1),
+        "the construction-fixed secret-id options must be what was applied"
+    );
+
+    verbs
+        .deregister(&deregister_request("piglet", &host, Some(1)))
+        .await
+        .expect("cleanup");
+}
+
+/// A same-host, same-spec re-mint returns fresh material and leaves the
+/// role and policy exactly as they were.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn same_host_rematch_reuses_the_role_and_returns_fresh_material() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+    let registration_id = format!("{host}-roxyd");
+    let role_name = service_role_name(&registration_id);
+
+    let request = mint_request("roxyd", &host, None);
+    let first = verbs.mint(&request).await.expect("first mint");
+    assert_eq!(first.kind(), MintKind::FirstMint);
+    let first_role_id = first.role_id().to_string();
+    let first_token = first.into_wrapped_secret_id();
+
+    // A different caller identity reaches the outcome unchanged and
+    // influences neither the derived identity nor the role it addresses.
+    let mut other_caller = request.clone();
+    other_caller.caller = CallerIdentity::new("spiffe://review/other#0001");
+    let second = verbs.mint(&other_caller).await.expect("re-mint");
+    assert_eq!(
+        second.context().caller().as_str(),
+        "spiffe://review/other#0001"
+    );
+    assert_eq!(
+        second.context().registration_id(),
+        Some(registration_id.as_str()),
+        "the caller identity is no part of the derivation"
+    );
+    assert_eq!(second.kind(), MintKind::IdempotentReMint);
+    assert_eq!(
+        second.role_id(),
+        first_role_id,
+        "a re-mint must not replace the role"
+    );
+    let second_token = second.into_wrapped_secret_id();
+    assert_ne!(first_token, second_token, "the material must be fresh");
+
+    // Both tokens are live and independent: the re-mint issued a new
+    // secret_id rather than re-wrapping the first.
+    let role = backend.read_role(&role_name).await.expect("role");
+    assert_eq!(role["token_policies"], json!([role_name]));
+    backend
+        .client()
+        .unwrap_secret_id(&first_token)
+        .await
+        .expect("the first token is still unused");
+    backend
+        .client()
+        .unwrap_secret_id(&second_token)
+        .await
+        .expect("the second token is unused");
+
+    verbs
+        .deregister(&deregister_request("roxyd", &host, None))
+        .await
+        .expect("cleanup");
+}
+
+/// A request larger than the registrar's maximum is clamped, and the
+/// deadline reported is the granted one — never the requested one.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn a_request_over_the_maximum_is_clamped_in_the_granted_expiry() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+
+    let mut request = mint_request("piglet", &host, Some(2));
+    request.wrap_ttl = Duration::hours(12);
+    let before = OffsetDateTime::now_utc();
+    let outcome = verbs.mint(&request).await.expect("mint");
+    let expires_at = outcome.expires_at();
+
+    assert!(
+        expires_at <= before + Duration::minutes(31),
+        "the granted deadline must reflect the registrar's 30m maximum, got {expires_at}"
+    );
+    assert!(
+        expires_at > before,
+        "the granted deadline must be in the future, got {expires_at}"
+    );
+
+    verbs
+        .deregister(&deregister_request("piglet", &host, Some(2)))
+        .await
+        .expect("cleanup");
+}
+
+/// The non-injective pair: `web` on `h1-aimer` and `aimer-web` on `h1`
+/// derive one id, and the second host is refused **before** any spec
+/// comparison — including from a second verb service, which is what a
+/// second process would be.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn a_second_host_is_refused_before_the_spec_comparison_across_instances() {
+    let backend = LiveBackend::from_env();
+    let stem = unique_label("n");
+    // `web` on `<stem>-aimer` and `aimer-web` on `<stem>` derive one id:
+    // both a component name and a host label may carry hyphens, so the
+    // derivation is not injective and the durable binding is the only
+    // thing that can tell the two installations apart.
+    let host_a = format!("{stem}-aimer");
+    let host_b = stem.clone();
+    let fixture = base_fixture()
+        .with_component("web", Multiplicity::ManyPerHost, &sample_spec())
+        .with_component("aimer-web", Multiplicity::ManyPerHost, &sample_spec());
+    let (_dir_one, config_one) = load_fixture(&fixture);
+    let (_dir_two, config_two) = load_fixture(&fixture);
+    let first = backend.verbs(config_one);
+    let second = backend.verbs(config_two);
+
+    let derived = format!("{host_a}-web-001");
+    assert_eq!(
+        derived,
+        format!("{host_b}-aimer-web-001"),
+        "the pair must derive one id"
+    );
+
+    first
+        .mint(&mint_request("web", &host_a, Some(1)))
+        .await
+        .expect("the first host claims the id");
+
+    // A different verb service, sharing only OpenBao: the refusal comes
+    // from the durable binding, not from process memory, so it is the
+    // same refusal a restarted registrar would produce.
+    let refusal = second
+        .mint(&mint_request("aimer-web", &host_b, Some(1)))
+        .await
+        .expect_err("the second host must be refused");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::RegistrationIdCollision { stored_host, .. } if *stored_host == host_a
+        ),
+        "expected a collision naming the bound host, got {:?}",
+        refusal.error()
+    );
+    assert_eq!(refusal.context().arm(), ProducingArm::Binding);
+
+    let binding = backend.binding_of(&derived).await.expect("binding");
+    assert_eq!(binding["host"], json!(host_a));
+    assert_eq!(binding["state"], json!("active"));
+
+    first
+        .deregister(&deregister_request("web", &host_a, Some(1)))
+        .await
+        .expect("cleanup");
+}
+
+/// Safe-set refusal and stored-spec conflict are distinct, and neither
+/// changes anything.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn safe_set_refusal_and_stored_spec_conflict_are_distinct_no_change_outcomes() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let component = unique_label("c");
+    let rendered = sample_spec();
+    let fixture = base_fixture().with_component(&component, Multiplicity::ManyPerHost, &rendered);
+    let (_dir, config) = load_fixture(&fixture);
+    let verbs = backend.verbs(config);
+    let registration_id = format!("{host}-{component}-001");
+
+    // No binding yet: a spec outside the rendered safe-set is refused,
+    // and nothing is claimed.
+    let mut outside = mint_request(&component, &host, Some(1));
+    outside.spec = requested(&RegistrationSpec {
+        cert_group: Some(9999),
+        reload: rendered.reload.clone(),
+    });
+    let refusal = verbs
+        .mint(&outside)
+        .await
+        .expect_err("a spec outside the safe-set must be refused");
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::ServiceSpecOutsideSafeSet { .. })
+    ));
+    assert_eq!(refusal.context().arm(), ProducingArm::SafeSet);
+    assert!(
+        backend.binding_of(&registration_id).await.is_none(),
+        "a safe-set refusal must claim nothing"
+    );
+
+    verbs
+        .mint(&mint_request(&component, &host, Some(1)))
+        .await
+        .expect("the in-safe-set mint succeeds");
+
+    // Now re-render the config so a different spec is inside the
+    // safe-set, and re-mint: the *stored* spec is what disagrees.
+    let widened = RegistrationSpec {
+        cert_group: Some(4242),
+        reload: rendered.reload.clone(),
+    };
+    let (_dir2, config2) = load_fixture(&base_fixture().with_component(
+        &component,
+        Multiplicity::ManyPerHost,
+        &widened,
+    ));
+    let rewidened = backend.verbs(config2);
+    let mut conflicting = mint_request(&component, &host, Some(1));
+    conflicting.spec = requested(&widened);
+    let refusal = rewidened
+        .mint(&conflicting)
+        .await
+        .expect_err("a stored-spec disagreement must be refused");
+    assert!(
+        matches!(refusal.error(), VerbError::StoredSpecConflict { .. }),
+        "expected a stored-spec conflict, got {:?}",
+        refusal.error()
+    );
+    let binding = backend.binding_of(&registration_id).await.expect("binding");
+    assert_eq!(binding["applied_spec"]["cert_group"], json!(3001));
+
+    verbs
+        .deregister(&deregister_request(&component, &host, Some(1)))
+        .await
+        .expect("cleanup");
+}
+
+/// A failed convergence retains its `creating` binding. The matching host
+/// recovers by re-driving the mint; a different host stays refused; and
+/// nothing manufactures an unbound partial state.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn a_failed_convergence_retains_its_creating_binding_and_recovers() {
+    let backend = LiveBackend::from_env();
+    let stem = unique_label("r");
+    let policy_name = format!("bootroot-test-{stem}");
+    install_binding_only_policy(&backend, &policy_name).await;
+    let restricted = backend.scoped_token(&[policy_name.as_str()]).await;
+
+    // One-per-deployment, so the derived id is the bare component name
+    // and two different hosts address the same identity.
+    let component = format!("{stem}c");
+    let host = format!("{stem}a");
+    let other_host = format!("{stem}b");
+    let fixture =
+        base_fixture().with_component(&component, Multiplicity::OnePerDeployment, &sample_spec());
+    let (_dir, config) = load_fixture(&fixture);
+    let crippled = verbs_with(
+        backend.client_with_token(&restricted),
+        &backend.kv_mount,
+        config,
+    );
+    let registration_id = component.clone();
+
+    let request = mint_request(&component, &host, None);
+    let refusal = crippled
+        .mint(&request)
+        .await
+        .expect_err("the convergence must fail without policy privileges");
+    assert!(
+        matches!(refusal.error(), VerbError::Unavailable { .. }),
+        "expected an unavailable refusal, got {:?}",
+        refusal.error()
+    );
+    assert_eq!(refusal.context().arm(), ProducingArm::Provisioning);
+
+    let binding = backend
+        .binding_of(&registration_id)
+        .await
+        .expect("the claim must be retained, not rolled back");
+    assert_eq!(binding["state"], json!("creating"));
+    assert_eq!(binding["host"], json!(host));
+    assert_eq!(binding["applied_spec"], json!(null));
+    assert!(
+        backend
+            .read_role(&service_role_name(&registration_id))
+            .await
+            .is_none(),
+        "no role was created, and the binding is what covers that"
+    );
+
+    let (_dir2, config2) = load_fixture(&fixture);
+    let privileged = backend.verbs(config2);
+
+    // A different host cannot take a `creating` binding over.
+    let refusal = privileged
+        .mint(&mint_request(&component, &other_host, None))
+        .await
+        .expect_err("another host must not take a creating binding over");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::RegistrationIdCollision { stored_host, .. } if *stored_host == host
+        ),
+        "expected a collision, got {:?}",
+        refusal.error()
+    );
+    let binding = backend.binding_of(&registration_id).await.expect("binding");
+    assert_eq!(binding["state"], json!("creating"));
+    assert_eq!(binding["host"], json!(host));
+
+    // The matching host re-drives exactly the claimant's path.
+    let recovered = privileged
+        .mint(&request)
+        .await
+        .expect("the matching host re-drives the same path");
+    assert_eq!(recovered.kind(), MintKind::FirstMint);
+    let binding = backend.binding_of(&registration_id).await.expect("binding");
+    assert_eq!(binding["state"], json!("active"));
+    assert_eq!(binding["applied_spec"], binding["requested_spec"]);
+    assert!(
+        backend
+            .read_role(&service_role_name(&registration_id))
+            .await
+            .is_some(),
+        "the re-drive converges the role"
+    );
+
+    privileged
+        .deregister(&deregister_request(&component, &host, None))
+        .await
+        .expect("cleanup");
+}
+
+/// A deregister from the wrong host changes neither the binding nor the
+/// material.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn wrong_host_deregister_changes_nothing() {
+    let backend = LiveBackend::from_env();
+    let stem = unique_label("w");
+    let component = format!("{stem}c");
+    let bound_host = format!("{stem}a");
+    let other_host = format!("{stem}b");
+    // One-per-deployment, so the derived id does not carry the host and
+    // both hosts address the same identity.
+    let fixture =
+        base_fixture().with_component(&component, Multiplicity::OnePerDeployment, &sample_spec());
+    let (_dir, config) = load_fixture(&fixture);
+    let verbs = backend.verbs(config);
+
+    verbs
+        .mint(&mint_request(&component, &bound_host, None))
+        .await
+        .expect("the bound host mints");
+
+    let refusal = verbs
+        .deregister(&deregister_request(&component, &other_host, None))
+        .await
+        .expect_err("a wrong-host deregister must be refused");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::HostMismatch { stored_host, .. } if *stored_host == bound_host
+        ),
+        "expected a host mismatch, got {:?}",
+        refusal.error()
+    );
+    assert!(refusal.teardown().is_none(), "nothing may be torn down");
+
+    assert!(backend.binding_of(&component).await.is_some());
+    assert!(
+        backend
+            .read_role(&service_role_name(&component))
+            .await
+            .is_some()
+    );
+
+    // And a wrong-host *mint* is a collision, not a re-mint.
+    let refusal = verbs
+        .mint(&mint_request(&component, &other_host, None))
+        .await
+        .expect_err("a wrong-host mint must be refused");
+    assert!(matches!(
+        refusal.error(),
+        VerbError::RegistrationIdCollision { .. }
+    ));
+
+    verbs
+        .deregister(&deregister_request(&component, &bound_host, None))
+        .await
+        .expect("cleanup");
+}
+
+/// Matching-host deregister tears the material down first and only then
+/// deletes the binding, and it sweeps all five suffixes.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn matching_host_deregister_tears_down_before_it_unbinds() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+    let registration_id = format!("{host}-piglet-003");
+
+    verbs
+        .mint(&mint_request("piglet", &host, Some(3)))
+        .await
+        .expect("mint");
+    for suffix in REGISTRAR_TEARDOWN_KV_SUFFIXES {
+        backend.plant(&registration_id, suffix).await;
+    }
+
+    let outcome = verbs
+        .deregister(&deregister_request("piglet", &host, Some(3)))
+        .await
+        .expect("deregister");
+    assert_eq!(outcome.kind(), DeregisterKind::IdentityRemoved);
+    assert!(outcome.teardown().aggregate_success());
+    assert_eq!(
+        outcome.teardown().attempts().len(),
+        REGISTRAR_TEARDOWN_KV_SUFFIXES.len() + 2,
+        "every KV suffix plus the role and the policy"
+    );
+
+    for suffix in REGISTRAR_TEARDOWN_KV_SUFFIXES {
+        assert!(
+            !backend.kv_exists(&registration_id, suffix).await,
+            "{suffix} must be swept"
+        );
+    }
+    assert!(
+        backend
+            .read_role(&service_role_name(&registration_id))
+            .await
+            .is_none()
+    );
+    assert!(backend.binding_of(&registration_id).await.is_none());
+
+    // A re-mint after deregister inherits nothing, `reissue` included.
+    verbs
+        .mint(&mint_request("piglet", &host, Some(3)))
+        .await
+        .expect("re-mint after removal");
+    assert!(
+        !backend
+            .kv_exists(
+                &registration_id,
+                crate::trust_bootstrap::SERVICE_REISSUE_KV_SUFFIX
+            )
+            .await,
+        "a re-mint must not inherit a reissue record"
+    );
+    verbs
+        .deregister(&deregister_request("piglet", &host, Some(3)))
+        .await
+        .expect("cleanup");
+}
+
+/// With no binding at all, deregister still sweeps the full five-suffix
+/// set plus the role and policy, and reports already-absent. This is the
+/// accepted hazard the module header documents, exercised deliberately.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn absent_binding_deregister_sweeps_planted_orphans() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+    let registration_id = format!("{host}-roxyd");
+
+    // Plant a full orphan: role, policy and every service record, with no
+    // binding anywhere.
+    backend
+        .client()
+        .write_policy(
+            &service_policy_name(&registration_id),
+            "path \"sys/health\" { capabilities = [\"read\"] }\n",
+        )
+        .await
+        .expect("plant a policy");
+    backend
+        .client()
+        .create_approle(
+            &service_role_name(&registration_id),
+            &[service_policy_name(&registration_id).as_str()],
+            TOKEN_TTL,
+            SECRET_ID_TTL,
+            true,
+        )
+        .await
+        .expect("plant a role");
+    for suffix in REGISTRAR_TEARDOWN_KV_SUFFIXES {
+        backend.plant(&registration_id, suffix).await;
+    }
+    assert!(backend.binding_of(&registration_id).await.is_none());
+
+    let outcome = verbs
+        .deregister(&deregister_request("roxyd", &host, None))
+        .await
+        .expect("an absent-binding deregister is idempotent");
+    assert_eq!(outcome.kind(), DeregisterKind::AlreadyAbsent);
+    assert!(outcome.teardown().aggregate_success());
+
+    for suffix in REGISTRAR_TEARDOWN_KV_SUFFIXES {
+        assert!(
+            !backend.kv_exists(&registration_id, suffix).await,
+            "{suffix} must be swept even with no binding"
+        );
+    }
+    assert!(
+        backend
+            .read_role(&service_role_name(&registration_id))
+            .await
+            .is_none()
+    );
+    assert!(backend.binding_of(&registration_id).await.is_none());
+}
+
+/// An already-absent role, policy and material is a successful idempotent
+/// teardown, and the binding is still removed after it.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn deregister_removes_the_binding_after_an_already_absent_teardown() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+    let registration_id = format!("{host}-roxyd");
+
+    verbs
+        .mint(&mint_request("roxyd", &host, None))
+        .await
+        .expect("mint");
+
+    // Delete the role and policy out from under the binding.
+    backend
+        .client()
+        .delete_approle(&service_role_name(&registration_id))
+        .await
+        .expect("delete role");
+    backend
+        .client()
+        .delete_policy(&service_policy_name(&registration_id))
+        .await
+        .expect("delete policy");
+
+    let outcome = verbs
+        .deregister(&deregister_request("roxyd", &host, None))
+        .await
+        .expect("an already-absent teardown is still a success");
+    assert_eq!(outcome.kind(), DeregisterKind::IdentityRemoved);
+    assert!(outcome.teardown().aggregate_success());
+    assert!(backend.binding_of(&registration_id).await.is_none());
+}
+
+/// A deregister whose component was removed from the rendered config
+/// cannot resolve a multiplicity, so it is a pre-derivation refusal that
+/// leaves the binding and the material intact.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn deregister_is_refused_when_the_component_left_the_configuration() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+    let registration_id = format!("{host}-roxyd");
+
+    verbs
+        .mint(&mint_request("roxyd", &host, None))
+        .await
+        .expect("mint");
+
+    let (_dir2, trimmed) = load_fixture(&base_fixture().without_component("roxyd"));
+    let after_rerender = backend.verbs(trimmed);
+    let refusal = after_rerender
+        .deregister(&deregister_request("roxyd", &host, None))
+        .await
+        .expect_err("an absent component cannot be deregistered");
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+    assert!(matches!(
+        refusal.error(),
+        VerbError::Registrar(RegistrarError::ComponentNotConfigured { .. })
+    ));
+
+    assert!(backend.binding_of(&registration_id).await.is_some());
+    assert!(
+        backend
+            .read_role(&service_role_name(&registration_id))
+            .await
+            .is_some()
+    );
+
+    // Restoring the entry restores the ability to deregister.
+    verbs
+        .deregister(&deregister_request("roxyd", &host, None))
+        .await
+        .expect("cleanup once the entry is back");
+}
+
+/// Two verb services sharing one live `OpenBao` — the in-process stand-in
+/// for two processes — race the compare-and-set for one derived id from
+/// two different hosts. Exactly one gets material; the other is refused
+/// through the CAS conflict path.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn two_instances_racing_one_id_produce_exactly_one_claimant() {
+    let backend = LiveBackend::from_env();
+    let stem = unique_label("x");
+    let component = format!("{stem}c");
+    let host_a = format!("{stem}a");
+    let host_b = format!("{stem}b");
+    let fixture =
+        base_fixture().with_component(&component, Multiplicity::OnePerDeployment, &sample_spec());
+    let (_dir_one, config_one) = load_fixture(&fixture);
+    let (_dir_two, config_two) = load_fixture(&fixture);
+    let first = backend.verbs(config_one);
+    let second = backend.verbs(config_two);
+
+    let request_a = mint_request(&component, &host_a, None);
+    let request_b = mint_request(&component, &host_b, None);
+    let (a, b) = tokio::join!(first.mint(&request_a), second.mint(&request_b));
+
+    let winners = usize::from(a.is_ok()) + usize::from(b.is_ok());
+    assert_eq!(winners, 1, "exactly one host may receive material");
+
+    let ((Ok(_), Err(loser)) | (Err(loser), Ok(_))) = (a, b) else {
+        unreachable!("exactly one winner was just asserted")
+    };
+    assert!(
+        matches!(loser.error(), VerbError::RegistrationIdCollision { .. }),
+        "the loser must be refused as a collision, got {:?}",
+        loser.error()
+    );
+
+    let binding = backend.binding_of(&component).await.expect("binding");
+    let bound = binding["host"].as_str().expect("a bound host").to_string();
+    assert!(bound == host_a || bound == host_b);
+    let winner = if bound == host_a { &first } else { &second };
+    winner
+        .deregister(&deregister_request(&component, &bound, None))
+        .await
+        .expect("cleanup");
+}
+
+/// A mint and a deregister for one identity, issued concurrently against
+/// one service, are serialized: the result is one of the two clean
+/// orderings, never a half-existing identity.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn a_concurrent_mint_and_deregister_never_interleave() {
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = Arc::new(backend.verbs(config));
+    let registration_id = format!("{host}-roxyd");
+
+    verbs
+        .mint(&mint_request("roxyd", &host, None))
+        .await
+        .expect("seed the identity");
+
+    let for_mint = Arc::clone(&verbs);
+    let for_deregister = Arc::clone(&verbs);
+    let mint_host = host.clone();
+    let remove_host = host.clone();
+    let mint_task = tokio::spawn(async move {
+        for_mint
+            .mint(&mint_request("roxyd", &mint_host, None))
+            .await
+            .is_ok()
+    });
+    let remove_task = tokio::spawn(async move {
+        for_deregister
+            .deregister(&deregister_request("roxyd", &remove_host, None))
+            .await
+            .is_ok()
+    });
+    let minted = mint_task.await.expect("the mint task must not panic");
+    let removed = remove_task
+        .await
+        .expect("the deregister task must not panic");
+    assert!(removed, "the deregister must complete either way");
+
+    let binding_present = backend.binding_of(&registration_id).await.is_some();
+    let role_present = backend
+        .read_role(&service_role_name(&registration_id))
+        .await
+        .is_some();
+    assert_eq!(
+        binding_present, role_present,
+        "the identity must be wholly present or wholly gone, never half: \
+         minted={minted}, binding={binding_present}, role={role_present}"
+    );
+
+    if binding_present {
+        verbs
+            .deregister(&deregister_request("roxyd", &host, None))
+            .await
+            .expect("cleanup");
+    }
+}
+
+/// The scenario passes the connection details in and the tests only read
+/// them. This asserts the contract rather than assuming it.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn the_scenario_environment_is_read_only_and_complete() {
+    let backend = LiveBackend::from_env();
+    assert!(!backend.url.is_empty());
+    assert!(!backend.token.is_empty());
+    assert!(!backend.kv_mount.is_empty());
+    backend
+        .client()
+        .health_check()
+        .await
+        .expect("the scenario's OpenBao must be reachable");
+    // Unchanged after the whole suite has run: nothing here writes them.
+    assert_eq!(
+        std::env::var(ENV_OPENBAO_URL).ok().as_deref(),
+        Some(backend.url.as_str())
+    );
+}

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -50,7 +50,9 @@ use crate::registrar::config::{
 use crate::registrar::error::{RegistrarError, SpecIdentityField};
 use crate::registrar::fixture::RegistrarConfigFixture;
 use crate::registrar::identity::RequestedSpec;
-use crate::service_material::{service_policy_name, service_role_name};
+use crate::service_material::{
+    ResourceOutcome, ServiceResource, service_policy_name, service_role_name,
+};
 
 /// Environment variable naming the live `OpenBao` the ignored tier runs
 /// against. Read, never written.
@@ -841,6 +843,27 @@ path "{mount}/metadata/bootroot/services/*" {{
         .expect("write the restricted policy");
 }
 
+/// Grants exactly what a teardown needs to sweep the KV material, and
+/// nothing that lets it see or delete the `AppRole` or the policy — so a
+/// deregister's sweep runs to the end and still fails in aggregate.
+async fn install_material_only_policy(backend: &LiveBackend, name: &str) {
+    let mount = &backend.kv_mount;
+    let policy = format!(
+        r#"path "{mount}/data/bootroot/services/*" {{
+  capabilities = ["read"]
+}}
+path "{mount}/metadata/bootroot/services/*" {{
+  capabilities = ["read", "list", "delete"]
+}}
+"#
+    );
+    backend
+        .client()
+        .write_policy(name, &policy)
+        .await
+        .expect("write the material-only policy");
+}
+
 #[tokio::test]
 #[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
 async fn first_mint_creates_exactly_the_derived_role_and_policy() {
@@ -1360,6 +1383,102 @@ async fn matching_host_deregister_tears_down_before_it_unbinds() {
         .deregister(&deregister_request("piglet", &host, Some(3)))
         .await
         .expect("cleanup");
+}
+
+/// A deregister whose teardown fails in aggregate keeps the binding.
+///
+/// This is the other half of the teardown-before-unbind rule: the sweep
+/// attempts every resource rather than stopping at the first failure, and
+/// the durable claim is what keeps whatever survived it covered until a
+/// re-run can finish the job. Deleting the binding here would manufacture
+/// exactly the unbound orphan the binding exists to prevent.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn a_failed_teardown_retains_the_binding_and_attempts_every_resource() {
+    let backend = LiveBackend::from_env();
+    let stem = unique_label("f");
+    let policy_name = format!("bootroot-test-{stem}");
+    install_material_only_policy(&backend, &policy_name).await;
+    let restricted = backend.scoped_token(&[policy_name.as_str()]).await;
+
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = backend.verbs(config);
+    let registration_id = format!("{host}-piglet-004");
+
+    verbs
+        .mint(&mint_request("piglet", &host, Some(4)))
+        .await
+        .expect("mint");
+    for suffix in REGISTRAR_TEARDOWN_KV_SUFFIXES {
+        backend.plant(&registration_id, suffix).await;
+    }
+
+    let (_dir2, config2) = load_fixture(&base_fixture());
+    let crippled = verbs_with(
+        backend.client_with_token(&restricted),
+        &backend.kv_mount,
+        config2,
+    );
+    let refusal = crippled
+        .deregister(&deregister_request("piglet", &host, Some(4)))
+        .await
+        .expect_err("a teardown that could not finish must refuse");
+    assert_eq!(refusal.context().arm(), ProducingArm::Teardown);
+    assert!(
+        matches!(refusal.error(), VerbError::Unavailable { .. }),
+        "expected an unavailable refusal, got {:?}",
+        refusal.error()
+    );
+
+    // The report reaches the caller, and it names every resource: the
+    // sweep did not stop at the role it could not read.
+    let report = refusal.teardown().expect("the partial report is carried");
+    assert!(!report.aggregate_success());
+    assert_eq!(
+        report.attempts().len(),
+        REGISTRAR_TEARDOWN_KV_SUFFIXES.len() + 2,
+        "every KV suffix plus the role and the policy must be attempted"
+    );
+    assert!(
+        report.attempts().iter().any(|attempt| matches!(
+            attempt.resource,
+            ServiceResource::AppRole(_)
+        ) && matches!(
+            attempt.outcome,
+            ResourceOutcome::Failed(_)
+        )),
+        "the AppRole attempt must be the failure, got {:?}",
+        report.attempts()
+    );
+    // What it *could* remove, it did — a retained binding is not a
+    // rolled-back sweep.
+    for suffix in REGISTRAR_TEARDOWN_KV_SUFFIXES {
+        assert!(
+            !backend.kv_exists(&registration_id, suffix).await,
+            "{suffix} was deletable and must have been swept"
+        );
+    }
+
+    assert!(
+        backend.binding_of(&registration_id).await.is_some(),
+        "the binding must outlive a teardown that did not finish"
+    );
+    assert!(
+        backend
+            .read_role(&service_role_name(&registration_id))
+            .await
+            .is_some(),
+        "the role the sweep could not touch is still there, and still bound"
+    );
+
+    // A privileged re-run finishes the job, binding included.
+    let outcome = verbs
+        .deregister(&deregister_request("piglet", &host, Some(4)))
+        .await
+        .expect("the re-run completes the teardown");
+    assert_eq!(outcome.kind(), DeregisterKind::IdentityRemoved);
+    assert!(backend.binding_of(&registration_id).await.is_none());
 }
 
 /// With no binding at all, deregister still sweeps the full five-suffix

--- a/src/registrar/verbs/wrap_ttl.rs
+++ b/src/registrar/verbs/wrap_ttl.rs
@@ -1,0 +1,141 @@
+//! The bounded wrap-TTL policy the mint verb grants under.
+//!
+//! The requested `wrap_ttl` is the one lifetime a caller gets to
+//! influence, and it is influence rather than choice: the policy is fixed
+//! at construction, the request never selects it, and what is granted is
+//! `min(requested, maximum)`. Everything else about the credential —
+//! the secret-id options, the role-level TTLs — is a construction
+//! dependency the request cannot reach at all.
+//!
+//! Validation happens **before** any `OpenBao` call, so a request that
+//! cannot produce a usable duration never reaches the wrapping endpoint
+//! and never creates a `secret_id` that would then have to be revoked.
+
+use std::fmt;
+
+use time::Duration;
+
+/// The wrap TTL a request asked for, refused before any `OpenBao` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum WrapTtlRefusal {
+    /// The request asked for zero. A wrapping token that expires on
+    /// creation delivers nothing, so it is refused rather than clamped
+    /// up to some floor the caller did not ask for.
+    #[error("requested wrap_ttl is zero")]
+    Zero,
+    /// The request asked for a negative duration.
+    #[error("requested wrap_ttl is negative")]
+    Negative,
+    /// The request's duration cannot be written as an `OpenBao` duration
+    /// string: `OpenBao` counts whole seconds, so a sub-second remainder
+    /// has no representation and truncating it would grant a lifetime
+    /// nobody chose.
+    #[error("requested wrap_ttl is not a whole number of seconds")]
+    NotWholeSeconds,
+}
+
+/// A validated, clamped wrap TTL and the `OpenBao` duration string it is
+/// spelled with.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GrantedWrapTtl {
+    duration: Duration,
+    openbao: String,
+}
+
+impl GrantedWrapTtl {
+    /// Returns the granted duration.
+    pub(crate) fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns the `OpenBao` duration string for the granted duration.
+    pub(crate) fn as_openbao_str(&self) -> &str {
+        &self.openbao
+    }
+}
+
+impl fmt::Display for GrantedWrapTtl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.openbao)
+    }
+}
+
+/// The registrar's bounded wrap-TTL policy: a maximum plus the rules a
+/// requested value is validated under.
+///
+/// Constructed once, at the verb service's construction, and never
+/// selected by a request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WrapTtlPolicy {
+    maximum: Duration,
+    maximum_openbao: String,
+}
+
+impl WrapTtlPolicy {
+    /// Creates a policy with `maximum` as its ceiling.
+    ///
+    /// The maximum is held to the same rules a request is: it has to be
+    /// a positive whole number of seconds, or nothing it clamps to could
+    /// be spelled for `OpenBao`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`WrapTtlRefusal`] the maximum itself fails.
+    pub(crate) fn new(maximum: Duration) -> Result<Self, WrapTtlRefusal> {
+        let openbao = openbao_duration(maximum)?;
+        Ok(Self {
+            maximum,
+            maximum_openbao: openbao,
+        })
+    }
+
+    /// Returns the ceiling this policy grants under.
+    pub(crate) fn maximum(&self) -> Duration {
+        self.maximum
+    }
+
+    /// Validates `requested` and returns the granted wrap TTL,
+    /// `min(requested, maximum)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WrapTtlRefusal`] for a zero, negative or
+    /// non-whole-second request. A request *larger* than the maximum is
+    /// not a refusal — it is clamped, which is exactly what the wire
+    /// contract's "the registrar MAY clamp it" means and why the granted
+    /// deadline is computed rather than echoed.
+    pub(crate) fn grant(&self, requested: Duration) -> Result<GrantedWrapTtl, WrapTtlRefusal> {
+        let requested_openbao = openbao_duration(requested)?;
+        if requested <= self.maximum {
+            Ok(GrantedWrapTtl {
+                duration: requested,
+                openbao: requested_openbao,
+            })
+        } else {
+            Ok(GrantedWrapTtl {
+                duration: self.maximum,
+                openbao: self.maximum_openbao.clone(),
+            })
+        }
+    }
+}
+
+/// Renders a duration as an `OpenBao` duration string, refusing every
+/// value that has no such spelling.
+fn openbao_duration(value: Duration) -> Result<String, WrapTtlRefusal> {
+    if value.is_negative() {
+        return Err(WrapTtlRefusal::Negative);
+    }
+    if value.is_zero() {
+        return Err(WrapTtlRefusal::Zero);
+    }
+    if value.subsec_nanoseconds() != 0 {
+        return Err(WrapTtlRefusal::NotWholeSeconds);
+    }
+    let seconds = value.whole_seconds();
+    // `is_negative` and `is_zero` above leave only positive values, and
+    // `subsec_nanoseconds` is zero, so the whole-second count is at
+    // least one and the conversion cannot fail.
+    let seconds = u64::try_from(seconds).map_err(|_| WrapTtlRefusal::NotWholeSeconds)?;
+    Ok(format!("{seconds}s"))
+}

--- a/src/registrar/verbs/wrap_ttl.rs
+++ b/src/registrar/verbs/wrap_ttl.rs
@@ -10,6 +10,9 @@
 //! Validation happens **before** any `OpenBao` call, so a request that
 //! cannot produce a usable duration never reaches the wrapping endpoint
 //! and never creates a `secret_id` that would then have to be revoked.
+//! It also runs before the comparison with the maximum, because a
+//! request with no `OpenBao` spelling is refused on its own terms — the
+//! clamp is for durations that could have been granted.
 
 use std::fmt;
 
@@ -32,7 +35,26 @@ pub(crate) enum WrapTtlRefusal {
     /// nobody chose.
     #[error("requested wrap_ttl is not a whole number of seconds")]
     NotWholeSeconds,
+    /// The request's duration is longer than an `OpenBao` duration
+    /// string can carry. `OpenBao` parses `<n>s` as a Go
+    /// `time.Duration`, a signed 64-bit nanosecond count, so the largest
+    /// whole-second value it can hold is
+    /// [`MAX_OPENBAO_WHOLE_SECONDS`]. A larger request is refused
+    /// rather than clamped to the policy maximum: the value has no
+    /// spelling, and clamping a request that could not be written down
+    /// would hide an unrepresentable request behind a lifetime nobody
+    /// asked for.
+    #[error("requested wrap_ttl exceeds the largest OpenBao duration")]
+    ExceedsOpenBaoRange,
 }
+
+/// The largest whole-second value an `OpenBao` duration string can
+/// carry, in seconds.
+///
+/// `OpenBao` hands the string to Go's `time.ParseDuration`, whose result
+/// is a nanosecond count in an `i64`; anything past that is a parse
+/// error on the server rather than a long lifetime.
+const MAX_OPENBAO_WHOLE_SECONDS: i64 = i64::MAX / 1_000_000_000;
 
 /// A validated, clamped wrap TTL and the `OpenBao` duration string it is
 /// spelled with.
@@ -99,11 +121,15 @@ impl WrapTtlPolicy {
     ///
     /// # Errors
     ///
-    /// Returns [`WrapTtlRefusal`] for a zero, negative or
-    /// non-whole-second request. A request *larger* than the maximum is
-    /// not a refusal — it is clamped, which is exactly what the wire
-    /// contract's "the registrar MAY clamp it" means and why the granted
-    /// deadline is computed rather than echoed.
+    /// Returns [`WrapTtlRefusal`] for a zero, negative,
+    /// non-whole-second or out-of-range request. A request *larger* than
+    /// the maximum is not a refusal — it is clamped, which is exactly
+    /// what the wire contract's "the registrar MAY clamp it" means and
+    /// why the granted deadline is computed rather than echoed. That
+    /// clamp applies only to a request that has an `OpenBao` spelling in
+    /// the first place: validation runs before the comparison with the
+    /// maximum, so an unrepresentable request is refused rather than
+    /// silently granted the ceiling.
     pub(crate) fn grant(&self, requested: Duration) -> Result<GrantedWrapTtl, WrapTtlRefusal> {
         let requested_openbao = openbao_duration(requested)?;
         if requested <= self.maximum {
@@ -133,9 +159,10 @@ fn openbao_duration(value: Duration) -> Result<String, WrapTtlRefusal> {
         return Err(WrapTtlRefusal::NotWholeSeconds);
     }
     let seconds = value.whole_seconds();
-    // `is_negative` and `is_zero` above leave only positive values, and
-    // `subsec_nanoseconds` is zero, so the whole-second count is at
-    // least one and the conversion cannot fail.
-    let seconds = u64::try_from(seconds).map_err(|_| WrapTtlRefusal::NotWholeSeconds)?;
+    if seconds > MAX_OPENBAO_WHOLE_SECONDS {
+        return Err(WrapTtlRefusal::ExceedsOpenBaoRange);
+    }
+    // The checks above leave a positive whole-second count within
+    // `OpenBao`'s range, which is what the `<n>s` form spells.
     Ok(format!("{seconds}s"))
 }

--- a/src/service_material.rs
+++ b/src/service_material.rs
@@ -1,0 +1,485 @@
+//! The `OpenBao` material one service registration owns, and the two
+//! operations both of its callers share: provisioning the derived policy
+//! and `AppRole`, and tearing that material down again.
+//!
+//! Two callers reach this module and they are deliberately asymmetric:
+//!
+//! - the CLI's `service add` / `service remove`, which construct an
+//!   authenticated client, read `state.json`, prompt, and own local
+//!   artifacts; and
+//! - the registrar's mint / deregister verbs, which have none of those
+//!   and run under a privileged client of their own.
+//!
+//! What is shared is exactly the part that must not drift: the derived
+//! `bootroot-service-<registration_id>` role and policy names, the policy
+//! body, and the delete sequence. What is **not** shared is credential
+//! issuance. [`provision_service_role`] never creates a `secret_id` and
+//! never returns one, because the two callers deliver it differently —
+//! the CLI writes a raw value to a file, the registrar hands a
+//! response-wrapping token to a remote caller and must never hold the
+//! unwrapped secret at all. Putting issuance here would force one of
+//! them onto the other's delivery.
+//!
+//! Nothing here reads `state.json`, prompts, or knows a delivery mode.
+//! Every value the operations depend on — the KV mount, the role-level
+//! TTLs, the KV suffixes to sweep — arrives as a parameter, so the two
+//! callers can keep the different sets they intentionally have.
+
+use anyhow::{Context, Result};
+use thiserror::Error;
+
+use crate::openbao::OpenBaoClient;
+use crate::trust_bootstrap::{SERVICE_KV_BASE, SERVICE_REISSUE_KV_SUFFIX};
+
+/// Prefix of the derived per-registration role and policy names. The two
+/// names are one derivation, so a registration's role and its policy are
+/// always spelled alike.
+pub const SERVICE_ROLE_PREFIX: &str = "bootroot-service-";
+
+/// Returns the derived `AppRole` name for a registration.
+#[must_use]
+pub fn service_role_name(registration_id: &str) -> String {
+    format!("{SERVICE_ROLE_PREFIX}{registration_id}")
+}
+
+/// Returns the derived policy name for a registration, which is the same
+/// derivation as [`service_role_name`].
+#[must_use]
+pub fn service_policy_name(registration_id: &str) -> String {
+    format!("{SERVICE_ROLE_PREFIX}{registration_id}")
+}
+
+/// Returns the KV v2 path of one of a registration's records.
+#[must_use]
+pub fn service_kv_path(registration_id: &str, suffix: &str) -> String {
+    format!("{SERVICE_KV_BASE}/{registration_id}/{suffix}")
+}
+
+/// Builds the service `AppRole` policy body.
+///
+/// Every path is scoped to the registration's own KV subtree, so two
+/// registrations of one component on one host never see each other's
+/// material. The subtree is read-only except for the registration's own
+/// reissue object: the fast-poll loop must write
+/// `completed_at`/`completed_version` back so the control plane's
+/// `rotate force-reissue --wait` can observe completion, and that one
+/// path — and no other — carries create/update.
+#[must_use]
+pub fn build_service_policy(kv_mount: &str, registration_id: &str) -> String {
+    let base = format!("{SERVICE_KV_BASE}/{registration_id}");
+    format!(
+        r#"path "{kv_mount}/data/{base}/{SERVICE_REISSUE_KV_SUFFIX}" {{
+  capabilities = ["read", "create", "update"]
+}}
+path "{kv_mount}/data/{base}/*" {{
+  capabilities = ["read"]
+}}
+path "{kv_mount}/metadata/{base}/*" {{
+  capabilities = ["list"]
+}}
+"#
+    )
+}
+
+/// The role-level `AppRole` lifetimes a caller provisions with.
+///
+/// These are *role* settings, not per-issuance ones, and they are the
+/// caller's to choose: the CLI passes the values its `init` constants
+/// fix, and the registrar passes the ones fixed at its construction. The
+/// library declares neither, so neither caller can silently inherit the
+/// other's.
+#[derive(Debug, Clone, Copy)]
+pub struct ServiceRoleTtls<'a> {
+    /// `token_ttl`, which is also used as `token_max_ttl`.
+    pub token_ttl: &'a str,
+    /// Role-level `secret_id_ttl`.
+    pub secret_id_ttl: &'a str,
+}
+
+/// Which step of [`provision_service_role`] failed.
+///
+/// Carried so a caller can keep the distinct diagnostic it reported
+/// before this logic was shared, rather than collapsing three failures
+/// onto one message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceProvisionStep {
+    /// Writing the derived policy.
+    Policy,
+    /// Creating or converging the derived `AppRole`.
+    AppRole,
+    /// Reading the role's `role_id` back.
+    RoleId,
+}
+
+impl ServiceProvisionStep {
+    /// Returns a stable lowercase name for the step.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Policy => "policy write",
+            Self::AppRole => "approle create",
+            Self::RoleId => "role id read",
+        }
+    }
+}
+
+/// A failure in one step of [`provision_service_role`].
+#[derive(Debug, Error)]
+#[error("service role provisioning failed for {registration_id} at the {} step", step.as_str())]
+pub struct ServiceProvisionError {
+    /// The step that failed.
+    pub step: ServiceProvisionStep,
+    /// The registration whose material was being provisioned.
+    pub registration_id: String,
+    /// The underlying `OpenBao` failure.
+    #[source]
+    pub source: anyhow::Error,
+}
+
+/// The derived role and policy a successful provisioning converged on.
+///
+/// There is deliberately no `secret_id` field: issuance stays at each
+/// caller's boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvisionedServiceRole {
+    /// The derived `AppRole` name.
+    pub role_name: String,
+    /// The derived policy name, which equals `role_name`.
+    pub policy_name: String,
+    /// The role's `role_id`, read back after the role was converged.
+    pub role_id: String,
+}
+
+/// Creates or converges the derived policy and `AppRole` for a
+/// registration and returns its `role_id`.
+///
+/// Idempotent in both directions: `write_policy` and `create_approle`
+/// are upserts, so re-running this against an already-provisioned
+/// registration re-applies the current policy body and role settings
+/// rather than failing. That is what lets a caller re-drive an
+/// interrupted provisioning without a separate repair path.
+///
+/// **No `secret_id` is created here, and none is returned.** A caller
+/// that needs one issues it itself, in the delivery its own boundary
+/// requires.
+///
+/// # Errors
+///
+/// Returns [`ServiceProvisionError`] naming the step that failed.
+pub async fn provision_service_role(
+    client: &OpenBaoClient,
+    kv_mount: &str,
+    registration_id: &str,
+    ttls: ServiceRoleTtls<'_>,
+) -> Result<ProvisionedServiceRole, ServiceProvisionError> {
+    let fail = |step: ServiceProvisionStep| {
+        move |source: anyhow::Error| ServiceProvisionError {
+            step,
+            registration_id: registration_id.to_string(),
+            source,
+        }
+    };
+
+    let policy_name = service_policy_name(registration_id);
+    let policy = build_service_policy(kv_mount, registration_id);
+    client
+        .write_policy(&policy_name, &policy)
+        .await
+        .map_err(fail(ServiceProvisionStep::Policy))?;
+
+    let role_name = service_role_name(registration_id);
+    client
+        .create_approle(
+            &role_name,
+            &[policy_name.as_str()],
+            ttls.token_ttl,
+            ttls.secret_id_ttl,
+            true,
+        )
+        .await
+        .map_err(fail(ServiceProvisionStep::AppRole))?;
+
+    let role_id = client
+        .read_role_id(&role_name)
+        .await
+        .map_err(fail(ServiceProvisionStep::RoleId))?;
+
+    Ok(ProvisionedServiceRole {
+        role_name,
+        policy_name,
+        role_id,
+    })
+}
+
+/// One `OpenBao` resource a teardown attempted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServiceResource {
+    /// A KV v2 path, spelled without the mount.
+    Kv(String),
+    /// An `AppRole`, by name.
+    AppRole(String),
+    /// An ACL policy, by name.
+    Policy(String),
+}
+
+/// What happened to one resource.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResourceOutcome {
+    /// The resource existed and was deleted.
+    Removed,
+    /// The resource was already absent — the idempotent re-run case,
+    /// which is a success.
+    AlreadyAbsent,
+    /// The deletion failed. Carries the rendered failure, because the
+    /// teardown keeps going and the `anyhow::Error` cannot be held
+    /// alongside a `Clone`/`PartialEq` outcome.
+    Failed(String),
+}
+
+impl ResourceOutcome {
+    /// Returns whether this outcome leaves the resource gone.
+    #[must_use]
+    pub fn succeeded(&self) -> bool {
+        matches!(self, Self::Removed | Self::AlreadyAbsent)
+    }
+}
+
+/// One resource and what happened to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceTeardown {
+    /// The resource the attempt targeted.
+    pub resource: ServiceResource,
+    /// The result of the attempt.
+    pub outcome: ResourceOutcome,
+}
+
+/// Every resource a teardown attempted, in attempt order.
+///
+/// A teardown never short-circuits: one failed deletion must not leave
+/// the rest of a registration's material behind, because the caller's
+/// durable record of the registration is retained on any failure and the
+/// re-run has to make progress.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TeardownReport {
+    attempts: Vec<ResourceTeardown>,
+}
+
+impl TeardownReport {
+    /// Returns every attempt, in the order they were made.
+    #[must_use]
+    pub fn attempts(&self) -> &[ResourceTeardown] {
+        &self.attempts
+    }
+
+    /// Returns whether every attempted resource is now gone.
+    ///
+    /// Already-absent counts as success: a deregistration is idempotent,
+    /// and a resource an earlier run removed is not a failure to remove
+    /// it again.
+    #[must_use]
+    pub fn aggregate_success(&self) -> bool {
+        self.attempts
+            .iter()
+            .all(|attempt| attempt.outcome.succeeded())
+    }
+
+    fn record(&mut self, resource: ServiceResource, result: Result<bool>) {
+        let outcome = match result {
+            Ok(true) => ResourceOutcome::Removed,
+            Ok(false) => ResourceOutcome::AlreadyAbsent,
+            Err(err) => ResourceOutcome::Failed(format!("{err:#}")),
+        };
+        self.attempts.push(ResourceTeardown { resource, outcome });
+    }
+}
+
+/// Deletes a registration's `OpenBao` material: every KV path named by
+/// `kv_suffixes`, then the derived `AppRole`, then the derived policy.
+///
+/// Every resource is attempted even when an earlier one failed, and the
+/// per-resource outcome is reported rather than raised, so the caller
+/// decides what a partial failure means for its own durable record. The
+/// role and policy names are derived from `registration_id` here; a
+/// caller does not pass them, so the names torn down cannot drift from
+/// the names [`provision_service_role`] created.
+///
+/// `kv_suffixes` is the caller's set on purpose. The CLI passes what its
+/// `state.json` entry says it wrote; the registrar passes the full
+/// service-material set. Neither includes a registrar binding — a
+/// binding outlives the material it covers and is deleted separately,
+/// only after this report reports aggregate success.
+pub async fn teardown_service_material(
+    client: &OpenBaoClient,
+    kv_mount: &str,
+    registration_id: &str,
+    kv_suffixes: &[&str],
+) -> TeardownReport {
+    let mut report = TeardownReport::default();
+
+    for suffix in kv_suffixes {
+        let path = service_kv_path(registration_id, suffix);
+        let result = delete_kv_if_present(client, kv_mount, &path).await;
+        report.record(ServiceResource::Kv(path), result);
+    }
+
+    let role_name = service_role_name(registration_id);
+    let result = delete_approle_if_present(client, &role_name).await;
+    report.record(ServiceResource::AppRole(role_name), result);
+
+    let policy_name = service_policy_name(registration_id);
+    let result = delete_policy_if_present(client, &policy_name).await;
+    report.record(ServiceResource::Policy(policy_name), result);
+
+    report
+}
+
+async fn delete_kv_if_present(client: &OpenBaoClient, mount: &str, path: &str) -> Result<bool> {
+    if client
+        .kv_exists(mount, path)
+        .await
+        .with_context(|| format!("checking KV path {path}"))?
+    {
+        client
+            .delete_kv(mount, path)
+            .await
+            .with_context(|| format!("deleting KV path {path}"))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+async fn delete_approle_if_present(client: &OpenBaoClient, role_name: &str) -> Result<bool> {
+    if client
+        .approle_exists(role_name)
+        .await
+        .with_context(|| format!("checking AppRole {role_name}"))?
+    {
+        client
+            .delete_approle(role_name)
+            .await
+            .with_context(|| format!("deleting AppRole {role_name}"))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+async fn delete_policy_if_present(client: &OpenBaoClient, policy_name: &str) -> Result<bool> {
+    if client
+        .policy_exists(policy_name)
+        .await
+        .with_context(|| format!("checking policy {policy_name}"))?
+    {
+        client
+            .delete_policy(policy_name)
+            .await
+            .with_context(|| format!("deleting policy {policy_name}"))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_policy_grants_write_only_on_reissue_path() {
+        let policy = build_service_policy("secret", "edge-proxy");
+
+        assert!(
+            policy.contains(
+                "path \"secret/data/bootroot/services/edge-proxy/reissue\" {\n  capabilities = [\"read\", \"create\", \"update\"]"
+            ),
+            "reissue path must carry create/update, got:\n{policy}"
+        );
+        assert!(
+            policy.contains(
+                "path \"secret/data/bootroot/services/edge-proxy/*\" {\n  capabilities = [\"read\"]"
+            ),
+            "rest of data subtree must stay read-only, got:\n{policy}"
+        );
+        assert!(
+            policy.contains(
+                "path \"secret/metadata/bootroot/services/edge-proxy/*\" {\n  capabilities = [\"list\"]"
+            ),
+            "metadata subtree must stay list-only, got:\n{policy}"
+        );
+    }
+
+    /// The policy body is keyed on `registration_id`, so two
+    /// registrations of one component on one host get disjoint KV
+    /// subtrees even though their `service_name` is identical.
+    #[test]
+    fn service_policy_paths_derive_from_registration_id() {
+        let first = build_service_policy("secret", "h1-piglet-001");
+        let second = build_service_policy("secret", "h1-piglet-002");
+
+        assert!(first.contains("secret/data/bootroot/services/h1-piglet-001/"));
+        assert!(second.contains("secret/data/bootroot/services/h1-piglet-002/"));
+        assert!(!first.contains("h1-piglet-002"));
+        assert!(!second.contains("h1-piglet-001"));
+    }
+
+    #[test]
+    fn service_policy_grants_no_broader_write_scope() {
+        let policy = build_service_policy("secret", "edge-proxy");
+
+        for block in policy.split("path ").filter(|b| !b.is_empty()) {
+            let has_write = block.contains("create") || block.contains("update");
+            let is_reissue =
+                block.starts_with("\"secret/data/bootroot/services/edge-proxy/reissue\"");
+            assert!(
+                !has_write || is_reissue,
+                "unexpected write capability outside the reissue path:\n{block}"
+            );
+        }
+    }
+
+    /// The role and policy names are one and the same derivation off
+    /// `registration_id`, and a one-per-deployment singleton whose key is
+    /// still the bare component name keeps the exact names it had before
+    /// the split.
+    #[test]
+    fn role_and_policy_names_derive_from_registration_id() {
+        assert_eq!(service_role_name("review"), "bootroot-service-review");
+        assert_eq!(service_policy_name("review"), "bootroot-service-review");
+        assert_eq!(
+            service_role_name("h1-piglet-001"),
+            "bootroot-service-h1-piglet-001"
+        );
+        assert_ne!(
+            service_role_name("h1-piglet-001"),
+            service_role_name("h1-piglet-002")
+        );
+    }
+
+    #[test]
+    fn kv_path_composes_under_the_service_base() {
+        assert_eq!(
+            service_kv_path("h1-piglet-001", "registrar_binding"),
+            "bootroot/services/h1-piglet-001/registrar_binding"
+        );
+    }
+
+    #[test]
+    fn aggregate_success_treats_already_absent_as_a_success() {
+        let mut report = TeardownReport::default();
+        report.record(ServiceResource::Kv("a".to_string()), Ok(true));
+        report.record(ServiceResource::Kv("b".to_string()), Ok(false));
+        assert!(report.aggregate_success());
+        assert_eq!(report.attempts().len(), 2);
+
+        report.record(
+            ServiceResource::Policy("p".to_string()),
+            Err(anyhow::anyhow!("boom")),
+        );
+        assert!(!report.aggregate_success());
+        assert_eq!(
+            report.attempts().last().map(|a| &a.outcome),
+            Some(&ResourceOutcome::Failed("boom".to_string()))
+        );
+    }
+}


### PR DESCRIPTION
## What this delivers

A transport-free registrar control plane: `src/registrar/verbs.rs` and its siblings, crate-private, with no socket, codec, peer authentication or serialization. The endpoint owns all of that; this is the decision procedure alone.

Both verbs take an opaque caller identity plus the identity's parts — `service_name`, `host`, an optional `instance`, and for mint the requested spec and a `time::Duration` `wrap_ttl`. No composed name, no `registration_id`, no domain, no policy body, no role definition, no credential. The privileged `OpenBaoClient`, KV mount, loaded `RegistrarConfig`, fixed `SecretIdOptions`, role-level TTLs and the bounded wrap-TTL policy are construction dependencies, so no request reaches any of them. The caller identity is carried into every outcome unchanged and used for nothing else.

Closes #758

### The fixed order

1. **Pre-derivation**, under a process-wide `tokio::sync::Mutex` released before any `.await`: label validation, the case-insensitive `is_reserved_service_name` guard *before* the component lookup, mint's spec-identity check, multiplicity resolution and the instance-shape check. Mint also validates its `wrap_ttl` here, so every refusal on this arm carries no `registration_id`.
2. **Derivation** of the `registration_id` and the SAN, treated as fallible even after the labels validated. A derivation failure takes no per-id lock and performs no OpenBao or binding operation.
3. **Per-id work** under the `registration_id`'s own `tokio::sync::Mutex`, shared by mint and deregister.

Inside stage 3 the binding is consulted before the safe-set: a different stored host is a collision, a same-host different spec is a conflict, and only then is the requested spec compared against the rendered safe-set. The rendered spec is host-agnostic, so a safe-set-first flow would match for a second host and re-wrap the first host's identity for it.

### The durable binding

`REGISTRAR_BINDING_KV_SUFFIX = "registrar_binding"`, at `bootroot/services/<registration_id>/registrar_binding`. Schema-version-1 JSON with `schema_version`, `host`, `state` (snake_case `creating`/`active`), `requested_spec` and `applied_spec` in the verb-local `{cert_group, reload: {kind, target}}` shape, reload kinds kebab-case. Decoding reads the version on its own before the body, rejects an unknown version fail-closed without touching the data, and rejects an unknown field. No serde derives were added to `RegistrationSpec`, `ReloadSpec` or `ReloadKind`; conversion is explicit both ways and a test pins each local spelling against `ReloadKind::as_str` / `FromStr`.

New bindings are claimed with a new public absent-only KV v2 API, `OpenBaoClient::create_kv_if_absent` → `KvCreateIfAbsent::{Created(Option<u64>), AlreadyExists}`, sending `{"options":{"cas":0},"data":...}`. Only the documented CAS-mismatch 400 becomes `AlreadyExists`; every other 400 and every transport/protocol failure stays an `anyhow` error. CAS is mandatory because the per-id mutex is a *process* lock and another process can write the same namespace.

A claim that wins is never rolled back. If convergence fails or is interrupted, the `creating` binding is retained and the failure returned — that is what keeps whatever role material got created covered by a durable claim rather than manufacturing an unbound orphan. The matching host recovers through a mint re-drive or through deregister's teardown-before-unbind sequence; every other host stays refused. No credential is issued before an active binding is persisted.

### Shared provisioning and teardown

`src/service_material.rs` holds the derived role/policy names, the policy body, `provision_service_role` (policy, AppRole and `role_id` only — it never creates or returns a `secret_id`) and `teardown_service_material`, which attempts every resource, never short-circuits, and returns per-resource outcomes plus an aggregate-success predicate. Role-level TTLs arrive as an explicit `ServiceRoleTtls`, so the CLI keeps `init`'s `TOKEN_TTL`/`SECRET_ID_TTL` and the registrar supplies its construction values.

Issuance stays at each caller's boundary. `service add` keeps its `create_secret_id_wrapped` wrap-and-immediate-unwrap delivery; registrar mint alone calls `create_secret_id_wrap_only` and retains the `WrapInfo` token. `expires_at` is `OffsetDateTime`, computed by parsing `WrapInfo.creation_time` as RFC 3339 and adding the TTL OpenBao actually reported with a checked conversion, so an OpenBao-side clamp is reflected as well as the registrar's own. The token lives in a private newtype whose hand-written `Debug` prints `<redacted>` and which derives neither `Clone` nor `PartialEq`; the consuming accessor is on the successful outcome, not the newtype, so the token is moved out exactly once at the serialization boundary.

`run_service_remove` remains a CLI adapter: it plans, prompts and reports exactly as before, keeps its state-derived suffix set and its intentional omission of `reissue`, and retains its `state.json` entry on aggregate failure. `remove.rs`'s duplicate private suffix strings are gone in favour of the public `trust_bootstrap` constants. Registrar deregister always sweeps all five material suffixes — `reissue` included, which is what keeps that inheritance hazard off registrar-managed identities — and never the binding, which it deletes separately after aggregate success.

### The accepted hazard, documented rather than masked

A deregister with no binding still sweeps the full material set and returns already-absent. That is how an identity whose binding was lost gets cleaned up, and it means a manually deleted/restored binding, or an identity created through the direct CLI, can leave live material sweepable by a registrar deregister for the same derived id. No intent marker and no second state store were added; the hazard is stated in the module header.

## Testing

`cargo test`: 570 lib + 1066 bin + every integration target, all green. `cargo fmt --check --config group_imports=StdExternalCrate`, `cargo clippy --all-targets -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` are clean; `markdownlint-cli2` reports 0 issues.

**Fast tier** (22 tests): reserved-name refusal proven to run before the component lookup — the fixture declares an ordinary `bootroot-decoy` component and it is still unmintable; invalid labels, absent component and instance-shape mismatch for both verbs; spec-identity disagreement for mint; both named derivation failures (63-octet host + 63-octet component with instance 1000, and an uppercase host against a lowercase component) asserted to make zero OpenBao requests and take zero per-id locks; the binding record's version-1 JSON for every reload kind, unknown field and unknown schema version; zero, negative, sub-second and past-`time.Duration`-range wrap-TTL refusal (a whole-second request larger than 9_223_372_036s has no `OpenBao` spelling, so it is refused rather than clamped) and registrar-side clamping; the redacted `Debug`; canned-response Wiremock coverage of the CAS API's envelope, success, exact mismatch classification and non-CAS 400; and the per-id lock map, where a released guard reclaims its entry, a second holder of one id blocks on the *same* lock until the first releases rather than being handed a private mutex, and a reclaimed id is lockable again.

**Ignored tier** (15 tests) in `src/registrar/verbs/tests.rs`, run by the new `scripts/impl/run-registrar-verbs-e2e.sh` against a live OpenBao container on a free loopback port at the image tag `docker-compose.yml` pins. Verified locally against real OpenBao — 15 passed, 0 failed. They cover first mint with `token_policies == ["bootroot-service-<id>"]` and the fixed role TTLs and secret-id options, wrap-only delivery proven by the test itself performing the one and only unwrap, registrar clamping in the granted expiry, fresh same-host re-mint without replacing the role, the non-injective pair refused across two verb service instances sharing one OpenBao, distinct safe-set and stored-spec no-change refusals, a forced post-CAS convergence failure (a scoped token with KV but no policy privileges) whose `creating` binding is retained, refuses a different host and is recovered by a matching-host re-drive, wrong-host deregister changing nothing, teardown-before-unbind across all five suffixes with no `reissue` inherited by a re-mint, a deregister whose sweep fails in aggregate (a token that can delete the KV material but cannot see the AppRole or policy) asserted to attempt every resource, report the partial outcome and retain both the binding and the role it could not remove, the absent-binding orphan sweep, an already-absent teardown still unbinding, the component-removed pre-derivation refusal leaving binding and material intact, two instances racing one id producing exactly one claimant through the CAS conflict path, and a concurrent mint plus deregister asserted never to leave a half-existing identity. The scenario is wired into `scripts/preflight/ci/e2e-matrix.sh` and the `test-docker-e2e-matrix` CI job as `registrar-verbs`, and documented on the manual's CI page in both languages; the connection details reach the child `cargo test` through the environment and the tests only read them. The scenario's log collection filters the `-dev` root token out of the uploaded container log.

No stateful OpenBao fake was introduced — one would be a second implementation of the CAS semantics the claim depends on, and a bug in the first would agree with it.

## Deviations worth a reviewer's attention

- **A fourth `wrap_ttl` refusal arm.** The issue names zero, negative and "values that cannot be represented as an `OpenBao` duration string". That last one is two distinct reasons, and `WrapTtlRefusal` splits them: a sub-second remainder has no whole-second spelling, and a whole-second value above 9_223_372_036s overflows the Go `time.Duration` `OpenBao` parses `<n>s` into. Both are refused before any `OpenBao` call rather than clamped — clamping is for durations that could have been granted — and they are separate arms because the reason a caller cannot have the value differs.
- **The `creating` record carries its `requested_spec`.** The issue says "A `creating` record has `requested_spec` and `applied_spec`: null", but the next sentences — compare a creating re-drive *against `requested_spec`*, and activation sets `applied_spec` "to that same requested value" — are vacuous unless the claim records it. The claim writes `requested_spec`, leaves `applied_spec` null, and decoding still accepts a `creating` record whose `requested_spec` is null (nothing to disagree with, so the re-drive proceeds), so both readings decode.
- **The per-id lock map's own guard is a `std::sync::Mutex`.** The locks themselves are `tokio::sync::Mutex`, as required, and the map guard is held across no `.await` at all. It is a std mutex because reclaiming a dead `Weak` has to happen in `Drop`, which runs when a verb's future is cancelled as well as when it returns — an explicit async reclaim would leak an entry per cancellation. The reclaim removes only the identical, now-dead entry while holding the guard.
- **No `CHANGELOG.md` entry.** Nothing here is observable to someone running the last release: the verbs are crate-private with no endpoint, and the CLI refactor preserves `service remove`'s reporting, suffix set and state-retention behaviour exactly. This matches the precedent set by the registrar config and identity work, which added none either.

## Test plan

- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` and `cargo clippy --all-targets -- -D warnings` are clean.
- [x] Fast tier: reserved names are refused case-insensitively before the component lookup; invalid labels, absent component and instance-shape mismatch are separately matchable pre-derivation refusals for both verbs, and spec-identity disagreement for mint.
- [x] Fast tier: both named derivation failures (63-octet host + 63-octet component at instance 1000; uppercase host against a lowercase component) perform no OpenBao request and take no per-id lock.
- [x] Fast tier: the version-1 binding record round-trips for every reload kind and rejects an unknown field and an unknown schema version without mutation.
- [x] Fast tier: zero, negative and OpenBao-unrepresentable `wrap_ttl` — sub-second remainders and whole-second values past Go's `time.Duration` range — are refused before any OpenBao call, and a valid request is clamped to the construction maximum.
- [x] Fast tier: Wiremock canned responses pin the CAS request envelope, `Created`, exact `AlreadyExists` classification and a non-CAS 400 staying an error.
- [x] Fast tier: the per-id lock map reclaims a released entry, shares one lock between two holders of the same id, and re-acquires a reclaimed id.
- [x] `scripts/impl/run-registrar-verbs-e2e.sh` runs green: 15 ignored library tests against live OpenBao.
- [x] Ignored tier: first mint reads back `token_policies == ["bootroot-service-<registration_id>"]`, the fixed role TTLs and secret-id options, and wrap-only material whose sole unwrap is the test's own; `expires_at` reflects an OpenBao-side clamp.
- [x] Ignored tier: same-host matching-spec re-mint returns fresh material without replacing role or policy; safe-set refusal and stored-spec conflict are distinct no-change outcomes.
- [x] Ignored tier: the non-injective pair derives one id and the second host is refused before spec comparison, across two verb service instances sharing one OpenBao.
- [x] Ignored tier: a forced post-CAS convergence failure retains its `creating` binding, refuses a different host, and is recovered by a matching-host re-drive or deregister.
- [x] Ignored tier: matching-host deregister tears down role, policy and all five material suffixes before deleting the binding; wrong-host deregister changes nothing.
- [x] Ignored tier: a teardown that fails in aggregate still attempts every resource, reports per-resource outcomes and retains the binding.
- [x] Ignored tier: absent-binding deregister sweeps planted orphan role, policy and all five records including `reissue` and `secret_id`, returns already-absent, and leaves no binding; a re-mint inherits no `reissue`.
- [x] Ignored tier: two instances racing one id produce exactly one claimant through the CAS conflict path, and concurrent mint plus deregister never leaves a half-existing identity.
- [x] Ignored tier: a component removed from the rendered configuration makes deregister a pre-derivation refusal that leaves binding and material intact.
- [x] A distinctive opaque caller identity is preserved in outcomes and affects neither derivation nor any OpenBao request.
- [x] `service remove` retains its planning, prompting, per-resource reporting, state-derived suffix set and `state.json` retention on aggregate failure.
- [x] CI: `test-docker-e2e-matrix` runs the `registrar-verbs` scenario, and `scripts/preflight/ci/e2e-matrix.sh` runs it locally.



