### PR TITLE
Drop extended E2E from default preflight (#882)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,14 +474,16 @@ Where the crate handles key material or secrets:
 - Before committing, ensure the `check` job (Quality Check) in `.github/workflows/ci.yml`
   would pass for the changed files.
 - Before pushing or opening a PR, ensure all CI jobs pass (`check`,
-  `test-core`, `test-docker-e2e-matrix` from `ci.yml`, and
-  `run-extended` from `e2e-extended.yml`).
+  `test-core`, and `test-docker-e2e-matrix` from `ci.yml`).
 - **Local preflight verification**: Run `scripts/preflight/run-all.sh`
-  before pushing. At minimum, run `scripts/preflight/ci/e2e-matrix.sh`
-  and `scripts/preflight/ci/e2e-extended.sh`. These may be skipped only
-  when your changes do not affect the Docker lifecycle, E2E scripts, or
-  any code paths exercised by the E2E tests (rotation, service add/verify,
-  daemon, config, etc.).
+  before pushing. At minimum, run `scripts/preflight/ci/e2e-matrix.sh`.
+  It may be skipped only when your changes do not affect the Docker
+  lifecycle, E2E scripts, or any code paths exercised by the E2E tests
+  (rotation, service add/verify, daemon, config, etc.).
+- The extended E2E suite is scheduled CI coverage in
+  `e2e-extended.yml`, not a per-pull-request requirement. Run
+  `scripts/preflight/ci/e2e-extended.sh` only for investigation or when
+  a run is explicitly requested.
 
 ## Documentation Build
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- markdownlint-configure-file {
+  "MD013": { "tables": false }
+} -->
+
 # bootroot
 
 [![CI](https://github.com/aicers/bootroot/actions/workflows/ci.yml/badge.svg)](https://github.com/aicers/bootroot/actions/workflows/ci.yml)
@@ -174,15 +178,14 @@ Docs PR quick checklist:
 
 ## Preflight (required before push)
 
-Run all preflight checks before pushing:
+Run the standard preflight checks before pushing:
 
 ```bash
 ./scripts/preflight/run-all.sh
 ```
 
-Or run individual scripts. Scripts under `preflight/ci/` cover CI workflow
-jobs — `deploy-no-build-smoke.sh` is the file CI itself runs, the rest mirror
-what CI runs; scripts under `preflight/extra/` are local-only checks not in CI.
+<!-- markdownlint-disable-next-line MD013 -->
+For individual CI-equivalent scripts, use the table below. The default runner does not invoke extended E2E; it is scheduled/manual coverage for investigation or an explicitly requested run. `deploy-no-build-smoke.sh` is the file CI itself runs; the other CI-equivalent scripts mirror what CI runs.
 
 ### CI-equivalent (`preflight/ci/`)
 
@@ -192,7 +195,9 @@ what CI runs; scripts under `preflight/extra/` are local-only checks not in CI.
 | `./scripts/preflight/ci/deploy-no-build-smoke.sh` | `ci.yml` No-Build Smoke |
 | `./scripts/preflight/ci/test-core.sh` | `ci.yml` Unit & CLI Smoke |
 | `./scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` Docker E2E Matrix |
-| `./scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` Run Extended |
+| `./scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` Run Extended (scheduled/manual; not run by `run-all.sh`) |
+
+Scripts under `preflight/extra/` are local-only checks not in CI.
 
 ### Local-only (`preflight/extra/`)
 

--- a/docs/en/e2e-ci.md
+++ b/docs/en/e2e-ci.md
@@ -867,7 +867,8 @@ RUNNER_MODE=cron ./scripts/impl/run-harness-smoke.sh
 
 ## Local preflight standard
 
-Before pushing code, run all preflight checks:
+Before pushing code, run the standard preflight checks, which exclude
+extended E2E:
 
 ```bash
 ./scripts/preflight/run-all.sh
@@ -886,7 +887,7 @@ Or run individual scripts:
 | `./scripts/preflight/ci/deploy-no-build-smoke.sh` | `ci.yml` Deploy Compose No-Build Smoke |
 | `./scripts/preflight/ci/test-core.sh` | `ci.yml` Unit & CLI Smoke |
 | `./scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` Docker E2E Matrix |
-| `./scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` Run Extended |
+| `./scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` Run Extended (optional/manual scheduled coverage; `run-all.sh` does not invoke it) |
 
 `deploy-no-build-smoke.sh` is the one entry that is not a mirror: the
 `Deploy Compose No-Build Smoke` step runs this same file, so it cannot

--- a/docs/ko/e2e-ci.md
+++ b/docs/ko/e2e-ci.md
@@ -853,7 +853,7 @@ RUNNER_MODE=cron ./scripts/impl/run-harness-smoke.sh
 
 ## 로컬 사전검증 표준
 
-푸시 전 `scripts/preflight/` 스크립트를 실행합니다.
+푸시 전 확장 E2E를 제외한 기본 사전검증을 실행합니다.
 
 CI 워크플로 동등 스크립트(`scripts/preflight/ci/`):
 
@@ -868,7 +868,7 @@ CI 워크플로 동등 스크립트(`scripts/preflight/ci/`):
 | `scripts/preflight/ci/deploy-no-build-smoke.sh` | `ci.yml` → Deploy Compose No-Build Smoke |
 | `scripts/preflight/ci/test-core.sh` | `ci.yml` → test-core |
 | `scripts/preflight/ci/e2e-matrix.sh` | `ci.yml` → test-docker-e2e-matrix |
-| `scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` → run-extended |
+| `scripts/preflight/ci/e2e-extended.sh` | `e2e-extended.yml` → run-extended (선택/수동 예약 커버리지, 기본 실행기가 호출하지 않음) |
 
 `deploy-no-build-smoke.sh`만은 CI를 흉내 낸 스크립트가 아닙니다.
 `Deploy Compose No-Build Smoke` 단계가 이 파일을 그대로 실행하므로 CI와

--- a/scripts/preflight/run-all.sh
+++ b/scripts/preflight/run-all.sh
@@ -32,9 +32,6 @@ echo "--- ci/test-core.sh ---"
 echo "--- ci/e2e-matrix.sh ---"
 "$SCRIPT_DIR/ci/e2e-matrix.sh" "$@"
 
-echo "--- ci/e2e-extended.sh ---"
-"$SCRIPT_DIR/ci/e2e-extended.sh"
-
 echo "=== Preflight: Extra local-only checks ==="
 
 echo "--- extra/agent-scenarios.sh ---"


### PR DESCRIPTION
## Summary

`scripts/preflight/run-all.sh` no longer invokes `scripts/preflight/ci/e2e-extended.sh`. The extended suite already has independent coverage in `.github/workflows/e2e-extended.yml` (daily KST schedule gated on `main` activity, plus `workflow_dispatch`), and that workflow has no pull-request trigger — so the previous AGENTS.md requirement to pass `run-extended` before every pull request could not be satisfied by observing pull-request CI. Because the runner is `set -euo pipefail`, a slow or failing extended run also prevented the local-only agent and CLI scenario checks that follow it from running at all.

The wrapper remains directly executable as the optional command for investigation or an explicitly requested run. Neither the wrapper, the extended-suite implementation, nor the workflow is touched.

## Changes

- `scripts/preflight/run-all.sh`: removed the `ci/e2e-extended.sh` invocation. The remaining order and arguments are unchanged, including `"$SCRIPT_DIR/ci/e2e-matrix.sh" "$@"`.
- `AGENTS.md` (non-generated CI Requirements section): dropped `run-extended` from the CI-jobs list and `ci/e2e-extended.sh` from the minimum local checks; the conditional-skip clause now has `ci/e2e-matrix.sh` as its sole subject, and a new bullet describes extended E2E as scheduled/manual coverage.
- `README.md`: new standard-preflight lead-in, the specified CI-equivalent-table introduction (retaining the `deploy-no-build-smoke.sh` CI-execution distinction), the local-only introduction before the `preflight/extra/` heading, and an extended-script row labelled scheduled/manual. Headings and both table layouts are unchanged.
- `docs/en/e2e-ci.md` / `docs/ko/e2e-ci.md`: the local-preflight sections state that the standard run excludes extended E2E and mark the extended-script row optional/manual. The Korean section keeps its sole `run-all.sh` command in the existing later `전체 실행:` block.

`README.md` gained a file-scoped `MD013: tables: false` configure block and one `markdownlint-disable-next-line MD013` — the mandated paragraph is specified verbatim and cannot be wrapped, and the extended row cannot name both the script and its workflow job within 80 columns. Both `docs/en/e2e-ci.md` and `docs/ko/e2e-ci.md` already carry the same file-scoped MD013 relaxation.

## Test plan

- [x] `bash -n scripts/preflight/run-all.sh` and `bash -n scripts/preflight/ci/e2e-extended.sh`, run as separate commands — both clean.
- [x] `test -x scripts/preflight/ci/e2e-extended.sh` — the optional wrapper is still directly executable.
- [x] `grep -n 'e2e-extended' scripts/preflight/run-all.sh` — no output, exit status 1.
- [x] The matrix invocation is still `"$SCRIPT_DIR/ci/e2e-matrix.sh" "$@"`, and the ordered invocation list matches the acceptance criterion: `ci/check.sh`, `validate-deploy-compose.sh`, `validate-compose-instance-names.sh`, `validate-e2e-openssl-compat.sh`, `validate-e2e-leftover-check.sh`, `validate-e2e-run-scope.sh`, `ci/deploy-no-build-smoke.sh`, `ci/test-core.sh`, `ci/e2e-matrix.sh "$@"`, `extra/agent-scenarios.sh happy`, `extra/cli-scenarios.sh`.
- [x] `markdownlint-cli2 "**/*.md" "#node_modules" "#target"` — 0 issues across 31 files.
- [x] `./scripts/check-docs.sh` — passes (theme verification, `mkdocs build --strict`, and the built-site theme assertions).
- [x] `AGENTS.md`, `README.md`, and the English `Local preflight standard` / Korean `로컬 사전검증 표준` sections say nowhere that extended E2E runs in the default pre-push suite or is mandatory before every push; the README carries the specified standard-runner and table framing, retains the `deploy-no-build-smoke.sh` distinction, and identifies `preflight/extra/` as local-only; the Korean section retains only its later `전체 실행:` `run-all.sh` command.
- [x] `.github/workflows/e2e-extended.yml` and `scripts/preflight/ci/e2e-extended.sh` are untouched — the diff covers five files, none of them these — so the scheduled and manual entry points and the implementation remain available.

Closes #882
