### PR TITLE
Share registrar verb locks across the process (#875)

### DIFF
--- a/src/registrar/verbs.rs
+++ b/src/registrar/verbs.rs
@@ -30,12 +30,12 @@
 //! Both verbs run the same three stages, and the order is a correctness
 //! requirement rather than a preference:
 //!
-//! 1. **Pre-derivation**, under a process-wide [`tokio::sync::Mutex`]
-//!    released before any `.await`: validate the two labels, refuse a
-//!    reserved `service_name`, resolve the component's multiplicity from
-//!    the rendered config, and check the instance shape. Mint also checks
-//!    the spec's identity restatement here. Every refusal on this arm
-//!    carries **no** `registration_id`, because none has been computed.
+//! 1. **Pre-derivation**, **stateless and unsynchronized**: validate the
+//!    two labels, refuse a reserved `service_name`, resolve the
+//!    component's multiplicity from the rendered config, and check the
+//!    instance shape. Mint also checks the spec's identity restatement
+//!    here. Every refusal on this arm carries **no** `registration_id`,
+//!    because none has been computed.
 //! 2. **Derivation** of the `registration_id` and the SAN. Fallible even
 //!    after the labels validated — the ≤131-octet bound is enforced on
 //!    the derived string — and a derivation failure takes no per-id lock
@@ -43,6 +43,17 @@
 //! 3. **Per-id work**, under the `registration_id`'s own
 //!    [`tokio::sync::Mutex`], shared by both verbs so a mint and a
 //!    deregister for one identity can never interleave.
+//!
+//! Stage 3's per-id lock is the **only** in-process serialization
+//! boundary either verb has. Its map is owned by this module rather than
+//! by a service instance, so two [`RegistrarVerbs`] in one process
+//! serialize against each other on one derived id instead of each
+//! holding a private lock for it. Stages 1 and 2 read only immutable
+//! per-instance configuration and call pure functions, so nothing there
+//! needs guarding and independent validations run concurrently; a future
+//! entry-stage feature that does introduce shared state — a rate limiter,
+//! say — synchronizes that state itself rather than reinstating a
+//! blanket entry lock over everything before derivation.
 //!
 //! Inside stage 3 the binding is consulted **before** the safe-set:
 //! a different stored host is a collision, a same-host different spec is
@@ -93,7 +104,7 @@ pub(crate) mod wrap_ttl;
 mod tests;
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex as StdMutex, PoisonError, Weak};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex, PoisonError, Weak};
 
 use anyhow::Context as _;
 use time::OffsetDateTime;
@@ -137,6 +148,19 @@ pub(crate) const REGISTRAR_TEARDOWN_KV_SUFFIXES: [&str; 5] = [
     SERVICE_SECRET_ID_KV_SUFFIX,
     SERVICE_REISSUE_KV_SUFFIX,
 ];
+
+/// The one per-`registration_id` lock map the whole process shares.
+///
+/// Ownership is deliberately the module's rather than a service
+/// instance's. Two [`RegistrarVerbs`] built over one `OpenBao` namespace
+/// — a re-rendered config, a second endpoint — derive the same
+/// `registration_id` from the same parts, and a per-instance map would
+/// hand each of them a private lock for it, letting one instance's mint
+/// interleave with another's deregister. The absent-only compare-and-set
+/// is the *cross-process* ownership primitive and stays exactly that; it
+/// cannot serialize a mint against a deregister inside one process, and
+/// this map cannot serialize anything outside it.
+static ID_LOCKS: LazyLock<IdLocks> = LazyLock::new(IdLocks::default);
 
 /// How many times a mint re-reads the binding after losing the
 /// compare-and-set race before giving up as unavailable.
@@ -215,11 +239,6 @@ pub(crate) struct RegistrarVerbs {
     token_ttl: String,
     secret_id_ttl: String,
     wrap_ttl_policy: WrapTtlPolicy,
-    /// Serializes the pre-derivation stage of every invocation. Held
-    /// across no `.await`.
-    entry_lock: TokioMutex<()>,
-    /// The per-`registration_id` locks.
-    id_locks: IdLocks,
 }
 
 impl RegistrarVerbs {
@@ -233,8 +252,6 @@ impl RegistrarVerbs {
             token_ttl: config.token_ttl,
             secret_id_ttl: config.secret_id_ttl,
             wrap_ttl_policy: config.wrap_ttl_policy,
-            entry_lock: TokioMutex::new(()),
-            id_locks: IdLocks::default(),
         }
     }
 
@@ -250,17 +267,15 @@ impl RegistrarVerbs {
             )
         };
 
-        // Stage 1. No `.await` inside the guard's scope.
-        let multiplicity = {
-            let _entry = self.entry_lock.lock().await;
-            self.pre_derivation(
+        // Stage 1. Stateless, so it runs unsynchronized.
+        let multiplicity = self
+            .pre_derivation(
                 &request.service_name,
                 &request.host,
                 request.instance,
                 Some(&request.spec),
             )
-        }
-        .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
+            .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
 
         // Still stage 1: the wrap TTL is a purely local property of the
         // request, checked under the construction-supplied policy well
@@ -291,7 +306,7 @@ impl RegistrarVerbs {
             .san_for(request.instance, &request.service_name, &request.host);
 
         // Stage 3.
-        let _id_guard = self.id_locks.acquire(&registration_id).await;
+        let _id_guard = self.id_locks().acquire(&registration_id).await;
         self.mint_locked(request, &request_id, &registration_id, &san, &granted)
             .await
     }
@@ -307,11 +322,9 @@ impl RegistrarVerbs {
             )
         };
 
-        let multiplicity = {
-            let _entry = self.entry_lock.lock().await;
-            self.pre_derivation(&request.service_name, &request.host, request.instance, None)
-        }
-        .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
+        let multiplicity = self
+            .pre_derivation(&request.service_name, &request.host, request.instance, None)
+            .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
 
         let registration_id = derive_registration_id(
             multiplicity,
@@ -321,13 +334,23 @@ impl RegistrarVerbs {
         )
         .map_err(|err| refuse(ProducingArm::Derivation, None, VerbError::Registrar(err)))?;
 
-        let _id_guard = self.id_locks.acquire(&registration_id).await;
+        let _id_guard = self.id_locks().acquire(&registration_id).await;
         self.deregister_locked(request, &request_id, &registration_id)
             .await
     }
 
-    /// Stage 1, shared by both verbs. Entirely synchronous, so the
-    /// process-wide guard around it is never held across an `.await`.
+    /// Stage 1, shared by both verbs: stateless, synchronous, and
+    /// **unsynchronized**.
+    ///
+    /// It reads only this instance's immutable construction dependencies
+    /// and calls pure validators, so there is no shared mutable state to
+    /// guard and independent requests validate concurrently. The only
+    /// in-process serialization boundary either verb has is the shared
+    /// per-`registration_id` lock taken in stage 3, and fallible
+    /// derivation completes before that lock is acquired. Anything added
+    /// here that *does* carry shared state brings its own
+    /// synchronization for that state; it does not reintroduce a lock
+    /// over the whole stage.
     ///
     /// `spec` is `Some` only for a mint: the spec's identity restatement
     /// is a mint-only pre-derivation refusal, because a deregister
@@ -796,12 +819,30 @@ impl RegistrarVerbs {
         ))
     }
 
-    /// Returns how many per-id lock entries the map is currently
-    /// holding, so a test can assert that a refusal before stage 3 took
-    /// no lock at all.
+    /// Returns the process-wide per-`registration_id` lock map both
+    /// verbs take their stage 3 lock from.
+    ///
+    /// Every acquisition goes through here, so no instance can end up
+    /// locking against a map of its own.
+    // The receiver is not read, and that is the point: routing every
+    // instance's lock selection through a method on `&self` is what lets
+    // the cross-instance contention test drive this path per service and
+    // observe that both land on one map. An associated function would
+    // make that assertion untestable, so the lint's suggestion is
+    // declined here and nowhere wider.
+    #[allow(clippy::unused_self)]
+    fn id_locks(&self) -> &'static IdLocks {
+        &ID_LOCKS
+    }
+
+    /// The lock map this instance would take a per-id lock from.
+    ///
+    /// Test-only, and deliberately a delegation rather than a second
+    /// path to the static: what the contention test has to exercise is
+    /// the production lock selection, once per instance.
     #[cfg(test)]
-    fn tracked_lock_count(&self) -> usize {
-        self.id_locks.lock_entries().len()
+    fn id_locks_for_test(&self) -> &'static IdLocks {
+        self.id_locks()
     }
 
     fn binding_path(registration_id: &str) -> String {
@@ -909,6 +950,11 @@ fn granted_deadline(wrap_info: &WrapInfo) -> anyhow::Result<OffsetDateTime> {
 /// all, and reclaiming a dead entry has to happen in `Drop` — which runs
 /// when a verb's future is cancelled as well as when it returns, where an
 /// explicit async reclaim would not.
+///
+/// Production has exactly one of these, the module's [`ID_LOCKS`]. The
+/// type stays independently constructible so the reclamation tests can
+/// assert entry counts on a map of their own, where no other test in the
+/// binary can be holding an id.
 #[derive(Default)]
 struct IdLocks {
     entries: StdMutex<HashMap<String, Weak<TokioMutex<()>>>>,

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -187,20 +187,27 @@ fn assert_envelope(refusal: &VerbRefusal, arm: ProducingArm) {
 // Fast tier: pre-derivation control flow
 // ---------------------------------------------------------------------
 
+/// A client pointed at a Wiremock with **no** mounted responses, so any
+/// request at all is visible in the server's recorded requests.
+fn mock_client(server: &MockServer) -> OpenBaoClient {
+    let mut client = OpenBaoClient::new(&server.uri()).expect("client");
+    client.set_token("test-token".to_string());
+    client
+}
+
 /// A verb service over a Wiremock with **no** mounted responses: any
 /// request at all fails the mock, and the count is asserted directly.
 async fn refusal_harness(
     fixture: &RegistrarConfigFixture,
 ) -> (MockServer, TempDir, RegistrarVerbs) {
     let server = MockServer::start().await;
-    let mut client = OpenBaoClient::new(&server.uri()).expect("client");
-    client.set_token("test-token".to_string());
+    let client = mock_client(&server);
     let (dir, config) = load_fixture(fixture);
     let verbs = verbs_with(client, "secret", config);
     (server, dir, verbs)
 }
 
-async fn assert_untouched(server: &MockServer, verbs: &RegistrarVerbs) {
+async fn assert_untouched(server: &MockServer) {
     let requests = server
         .received_requests()
         .await
@@ -209,11 +216,6 @@ async fn assert_untouched(server: &MockServer, verbs: &RegistrarVerbs) {
         requests.is_empty(),
         "a pre-derivation refusal must reach OpenBao not at all, saw {} request(s)",
         requests.len()
-    );
-    assert_eq!(
-        verbs.tracked_lock_count(),
-        0,
-        "a refusal before the per-id stage must take no per-id lock"
     );
 }
 
@@ -247,7 +249,7 @@ async fn both_verbs_refuse_a_reserved_service_name_before_the_component_lookup()
             VerbError::ReservedServiceName { .. }
         ));
     }
-    assert_untouched(&server, &verbs).await;
+    assert_untouched(&server).await;
 }
 
 #[tokio::test]
@@ -274,7 +276,7 @@ async fn both_verbs_refuse_an_invalid_label() {
         VerbError::Registrar(RegistrarError::InvalidHost { .. })
     ));
 
-    assert_untouched(&server, &verbs).await;
+    assert_untouched(&server).await;
 }
 
 #[tokio::test]
@@ -301,7 +303,7 @@ async fn both_verbs_refuse_an_absent_component() {
         VerbError::Registrar(RegistrarError::ComponentNotConfigured { .. })
     ));
 
-    assert_untouched(&server, &verbs).await;
+    assert_untouched(&server).await;
 }
 
 #[tokio::test]
@@ -330,7 +332,7 @@ async fn both_verbs_refuse_an_instance_shape_mismatch() {
         VerbError::Registrar(RegistrarError::ServiceInstanceMismatch { .. })
     ));
 
-    assert_untouched(&server, &verbs).await;
+    assert_untouched(&server).await;
 }
 
 /// A mint-only refusal: a deregister carries no spec to restate an
@@ -354,14 +356,17 @@ async fn mint_refuses_a_spec_identity_disagreement_before_derivation() {
         })
     ));
 
-    assert_untouched(&server, &verbs).await;
+    assert_untouched(&server).await;
 }
 
 /// Both named derivation failures: the derived key exceeds the 131-octet
-/// bound, and an uppercase host makes it non-path-safe. Neither takes a
-/// per-id lock, and neither reaches `OpenBao`.
+/// bound, and an uppercase host makes it non-path-safe. Neither reaches
+/// `OpenBao`, which is what a refusal short of stage 3 is observable by:
+/// the per-id map is process-wide, so a count over it would be shared
+/// mutable state across this whole test binary rather than a statement
+/// about this request.
 #[tokio::test]
-async fn derivation_failures_take_no_lock_and_no_openbao_work() {
+async fn derivation_failures_reach_no_openbao_work() {
     let long_component = "c".repeat(63);
     let long_host = "h".repeat(63);
     let fixture =
@@ -391,7 +396,7 @@ async fn derivation_failures_take_no_lock_and_no_openbao_work() {
         VerbError::Registrar(RegistrarError::DerivedKeyInvalid { .. })
     ));
 
-    assert_untouched(&server, &verbs).await;
+    assert_untouched(&server).await;
 }
 
 // ---------------------------------------------------------------------
@@ -656,7 +661,7 @@ async fn mint_refuses_an_unusable_wrap_ttl_before_touching_openbao() {
             refusal.error()
         );
     }
-    assert_untouched(&server, &verbs).await;
+    assert_untouched(&server).await;
 }
 
 // ---------------------------------------------------------------------
@@ -666,9 +671,10 @@ async fn mint_refuses_an_unusable_wrap_ttl_before_touching_openbao() {
 /// A released guard reclaims its entry, so the map does not grow with
 /// every id a caller has ever named.
 ///
-/// `assert_untouched` proves only that a refusal *before* stage 3 takes
-/// no lock. This is the other half: an id that did reach stage 3 leaves
-/// nothing behind once its guard is dropped.
+/// The three reclamation tests below run against locally constructed
+/// maps rather than the process-wide static, so what they assert about
+/// entry counts is theirs alone and cannot be perturbed by another test
+/// holding a lock for the same id.
 #[tokio::test]
 async fn a_released_id_lock_reclaims_its_map_entry() {
     let locks = IdLocks::default();
@@ -757,6 +763,58 @@ async fn a_reclaimed_id_is_re_acquirable() {
     );
     drop(guard);
     assert_eq!(locks.lock_entries().len(), 0);
+}
+
+/// Two separately constructed services must serialize on one derived id.
+///
+/// This is the defect the shared map exists to close: a mint driven
+/// through one service and a deregister driven through another derive
+/// the same `registration_id`, and with a map per instance each would
+/// take a private lock for it and their binding and `OpenBao` work would
+/// interleave. Both acquisitions go through the services' own
+/// lock-selection path rather than naming the static, so an
+/// implementation that handed each instance its own map would let the
+/// waiter through immediately and fail the blocking assertion below.
+///
+/// The id is unique because the map is process-wide: a fixed label would
+/// queue behind any other test in this binary that happened to use it.
+#[tokio::test]
+async fn two_instances_share_one_per_id_lock() {
+    let server = MockServer::start().await;
+    let (_dir_one, config_one) = load_fixture(&base_fixture());
+    let (_dir_two, config_two) = load_fixture(&base_fixture());
+    let first = verbs_with(mock_client(&server), "secret", config_one);
+    let second = Arc::new(verbs_with(mock_client(&server), "secret", config_two));
+
+    let registration_id = unique_label("lk");
+    let held = first.id_locks_for_test().acquire(&registration_id).await;
+
+    let acquired = Arc::new(AtomicBool::new(false));
+    let waiter = tokio::spawn({
+        let second = Arc::clone(&second);
+        let acquired = Arc::clone(&acquired);
+        let registration_id = registration_id.clone();
+        async move {
+            let guard = second.id_locks_for_test().acquire(&registration_id).await;
+            acquired.store(true, Ordering::SeqCst);
+            drop(guard);
+        }
+    });
+
+    // Give the second service every chance to run.
+    for _ in 0..64 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !acquired.load(Ordering::SeqCst),
+        "a second service instance must queue on the lock the first is holding for {registration_id}"
+    );
+
+    drop(held);
+    waiter
+        .await
+        .expect("the second service must acquire and release");
+    assert!(acquired.load(Ordering::SeqCst));
 }
 
 // ---------------------------------------------------------------------
@@ -1746,10 +1804,21 @@ async fn deregister_is_refused_when_the_component_left_the_configuration() {
         .expect("cleanup once the entry is back");
 }
 
-/// Two verb services sharing one live `OpenBao` — the in-process stand-in
-/// for two processes — race the compare-and-set for one derived id from
-/// two different hosts. Exactly one gets material; the other is refused
-/// through the CAS conflict path.
+/// Two verb services sharing one live `OpenBao` race one derived id from
+/// two different hosts. Exactly one gets material; the other is refused.
+///
+/// The two services share the process-wide per-id lock, so the race is
+/// resolved in-process: the loser runs after the winner has persisted
+/// the binding, reads it, and is refused for the host collision. It does
+/// **not** reach the compare-and-set conflict. The verb layer's
+/// `KvCreateIfAbsent::AlreadyExists` re-read branch is by construction
+/// only reachable from another process writing the same namespace, and
+/// nothing in this suite exercises it; `src/openbao.rs` covers the
+/// client-level distinction between `OpenBao`'s documented CAS mismatch
+/// and other HTTP 400 responses against canned responses. What is
+/// asserted here remains worth asserting: concurrent requests for one
+/// derived id from two hosts produce exactly one winner and one durable
+/// binding, whichever of them gets there first.
 #[tokio::test]
 #[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
 async fn two_instances_racing_one_id_produce_exactly_one_claimant() {
@@ -1791,25 +1860,32 @@ async fn two_instances_racing_one_id_produce_exactly_one_claimant() {
         .expect("cleanup");
 }
 
-/// A mint and a deregister for one identity, issued concurrently against
-/// one service, are serialized: the result is one of the two clean
-/// orderings, never a half-existing identity.
+/// A mint and a deregister for one identity, issued concurrently through
+/// two **separately constructed** services, are serialized: the result is
+/// one of the two clean orderings, never a half-existing identity.
+///
+/// The two services are what makes this a test of the shared lock rather
+/// than of one instance's private map. Each loads the fixture into its
+/// own directory, and both `TempDir` guards stay alive for the whole
+/// body so neither rendered config is removed underneath its service.
 #[tokio::test]
 #[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
 async fn a_concurrent_mint_and_deregister_never_interleave() {
     let backend = LiveBackend::from_env();
     let host = unique_label("h");
-    let (_dir, config) = load_fixture(&base_fixture());
-    let verbs = Arc::new(backend.verbs(config));
+    let (_dir_one, config_one) = load_fixture(&base_fixture());
+    let (_dir_two, config_two) = load_fixture(&base_fixture());
+    let minting = Arc::new(backend.verbs(config_one));
+    let deregistering = Arc::new(backend.verbs(config_two));
     let registration_id = format!("{host}-roxyd");
 
-    verbs
+    minting
         .mint(&mint_request("roxyd", &host, None))
         .await
         .expect("seed the identity");
 
-    let for_mint = Arc::clone(&verbs);
-    let for_deregister = Arc::clone(&verbs);
+    let for_mint = Arc::clone(&minting);
+    let for_deregister = Arc::clone(&deregistering);
     let mint_host = host.clone();
     let remove_host = host.clone();
     let mint_task = tokio::spawn(async move {
@@ -1842,7 +1918,7 @@ async fn a_concurrent_mint_and_deregister_never_interleave() {
     );
 
     if binding_present {
-        verbs
+        deregistering
             .deregister(&deregister_request("roxyd", &host, None))
             .await
             .expect("cleanup");


### PR DESCRIPTION
Two `RegistrarVerbs` in one process derived the same `registration_id` and each took a per-id lock from its own map, so one instance's mint could interleave with another's deregister over the same binding and `OpenBao` material. The map is now a private module-owned `LazyLock<IdLocks>` and both verbs reach it through one private instance helper, `RegistrarVerbs::id_locks`. Neither `RegistrarVerbs` nor `RegistrarVerbsConfig` carries lock state any more, and sharing is not a caller convention.

The helper keeps its `&self` receiver deliberately: routing every instance's lock selection through it is what lets the new cross-instance test drive that path per service. It carries one local `#[allow(clippy::unused_self)]` with a comment stating that reason; the lint's associated-function suggestion is declined there and nowhere wider. A `cfg(test)` accessor, `id_locks_for_test`, delegates to the production helper and is not public.

The absent-only KV compare-and-set is untouched and remains the cross-process ownership primitive. The per-id Tokio mutex is still held across the binding and `OpenBao` awaits; the map's `std::sync::Mutex` is still held across none of them, and weak-entry reclamation is unchanged — an acquisition upgrades or inserts under the map guard, and a release removes only the identical dead `Weak`.

`entry_lock` is removed. Pre-derivation reads only immutable per-instance configuration and calls pure validators, so it had no shared mutable state to guard and the mutex only serialized unrelated requests. The module header and the `pre_derivation` docs now say that the stage is stateless and unsynchronized and that the shared per-id lock is the only in-process serialization boundary; a future entry-stage feature with shared state, such as the rate limiter owned by #788, synchronizes that state itself. Fallible derivation still completes before the per-id lock is acquired.

Closes #875

## Tests

- `two_instances_share_one_per_id_lock` (fast tier): holds a unique id through one service's accessor and proves acquisition through a second service stays pending until release, with the existing yield-and-atomic waiter. Verified to fail its blocking assertion under a mutant helper that returns a per-instance map.
- `tracked_lock_count` and its `assert_untouched` assertion are deleted — a count over a process-wide map is shared mutable state across the test binary. Every pre-derivation refusal still asserts no `OpenBao` request; `derivation_failures_take_no_lock_and_no_openbao_work` is renamed to `derivation_failures_reach_no_openbao_work` to match what it now asserts.
- The three `IdLocks` reclamation tests keep their locally constructed maps and their entry-creation, contention, cleanup and reacquisition assertions.
- `a_concurrent_mint_and_deregister_never_interleave` now drives the mint and the deregister through two separately constructed services, each with its own loaded fixture directory, both `TempDir` guards alive for the whole body; its complete-or-absent final-state assertion is unchanged.
- `two_instances_racing_one_id_produce_exactly_one_claimant` keeps its exactly-one-winner assertions, and its stale comment now records that with shared in-process locking the loser reads the persisted binding and is refused for the host collision, so the verb layer's `KvCreateIfAbsent::AlreadyExists` reread branch is only reachable from another process and is not covered by this suite. The canned-response tests in `src/openbao.rs` still draw the client-level CAS-mismatch distinction and are untouched.

## Test plan

- [x] A private module-owned `LazyLock` supplies the one weak per-id map; neither `RegistrarVerbs` nor `RegistrarVerbsConfig` owns lock state, and both verbs acquire through the single private instance helper.
- [x] The helper keeps its receiver under one local, commented `#[allow(clippy::unused_self)]`; the `cfg(test)` accessor delegates to it and is not public.
- [x] `two_instances_share_one_per_id_lock` uses a unique id and each instance's `cfg(test)` accessor rather than naming the static, and fails its blocking assertion when the helper returns a per-instance map.
- [x] `entry_lock` is gone, no entry-stage mutex or entry-serialization test remains, and the module header and `pre_derivation` docs state the stage is stateless and unsynchronized with the per-id lock as the only in-process boundary.
- [x] `tracked_lock_count` and its `assert_untouched` assertion are deleted; every pre-derivation refusal still asserts no `OpenBao` request.
- [x] `a_released_id_lock_reclaims_its_map_entry`, `a_contended_id_lock_is_shared_and_survives_the_first_release` and `a_reclaimed_id_is_re_acquirable` still run on locally constructed `IdLocks` values.
- [x] Acquisition upgrades or inserts under the map mutex, cleanup removes only the identical dead `Weak` under it, the map mutex crosses no `.await`, and the per-id Tokio mutex is still held through binding and `OpenBao` work.
- [x] The ignored live-`OpenBao` mint/deregister test uses two separately constructed services with two live fixture directories and keeps its complete-or-absent final-state assertion.
- [x] The two-instance claimant test keeps its exactly-one-winner assertions and documents that a cross-process `AlreadyExists` reread is not exercised here; `src/openbao.rs`'s canned-response CAS tests are unchanged.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `scripts/preflight/ci/check.sh` — passes end to end, all nine steps including the `--strict` docs build and `cargo audit` (its only warning is the pre-existing allowed `RUSTSEC-2025-0134` on `rustls-pemfile`). `mkdocs` is not installed system-wide on this host, and without it on PATH the docs step aborts the script at exit 127 before `cargo audit` runs, so it was run with `mkdocs` supplied from a virtualenv. No documentation changed here either way.
- [x] `cargo test --lib` — 571 passed.
- [x] `scripts/impl/run-registrar-verbs-e2e.sh` against a live `OpenBao` — all 15 ignored registrar verb tests pass. That script is what `scripts/preflight/ci/e2e-matrix.sh` invokes for the `registrar-verbs` scenario.

