### PR TITLE
Record intent and outcome around both registrar verbs (#777)

### DIFF
--- a/src/registrar/audit.rs
+++ b/src/registrar/audit.rs
@@ -55,11 +55,11 @@
 //! There is no best-effort mode, no buffering, no fire-and-forget path
 //! and no caller-selectable suppression: [`AuditRecordStore::append`]
 //! either durably wrote one line or returns a typed
-//! [`AuditStoreError`]. Writing records around the two verbs — where
-//! the intent and outcome lines go relative to the `OpenBao` work, and
-//! what a failed write returns to a caller — is not here either. The
-//! verb layer holds the store as a fixed dependency and the sibling
-//! issue that adds those call sites owns that ordering.
+//! [`AuditStoreError`]. Where the intent and outcome lines go relative
+//! to the `OpenBao` work, and what a failed write returns to a caller,
+//! is not here either: `crate::registrar::verbs` owns those call sites
+//! and their ordering, and every failure this module reports reaches it
+//! as one of the two audit-failure refusals.
 
 use std::fs::{DirBuilder, File, OpenOptions, Permissions};
 use std::io::Write as _;
@@ -756,14 +756,6 @@ mod millisecond_rfc3339 {
 /// is one definition of "which reason is this" in the repository and a
 /// second copy in `verbs.rs` would drift from the format it is supposed
 /// to spell.
-// Transitional. The sibling issue that writes intent and outcome
-// records around the two verbs is the first production caller of every
-// function here; until it lands nothing but this module's own tests
-// calls them. Widening them to `pub` to silence the lint would put a
-// crate-private control plane's refusal taxonomy on the library's
-// public surface, which is the opposite of what the visibility rule
-// asks for.
-#[allow(dead_code)]
 pub(crate) mod bridge {
     use super::{AuditOutcome, RefusalReason};
     use crate::registrar::RegistrarError;
@@ -787,7 +779,19 @@ pub(crate) mod bridge {
     }
 
     /// Returns the record outcome for a refusal: its flattened reason
-    /// and the operator-facing detail that goes with it.
+    /// and the operator-facing detail that goes with it, or `None` for a
+    /// refusal that can never reach the trail.
+    ///
+    /// The two audit-failure variants are the whole of that `None`.
+    /// `VerbError::AuditUnwritable` and `VerbError::PostMintUnrecordable`
+    /// are produced *by* a failed record write, so the record that would
+    /// carry one is the record whose write just failed. Saying so in the
+    /// return type rather than in prose is what keeps a call site from
+    /// answering a failed write with a second one: where this returns
+    /// `None`, no outcome record is written and the refusal is returned
+    /// unchanged. [`RefusalReason`] therefore gains no member for either,
+    /// and the reason table stays a total, one-to-one mapping of the
+    /// refusals a durable line can hold.
     ///
     /// The detail is the refusal's *own* message and never a formatted
     /// error chain. `VerbError::Unavailable` is taken from its explicit
@@ -795,8 +799,11 @@ pub(crate) mod bridge {
     /// source — which can carry anything at all, including values from
     /// other systems — cannot reach a durable record even if that
     /// `Display` were later changed to interpolate it.
-    pub(crate) fn refusal_outcome(error: &VerbError) -> AuditOutcome {
+    pub(crate) fn refusal_outcome(error: &VerbError) -> Option<AuditOutcome> {
         let (reason, detail) = match error {
+            VerbError::AuditUnwritable { .. } | VerbError::PostMintUnrecordable { .. } => {
+                return None;
+            }
             VerbError::ReservedServiceName { .. } => {
                 (RefusalReason::ReservedServiceName, Some(error.to_string()))
             }
@@ -816,7 +823,7 @@ pub(crate) mod bridge {
                 (RefusalReason::Unavailable, Some(activity.clone()))
             }
         };
-        AuditOutcome::Refused { reason, detail }
+        Some(AuditOutcome::Refused { reason, detail })
     }
 
     /// Flattens every refusal the config loader and the derivation

--- a/src/registrar/audit/tests.rs
+++ b/src/registrar/audit/tests.rs
@@ -407,13 +407,22 @@ fn appending_preserves_the_caller_supplied_timestamp() {
 // Format: the flattened refusal table
 // ---------------------------------------------------------------------
 
-/// Every variant of the three source enums, paired with the record
-/// reason it must flatten to.
+/// Every variant of the three source enums that a durable line can
+/// hold, paired with the record reason it must flatten to.
 ///
 /// The list is the test's definition of "all of them": adding a variant
 /// upstream without adding it here leaves `refusal_outcome`'s `match`
 /// failing to compile, and adding it here without adding a reason fails
 /// the distinctness assertion below.
+///
+/// The two audit-failure variants — `VerbError::AuditUnwritable` and
+/// `VerbError::PostMintUnrecordable` — are deliberately **not** in this
+/// table and have no [`RefusalReason`]. They are produced by a failed
+/// record write, so the record that would carry one is the record whose
+/// write just failed, and `refusal_outcome` returns `None` for exactly
+/// them. That is covered by
+/// [`the_two_audit_failures_are_the_only_unrecordable_refusals`] rather
+/// than here.
 // One entry per source variant; the exhaustiveness is the point.
 #[allow(clippy::too_many_lines)]
 fn every_refusal() -> Vec<(VerbError, RefusalReason, &'static str)> {
@@ -643,7 +652,7 @@ fn every_source_refusal_maps_to_one_distinct_record_reason() {
 
     let mut seen: Vec<String> = Vec::new();
     for (error, expected_reason, expected_name) in table {
-        let outcome = refusal_outcome(&error);
+        let outcome = refusal_outcome(&error).expect("a recordable refusal produces an outcome");
         let AuditOutcome::Refused { reason, .. } = &outcome else {
             panic!("a refusal must produce the refused class, got {outcome:?}");
         };
@@ -658,6 +667,53 @@ fn every_source_refusal_maps_to_one_distinct_record_reason() {
     assert_eq!(sorted.len(), seen.len(), "every reason must be distinct");
 }
 
+/// The two audit-failure refusals can never reach the trail, and that
+/// is enforced by the return type rather than by prose.
+///
+/// The record that would carry one of them is the record whose write
+/// just failed, so a call site that met a `Some` here would answer a
+/// failed write with a second write of the same kind. Both halves are
+/// asserted together: `None` for exactly these two, and `Some` for every
+/// other refusal the verb layer produces.
+#[test]
+fn the_two_audit_failures_are_the_only_unrecordable_refusals() {
+    let unrecordable = [
+        VerbError::AuditUnwritable {
+            phase: AuditPhase::Intent,
+            source: AuditStoreError::RecordTooLarge {
+                bytes: 1,
+                limit: MIN_AUDIT_MAX_FILE_BYTES,
+            },
+        },
+        VerbError::AuditUnwritable {
+            phase: AuditPhase::Outcome,
+            source: AuditStoreError::Sync {
+                path: PathBuf::from("/var/lib/bootroot/registrar-audit/registrar-audit.jsonl"),
+                source: std::io::Error::from(std::io::ErrorKind::StorageFull),
+            },
+        },
+        VerbError::PostMintUnrecordable {
+            source: AuditStoreError::Append {
+                path: PathBuf::from("/var/lib/bootroot/registrar-audit/registrar-audit.jsonl"),
+                source: std::io::Error::from(std::io::ErrorKind::StorageFull),
+            },
+        },
+    ];
+    for error in &unrecordable {
+        assert!(
+            refusal_outcome(error).is_none(),
+            "{error:?} must produce no record at all"
+        );
+    }
+
+    for (error, _, name) in every_refusal() {
+        assert!(
+            refusal_outcome(&error).is_some(),
+            "{name} is a durable reason and must still be recordable"
+        );
+    }
+}
+
 #[test]
 fn a_refusal_reason_round_trips_through_the_record_types() {
     for (error, _, name) in every_refusal() {
@@ -668,7 +724,7 @@ fn a_refusal_reason_round_trips_through_the_record_types() {
             CALLER.to_string(),
             requested(None),
             None,
-            refusal_outcome(&error),
+            refusal_outcome(&error).expect("a recordable refusal produces an outcome"),
         );
         let rendered = serde_json::to_string(&record).expect("serializes");
         assert!(
@@ -713,7 +769,7 @@ fn an_unavailable_refusal_records_its_activity_and_nothing_else() {
         "reading the durable binding",
         anyhow::anyhow!("connection refused").context("dialling openbao at https://vault.internal"),
     );
-    let AuditOutcome::Refused { reason, detail } = refusal_outcome(&error) else {
+    let Some(AuditOutcome::Refused { reason, detail }) = refusal_outcome(&error) else {
         panic!("an unavailable refusal must produce the refused class");
     };
     assert_eq!(reason, RefusalReason::Unavailable);
@@ -726,7 +782,7 @@ fn an_unavailable_refusal_records_its_activity_and_nothing_else() {
         CALLER.to_string(),
         requested(None),
         None,
-        refusal_outcome(&error),
+        refusal_outcome(&error).expect("an unavailable refusal is recordable"),
     );
     let rendered = serde_json::to_string(&record).expect("serializes");
     for leaked in ["connection refused", "vault.internal", "dialling openbao"] {

--- a/src/registrar/verbs.rs
+++ b/src/registrar/verbs.rs
@@ -44,6 +44,32 @@
 //!    [`tokio::sync::Mutex`], shared by both verbs so a mint and a
 //!    deregister for one identity can never interleave.
 //!
+//! # The audit trail around those stages
+//!
+//! Every invocation that reaches a verb body attempts **two** record
+//! writes into the daemon-owned store: an `intent` line at entry, before
+//! stage 1 and therefore before any `OpenBao` call, and an `outcome`
+//! line once the verb has run. The two are paired by `request_id` rather
+//! than by adjacency — intent lines are ordered only by arrival, which
+//! is correct, because nothing holds a lock across a whole invocation.
+//! The outcome line for a result produced under the per-id guard is
+//! written **before that guard is released**, so the next invocation for
+//! the same identity cannot change `OpenBao` and land its outcome line
+//! ahead of the line describing the change it superseded.
+//!
+//! Neither write is best-effort. A failed intent write refuses the
+//! invocation with nothing created, which is free at that point. A
+//! failed outcome write may arrive after `OpenBao` has already changed,
+//! so what it returns is decided by a per-invocation **mutation
+//! disposition** — see [`MutationDisposition`] — and by nothing else:
+//! not the verb, not the outcome class, not the [`ProducingArm`], and
+//! not a re-read of `OpenBao`.
+//!
+//! The `OpenBao` file audit device stays mandatory and is not replaced.
+//! It cannot see a request refused before any `OpenBao` write, and it
+//! does not know who asked or for which `(service_name, host,
+//! instance)`; this trail does.
+//!
 //! Stage 3's per-id lock is the **only** in-process serialization
 //! boundary either verb has. Its map is owned by this module rather than
 //! by a service instance, so two [`RegistrarVerbs`] in one process
@@ -104,6 +130,7 @@ pub(crate) mod wrap_ttl;
 mod tests;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex as StdMutex, PoisonError, Weak};
 
 use anyhow::Context as _;
@@ -118,14 +145,16 @@ use self::outcome::{
 };
 use self::wrap_ttl::{GrantedWrapTtl, WrapTtlPolicy};
 use crate::openbao::{KvCreateIfAbsent, OpenBaoClient, SecretIdOptions, WrapInfo};
-use crate::registrar::audit::AuditRecordStore;
+use crate::registrar::audit::{
+    AuditOutcome, AuditPhase, AuditRecord, AuditRecordStore, AuditVerb, RequestedIdentity, bridge,
+};
 use crate::registrar::config::{Multiplicity, RegistrarConfig};
 use crate::registrar::identity::{RequestedSpec, check_instance_shape, derive_registration_id};
 use crate::registrar::internal::{InternalCredential, InternalCredentialError};
 use crate::registrar::{check_spec_identity, is_reserved_service_name, validate_request_labels};
 use crate::service_material::{
-    ProvisionedServiceRole, ServiceRoleTtls, provision_service_role, service_kv_path,
-    service_role_name, teardown_service_material,
+    ProvisionedServiceRole, ResourceOutcome, ServiceRoleTtls, provision_service_role,
+    service_kv_path, service_role_name, teardown_service_material,
 };
 use crate::trust_bootstrap::{
     SERVICE_EAB_KV_SUFFIX, SERVICE_REISSUE_KV_SUFFIX, SERVICE_RESPONDER_HMAC_KV_SUFFIX,
@@ -174,6 +203,106 @@ static ID_LOCKS: LazyLock<IdLocks> = LazyLock::new(IdLocks::default);
 /// a pathological pair of processes from spinning here forever.
 const MAX_CLAIM_ATTEMPTS: usize = 3;
 
+/// Whether one invocation has made an `OpenBao` call that can have
+/// changed durable state.
+///
+/// Set from the *result* of each such call and **never cleared**, so it
+/// is monotone over the invocation. Reads never set it — a binding read,
+/// a `role_id` read, acquiring an authenticated client — and neither
+/// does a lost compare-and-set, which wrote nothing at all; that is why
+/// exhausting [`MAX_CLAIM_ATTEMPTS`] refuses with it still clear.
+///
+/// Every *error* does set it, and that asymmetry is the whole point. A
+/// call that failed may have failed after its write reached `OpenBao`,
+/// and the two ways of being wrong are not symmetrical: reporting a
+/// change as an ordinary refusal leaves live, unrecorded state that
+/// nobody is told to clean up, while reporting an unchanged invocation
+/// as owed costs at most one idempotent re-drive that finds nothing. A
+/// `ResourceOutcome::Failed` teardown attempt is indeterminate in
+/// exactly the same way and counts the same.
+///
+/// It is shared behind `&` across `.await` points in a `Send` future, so
+/// an [`AtomicBool`] is the shape to use; the value is per-invocation and
+/// is read by the same task that set it, so no ordering stronger than
+/// the module already uses is needed.
+#[derive(Debug, Default)]
+struct MutationDisposition(AtomicBool);
+
+impl MutationDisposition {
+    /// Records that a call which can have changed `OpenBao` state has
+    /// completed, however it completed.
+    fn set(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Records the outcome of a state-changing call and hands its result
+    /// straight back, so the call site reads as it did before.
+    fn note<T, E>(&self, result: Result<T, E>) -> Result<T, E> {
+        self.set();
+        result
+    }
+
+    /// Reports whether this invocation is owed a teardown.
+    fn is_set(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Everything one invocation's two record writes need.
+///
+/// Built at verb entry, before stage 1. The caller identity and the
+/// requested parts are carried into the builders **unchanged and
+/// uninterpreted**: whatever [`CallerIdentity`] holds is what the record
+/// is handed, and what a durable line ends up saying is the store's
+/// business — `AuditRecord::into_bounded` caps the field and records a
+/// digest when it had to. Nothing here pre-truncates or works around
+/// that.
+struct AuditContext {
+    request_id: RequestId,
+    verb: AuditVerb,
+    caller: CallerIdentity,
+    requested: RequestedIdentity,
+    disposition: MutationDisposition,
+}
+
+impl AuditContext {
+    /// Opens the context for one invocation, generating its request id.
+    fn new(verb: AuditVerb, caller: &CallerIdentity, requested: RequestedIdentity) -> Self {
+        Self {
+            request_id: RequestId::generate(),
+            verb,
+            caller: caller.clone(),
+            requested,
+            disposition: MutationDisposition::default(),
+        }
+    }
+
+    /// Builds the record shared by both phases: the timestamp, the
+    /// correlation handle, the verb, the caller and the requested parts.
+    fn intent_record(&self) -> AuditRecord {
+        AuditRecord::intent(
+            OffsetDateTime::now_utc(),
+            self.request_id.as_str().to_string(),
+            self.verb,
+            self.caller.as_str().to_string(),
+            self.requested.clone(),
+        )
+    }
+
+    /// Builds the `outcome` line for a produced result.
+    fn outcome_record(&self, registration_id: Option<&str>, outcome: AuditOutcome) -> AuditRecord {
+        AuditRecord::outcome(
+            OffsetDateTime::now_utc(),
+            self.request_id.as_str().to_string(),
+            self.verb,
+            self.caller.as_str().to_string(),
+            self.requested.clone(),
+            registration_id.map(str::to_string),
+            outcome,
+        )
+    }
+}
+
 /// The fixed dependencies a [`RegistrarVerbs`] is constructed with.
 ///
 /// Every one of these is chosen once, by whatever provisions the
@@ -205,10 +334,9 @@ pub(crate) struct RegistrarVerbsConfig {
     /// fails that surface closed rather than leaving the verbs running
     /// with no trail.
     ///
-    /// No verb arm calls its append API yet. The sibling issue that
-    /// writes intent and outcome records owns the call sites, their
-    /// ordering around the `OpenBao` work, and what a failed write
-    /// returns to a caller; this field is the seam it consumes.
+    /// Both verbs write through it, twice per invocation, and an
+    /// invocation whose record cannot be written is refused rather than
+    /// served silently — see this module's header.
     pub(crate) audit_store: AuditRecordStore,
 }
 
@@ -424,85 +552,316 @@ impl RegistrarVerbs {
     /// Mints — or idempotently re-mints — one service identity and
     /// returns fresh wrap-only material for it.
     pub(crate) async fn mint(&self, request: &MintRequest) -> MintResult {
-        let request_id = RequestId::generate();
-        let caller = request.caller.clone();
+        let audit = AuditContext::new(
+            AuditVerb::Mint,
+            &request.caller,
+            requested_identity(&request.service_name, &request.host, request.instance),
+        );
         let refuse = |arm: ProducingArm, registration_id: Option<String>, error: VerbError| {
             VerbRefusal::new(
-                VerbContext::new(request_id.clone(), caller.clone(), registration_id, arm),
+                VerbContext::new(
+                    audit.request_id.clone(),
+                    audit.caller.clone(),
+                    registration_id,
+                    arm,
+                ),
                 error,
             )
         };
 
+        // Before stage 1, and therefore before any OpenBao call. A store
+        // that cannot take this line refuses the invocation here, where
+        // refusing is free: nothing has been derived and nothing has
+        // been created, which is what the arm and the absent
+        // registration_id both say.
+        if let Err(err) = self.write_intent(&audit).await {
+            return Err(refuse(ProducingArm::PreDerivation, None, err));
+        }
+
         // Stage 1. Stateless, so it runs unsynchronized.
-        let multiplicity = self
-            .pre_derivation(
-                &request.service_name,
-                &request.host,
-                request.instance,
-                Some(&request.spec),
-            )
-            .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
+        let multiplicity = match self.pre_derivation(
+            &request.service_name,
+            &request.host,
+            request.instance,
+            Some(&request.spec),
+        ) {
+            Ok(multiplicity) => multiplicity,
+            Err(err) => {
+                let refusal = refuse(ProducingArm::PreDerivation, None, err);
+                return Err(self.record_refusal(&audit, refusal).await);
+            }
+        };
 
         // Still stage 1: the wrap TTL is a purely local property of the
         // request, checked under the construction-supplied policy well
         // before any OpenBao call, so an unusable request never creates
         // material that would then have to be revoked.
-        let granted = self
-            .wrap_ttl_policy
-            .grant(request.wrap_ttl)
-            .map_err(|err| {
-                refuse(
+        let granted = match self.wrap_ttl_policy.grant(request.wrap_ttl) {
+            Ok(granted) => granted,
+            Err(err) => {
+                let refusal = refuse(
                     ProducingArm::PreDerivation,
                     None,
                     VerbError::InvalidWrapTtl(err),
-                )
-            })?;
+                );
+                return Err(self.record_refusal(&audit, refusal).await);
+            }
+        };
 
         // Stage 2. Derivation is fallible even after the labels
         // validated, and a failure here takes no per-id lock.
-        let registration_id = derive_registration_id(
+        let registration_id = match derive_registration_id(
             multiplicity,
             &request.service_name,
             &request.host,
             request.instance,
-        )
-        .map_err(|err| refuse(ProducingArm::Derivation, None, VerbError::Registrar(err)))?;
+        ) {
+            Ok(registration_id) => registration_id,
+            Err(err) => {
+                let refusal = refuse(ProducingArm::Derivation, None, VerbError::Registrar(err));
+                return Err(self.record_refusal(&audit, refusal).await);
+            }
+        };
         let san = self
             .config
             .san_for(request.instance, &request.service_name, &request.host);
 
-        // Stage 3.
-        let _id_guard = self.id_locks().acquire(&registration_id).await;
-        self.mint_locked(request, &request_id, &registration_id, &san, &granted)
-            .await
+        // Stage 3. The outcome record is written while the per-id guard
+        // is still held: releasing it first would let the next
+        // invocation for this identity claim the binding, change
+        // `OpenBao` and land its outcome line ahead of the line
+        // describing the change it just superseded.
+        let id_guard = self.id_locks().acquire(&registration_id).await;
+        let result = self
+            .mint_locked(
+                request,
+                &audit.request_id,
+                &registration_id,
+                &san,
+                &granted,
+                &audit.disposition,
+            )
+            .await;
+        let recorded = self.record_mint(&audit, result).await;
+        drop(id_guard);
+        recorded
     }
 
     /// Tears one service identity down and removes its durable binding.
     pub(crate) async fn deregister(&self, request: &DeregisterRequest) -> DeregisterResult {
-        let request_id = RequestId::generate();
-        let caller = request.caller.clone();
+        let audit = AuditContext::new(
+            AuditVerb::Deregister,
+            &request.caller,
+            requested_identity(&request.service_name, &request.host, request.instance),
+        );
         let refuse = |arm: ProducingArm, registration_id: Option<String>, error: VerbError| {
             VerbRefusal::new(
-                VerbContext::new(request_id.clone(), caller.clone(), registration_id, arm),
+                VerbContext::new(
+                    audit.request_id.clone(),
+                    audit.caller.clone(),
+                    registration_id,
+                    arm,
+                ),
                 error,
             )
         };
 
-        let multiplicity = self
-            .pre_derivation(&request.service_name, &request.host, request.instance, None)
-            .map_err(|err| refuse(ProducingArm::PreDerivation, None, err))?;
+        // Identical to the mint's, and deliberately so: one intent write
+        // per invocation, at entry, needing no arm analysis at all.
+        if let Err(err) = self.write_intent(&audit).await {
+            return Err(refuse(ProducingArm::PreDerivation, None, err));
+        }
 
-        let registration_id = derive_registration_id(
+        let multiplicity =
+            match self.pre_derivation(&request.service_name, &request.host, request.instance, None)
+            {
+                Ok(multiplicity) => multiplicity,
+                Err(err) => {
+                    let refusal = refuse(ProducingArm::PreDerivation, None, err);
+                    return Err(self.record_refusal(&audit, refusal).await);
+                }
+            };
+
+        let registration_id = match derive_registration_id(
             multiplicity,
             &request.service_name,
             &request.host,
             request.instance,
-        )
-        .map_err(|err| refuse(ProducingArm::Derivation, None, VerbError::Registrar(err)))?;
+        ) {
+            Ok(registration_id) => registration_id,
+            Err(err) => {
+                let refusal = refuse(ProducingArm::Derivation, None, VerbError::Registrar(err));
+                return Err(self.record_refusal(&audit, refusal).await);
+            }
+        };
 
-        let _id_guard = self.id_locks().acquire(&registration_id).await;
-        self.deregister_locked(request, &request_id, &registration_id)
+        // As in the mint: the outcome line is written under the guard.
+        let id_guard = self.id_locks().acquire(&registration_id).await;
+        let result = self
+            .deregister_locked(
+                request,
+                &audit.request_id,
+                &registration_id,
+                &audit.disposition,
+            )
+            .await;
+        let recorded = self.record_deregister(&audit, result).await;
+        drop(id_guard);
+        recorded
+    }
+
+    /// Writes the invocation's `intent` line.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VerbError::AuditUnwritable`] carrying
+    /// [`AuditPhase::Intent`] for every way the store can fail. There is
+    /// no fallback: the write is not buffered, deferred, retried into a
+    /// second file or substituted with a log line. The `tracing` event
+    /// below carries the store's own error, which may be finer than the
+    /// variant a caller eventually sees, and stands in for nothing.
+    async fn write_intent(&self, audit: &AuditContext) -> Result<(), VerbError> {
+        match self.audit_store.append(audit.intent_record()).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                tracing::error!(
+                    error = %err,
+                    request_id = audit.request_id.as_str(),
+                    verb = ?audit.verb,
+                    phase = AuditPhase::Intent.as_str(),
+                    "the registrar audit record could not be written; refusing the invocation \
+                     with nothing created"
+                );
+                Err(VerbError::AuditUnwritable {
+                    phase: AuditPhase::Intent,
+                    source: err,
+                })
+            }
+        }
+    }
+
+    /// Writes the invocation's `outcome` line.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VerbError::PostMintUnrecordable`] when the mutation
+    /// disposition is set and [`VerbError::AuditUnwritable`] carrying
+    /// [`AuditPhase::Outcome`] when it is clear. Which store error it
+    /// was does not enter into that — every one of them is a write
+    /// failure for this phase, `Sync` and `DirectorySync` included.
+    async fn write_outcome(
+        &self,
+        audit: &AuditContext,
+        registration_id: Option<&str>,
+        outcome: AuditOutcome,
+    ) -> Result<(), VerbError> {
+        let record = audit.outcome_record(registration_id, outcome);
+        match self.audit_store.append(record).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                let owed = audit.disposition.is_set();
+                tracing::error!(
+                    error = %err,
+                    request_id = audit.request_id.as_str(),
+                    verb = ?audit.verb,
+                    phase = AuditPhase::Outcome.as_str(),
+                    teardown_owed = owed,
+                    "the registrar audit record could not be written"
+                );
+                Err(if owed {
+                    VerbError::PostMintUnrecordable { source: err }
+                } else {
+                    VerbError::AuditUnwritable {
+                        phase: AuditPhase::Outcome,
+                        source: err,
+                    }
+                })
+            }
+        }
+    }
+
+    /// Records a mint's result and returns what the caller gets.
+    ///
+    /// A successful mint whose outcome write failed does **not** return
+    /// its material: the freshly issued wrapped `secret_id` is dropped
+    /// and expires unused. The caller is told the identity exists and a
+    /// teardown is owed, and re-driving the mint once the store recovers
+    /// issues fresh material.
+    async fn record_mint(&self, audit: &AuditContext, result: MintResult) -> MintResult {
+        match result {
+            Ok(outcome) => {
+                let written = self
+                    .write_outcome(
+                        audit,
+                        outcome.context().registration_id(),
+                        bridge::mint_outcome(outcome.kind()),
+                    )
+                    .await;
+                match written {
+                    Ok(()) => Ok(outcome),
+                    Err(err) => Err(VerbRefusal::new(outcome.context().clone(), err)),
+                }
+            }
+            Err(refusal) => Err(self.record_refusal(audit, refusal).await),
+        }
+    }
+
+    /// Records a deregister's result and returns what the caller gets.
+    ///
+    /// A sweep that ran is still reported: the teardown report rides
+    /// out on the refusal a failed outcome write produces, so the caller
+    /// sees what was deleted.
+    async fn record_deregister(
+        &self,
+        audit: &AuditContext,
+        result: DeregisterResult,
+    ) -> DeregisterResult {
+        match result {
+            Ok(outcome) => {
+                let written = self
+                    .write_outcome(
+                        audit,
+                        outcome.context().registration_id(),
+                        bridge::deregister_outcome(outcome.kind()),
+                    )
+                    .await;
+                match written {
+                    Ok(()) => Ok(outcome),
+                    Err(err) => Err(VerbRefusal::new(outcome.context().clone(), err)
+                        .with_teardown(outcome.teardown().clone())),
+                }
+            }
+            Err(refusal) => Err(self.record_refusal(audit, refusal).await),
+        }
+    }
+
+    /// Records a refusal and returns the refusal the caller gets: the
+    /// one the verb produced, or the audit failure that replaced it.
+    ///
+    /// A replacement keeps the produced refusal's own envelope — the arm
+    /// says how far the verb got, which is still true — and its teardown
+    /// report, which is the only account of what the sweep managed.
+    async fn record_refusal(&self, audit: &AuditContext, refusal: VerbRefusal) -> VerbRefusal {
+        let Some(outcome) = bridge::refusal_outcome(refusal.error()) else {
+            // Neither audit-failure variant is recordable, by
+            // construction: the record that would carry one is the
+            // record whose write just failed. Nothing is written and the
+            // refusal is returned unchanged.
+            return refusal;
+        };
+        match self
+            .write_outcome(audit, refusal.context().registration_id(), outcome)
             .await
+        {
+            Ok(()) => refusal,
+            Err(err) => {
+                let replaced = VerbRefusal::new(refusal.context().clone(), err);
+                match refusal.teardown() {
+                    Some(teardown) => replaced.with_teardown(teardown.clone()),
+                    None => replaced,
+                }
+            }
+        }
     }
 
     /// Stage 1, shared by both verbs: stateless, synchronous, and
@@ -552,6 +911,7 @@ impl RegistrarVerbs {
         registration_id: &str,
         san: &str,
         granted: &GrantedWrapTtl,
+        disposition: &MutationDisposition,
     ) -> MintResult {
         let refuse = |arm: ProducingArm, error: VerbError| {
             VerbRefusal::new(
@@ -573,7 +933,14 @@ impl RegistrarVerbs {
 
             let Some(record) = existing else {
                 match self
-                    .claim_and_mint(request, request_id, registration_id, san, granted)
+                    .claim_and_mint(
+                        request,
+                        request_id,
+                        registration_id,
+                        san,
+                        granted,
+                        disposition,
+                    )
                     .await?
                 {
                     Some(outcome) => return Ok(outcome),
@@ -585,7 +952,15 @@ impl RegistrarVerbs {
             };
 
             return self
-                .mint_against_binding(request, request_id, registration_id, san, granted, &record)
+                .mint_against_binding(
+                    request,
+                    request_id,
+                    registration_id,
+                    san,
+                    granted,
+                    &record,
+                    disposition,
+                )
                 .await;
         }
 
@@ -613,6 +988,7 @@ impl RegistrarVerbs {
         registration_id: &str,
         san: &str,
         granted: &GrantedWrapTtl,
+        disposition: &MutationDisposition,
     ) -> Result<Option<MintOutcome>, VerbRefusal> {
         let refuse = |arm: ProducingArm, error: VerbError| {
             VerbRefusal::new(
@@ -634,7 +1010,7 @@ impl RegistrarVerbs {
 
         let claim = BindingRecord::creating(&request.host, &request.spec);
         let claimed = self
-            .claim_binding(registration_id, &claim)
+            .claim_binding(registration_id, &claim, disposition)
             .await
             .map_err(|err| refuse(ProducingArm::Binding, err))?;
         if claimed == KvCreateIfAbsent::AlreadyExists {
@@ -648,6 +1024,7 @@ impl RegistrarVerbs {
             granted,
             &claim,
             MintKind::FirstMint,
+            disposition,
         )
         .await
         .map(Some)
@@ -655,6 +1032,11 @@ impl RegistrarVerbs {
 
     /// The existing-binding arm, in its required order: host, then the
     /// stored spec, then the rendered safe-set.
+    // One more than the lint allows, and the extra one is the
+    // per-invocation mutation disposition every locked helper now
+    // threads. Grouping the rest into a struct would restructure the
+    // decision procedure this change is required to leave alone.
+    #[allow(clippy::too_many_arguments)]
     async fn mint_against_binding(
         &self,
         request: &MintRequest,
@@ -663,6 +1045,7 @@ impl RegistrarVerbs {
         san: &str,
         granted: &GrantedWrapTtl,
         record: &BindingRecord,
+        disposition: &MutationDisposition,
     ) -> MintResult {
         let refuse = |arm: ProducingArm, error: VerbError| {
             VerbRefusal::new(
@@ -758,6 +1141,7 @@ impl RegistrarVerbs {
                     &role_name,
                     role_id,
                     MintKind::IdempotentReMint,
+                    disposition,
                 )
                 .await
             }
@@ -773,6 +1157,7 @@ impl RegistrarVerbs {
                     granted,
                     record,
                     MintKind::FirstMint,
+                    disposition,
                 )
                 .await
             }
@@ -797,6 +1182,7 @@ impl RegistrarVerbs {
         granted: &GrantedWrapTtl,
         claim: &BindingRecord,
         kind: MintKind,
+        disposition: &MutationDisposition,
     ) -> MintResult {
         let refuse = |arm: ProducingArm, error: VerbError| {
             VerbRefusal::new(
@@ -814,16 +1200,22 @@ impl RegistrarVerbs {
             .client()
             .await
             .map_err(|err| refuse(ProducingArm::Provisioning, err))?;
-        let provisioned = provision_service_role(
-            &client,
-            &self.kv_mount,
-            registration_id,
-            ServiceRoleTtls {
-                token_ttl: &self.token_ttl,
-                secret_id_ttl: &self.secret_id_ttl,
-            },
-        )
-        .await;
+        // Convergence writes a policy and a role either way: a failure
+        // here may be one that failed after the write reached
+        // `OpenBao`, which is exactly what the disposition is monotone
+        // for.
+        let provisioned = disposition.note(
+            provision_service_role(
+                &client,
+                &self.kv_mount,
+                registration_id,
+                ServiceRoleTtls {
+                    token_ttl: &self.token_ttl,
+                    secret_id_ttl: &self.secret_id_ttl,
+                },
+            )
+            .await,
+        );
         let ProvisionedServiceRole {
             role_name, role_id, ..
         } = match provisioned {
@@ -839,7 +1231,7 @@ impl RegistrarVerbs {
         };
 
         let active = claim.activated(&request.spec);
-        self.write_binding(registration_id, &active)
+        self.write_binding(registration_id, &active, disposition)
             .await
             .map_err(|err| refuse(ProducingArm::Binding, err))?;
 
@@ -852,6 +1244,7 @@ impl RegistrarVerbs {
             &role_name,
             role_id,
             kind,
+            disposition,
         )
         .await
     }
@@ -873,6 +1266,7 @@ impl RegistrarVerbs {
         role_name: &str,
         role_id: String,
         kind: MintKind,
+        disposition: &MutationDisposition,
     ) -> MintResult {
         let refuse = |error: VerbError| {
             VerbRefusal::new(
@@ -887,14 +1281,19 @@ impl RegistrarVerbs {
         };
 
         let client = self.client().await.map_err(refuse)?;
-        let wrap_info = match client
-            .create_secret_id_wrap_only(
-                role_name,
-                &self.secret_id_options,
-                granted.as_openbao_str(),
-            )
-            .await
-        {
+        // An issuance creates a `secret_id` on the role, so it counts as
+        // a state change whether it returned one or failed on the way
+        // back.
+        let issued = disposition.note(
+            client
+                .create_secret_id_wrap_only(
+                    role_name,
+                    &self.secret_id_options,
+                    granted.as_openbao_str(),
+                )
+                .await,
+        );
+        let wrap_info = match issued {
             Ok(wrap_info) => wrap_info,
             Err(err) => {
                 self.client.note_failure(&err).await;
@@ -932,6 +1331,7 @@ impl RegistrarVerbs {
         request: &DeregisterRequest,
         request_id: &RequestId,
         registration_id: &str,
+        disposition: &MutationDisposition,
     ) -> DeregisterResult {
         let context = |arm: ProducingArm| {
             VerbContext::new(
@@ -977,6 +1377,20 @@ impl RegistrarVerbs {
             &REGISTRAR_TEARDOWN_KV_SUFFIXES,
         )
         .await;
+        // A sweep that removed something changed `OpenBao`, and one that
+        // failed may have. An all-`AlreadyAbsent` report deleted nothing
+        // and leaves the disposition clear — which is what makes an
+        // already-absent deregister with nothing to sweep distinguishable
+        // from one that swept a planted orphan, though both produce
+        // `DeregisterKind::AlreadyAbsent`.
+        if teardown.attempts().iter().any(|attempt| {
+            matches!(
+                attempt.outcome,
+                ResourceOutcome::Removed | ResourceOutcome::Failed(_)
+            )
+        }) {
+            disposition.set();
+        }
 
         if !teardown.aggregate_success() {
             return Err(VerbRefusal::new(
@@ -1001,7 +1415,7 @@ impl RegistrarVerbs {
             ));
         }
 
-        self.delete_binding(registration_id)
+        self.delete_binding(registration_id, disposition)
             .await
             .map_err(|err| VerbRefusal::new(context(ProducingArm::Binding), err))?;
 
@@ -1075,6 +1489,7 @@ impl RegistrarVerbs {
         &self,
         registration_id: &str,
         record: &BindingRecord,
+        disposition: &MutationDisposition,
     ) -> Result<KvCreateIfAbsent, VerbError> {
         let path = Self::binding_path(registration_id);
         let body = record
@@ -1085,8 +1500,17 @@ impl RegistrarVerbs {
             .create_kv_if_absent(&self.kv_mount, &path, body)
             .await
         {
-            Ok(outcome) => Ok(outcome),
+            // A won claim wrote the binding. A lost one is the single
+            // outcome of the six call sites that leaves the disposition
+            // clear: the compare-and-set was refused and nothing at all
+            // reached `OpenBao`.
+            Ok(created @ KvCreateIfAbsent::Created(_)) => {
+                disposition.set();
+                Ok(created)
+            }
+            Ok(KvCreateIfAbsent::AlreadyExists) => Ok(KvCreateIfAbsent::AlreadyExists),
             Err(err) => {
+                disposition.set();
                 self.client.note_failure(&err).await;
                 Err(VerbError::unavailable(
                     "claiming the durable binding",
@@ -1100,13 +1524,14 @@ impl RegistrarVerbs {
         &self,
         registration_id: &str,
         record: &BindingRecord,
+        disposition: &MutationDisposition,
     ) -> Result<(), VerbError> {
         let path = Self::binding_path(registration_id);
         let body = record
             .encode()
             .map_err(|err| VerbError::unavailable("encoding the durable binding", err.into()))?;
         let client = self.client().await?;
-        match client.write_kv(&self.kv_mount, &path, body).await {
+        match disposition.note(client.write_kv(&self.kv_mount, &path, body).await) {
             Ok(()) => Ok(()),
             Err(err) => {
                 self.client.note_failure(&err).await;
@@ -1118,10 +1543,14 @@ impl RegistrarVerbs {
         }
     }
 
-    async fn delete_binding(&self, registration_id: &str) -> Result<(), VerbError> {
+    async fn delete_binding(
+        &self,
+        registration_id: &str,
+        disposition: &MutationDisposition,
+    ) -> Result<(), VerbError> {
         let path = Self::binding_path(registration_id);
         let client = self.client().await?;
-        match client.delete_kv(&self.kv_mount, &path).await {
+        match disposition.note(client.delete_kv(&self.kv_mount, &path).await) {
             Ok(()) => Ok(()),
             Err(err) => {
                 self.client.note_failure(&err).await;
@@ -1131,6 +1560,21 @@ impl RegistrarVerbs {
                 ))
             }
         }
+    }
+}
+
+/// Takes the identity parts a request asked about, exactly as they
+/// arrived.
+///
+/// The three fields of [`RequestedIdentity`] are the whole of what the
+/// format records about a request. A mint's `spec`, `delivery_mode` and
+/// `wrap_ttl` are deliberately absent: the format defines no field for
+/// them, and this module consumes the format rather than extending it.
+fn requested_identity(service_name: &str, host: &str, instance: Option<u32>) -> RequestedIdentity {
+    RequestedIdentity {
+        service_name: service_name.to_string(),
+        host: host.to_string(),
+        instance,
     }
 }
 

--- a/src/registrar/verbs/outcome.rs
+++ b/src/registrar/verbs/outcome.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use time::OffsetDateTime;
 
+use crate::registrar::audit::{AuditPhase, AuditStoreError};
 use crate::registrar::error::RegistrarError;
 use crate::registrar::verbs::wrap_ttl::WrapTtlRefusal;
 use crate::service_material::TeardownReport;
@@ -392,6 +393,65 @@ pub(crate) enum VerbError {
     /// identically forever.
     #[error("requested wrap_ttl is not usable")]
     InvalidWrapTtl(#[from] WrapTtlRefusal),
+
+    /// An audit record could not be written, on an invocation that
+    /// changed no `OpenBao` state.
+    ///
+    /// Two writes produce it: the **intent** write, which precedes every
+    /// `OpenBao` call and so refuses with nothing created at all, and an
+    /// **outcome** write on an invocation whose mutation disposition is
+    /// still clear. Which one is in [`VerbError::AuditUnwritable::phase`]
+    /// and is inferable from nothing else on the refusal:
+    /// [`ProducingArm`] says how far the *verb* got and has no member
+    /// that tells an intent write from an outcome write.
+    ///
+    /// The name is the one `docs/reference/registrar-wire-contract.md`
+    /// §6.5 records for the closed `RegistrarUnavailable` reason set, and
+    /// is adopted rather than coined here. That set describes it as
+    /// "intent phase only", which is narrower than the condition above;
+    /// the divergence is deliberate and is not resolved here, because
+    /// narrowing the condition to fit the name would leave a
+    /// non-mutating outcome-write failure unreported. This variant is
+    /// internal to the verb layer and nothing more — there is no
+    /// verb-to-wire mapping in this repository, and carrying the phase
+    /// is what lets a later endpoint map [`AuditPhase::Intent`] onto the
+    /// transcribed reason and decide on its own terms what an
+    /// [`AuditPhase::Outcome`] failure tells a caller.
+    #[error("the registrar could not write the {phase} audit record")]
+    AuditUnwritable {
+        /// The write that failed. Reused from the record format rather
+        /// than restated, so a third phase breaks this `match` too.
+        phase: AuditPhase,
+        /// The store's own typed failure.
+        #[source]
+        source: AuditStoreError,
+    },
+
+    /// The outcome record could not be written on an invocation that
+    /// did, or may have, changed `OpenBao` state.
+    ///
+    /// A teardown is owed: the identity may exist, or may have been
+    /// removed, and no durable outcome line says which. A successful
+    /// mint that lands here does **not** return its material — the
+    /// wrapped `secret_id` is dropped and expires unused — so a caller
+    /// re-drives the verb once the store recovers and receives fresh
+    /// material then.
+    ///
+    /// It carries no phase, and that is not an oversight: only an
+    /// outcome write can produce it, because the disposition cannot be
+    /// set before the intent write has already succeeded.
+    ///
+    /// Like [`VerbError::AuditUnwritable`], the name comes from the wire
+    /// contract's §6.5 reason set, which describes it as following "a
+    /// successful mint". The condition here is wider — every invocation
+    /// whose disposition is set, refusals and completed removals
+    /// included — and is deliberately not narrowed to fit the name.
+    #[error("the registrar changed OpenBao state but could not record the outcome")]
+    PostMintUnrecordable {
+        /// The store's own typed failure.
+        #[source]
+        source: AuditStoreError,
+    },
 
     /// A fail-closed failure: `OpenBao` was unreachable or answered
     /// unexpectedly, a stored binding could not be read, or a

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -1477,6 +1477,60 @@ async fn a_recorded_mint_returns_its_material_on_both_arms() {
     );
 }
 
+/// An already-absent deregister the store *can* record leaves a
+/// complete pair behind, under the idempotent class that arm owes.
+///
+/// Every other already-absent test in this section injects a write
+/// failure — that is how a sweeping deregister is told from an empty
+/// one — and so asserts the returned variant rather than the line. This
+/// is what holds the line itself: `idempotent_already_absent` is
+/// otherwise the one outcome class whose record is asserted only in the
+/// ignored live tier, where CI's `test-core` job never reaches it.
+#[tokio::test]
+async fn a_recorded_already_absent_deregister_records_its_idempotent_class() {
+    // Nothing mounted at all: no binding, and every resource reads
+    // absent, so the sweep deletes nothing.
+    let (_server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let outcome = verbs
+        .deregister(&deregister_request("roxyd", "h1", None))
+        .await
+        .expect("an absent-binding deregister is idempotent");
+    assert_eq!(outcome.kind(), DeregisterKind::AlreadyAbsent);
+    let swept_nothing = assert_pair(
+        &verbs,
+        outcome.context().request_id().as_str(),
+        &Asked::new("deregister", "roxyd", "h1", None),
+    );
+    assert_eq!(
+        swept_nothing["outcome"]["class"],
+        json!("idempotent_already_absent")
+    );
+    assert_eq!(swept_nothing["registration_id"], json!("h1-roxyd"));
+
+    // The same class, reached by a sweep that removed a planted orphan.
+    // The two are one class in the record — what tells them apart is the
+    // mutation disposition, and only when a write fails — so the line is
+    // the trail's only trace that the orphan is gone.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    mock_material_present(&server, "h1-roxyd").await;
+    let outcome = verbs
+        .deregister(&deregister_request("roxyd", "h1", None))
+        .await
+        .expect("a sweeping absent-binding deregister is idempotent too");
+    assert_eq!(outcome.kind(), DeregisterKind::AlreadyAbsent);
+    assert!(outcome.teardown().aggregate_success());
+    let swept = assert_pair(
+        &verbs,
+        outcome.context().request_id().as_str(),
+        &Asked::new("deregister", "roxyd", "h1", None),
+    );
+    assert_eq!(
+        swept["outcome"]["class"],
+        json!("idempotent_already_absent")
+    );
+    assert_eq!(swept["registration_id"], json!("h1-roxyd"));
+}
+
 /// With the store failing the intent write, the invocation is refused
 /// having made **no** `OpenBao` request at all.
 ///

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -28,7 +28,8 @@ use serde_json::json;
 use tempfile::TempDir;
 use time::format_description::well_known::Rfc3339;
 use time::{Duration, OffsetDateTime};
-use wiremock::MockServer;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::binding::{
     BINDING_SCHEMA_VERSION, BindingRecord, BindingReloadKind, BindingSpec, BindingState,
@@ -44,7 +45,10 @@ use super::{
     RegistrarVerbsConfig, granted_deadline,
 };
 use crate::openbao::{OpenBaoClient, SecretIdOptions, WrapInfo};
-use crate::registrar::audit::{AuditRecordStore, AuditStoreSettings, MIN_AUDIT_MAX_FILE_BYTES};
+use crate::registrar::audit::{
+    AppendGate, AuditPhase, AuditRecordStore, AuditStoreSettings, FaultInjection,
+    MIN_AUDIT_MAX_FILE_BYTES,
+};
 use crate::registrar::config::{
     Multiplicity, RegistrarConfig, RegistrationSpec, ReloadKind, ReloadSpec,
 };
@@ -52,7 +56,7 @@ use crate::registrar::error::{RegistrarError, SpecIdentityField};
 use crate::registrar::fixture::RegistrarConfigFixture;
 use crate::registrar::identity::RequestedSpec;
 use crate::service_material::{
-    ResourceOutcome, ServiceResource, service_policy_name, service_role_name,
+    ResourceOutcome, ServiceResource, service_kv_path, service_policy_name, service_role_name,
 };
 
 /// Environment variable naming the live `OpenBao` the ignored tier runs
@@ -132,6 +136,22 @@ fn base_fixture() -> RegistrarConfigFixture {
 }
 
 fn verbs_with(client: OpenBaoClient, kv_mount: &str, config: RegistrarConfig) -> RegistrarVerbs {
+    // Every fixture gets its own throwaway store, so what a test reads
+    // back out of the trail is only what its own invocations wrote.
+    verbs_with_store(
+        client,
+        kv_mount,
+        config,
+        AuditRecordStore::open_temporary().expect("a temporary audit store"),
+    )
+}
+
+fn verbs_with_store(
+    client: OpenBaoClient,
+    kv_mount: &str,
+    config: RegistrarConfig,
+    audit_store: AuditRecordStore,
+) -> RegistrarVerbs {
     RegistrarVerbs::new(RegistrarVerbsConfig {
         client,
         kv_mount: kv_mount.to_string(),
@@ -144,10 +164,7 @@ fn verbs_with(client: OpenBaoClient, kv_mount: &str, config: RegistrarConfig) ->
         token_ttl: TOKEN_TTL.to_string(),
         secret_id_ttl: SECRET_ID_TTL.to_string(),
         wrap_ttl_policy: WrapTtlPolicy::new(Duration::minutes(30)).expect("policy maximum"),
-        // Every fixture gets its own throwaway store, so a test can
-        // assert nothing was written without another test's records
-        // showing up in it.
-        audit_store: AuditRecordStore::open_temporary().expect("a temporary audit store"),
+        audit_store,
     })
 }
 
@@ -189,117 +206,225 @@ fn assert_envelope(refusal: &VerbRefusal, arm: ProducingArm) {
 }
 
 // ---------------------------------------------------------------------
-// Fast tier: pre-derivation control flow
+// Reading the audit trail back
 // ---------------------------------------------------------------------
 
-/// The verb layer holds the audit record store as a fixed construction
-/// dependency, and **no** verb arm writes to it.
+/// Every line the verb service's trail holds, as raw JSON, in file
+/// order.
 ///
-/// Both halves matter. The dependency has to be here already, so the
-/// sibling issue that writes intent and outcome records can add its call
-/// sites without another visibility or wiring change; and nothing may be
-/// written yet, because that sibling owns the ordering of those writes
-/// around the `OpenBao` work and a stray append here would decide it.
+/// Raw `Value`s rather than `AuditRecord`s on purpose: several
+/// assertions here are about a key being **absent** from the object,
+/// which a `serde` round trip through an `Option` field cannot tell
+/// from `null`. Every line is still required to parse.
+fn trail(verbs: &RegistrarVerbs) -> Vec<serde_json::Value> {
+    let path = verbs.audit_store().active_path();
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => panic!("read {}: {err}", path.display()),
+    };
+    contents
+        .lines()
+        .map(|line| {
+            serde_json::from_str(line)
+                .unwrap_or_else(|err| panic!("every trail line must parse: {err}: {line}"))
+        })
+        .collect()
+}
+
+/// The lines one invocation wrote, selected by `request_id`.
+fn lines_for(verbs: &RegistrarVerbs, request_id: &str) -> Vec<serde_json::Value> {
+    trail(verbs)
+        .into_iter()
+        .filter(|line| line["request_id"] == json!(request_id))
+        .collect()
+}
+
+/// What one invocation asked for, as the record spells it.
+struct Asked<'a> {
+    verb: &'a str,
+    caller: &'a str,
+    service_name: &'a str,
+    host: &'a str,
+    instance: Option<u32>,
+}
+
+impl<'a> Asked<'a> {
+    fn new(verb: &'a str, service_name: &'a str, host: &'a str, instance: Option<u32>) -> Self {
+        Self {
+            verb,
+            caller: CALLER,
+            service_name,
+            host,
+            instance,
+        }
+    }
+
+    /// Names a caller other than the suite's default one.
+    fn by(mut self, caller: &'a str) -> Self {
+        self.caller = caller;
+        self
+    }
+}
+
+/// Asserts that `request_id` produced one complete intent/outcome pair
+/// and returns the outcome line.
 ///
-/// Driven over every refusal arm that reaches a decision without
-/// `OpenBao`, so a call site added to any of them would show up as a
-/// record in a store that must stay empty.
-#[tokio::test]
-async fn the_verbs_hold_an_audit_store_and_write_nothing_to_it() {
-    let audit_root = tempfile::tempdir().expect("tempdir");
+/// This is the shape every invocation owes, so it is asserted in one
+/// place: the two lines share the request id, the intent line comes
+/// first and **omits** the `registration_id` key entirely rather than
+/// carrying `null` or `""`, both carry a timestamp, the verb, the caller
+/// identity verbatim and the requested parts, and the outcome line
+/// carries an outcome while the intent line does not.
+fn assert_pair(verbs: &RegistrarVerbs, request_id: &str, asked: &Asked<'_>) -> serde_json::Value {
+    let lines = lines_for(verbs, request_id);
+    assert_eq!(
+        lines.len(),
+        2,
+        "one invocation owes exactly one intent line and one outcome line, got {lines:#?}"
+    );
+    let (intent, outcome) = (&lines[0], &lines[1]);
+
+    assert_eq!(intent["phase"], json!("intent"), "{intent}");
+    assert_eq!(outcome["phase"], json!("outcome"), "{outcome}");
+    assert!(
+        !intent
+            .as_object()
+            .expect("a record is a JSON object")
+            .contains_key("registration_id"),
+        "an intent line must omit the registration_id key entirely, got {intent}"
+    );
+    assert!(intent.get("outcome").is_none(), "{intent}");
+    assert!(outcome.get("outcome").is_some(), "{outcome}");
+
+    for line in &lines {
+        assert_eq!(line["request_id"], json!(request_id));
+        assert_eq!(line["verb"], json!(asked.verb), "{line}");
+        assert_eq!(line["caller_identity"], json!(asked.caller), "{line}");
+        assert_eq!(line["requested"]["service_name"], json!(asked.service_name));
+        assert_eq!(line["requested"]["host"], json!(asked.host));
+        assert_eq!(
+            line["requested"]
+                .get("instance")
+                .and_then(serde_json::Value::as_u64),
+            asked.instance.map(u64::from),
+            "{line}"
+        );
+        assert!(
+            line["ts"].as_str().is_some_and(|ts| ts.ends_with('Z')),
+            "every line carries a UTC timestamp: {line}"
+        );
+        assert_eq!(line["record_version"], json!(1), "{line}");
+    }
+    outcome.clone()
+}
+
+/// Asserts the pair a refused invocation owes, and returns its
+/// `outcome.reason`.
+fn assert_refusal_pair(verbs: &RegistrarVerbs, refusal: &VerbRefusal, asked: &Asked<'_>) -> String {
+    let outcome = assert_pair(verbs, refusal.context().request_id().as_str(), asked);
+    assert_eq!(outcome["outcome"]["class"], json!("refused"), "{outcome}");
+    outcome["outcome"]["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a refusal outcome names a reason: {outcome}"))
+        .to_string()
+}
+
+/// A store over a directory the caller keeps alive, so a test can pick
+/// its size limit and reach its fault switches.
+///
+/// [`AuditRecordStore::open_temporary`] owns its directory and fixes the
+/// defaults; this is for the tests that need neither.
+async fn open_store(root: &std::path::Path, max_file_bytes: u64) -> AuditRecordStore {
     // The store audits its immediate parent, which is this directory.
     // `tempfile` creates it under the ambient umask — `002` on a
     // Debian-style account — so state the mode rather than inherit a
     // group-writable one the store would rightly refuse.
-    std::fs::set_permissions(
-        audit_root.path(),
-        std::os::unix::fs::PermissionsExt::from_mode(0o700),
-    )
-    .expect("chmod");
-    let store = AuditRecordStore::open_for_tests(AuditStoreSettings {
-        dir: audit_root.path().join("registrar-audit"),
-        max_file_bytes: MIN_AUDIT_MAX_FILE_BYTES,
+    std::fs::set_permissions(root, std::os::unix::fs::PermissionsExt::from_mode(0o700))
+        .expect("chmod");
+    AuditRecordStore::open_for_tests(AuditStoreSettings {
+        dir: root.join("registrar-audit"),
+        max_file_bytes,
         max_retained_files: 4,
     })
     .await
-    .expect("a store opens over a temporary directory");
-
-    let server = MockServer::start().await;
-    let (_dir, config) = load_fixture(&base_fixture());
-    let verbs = RegistrarVerbs::new(RegistrarVerbsConfig {
-        client: mock_client(&server),
-        kv_mount: "secret".to_string(),
-        config,
-        secret_id_options: SecretIdOptions {
-            ttl: Some("10m".to_string()),
-            num_uses: Some(1),
-            ..Default::default()
-        },
-        token_ttl: TOKEN_TTL.to_string(),
-        secret_id_ttl: SECRET_ID_TTL.to_string(),
-        wrap_ttl_policy: WrapTtlPolicy::new(Duration::minutes(30)).expect("policy maximum"),
-        audit_store: store.clone(),
-    });
-
-    assert_eq!(
-        verbs.audit_store().active_path(),
-        store.active_path(),
-        "the verb service must retain the store it was constructed with"
-    );
-
-    // A reserved name, an unconfigured component, an invalid label and
-    // an instance-shape mismatch: one refusal per pre-derivation arm.
-    for (service_name, host, instance) in [
-        ("bootroot-decoy", "h1", None),
-        ("absent", "h1", None),
-        ("not a label", "h1", None),
-        ("roxyd", "h1", Some(4)),
-    ] {
-        verbs
-            .mint(&mint_request(service_name, host, instance))
-            .await
-            .expect_err("every one of these must refuse");
-        verbs
-            .deregister(&deregister_request(service_name, host, instance))
-            .await
-            .expect_err("every one of these must refuse");
-    }
-    // A wrap TTL no credential could be issued under, refused on the
-    // same arm but through a different enum.
-    let mut unusable = mint_request("roxyd", "h1", None);
-    unusable.wrap_ttl = Duration::ZERO;
-    verbs
-        .mint(&unusable)
-        .await
-        .expect_err("a zero wrap_ttl must refuse");
-
-    assert_untouched(&server).await;
-    assert_no_audit_records(&verbs);
+    .expect("a store opens over a temporary directory")
 }
 
-/// Asserts the verb service wrote no audit record.
+/// A verb service whose store's faults a test can arm, over a Wiremock
+/// with no mounted responses.
 ///
-/// The store is a construction dependency in this issue and nothing
-/// more: the sibling that writes intent and outcome records owns where
-/// they go relative to the `OpenBao` work, so an append from any arm
-/// here would decide that ordering by accident. Read through
-/// `RegistrarVerbs::audit_store` rather than from a path the test
-/// happens to know, so it also holds for a service built by the live
-/// backend's own fixture.
-fn assert_no_audit_records(verbs: &RegistrarVerbs) {
-    let path = verbs.audit_store().active_path();
-    let written = match std::fs::metadata(path) {
-        Ok(meta) => meta.len(),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => 0,
-        Err(err) => panic!("stat {}: {err}", path.display()),
-    };
-    assert_eq!(
-        written,
-        0,
-        "no verb arm may write an audit record in this issue's scope, but {} is {written} bytes",
-        path.display()
-    );
+/// The `TempDir` is returned so the caller keeps the store's directory
+/// alive for the whole test.
+async fn audit_harness(
+    fixture: &RegistrarConfigFixture,
+) -> (MockServer, TempDir, TempDir, RegistrarVerbs) {
+    let server = MockServer::start().await;
+    let store_root = tempfile::tempdir().expect("tempdir");
+    let store = open_store(store_root.path(), MIN_AUDIT_MAX_FILE_BYTES).await;
+    let (dir, config) = load_fixture(fixture);
+    let verbs = verbs_with_store(mock_client(&server), "secret", config, store);
+    (server, dir, store_root, verbs)
 }
+
+/// Drives `verb` with the store's `append` fault armed for the
+/// **outcome** write only.
+///
+/// The gate parks each blocking append at its entry and notifies here,
+/// so the fault can be armed in the window between the two: the intent
+/// append is released before it is set, and the outcome append is
+/// already parked when it is. This is the only way to fail one specific
+/// append rather than all of them, and it needs no production branch.
+async fn with_outcome_append_failure<F, T>(verbs: &RegistrarVerbs, verb: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    fail_the_outcome_write(verbs, verb, |faults| {
+        faults.append.store(true, Ordering::SeqCst);
+    })
+    .await
+}
+
+/// As [`with_outcome_append_failure`], with the store step the caller
+/// names failed instead.
+async fn fail_the_outcome_write<F, T>(
+    verbs: &RegistrarVerbs,
+    verb: F,
+    arm: impl FnOnce(&FaultInjection),
+) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    let store = verbs.audit_store().clone();
+    let (gate, mut entries, releases) = AppendGate::new();
+    *store.faults().gate.lock().expect("arm the gate") = Some(gate);
+
+    let mut driven = Box::pin(verb);
+    // The intent append, released before anything is armed.
+    tokio::select! {
+        () = async { (&mut driven).await; } => {
+            panic!("a gated invocation cannot have finished its verb")
+        }
+        entered = entries.recv() => entered.expect("the intent append reaches the gate"),
+    }
+    releases.send(()).expect("release the intent append");
+
+    // The outcome append, parked at the gate before it has opened the
+    // file — which is the window the fault is armed in.
+    tokio::select! {
+        () = async { (&mut driven).await; } => {
+            panic!("the invocation finished without attempting its outcome write")
+        }
+        entered = entries.recv() => entered.expect("the outcome append reaches the gate"),
+    }
+    arm(store.faults());
+    releases.send(()).expect("release the outcome append");
+    driven.await
+}
+
+// ---------------------------------------------------------------------
+// Fast tier: pre-derivation control flow
+// ---------------------------------------------------------------------
 
 /// A client pointed at a Wiremock with **no** mounted responses, so any
 /// request at all is visible in the server's recorded requests.
@@ -1001,6 +1126,985 @@ fn the_registrar_teardown_set_is_the_five_material_suffixes_and_not_the_binding(
 }
 
 // ---------------------------------------------------------------------
+// Fast tier: the audit trail around both verbs
+// ---------------------------------------------------------------------
+
+/// The URL path a registrar binding's KV data lives at.
+fn binding_data_url(registration_id: &str) -> String {
+    format!(
+        "/v1/secret/data/{}",
+        service_kv_path(registration_id, REGISTRAR_BINDING_KV_SUFFIX)
+    )
+}
+
+/// The URL path a registrar binding's KV metadata lives at, which is
+/// what a delete addresses.
+fn binding_metadata_url(registration_id: &str) -> String {
+    format!(
+        "/v1/secret/metadata/{}",
+        service_kv_path(registration_id, REGISTRAR_BINDING_KV_SUFFIX)
+    )
+}
+
+/// Answers the binding read with `record`.
+///
+/// Everything this suite leaves unmounted answers 404, which the client
+/// reads as absent — so a resource is "not there" by saying nothing
+/// about it.
+async fn mock_binding_read(server: &MockServer, registration_id: &str, record: &BindingRecord) {
+    Mock::given(method("GET"))
+        .and(path(binding_data_url(registration_id)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "data": record.encode().expect("the record encodes") }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Answers both binding writes — the absent-only claim and the
+/// activation, which address one path — as accepted.
+async fn mock_binding_writes(server: &MockServer, registration_id: &str) {
+    Mock::given(method("POST"))
+        .and(path(binding_data_url(registration_id)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "version": 1 }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Answers the binding delete as done.
+async fn mock_binding_delete(server: &MockServer, registration_id: &str) {
+    Mock::given(method("DELETE"))
+        .and(path(binding_metadata_url(registration_id)))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(server)
+        .await;
+}
+
+/// Answers every service-material read as present and every delete as
+/// done, which is the planted-orphan sweep.
+async fn mock_material_present(server: &MockServer, registration_id: &str) {
+    for suffix in REGISTRAR_TEARDOWN_KV_SUFFIXES {
+        let url = format!(
+            "/v1/secret/metadata/{}",
+            service_kv_path(registration_id, suffix)
+        );
+        Mock::given(method("GET"))
+            .and(path(url.clone()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": {} })))
+            .mount(server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(url))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(server)
+            .await;
+    }
+}
+
+/// Answers everything a first mint needs, through to wrapped material.
+async fn mock_first_mint(server: &MockServer, registration_id: &str) {
+    mock_binding_writes(server, registration_id).await;
+    let role_name = service_role_name(registration_id);
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/v1/sys/policies/acl/{}",
+            service_policy_name(registration_id)
+        )))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/auth/approle/role/{role_name}")))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/auth/approle/role/{role_name}/role-id")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "data": { "role_id": "role-id-1" } })),
+        )
+        .mount(server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/auth/approle/role/{role_name}/secret-id")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "wrap_info": {
+                "token": "hvs.wrap-token",
+                "ttl": 300,
+                "creation_time": "2026-08-23T12:00:00Z",
+                "creation_path": format!("auth/approle/role/{role_name}/secret-id"),
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Reports whether the mock server was asked to write a `creating`
+/// binding and never asked to delete one.
+async fn creating_binding_left_behind(server: &MockServer, registration_id: &str) -> bool {
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    let claimed = requests.iter().any(|request| {
+        request.url.path() == binding_data_url(registration_id)
+            && serde_json::from_slice::<serde_json::Value>(&request.body)
+                .is_ok_and(|body| body["data"]["state"] == json!("creating"))
+    });
+    let deleted = requests
+        .iter()
+        .any(|request| request.url.path() == binding_metadata_url(registration_id));
+    claimed && !deleted
+}
+
+/// Every refusal decided before the per-id lock owes a complete pair,
+/// and neither of its lines carries a `registration_id` — nothing has
+/// derived one.
+///
+/// One case per pre-lock arm, driven through both verbs, each against
+/// its own store and its own mock so what is read back is only what
+/// these two invocations wrote.
+#[tokio::test]
+async fn every_pre_lock_refusal_writes_a_pair_with_no_registration_id() {
+    let long_component = "c".repeat(63);
+    let long_host = "h".repeat(63);
+    let cases: Vec<(RegistrarConfigFixture, &str, String, String, Option<u32>)> = vec![
+        // A `service_name` that is not a DNS label.
+        (
+            base_fixture(),
+            "invalid_service_name",
+            "not a label".to_string(),
+            "h1".to_string(),
+            None,
+        ),
+        // A reserved `bootroot-` name, declared as an ordinary
+        // component so the reserved guard is what refuses it.
+        (
+            base_fixture(),
+            "reserved_service_name",
+            "bootroot-decoy".to_string(),
+            "h1".to_string(),
+            None,
+        ),
+        // A component with no multiplicity entry.
+        (
+            base_fixture().without_component("roxyd"),
+            "component_not_configured",
+            "roxyd".to_string(),
+            "h1".to_string(),
+            None,
+        ),
+        // An instance where the component is one-per-host.
+        (
+            base_fixture(),
+            "service_instance_mismatch",
+            "roxyd".to_string(),
+            "h1".to_string(),
+            Some(4),
+        ),
+        // A derived key one octet past the 131-octet bound.
+        (
+            base_fixture().with_component(
+                &long_component,
+                Multiplicity::ManyPerHost,
+                &sample_spec(),
+            ),
+            "derived_key_invalid",
+            long_component.clone(),
+            long_host.clone(),
+            Some(1000),
+        ),
+    ];
+
+    for (fixture, expected_reason, service_name, host, instance) in cases {
+        let (server, _dir, _store_root, verbs) = audit_harness(&fixture).await;
+
+        for verb in ["mint", "deregister"] {
+            let refusal = if verb == "mint" {
+                verbs
+                    .mint(&mint_request(&service_name, &host, instance))
+                    .await
+                    .expect_err("every one of these must refuse")
+            } else {
+                verbs
+                    .deregister(&deregister_request(&service_name, &host, instance))
+                    .await
+                    .expect_err("every one of these must refuse")
+            };
+            let asked = Asked::new(verb, &service_name, &host, instance);
+            let reason = assert_refusal_pair(&verbs, &refusal, &asked);
+            assert_eq!(reason, expected_reason, "{service_name}/{host} as a {verb}");
+            for line in lines_for(&verbs, refusal.context().request_id().as_str()) {
+                assert!(
+                    !line
+                        .as_object()
+                        .expect("a record is a JSON object")
+                        .contains_key("registration_id"),
+                    "a refusal before the lock carries no registration_id: {line}"
+                );
+            }
+        }
+        assert_untouched(&server).await;
+    }
+}
+
+/// The two mint-only pre-lock refusals: a spec that restates a
+/// different identity, and a `wrap_ttl` no credential could be issued
+/// under.
+#[tokio::test]
+async fn the_mint_only_pre_lock_refusals_write_their_pairs() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+
+    let mut disagreeing = mint_request("roxyd", "h1", None);
+    disagreeing.spec = requested(&sample_spec()).with_service_name("roxyd-h1");
+    let refusal = verbs
+        .mint(&disagreeing)
+        .await
+        .expect_err("a restated identity that disagrees must be refused");
+    assert_eq!(
+        assert_refusal_pair(&verbs, &refusal, &Asked::new("mint", "roxyd", "h1", None)),
+        "spec_identity_disagreement"
+    );
+
+    let mut unusable = mint_request("roxyd", "h1", None);
+    unusable.wrap_ttl = Duration::ZERO;
+    let refusal = verbs
+        .mint(&unusable)
+        .await
+        .expect_err("a zero wrap_ttl must be refused");
+    assert_eq!(
+        assert_refusal_pair(&verbs, &refusal, &Asked::new("mint", "roxyd", "h1", None)),
+        "zero"
+    );
+
+    assert_untouched(&server).await;
+}
+
+/// A `RegistrationIdCollision` is decided by *reading* the binding and
+/// writes nothing, so the `OpenBao` audit device cannot see it. This
+/// trail can, and the pair proves it.
+#[tokio::test]
+async fn a_registration_id_collision_writes_a_complete_pair() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let registration_id = "h1-roxyd";
+    let bound = BindingRecord::creating("h2", &requested(&spec_for("roxyd")))
+        .activated(&requested(&spec_for("roxyd")));
+    mock_binding_read(&server, registration_id, &bound).await;
+
+    let refusal = verbs
+        .mint(&mint_request("roxyd", "h1", None))
+        .await
+        .expect_err("a binding bound to another host must be refused");
+    assert!(matches!(
+        refusal.error(),
+        VerbError::RegistrationIdCollision { .. }
+    ));
+
+    let outcome = assert_pair(
+        &verbs,
+        refusal.context().request_id().as_str(),
+        &Asked::new("mint", "roxyd", "h1", None),
+    );
+    assert_eq!(
+        outcome["outcome"]["reason"],
+        json!("registration_id_collision")
+    );
+    assert_eq!(outcome["registration_id"], json!(registration_id));
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert_eq!(requests.len(), 1, "the binding read and nothing else");
+    assert_eq!(requests[0].method, wiremock::http::Method::GET);
+}
+
+/// With the store failing the intent write, the invocation is refused
+/// having made **no** `OpenBao` request at all.
+///
+/// This is the direct test that the intent write precedes every
+/// `OpenBao` write: an implementation that wrote one record after the
+/// fact and refused on failure would have reached the mock by now.
+/// The trail is then empty — a property of *this* fault mode, which
+/// fails before any byte reaches the file, not of failed intent writes
+/// in general.
+#[tokio::test]
+async fn an_intent_write_failure_refuses_before_any_openbao_call() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    verbs
+        .audit_store()
+        .faults()
+        .append
+        .store(true, Ordering::SeqCst);
+
+    let refusal = verbs
+        .mint(&mint_request("roxyd", "h1", None))
+        .await
+        .expect_err("a mint whose intent record cannot be written must refuse");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Intent,
+                ..
+            }
+        ),
+        "expected an intent-phase audit failure, got {:?}",
+        refusal.error()
+    );
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+
+    let refusal = verbs
+        .deregister(&deregister_request("roxyd", "h1", None))
+        .await
+        .expect_err("a deregister whose intent record cannot be written must refuse");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Intent,
+                ..
+            }
+        ),
+        "expected an intent-phase audit failure, got {:?}",
+        refusal.error()
+    );
+    assert_envelope(&refusal, ProducingArm::PreDerivation);
+
+    assert_untouched(&server).await;
+    assert!(
+        trail(&verbs).is_empty(),
+        "this fault fails before any byte reaches the file"
+    );
+}
+
+/// **The mint discriminating pair**, over one injected outcome-phase
+/// failure.
+///
+/// A `StoredSpecConflict` is decided from a read and must not arm a
+/// teardown obligation — a caller told one was owed there would
+/// deregister a live identity this invocation did not create. A
+/// provisioning failure that followed a successful claim must arm it,
+/// and its `creating` binding is still in `OpenBao`. Asserting the two
+/// together is what catches an implementation that classifies from
+/// success-versus-refusal: both of these are refusals.
+#[tokio::test]
+async fn a_failed_outcome_write_tells_a_read_refusal_from_one_that_wrote() {
+    let conflicting = RegistrationSpec {
+        cert_group: Some(4242),
+        reload: spec_for("roxyd").reload.clone(),
+    };
+
+    // Decided from a read: the binding exists, is bound to this host,
+    // and carries a different spec.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let stored =
+        BindingRecord::creating("h1", &requested(&conflicting)).activated(&requested(&conflicting));
+    mock_binding_read(&server, "h1-roxyd", &stored).await;
+    let refusal =
+        with_outcome_append_failure(&verbs, verbs.mint(&mint_request("roxyd", "h1", None)))
+            .await
+            .expect_err("a stored-spec conflict is a refusal");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Outcome,
+                ..
+            }
+        ),
+        "a refusal decided from a read owes no teardown, got {:?}",
+        refusal.error()
+    );
+
+    // Wrote first: the claim landed, and the convergence then failed.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    mock_binding_writes(&server, "h1-roxyd").await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/v1/sys/policies/acl/{}",
+            service_policy_name("h1-roxyd")
+        )))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+    let refusal =
+        with_outcome_append_failure(&verbs, verbs.mint(&mint_request("roxyd", "h1", None)))
+            .await
+            .expect_err("a failed convergence is a refusal");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "a refusal that followed a durable write owes a teardown, got {:?}",
+        refusal.error()
+    );
+    assert!(
+        creating_binding_left_behind(&server, "h1-roxyd").await,
+        "the claim is retained through a failed convergence"
+    );
+}
+
+/// **The deregister discriminating pair**, over one injected
+/// outcome-phase failure.
+///
+/// Both invocations produce `DeregisterKind::AlreadyAbsent`. One swept
+/// a planted orphan and is the only trace that the orphan is gone; the
+/// other found nothing at all and changed nothing. An implementation
+/// that classified from the outcome class fails one of them.
+#[tokio::test]
+async fn a_failed_outcome_write_tells_a_sweeping_already_absent_from_an_empty_one() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    mock_material_present(&server, "h1-roxyd").await;
+    let refusal = with_outcome_append_failure(
+        &verbs,
+        verbs.deregister(&deregister_request("roxyd", "h1", None)),
+    )
+    .await
+    .expect_err("a failed outcome write refuses");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "a sweep that removed material owes a teardown, got {:?}",
+        refusal.error()
+    );
+
+    // Nothing mounted at all: every resource reads absent, so the sweep
+    // deleted nothing.
+    let (_server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let refusal = with_outcome_append_failure(
+        &verbs,
+        verbs.deregister(&deregister_request("roxyd", "h1", None)),
+    )
+    .await
+    .expect_err("a failed outcome write refuses");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Outcome,
+                ..
+            }
+        ),
+        "an all-already-absent sweep changed nothing, got {:?}",
+        refusal.error()
+    );
+}
+
+/// A failed outcome write after a successful mint returns
+/// `PostMintUnrecordable`, and the mint's `OpenBao` state is exactly
+/// where the verb left it.
+#[tokio::test]
+async fn a_failed_outcome_write_after_a_first_mint_owes_a_teardown() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    mock_first_mint(&server, "h1-roxyd").await;
+
+    let refusal =
+        with_outcome_append_failure(&verbs, verbs.mint(&mint_request("roxyd", "h1", None)))
+            .await
+            .expect_err("a mint whose outcome cannot be recorded does not return its material");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "expected a teardown obligation, got {:?}",
+        refusal.error()
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert!(
+        requests.iter().any(|request| request.url.path()
+            == format!("/v1/auth/approle/role/{}", service_role_name("h1-roxyd"))),
+        "the role the mint created is where it left it"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.url.path() != binding_metadata_url("h1-roxyd")),
+        "nothing rolls the binding back"
+    );
+
+    // A property of *this* fault mode, which fails before any byte
+    // reaches the file — not a general consequence of a failed outcome
+    // write, several of which leave the line complete and readable.
+    let lines = trail(&verbs);
+    assert_eq!(lines.len(), 1, "the intent line and no outcome line");
+    assert_eq!(lines[0]["phase"], json!("intent"));
+}
+
+/// A mint that lost the compare-and-set on every attempt wrote nothing,
+/// so its failed outcome write owes no teardown.
+///
+/// `Ok(KvCreateIfAbsent::AlreadyExists)` is the one result of the six
+/// call sites that leaves the disposition clear: the claim was refused
+/// and nothing at all reached `OpenBao`. Exhausting the bounded retry is
+/// what drives it, and it is a refusal like the mutating ones above —
+/// which is again why the class cannot be read off success versus
+/// refusal.
+#[tokio::test]
+async fn a_lost_claim_race_leaves_the_disposition_clear() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    // The binding read finds nothing every time, and the claim is
+    // refused by the absent-only compare-and-set every time — which is
+    // another writer creating and removing it under this mint.
+    Mock::given(method("POST"))
+        .and(path(binding_data_url("h1-roxyd")))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "errors": ["check-and-set parameter did not match the current version"]
+        })))
+        .mount(&server)
+        .await;
+
+    let refusal =
+        with_outcome_append_failure(&verbs, verbs.mint(&mint_request("roxyd", "h1", None)))
+            .await
+            .expect_err("an exhausted claim retry refuses");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Outcome,
+                ..
+            }
+        ),
+        "a lost compare-and-set wrote nothing, got {:?}",
+        refusal.error()
+    );
+}
+
+/// A failed outcome write after an idempotent re-mint owes a teardown
+/// too: the re-mint issued fresh material, which is a state change even
+/// though the role and the policy were reused untouched.
+#[tokio::test]
+async fn a_failed_outcome_write_after_a_remint_owes_a_teardown() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let active = BindingRecord::creating("h1", &requested(&spec_for("roxyd")))
+        .activated(&requested(&spec_for("roxyd")));
+    mock_binding_read(&server, "h1-roxyd", &active).await;
+    mock_first_mint(&server, "h1-roxyd").await;
+
+    let refusal =
+        with_outcome_append_failure(&verbs, verbs.mint(&mint_request("roxyd", "h1", None)))
+            .await
+            .expect_err("a re-mint whose outcome cannot be recorded does not return its material");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "expected a teardown obligation, got {:?}",
+        refusal.error()
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert!(
+        requests.iter().any(|request| request.url.path()
+            == format!(
+                "/v1/auth/approle/role/{}/secret-id",
+                service_role_name("h1-roxyd")
+            )),
+        "the re-mint issued fresh material before the record could be written"
+    );
+    assert!(
+        requests.iter().all(|request| {
+            request.url.path() != binding_data_url("h1-roxyd")
+                || request.method == wiremock::http::Method::GET
+        }),
+        "a re-mint against an active binding rewrites nothing"
+    );
+}
+
+/// A failed outcome write after a deregister that removed a bound
+/// identity owes a teardown, still reports what the sweep managed, and
+/// re-drives cleanly once the store recovers.
+#[tokio::test]
+async fn a_failed_outcome_write_after_an_identity_removal_re_drives() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let bound = BindingRecord::creating("h1", &requested(&spec_for("roxyd")))
+        .activated(&requested(&spec_for("roxyd")));
+    mock_binding_read(&server, "h1-roxyd", &bound).await;
+    mock_material_present(&server, "h1-roxyd").await;
+    mock_binding_delete(&server, "h1-roxyd").await;
+
+    let refusal = with_outcome_append_failure(
+        &verbs,
+        verbs.deregister(&deregister_request("roxyd", "h1", None)),
+    )
+    .await
+    .expect_err("a failed outcome write refuses");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "expected a teardown obligation, got {:?}",
+        refusal.error()
+    );
+    let report = refusal
+        .teardown()
+        .expect("the sweep's report still reaches the caller");
+    assert!(report.aggregate_success());
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert!(
+        requests.iter().any(|request| {
+            request.url.path() == binding_metadata_url("h1-roxyd")
+                && request.method == wiremock::http::Method::DELETE
+        }),
+        "the binding was deleted before the record could be written"
+    );
+
+    // The store recovers, and the re-drive writes its own pair.
+    verbs
+        .audit_store()
+        .faults()
+        .append
+        .store(false, Ordering::SeqCst);
+    let outcome = verbs
+        .deregister(&deregister_request("roxyd", "h1", None))
+        .await
+        .expect("a re-drive against a working store succeeds");
+    assert_eq!(outcome.kind(), DeregisterKind::IdentityRemoved);
+    let line = assert_pair(
+        &verbs,
+        outcome.context().request_id().as_str(),
+        &Asked::new("deregister", "roxyd", "h1", None),
+    );
+    assert_eq!(line["outcome"]["class"], json!("identity_removed"));
+    assert_eq!(line["registration_id"], json!("h1-roxyd"));
+}
+
+/// A failed outcome write on a refusal decided before anything was
+/// touched carries `AuditPhase::Outcome` and never a teardown
+/// obligation.
+///
+/// Paired with the intent-failure test above, this is what pins both
+/// phase values: a variant that hard-coded `Intent` would satisfy that
+/// one and fail here, and one that hard-coded `Outcome` the reverse.
+#[tokio::test]
+async fn a_failed_outcome_write_on_a_no_change_refusal_carries_the_outcome_phase() {
+    // Decided from a read, before the sweep.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let bound = BindingRecord::creating("h2", &requested(&spec_for("roxyd")))
+        .activated(&requested(&spec_for("roxyd")));
+    mock_binding_read(&server, "h1-roxyd", &bound).await;
+    let refusal = with_outcome_append_failure(
+        &verbs,
+        verbs.deregister(&deregister_request("roxyd", "h1", None)),
+    )
+    .await
+    .expect_err("a wrong-host deregister is refused");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Outcome,
+                ..
+            }
+        ),
+        "a host mismatch changes nothing, got {:?}",
+        refusal.error()
+    );
+    assert!(
+        !matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "a host mismatch owes no teardown"
+    );
+
+    // Decided before derivation, with no `OpenBao` call at all.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let refusal = with_outcome_append_failure(
+        &verbs,
+        verbs.mint(&mint_request("bootroot-decoy", "h1", None)),
+    )
+    .await
+    .expect_err("a reserved name is refused");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Outcome,
+                ..
+            }
+        ),
+        "a pre-derivation refusal changes nothing, got {:?}",
+        refusal.error()
+    );
+    assert_untouched(&server).await;
+}
+
+/// A failed outcome write after a teardown whose report shows a
+/// resource `Removed` or `Failed` owes a teardown, even though the
+/// invocation was refused.
+#[tokio::test]
+async fn a_failed_outcome_write_after_a_failed_teardown_owes_a_teardown() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let bound = BindingRecord::creating("h1", &requested(&spec_for("roxyd")))
+        .activated(&requested(&spec_for("roxyd")));
+    mock_binding_read(&server, "h1-roxyd", &bound).await;
+    mock_material_present(&server, "h1-roxyd").await;
+    // The role read fails outright, so the sweep records a `Failed`
+    // attempt and refuses in aggregate having already removed the KV
+    // material.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/auth/approle/role/{}",
+            service_role_name("h1-roxyd")
+        )))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let refusal = with_outcome_append_failure(
+        &verbs,
+        verbs.deregister(&deregister_request("roxyd", "h1", None)),
+    )
+    .await
+    .expect_err("a teardown that could not finish must refuse");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "expected a teardown obligation, got {:?}",
+        refusal.error()
+    );
+    let report = refusal.teardown().expect("the partial report is carried");
+    assert!(!report.aggregate_success());
+    assert!(
+        report
+            .attempts()
+            .iter()
+            .any(|attempt| matches!(attempt.outcome, ResourceOutcome::Removed)),
+        "the KV material was removed before the role read failed: {:?}",
+        report.attempts()
+    );
+}
+
+/// A `sync_data` failure is a write failure for its phase like any
+/// other, and the disposition still decides what it returns.
+///
+/// It is the one failure mode that leaves a complete, newline-terminated
+/// line already in the file, so the trail is asserted only for JSONL
+/// integrity: whether the unflushed line is there is the store's
+/// business and this issue neither promises nor removes it.
+#[tokio::test]
+async fn a_sync_failure_is_a_write_failure_for_its_phase() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    verbs
+        .audit_store()
+        .faults()
+        .sync
+        .store(true, Ordering::SeqCst);
+    let refusal = verbs
+        .mint(&mint_request("roxyd", "h1", None))
+        .await
+        .expect_err("an unflushed intent record is not a written one");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Intent,
+                ..
+            }
+        ),
+        "expected an intent-phase audit failure, got {:?}",
+        refusal.error()
+    );
+    assert_untouched(&server).await;
+
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    mock_first_mint(&server, "h1-roxyd").await;
+    let refusal = fail_the_outcome_write(
+        &verbs,
+        verbs.mint(&mint_request("roxyd", "h1", None)),
+        |faults| faults.sync.store(true, Ordering::SeqCst),
+    )
+    .await
+    .expect_err("an unflushed outcome record is not a written one");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "expected a teardown obligation, got {:?}",
+        refusal.error()
+    );
+    let requests = server
+        .received_requests()
+        .await
+        .expect("the mock server records requests");
+    assert!(
+        requests.iter().any(|request| request.url.path()
+            == format!("/v1/auth/approle/role/{}", service_role_name("h1-roxyd"))),
+        "the mint's state is where the verb left it"
+    );
+    // Every line parses, whether or not the unflushed one is there.
+    let lines = trail(&verbs);
+    assert!((1..=2).contains(&lines.len()), "got {lines:#?}");
+}
+
+/// A rotation the pending record required, and that failed, is a write
+/// failure for its phase too.
+#[tokio::test]
+async fn a_failed_rotation_is_a_write_failure_for_its_phase() {
+    /// Fills the active file to one byte short of the limit, so the very
+    /// next record genuinely requires a rotation.
+    fn fill_to_limit(store: &AuditRecordStore) {
+        use std::io::Write as _;
+
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(store.active_path())
+            .expect("open the active file");
+        let existing = file.metadata().expect("stat").len();
+        let padding = MIN_AUDIT_MAX_FILE_BYTES - existing - 1;
+        let line = "{\"filler\":\"x\"}\n";
+        let step = u64::try_from(line.len()).expect("the filler line fits a u64");
+        let mut written = 0u64;
+        while written + step <= padding {
+            file.write_all(line.as_bytes()).expect("pad");
+            written += step;
+        }
+    }
+
+    // Intent phase: the very first append has to rotate, and cannot.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    fill_to_limit(verbs.audit_store());
+    verbs
+        .audit_store()
+        .faults()
+        .rotate
+        .store(true, Ordering::SeqCst);
+    let refusal = verbs
+        .mint(&mint_request("roxyd", "h1", None))
+        .await
+        .expect_err("a record that cannot be rotated into place is not written");
+    assert!(
+        matches!(
+            refusal.error(),
+            VerbError::AuditUnwritable {
+                phase: AuditPhase::Intent,
+                ..
+            }
+        ),
+        "expected an intent-phase audit failure, got {:?}",
+        refusal.error()
+    );
+    assert_untouched(&server).await;
+
+    // Outcome phase, after a mint that changed `OpenBao`. The file is
+    // filled while the outcome append is parked at the gate — it has
+    // not opened the file yet — so the rotation it then needs is the
+    // one that fails.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    mock_first_mint(&server, "h1-roxyd").await;
+    let store = verbs.audit_store().clone();
+    let refusal = fail_the_outcome_write(
+        &verbs,
+        verbs.mint(&mint_request("roxyd", "h1", None)),
+        |faults| {
+            fill_to_limit(&store);
+            faults.rotate.store(true, Ordering::SeqCst);
+        },
+    )
+    .await
+    .expect_err("a record that cannot be rotated into place is not written");
+    assert!(
+        matches!(refusal.error(), VerbError::PostMintUnrecordable { .. }),
+        "expected a teardown obligation, got {:?}",
+        refusal.error()
+    );
+}
+
+/// The record carries the verb layer's own refusal variant, not a
+/// coarser wire grouping: three refusals a wire contract would collapse
+/// produce three different `outcome.reason` values.
+#[tokio::test]
+async fn three_close_refusals_produce_three_distinct_reasons() {
+    let widened = RegistrationSpec {
+        cert_group: Some(4242),
+        reload: spec_for("roxyd").reload.clone(),
+    };
+
+    // Outside the rendered safe-set, with no binding at all.
+    let (_server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let mut outside = mint_request("roxyd", "h1", None);
+    outside.spec = requested(&widened);
+    let refusal = verbs
+        .mint(&outside)
+        .await
+        .expect_err("a spec outside the safe-set must be refused");
+    let outside_reason =
+        assert_refusal_pair(&verbs, &refusal, &Asked::new("mint", "roxyd", "h1", None));
+
+    // Inside the safe-set, and disagreeing with what the identity
+    // already carries.
+    let (server, _dir, _store_root, verbs) =
+        audit_harness(&base_fixture().with_component("roxyd", Multiplicity::OnePerHost, &widened))
+            .await;
+    let stored = BindingRecord::creating("h1", &requested(&spec_for("roxyd")))
+        .activated(&requested(&spec_for("roxyd")));
+    mock_binding_read(&server, "h1-roxyd", &stored).await;
+    let mut conflicting = mint_request("roxyd", "h1", None);
+    conflicting.spec = requested(&widened);
+    let refusal = verbs
+        .mint(&conflicting)
+        .await
+        .expect_err("a stored-spec disagreement must be refused");
+    let conflict_reason =
+        assert_refusal_pair(&verbs, &refusal, &Asked::new("mint", "roxyd", "h1", None));
+
+    // A spec that restates a different identity, refused before
+    // derivation.
+    let (_server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let mut disagreeing = mint_request("roxyd", "h1", None);
+    disagreeing.spec = requested(&sample_spec()).with_service_name("roxyd-h1");
+    let refusal = verbs
+        .mint(&disagreeing)
+        .await
+        .expect_err("a restated identity that disagrees must be refused");
+    let identity_reason =
+        assert_refusal_pair(&verbs, &refusal, &Asked::new("mint", "roxyd", "h1", None));
+
+    assert_eq!(outside_reason, "service_spec_outside_safe_set");
+    assert_eq!(conflict_reason, "stored_spec_conflict");
+    assert_eq!(identity_reason, "spec_identity_disagreement");
+    let mut all = vec![outside_reason, conflict_reason, identity_reason];
+    all.sort_unstable();
+    all.dedup();
+    assert_eq!(all.len(), 3, "the trail must tell the three apart");
+}
+
+/// The caller identity reaches the record unchanged and uninterpreted.
+///
+/// A distinctive value **within** the store's field cap, so what is
+/// asserted is that the verb layer passes it through — the bounding of
+/// an over-long one is the store's own, and is tested there.
+#[tokio::test]
+async fn the_caller_identity_reaches_the_record_unchanged() {
+    const DISTINCTIVE: &str = "spiffe://review/manager#7f3a \"quoted\" \\ and a tab\t";
+
+    let (_server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+
+    let mut request = mint_request("bootroot-decoy", "h1", None);
+    request.caller = CallerIdentity::new(DISTINCTIVE);
+    let refusal = verbs
+        .mint(&request)
+        .await
+        .expect_err("a reserved name is refused");
+
+    let lines = lines_for(&verbs, refusal.context().request_id().as_str());
+    assert_eq!(lines.len(), 2);
+    for line in &lines {
+        assert_eq!(line["caller_identity"], json!(DISTINCTIVE), "{line}");
+        assert!(
+            line.get("truncated").is_none(),
+            "a value inside the cap is not shortened: {line}"
+        );
+    }
+    assert_eq!(
+        refusal.context().caller().as_str(),
+        DISTINCTIVE,
+        "and the outcome carries it too"
+    );
+}
+
+// ---------------------------------------------------------------------
 // Ignored tier: everything that depends on a prior OpenBao write
 // ---------------------------------------------------------------------
 
@@ -1173,6 +2277,7 @@ async fn first_mint_creates_exactly_the_derived_role_and_policy() {
         .await
         .expect("the first mint must succeed");
     let registration_id = format!("{host}-piglet-001");
+    let mint_id = outcome.context().request_id().as_str().to_string();
 
     assert_eq!(outcome.kind(), MintKind::FirstMint);
     assert_eq!(outcome.context().caller().as_str(), CALLER);
@@ -1226,14 +2331,29 @@ async fn first_mint_creates_exactly_the_derived_role_and_policy() {
         "the construction-fixed secret-id options must be what was applied"
     );
 
-    verbs
+    let removal = verbs
         .deregister(&deregister_request("piglet", &host, Some(1)))
         .await
         .expect("cleanup");
+
     // The success arms are only reachable with a live backend, so this
     // is where a first mint and an identity removal are held to the
-    // same "writes nothing yet" rule the refusal arms are.
-    assert_no_audit_records(&verbs);
+    // pairing rule the refusal arms are held to in the fast tier.
+    let minted = assert_pair(
+        &verbs,
+        &mint_id,
+        &Asked::new("mint", "piglet", &host, Some(1)),
+    );
+    assert_eq!(minted["outcome"]["class"], json!("first_mint"));
+    assert_eq!(minted["registration_id"], json!(registration_id));
+
+    let removed = assert_pair(
+        &verbs,
+        removal.context().request_id().as_str(),
+        &Asked::new("deregister", "piglet", &host, Some(1)),
+    );
+    assert_eq!(removed["outcome"]["class"], json!("identity_removed"));
+    assert_eq!(removed["registration_id"], json!(registration_id));
 }
 
 /// A same-host, same-spec re-mint returns fresh material and leaves the
@@ -1251,6 +2371,7 @@ async fn same_host_rematch_reuses_the_role_and_returns_fresh_material() {
     let request = mint_request("roxyd", &host, None);
     let first = verbs.mint(&request).await.expect("first mint");
     assert_eq!(first.kind(), MintKind::FirstMint);
+    let first_id = first.context().request_id().as_str().to_string();
     let first_role_id = first.role_id().to_string();
     let first_token = first.into_wrapped_secret_id();
 
@@ -1274,6 +2395,7 @@ async fn same_host_rematch_reuses_the_role_and_returns_fresh_material() {
         first_role_id,
         "a re-mint must not replace the role"
     );
+    let second_id = second.context().request_id().as_str().to_string();
     let second_token = second.into_wrapped_secret_id();
     assert_ne!(first_token, second_token, "the material must be fresh");
 
@@ -1292,11 +2414,28 @@ async fn same_host_rematch_reuses_the_role_and_returns_fresh_material() {
         .await
         .expect("the second token is unused");
 
-    verbs
+    let removal = verbs
         .deregister(&deregister_request("roxyd", &host, None))
         .await
         .expect("cleanup");
-    assert_no_audit_records(&verbs);
+
+    // Three invocations, three pairs — and the second one's line names
+    // the caller that drove it, not the one before it.
+    let minted = assert_pair(&verbs, &first_id, &Asked::new("mint", "roxyd", &host, None));
+    assert_eq!(minted["outcome"]["class"], json!("first_mint"));
+    let reminted = assert_pair(
+        &verbs,
+        &second_id,
+        &Asked::new("mint", "roxyd", &host, None).by("spiffe://review/other#0001"),
+    );
+    assert_eq!(reminted["outcome"]["class"], json!("idempotent_remint"));
+    assert_eq!(reminted["registration_id"], json!(registration_id));
+    let removed = assert_pair(
+        &verbs,
+        removal.context().request_id().as_str(),
+        &Asked::new("deregister", "roxyd", &host, None),
+    );
+    assert_eq!(removed["outcome"]["class"], json!("identity_removed"));
 }
 
 /// A request larger than the registrar's maximum is clamped, and the
@@ -1427,10 +2566,12 @@ async fn safe_set_refusal_and_stored_spec_conflict_are_distinct_no_change_outcom
         "a safe-set refusal must claim nothing"
     );
 
-    verbs
+    let outside_id = refusal.context().request_id().as_str().to_string();
+    let accepted = verbs
         .mint(&mint_request(&component, &host, Some(1)))
         .await
         .expect("the in-safe-set mint succeeds");
+    let accepted_id = accepted.context().request_id().as_str().to_string();
 
     // Now re-render the config so a different spec is inside the
     // safe-set, and re-mint: the *stored* spec is what disagrees.
@@ -1458,13 +2599,38 @@ async fn safe_set_refusal_and_stored_spec_conflict_are_distinct_no_change_outcom
     let binding = backend.binding_of(&registration_id).await.expect("binding");
     assert_eq!(binding["applied_spec"]["cert_group"], json!(3001));
 
-    verbs
+    let conflict_id = refusal.context().request_id().as_str().to_string();
+    let removal = verbs
         .deregister(&deregister_request(&component, &host, Some(1)))
         .await
         .expect("cleanup");
-    // Post-derivation refusals reach further into the verb than any
-    // arm the mock-server tier can drive, and still write nothing.
-    assert_no_audit_records(&verbs);
+
+    // Post-derivation refusals reach further into the verb than any arm
+    // the mock-server tier can drive, and each still owes its pair. The
+    // stored-spec conflict was driven through a second service, so its
+    // line is in that service's own trail.
+    let asked = Asked::new("mint", &component, &host, Some(1));
+    let outside_line = assert_pair(&verbs, &outside_id, &asked);
+    assert_eq!(
+        outside_line["outcome"]["reason"],
+        json!("service_spec_outside_safe_set")
+    );
+    assert_eq!(outside_line["registration_id"], json!(registration_id));
+    let minted = assert_pair(&verbs, &accepted_id, &asked);
+    assert_eq!(minted["outcome"]["class"], json!("first_mint"));
+    assert_eq!(minted["registration_id"], json!(registration_id));
+    let conflicted = assert_pair(&rewidened, &conflict_id, &asked);
+    assert_eq!(
+        conflicted["outcome"]["reason"],
+        json!("stored_spec_conflict")
+    );
+    assert_eq!(conflicted["registration_id"], json!(registration_id));
+    let removed = assert_pair(
+        &verbs,
+        removal.context().request_id().as_str(),
+        &Asked::new("deregister", &component, &host, Some(1)),
+    );
+    assert_eq!(removed["outcome"]["class"], json!("identity_removed"));
 }
 
 /// A failed convergence retains its `creating` binding. The matching host
@@ -1843,7 +3009,18 @@ async fn absent_binding_deregister_sweeps_planted_orphans() {
             .is_none()
     );
     assert!(backend.binding_of(&registration_id).await.is_none());
-    assert_no_audit_records(&verbs);
+
+    let swept = assert_pair(
+        &verbs,
+        outcome.context().request_id().as_str(),
+        &Asked::new("deregister", "roxyd", &host, None),
+    );
+    assert_eq!(
+        swept["outcome"]["class"],
+        json!("idempotent_already_absent"),
+        "an absent-binding sweep is recorded as the idempotent class it is"
+    );
+    assert_eq!(swept["registration_id"], json!(registration_id));
 }
 
 /// An already-absent role, policy and material is a successful idempotent
@@ -1979,6 +3156,95 @@ async fn two_instances_racing_one_id_produce_exactly_one_claimant() {
     let winner = if bound == host_a { &first } else { &second };
     winner
         .deregister(&deregister_request(&component, &bound, None))
+        .await
+        .expect("cleanup");
+}
+
+/// Concurrent mints for one identity each produce a correctly paired
+/// intent and outcome, and the `first_mint` outcome line precedes every
+/// `idempotent_remint` outcome line in the file.
+///
+/// That ordering is what writing the outcome record **inside** the
+/// per-id guard buys: releasing the guard first would let a re-mint
+/// change `OpenBao` and land its line ahead of the line describing the
+/// claim it superseded. It is a property test rather than a
+/// discriminator — an implementation that wrote outside the guard races
+/// and may still pass — so the in-guard placement is a code-review
+/// criterion as well.
+///
+/// Intent lines are deliberately **not** ordered here. They are written
+/// before stage 1, so concurrent invocations interleave them freely;
+/// the trail is paired by `request_id`, not by adjacency.
+#[tokio::test]
+#[ignore = "needs a live OpenBao; run scripts/impl/run-registrar-verbs-e2e.sh"]
+async fn concurrent_mints_for_one_identity_write_ordered_outcome_lines() {
+    const MINTS: usize = 4;
+
+    let backend = LiveBackend::from_env();
+    let host = unique_label("h");
+    let (_dir, config) = load_fixture(&base_fixture());
+    let verbs = Arc::new(backend.verbs(config));
+
+    let mut handles = Vec::new();
+    for _ in 0..MINTS {
+        let verbs = Arc::clone(&verbs);
+        let host = host.clone();
+        handles.push(tokio::spawn(async move {
+            let outcome = verbs
+                .mint(&mint_request("roxyd", &host, None))
+                .await
+                .expect("every concurrent mint for one identity must succeed");
+            (
+                outcome.context().request_id().as_str().to_string(),
+                outcome.kind(),
+            )
+        }));
+    }
+    let mut minted = Vec::new();
+    for handle in handles {
+        minted.push(handle.await.expect("a mint task must not panic"));
+    }
+
+    let firsts = minted
+        .iter()
+        .filter(|(_, kind)| *kind == MintKind::FirstMint)
+        .count();
+    assert_eq!(firsts, 1, "exactly one invocation may claim the identity");
+
+    // Every invocation owes a complete pair, whichever arm produced it.
+    for (request_id, kind) in &minted {
+        let outcome = assert_pair(
+            &verbs,
+            request_id,
+            &Asked::new("mint", "roxyd", &host, None),
+        );
+        let expected = match kind {
+            MintKind::FirstMint => "first_mint",
+            MintKind::IdempotentReMint => "idempotent_remint",
+        };
+        assert_eq!(outcome["outcome"]["class"], json!(expected));
+        assert_eq!(outcome["registration_id"], json!(format!("{host}-roxyd")));
+    }
+
+    let outcome_classes: Vec<String> = trail(&verbs)
+        .into_iter()
+        .filter(|line| line["phase"] == json!("outcome"))
+        .map(|line| {
+            line["outcome"]["class"]
+                .as_str()
+                .expect("an outcome line names a class")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(outcome_classes.len(), MINTS);
+    assert_eq!(
+        outcome_classes.first().map(String::as_str),
+        Some("first_mint"),
+        "the claim's outcome line must precede every re-mint's, got {outcome_classes:?}"
+    );
+
+    verbs
+        .deregister(&deregister_request("roxyd", &host, None))
         .await
         .expect("cleanup");
 }

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -1421,6 +1421,62 @@ async fn a_registration_id_collision_writes_a_complete_pair() {
     assert_eq!(requests[0].method, wiremock::http::Method::GET);
 }
 
+/// A mint the store *can* record returns its material and leaves a
+/// complete pair behind, on both mint arms.
+///
+/// Every other mint test in this section injects a write failure and so
+/// stops short of the recorded-and-returned path. This is what holds it:
+/// an outcome write that succeeded must hand back the wrapped
+/// `secret_id` that a failed one drops, and the two arms must land under
+/// their two different classes.
+#[tokio::test]
+async fn a_recorded_mint_returns_its_material_on_both_arms() {
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    mock_first_mint(&server, "h1-roxyd").await;
+
+    let first = verbs
+        .mint(&mint_request("roxyd", "h1", None))
+        .await
+        .expect("a mint against a writable store succeeds");
+    assert_eq!(first.kind(), MintKind::FirstMint);
+    let minted = assert_pair(
+        &verbs,
+        first.context().request_id().as_str(),
+        &Asked::new("mint", "roxyd", "h1", None),
+    );
+    assert_eq!(minted["outcome"]["class"], json!("first_mint"));
+    assert_eq!(minted["registration_id"], json!("h1-roxyd"));
+    assert!(
+        !first.into_wrapped_secret_id().is_empty(),
+        "a recorded mint still hands its material back"
+    );
+
+    // The same identity, answered by an active binding: the re-mint arm,
+    // through the same outcome write.
+    let (server, _dir, _store_root, verbs) = audit_harness(&base_fixture()).await;
+    let active = BindingRecord::creating("h1", &requested(&spec_for("roxyd")))
+        .activated(&requested(&spec_for("roxyd")));
+    mock_binding_read(&server, "h1-roxyd", &active).await;
+    mock_first_mint(&server, "h1-roxyd").await;
+
+    let again = verbs
+        .mint(&mint_request("roxyd", "h1", None))
+        .await
+        .expect("a re-mint against a writable store succeeds");
+    assert_eq!(again.kind(), MintKind::IdempotentReMint);
+    let reminted = assert_pair(
+        &verbs,
+        again.context().request_id().as_str(),
+        &Asked::new("mint", "roxyd", "h1", None),
+    );
+    assert_eq!(reminted["outcome"]["class"], json!("idempotent_remint"));
+    assert_eq!(reminted["registration_id"], json!("h1-roxyd"));
+    assert!(
+        !again.into_wrapped_secret_id().is_empty(),
+        "a recorded re-mint still hands its material back"
+    );
+}
+
 /// With the store failing the intent write, the invocation is refused
 /// having made **no** `OpenBao` request at all.
 ///


### PR DESCRIPTION
## What this does

Both registrar verbs now write two audit records per invocation into the daemon-owned store that has been sitting on `RegistrarVerbs` unused.

The **intent** line goes in at the very top of `mint` and `deregister`, before stage 1 and therefore before any `OpenBao` call. The **outcome** line goes in while the per-`registration_id` guard is still held, so the next invocation for that identity cannot change `OpenBao` and land its outcome line ahead of the line describing the change it superseded. The two are paired by `request_id`; intent lines are ordered only by arrival, which is correct because nothing holds a lock across a whole invocation.

Neither write is best-effort, so each has to say what a failure returns. `VerbError` gains two variants, both ordinary `VerbRefusal`s and both individually matchable:

- `AuditUnwritable { phase: AuditPhase, source: AuditStoreError }` — a failed intent write, and a failed outcome write on an invocation that changed no `OpenBao` state. A failed intent write refuses with nothing created and no `OpenBao` request made at all.
- `PostMintUnrecordable { source: AuditStoreError }` — a failed outcome write on an invocation that did, or may have, changed `OpenBao` state. A successful mint that lands here does not return its material; the wrapped `secret_id` is dropped and expires unused.

No fallback path was added on either: no buffer, queue, retry, secondary file, truncation, repair, or log-as-record substitute. The `tracing` event carries the store's own error and stands in for nothing.

## Why a separate mutation disposition

Nothing already on the refusal says whether the invocation touched `OpenBao`. A refusal can follow a durable claim (`claim_and_mint` retains its `creating` binding through a failed convergence), an `AlreadyAbsent` deregister can have swept a full planted orphan, a failed teardown's report can already show resources `Removed`, and `ProducingArm::Binding` covers reads and writes alike.

So the invocation carries an explicit monotone `AtomicBool`, threaded through the locked helpers, set from the result of exactly the six calls that can change state: `create_kv_if_absent` (only on `Created`), `write_kv`, `provision_service_role`, `create_secret_id_wrap_only`, a teardown attempt that is `Removed` or `Failed`, and `delete_kv`. Reads never set it, and a lost compare-and-set never does — nothing reached `OpenBao`. Every *error* does, because a call that failed may have failed after its write landed: reporting a change as an ordinary refusal leaves live state nobody is told to clean up, while the converse costs one idempotent re-drive that finds nothing.

## `refusal_outcome` returns `Option`

Neither new variant can ever reach the trail, since the record that would carry one is the record whose write just failed. That is now a type error rather than a convention: `bridge::refusal_outcome` returns `Option<AuditOutcome>` and yields `None` for exactly those two. `RefusalReason` gains no member, so the store's exhaustive reason table and its golden fixtures are untouched. `bridge`'s `#[allow(dead_code)]` is gone — all three functions are live.

## Names, and where they diverge from the wire contract

`AuditUnwritable` and `PostMintUnrecordable` are the spellings `docs/reference/registrar-wire-contract.md` §6.5 records for the closed `RegistrarUnavailable` reason set, adopted rather than coined. Both are internal verb-layer variants and nothing more — there is no verb-to-wire mapping in this repository and none is built here. Both names are narrower than the conditions above (that set says "intent phase only" and "after a successful mint"); the divergence is recorded in the variants' rustdoc and deliberately not resolved, because narrowing the conditions to fit the names would leave exactly the state changes above unreported.

## Tests

Fast tier, against `wiremock` and a `tempfile::tempdir()` store:

- a complete pair, with no `registration_id` on either line, for every pre-lock refusal through both verbs, plus the two mint-only ones and a `RegistrationIdCollision` (which is decided from a read and so is invisible to the `OpenBao` audit device)
- **intent-failure**: `AuditUnwritable { phase: Intent }` with `assert_untouched(&server)` passing — the direct test that the intent write precedes every `OpenBao` write
- **the mint discriminating pair**, over one injected outcome-phase failure: a `StoredSpecConflict` gives `AuditUnwritable { phase: Outcome }` and a provisioning failure after a landed claim gives `PostMintUnrecordable`, with its `creating` binding still there. Both are refusals, so an implementation classifying from success-versus-refusal fails one
- **the deregister discriminating pair**, likewise: an `AlreadyAbsent` that swept material gives `PostMintUnrecordable`, one with nothing to sweep gives `AuditUnwritable { phase: Outcome }`. Same outcome class, opposite variants
- the two paths where the outcome write succeeds and the caller is served — a recorded mint returning its material on both arms, and a recorded already-absent deregister — so a regression on the success arm does not hide behind the fault-injecting tests
- outcome-failure after a first mint, after an idempotent re-mint, after an identity removal (which then re-drives cleanly once the store recovers), after a failed teardown, on a `HostMismatch`, on a pre-derivation refusal, and on a claim race lost on every attempt
- `sync` and `rotate` failures, each driven in both phases
- three distinct `outcome.reason` values for `ServiceSpecOutsideSafeSet`, `StoredSpecConflict` and `SpecIdentityDisagreement`
- the caller identity reaching `caller_identity` unchanged
- in `src/registrar/audit/tests.rs`, `refusal_outcome` returning `None` for exactly the two audit-failure variants and `Some` for every entry in `every_refusal()`

The fault for one specific append is armed through the existing `AppendGate`, which parks each blocking append at its entry: the intent append is released before the fault is set, and the outcome append is already parked when it is. No production branch was added.

In the ignored tier, `the_verbs_hold_an_audit_store_and_write_nothing_to_it` and `assert_no_audit_records` are gone and their four call sites are inverted to assert the pairs their invocations now produce. One test is added — concurrent mints for one identity, asserting every invocation is correctly paired, that exactly one is a `first_mint`, and that its outcome line precedes every `idempotent_remint` outcome line, which is what the in-guard placement buys. That takes the ignored `registrar::verbs` suite to sixteen.

No `CHANGELOG.md` entry: the registrar verbs are unreachable from any production code path in the last release and remain so after this change.

Closes #777

## Test plan

- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (the crate declares no features, so this is the whole configuration)
- [x] `cargo test` green — 745 lib tests plus every integration binary, 0 failed
- [x] `scripts/impl/run-registrar-verbs-e2e.sh` green: all sixteen ignored `registrar::verbs` tests pass, every one of them now writing audit records
- [x] Every invocation of either verb attempts an intent write before any `OpenBao` call and an outcome write after the verb ran; against a writable store the pair shares one `request_id`
- [x] Intent lines omit the `registration_id` key entirely — absent from the JSON object, not `null` and not `""`
- [x] Every pre-lock refusal (non-DNS-label name, reserved `bootroot-` name, unconfigured component, instance-shape mismatch, spec-identity disagreement, unusable `wrap_ttl`, over-long derived key) produces a pair with no `registration_id` on either line
- [x] A `RegistrationIdCollision` produces a complete pair, with the mock showing the binding read and no write
- [x] An intent-write failure returns `AuditUnwritable { phase: AuditPhase::Intent }` and `assert_untouched(&server)` passes
- [x] The disposition is set from exactly the six enumerated call sites, never cleared, set by every error return; `Ok(KvCreateIfAbsent::AlreadyExists)` and an all-`AlreadyAbsent` teardown leave it clear
- [x] Mint discriminating pair: `StoredSpecConflict` → `AuditUnwritable { phase: Outcome }`; provisioning failure after a landed claim → `PostMintUnrecordable`, with the `creating` binding still in `OpenBao`
- [x] Deregister discriminating pair: sweeping `AlreadyAbsent` → `PostMintUnrecordable`; nothing-to-sweep `AlreadyAbsent` → `AuditUnwritable { phase: Outcome }`
- [x] Outcome-write failure after a `FirstMint`, an `IdempotentReMint` and a removal returns `PostMintUnrecordable`, with `OpenBao` state as the verb left it; re-driving the deregister once the store recovers succeeds and writes its pair
- [x] A `HostMismatch` deregister's outcome-write failure returns `AuditUnwritable { phase: Outcome }`
- [x] The outcome record is written before the per-`registration_id` guard is released; `ID_LOCKS` remains the only verb-layer lock and stages 1 and 2 stay unsynchronized
- [x] `ServiceSpecOutsideSafeSet`, `StoredSpecConflict` and a spec-identity disagreement produce three different `outcome.reason` values
- [x] The caller identity reaches `caller_identity` unchanged and uninterpreted
- [x] `AuditUnwritable` carries both `AuditPhase` values across the suite; `PostMintUnrecordable` carries no phase field
- [x] `bridge::refusal_outcome` returns `Option<AuditOutcome>`, `None` for exactly the two audit-failure variants, and `RefusalReason` gained no member
- [x] `scripts/preflight/ci/check.sh` green; the five `validate-*` scripts green; `ci/deploy-no-build-smoke.sh` green; `ci/test-core.sh` green
- [ ] `scripts/preflight/ci/e2e-matrix.sh` end to end — see below; the arms that need passwordless `sudo` are left to CI

## Verification notes

`scripts/preflight/ci/e2e-matrix.sh --skip-hosts` was run and not skipped: local lifecycle, remote lifecycle, the rotation/recovery matrix and reinit recovery all passed, and the `registrar-verbs` step — the one this change exercises directly — is green. It then stopped at `run-stepca-san.sh`, which fails identically on the unmodified base commit: `bootroot infra install` finds host port 8080 still held by the OrbStack helper for the container `compose_stop` just stopped, and moving the port with `HTTP01_ADMIN_HOST_PORT` moves the conflict with it.

The steps after it were run standalone and passed: OpenBao TLS no-delta, two-instance isolation, registrar verbs, and the registrar internal credential. OpenBao TLS re-own and registrar internal credential init need passwordless `sudo`, which this development host does not have, so those two are left to CI.

### Re-verification, 2026-08-25

Re-run independently on the same host. `cargo fmt --check`, `cargo clippy --all-targets -D warnings` and `cargo test` are green (745 lib tests), as are `ci/check.sh`, the five `validate-*` scripts, `ci/deploy-no-build-smoke.sh` and `ci/test-core.sh`. `scripts/impl/run-registrar-verbs-e2e.sh` passes 16/16.

`scripts/preflight/ci/e2e-matrix.sh --skip-hosts` no longer reaches `run-stepca-san.sh`: it now stops earlier, at step 5, `run-rotation-recovery.sh`, which fails its first `scenario-a` verify with `Leaf certificate at certs/daemon-c1.crt does not chain to CA bundle ...; reissue the leaf so it matches the current PKI generation.` That is this development host and not this branch — the same script run from a throwaway worktree at the merge-base `d8d1907`, with binaries built there, fails with the byte-identical message. It also reproduces from a fully cleaned Docker and secrets state, so it is not run-to-run residue.

Steps 1-4 pass in the matrix (local and remote lifecycle, no-hosts arms; the hosts arms are skipped for lack of passwordless `sudo`). Everything after the rotation step was run standalone against a cleaned host and passes: reinit recovery, OpenBao TLS no-delta, two-instance isolation, registrar verbs, and the registrar internal credential. `run-stepca-san.sh`, OpenBao TLS re-own and registrar internal credential init remain blocked here — the first on the OrbStack published-port race described above, the other two on passwordless `sudo`. All three, and the rotation arm, are green in this PR's CI, where all 13 `Docker E2E` jobs pass.
