### PR TITLE
Harden audit-status failure reporting (#892)

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -257,17 +257,14 @@ enum AuditSettingsLoad {
 
 async fn load_audit_status(args: &StatusArgs, messages: &Messages) -> Result<AuditStatus> {
     let settings_path = audit_settings_path(args.agent_config.as_ref());
-    let settings = match map_audit_settings_join_result(
+    let settings = map_audit_settings_join_result(
         settings_path,
         tokio::task::spawn_blocking({
             let agent_config = args.agent_config.clone();
             move || load_audit_settings(agent_config)
         })
         .await,
-    ) {
-        Ok(settings) => settings,
-        Err(status) => return Ok(status),
-    };
+    );
 
     let settings = match settings {
         AuditSettingsLoad::Ready(settings) => settings,
@@ -306,8 +303,8 @@ fn audit_settings_path(agent_config: Option<&PathBuf>) -> PathBuf {
 fn map_audit_settings_join_result(
     settings_path: PathBuf,
     result: std::result::Result<AuditSettingsLoad, tokio::task::JoinError>,
-) -> std::result::Result<AuditSettingsLoad, AuditStatus> {
-    result.map_err(|error| AuditStatus::Failed {
+) -> AuditSettingsLoad {
+    result.unwrap_or_else(|error| AuditSettingsLoad::Failed {
         path: settings_path,
         reason: AuditFailureReason::Diagnostic(error.to_string()),
     })
@@ -772,8 +769,7 @@ mod tests {
     async fn unreadable_regular_agent_config_is_a_failed_scan() {
         use std::os::unix::fs::PermissionsExt;
 
-        // SAFETY: geteuid only reads the process identity and has no preconditions.
-        if unsafe { libc::geteuid() } == 0 {
+        if bootroot::fs_util::current_process_euid() == 0 {
             return;
         }
 
@@ -903,12 +899,12 @@ mod tests {
             .to_string();
         let path = PathBuf::from("selected-agent.toml");
 
-        let Err(AuditStatus::Failed {
+        let AuditSettingsLoad::Failed {
             path: failed_path,
             reason,
-        }) = map_audit_settings_join_result(path.clone(), join_result)
+        } = map_audit_settings_join_result(path.clone(), join_result)
         else {
-            panic!("the join failure must return failed audit status");
+            panic!("the join failure must return failed audit settings");
         };
         assert_eq!(failed_path, path);
         let AuditFailureReason::Diagnostic(reason) = reason else {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -229,8 +229,13 @@ enum AuditStatus {
     Scan(AuditScan),
     Failed {
         path: std::path::PathBuf,
-        error: String,
+        reason: AuditFailureReason,
     },
+}
+
+enum AuditFailureReason {
+    ExplicitConfigNotRegularFile,
+    Diagnostic(String),
 }
 
 struct AuditScanSettings {
@@ -241,22 +246,33 @@ struct AuditScanSettings {
 
 enum AuditSettingsLoad {
     Ready(AuditScanSettings),
-    Failed { path: PathBuf, error: String },
-    MissingExplicitConfig { path: PathBuf },
+    Failed {
+        path: PathBuf,
+        reason: AuditFailureReason,
+    },
+    MissingExplicitConfig {
+        path: PathBuf,
+    },
 }
 
 async fn load_audit_status(args: &StatusArgs, messages: &Messages) -> Result<AuditStatus> {
-    let settings = tokio::task::spawn_blocking({
-        let agent_config = args.agent_config.clone();
-        move || load_audit_settings(agent_config)
-    })
-    .await
-    .context("loading registrar audit settings off runtime")?;
+    let settings_path = audit_settings_path(args.agent_config.as_ref());
+    let settings = match map_audit_settings_join_result(
+        settings_path,
+        tokio::task::spawn_blocking({
+            let agent_config = args.agent_config.clone();
+            move || load_audit_settings(agent_config)
+        })
+        .await,
+    ) {
+        Ok(settings) => settings,
+        Err(status) => return Ok(status),
+    };
 
     let settings = match settings {
         AuditSettingsLoad::Ready(settings) => settings,
-        AuditSettingsLoad::Failed { path, error } => {
-            return Ok(AuditStatus::Failed { path, error });
+        AuditSettingsLoad::Failed { path, reason } => {
+            return Ok(AuditStatus::Failed { path, reason });
         }
         AuditSettingsLoad::MissingExplicitConfig { path } => {
             anyhow::bail!(messages.status_error_agent_config_missing(&path.display().to_string()));
@@ -276,9 +292,25 @@ async fn load_audit_status(args: &StatusArgs, messages: &Messages) -> Result<Aud
         Err(AuditScanError::StoreAbsent { .. }) => Ok(AuditStatus::Absent),
         Err(error) => Ok(AuditStatus::Failed {
             path: settings.directory,
-            error: error.to_string(),
+            reason: AuditFailureReason::Diagnostic(error.to_string()),
         }),
     }
+}
+
+fn audit_settings_path(agent_config: Option<&PathBuf>) -> PathBuf {
+    agent_config
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from("agent.toml"))
+}
+
+fn map_audit_settings_join_result(
+    settings_path: PathBuf,
+    result: std::result::Result<AuditSettingsLoad, tokio::task::JoinError>,
+) -> std::result::Result<AuditSettingsLoad, AuditStatus> {
+    result.map_err(|error| AuditStatus::Failed {
+        path: settings_path,
+        reason: AuditFailureReason::Diagnostic(error.to_string()),
+    })
 }
 
 fn load_audit_settings(agent_config: Option<PathBuf>) -> AuditSettingsLoad {
@@ -288,7 +320,7 @@ fn load_audit_settings(agent_config: Option<PathBuf>) -> AuditSettingsLoad {
             Ok(_) => {
                 return AuditSettingsLoad::Failed {
                     path: path.clone(),
-                    error: "agent configuration path is not a regular file".to_string(),
+                    reason: AuditFailureReason::ExplicitConfigNotRegularFile,
                 };
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -297,27 +329,29 @@ fn load_audit_settings(agent_config: Option<PathBuf>) -> AuditSettingsLoad {
             Err(error) => {
                 return AuditSettingsLoad::Failed {
                     path: path.clone(),
-                    error: error.to_string(),
+                    reason: AuditFailureReason::Diagnostic(error.to_string()),
                 };
             }
         }
     }
-    let settings_path = agent_config
-        .clone()
-        .unwrap_or_else(|| PathBuf::from("agent.toml"));
-    let settings = match Settings::from_file(agent_config) {
+    let settings_path = audit_settings_path(agent_config.as_ref());
+    let settings_result = match agent_config {
+        Some(path) => Settings::from_required_file(path),
+        None => Settings::from_file(None),
+    };
+    let settings = match settings_result {
         Ok(settings) => settings,
         Err(error) => {
             return AuditSettingsLoad::Failed {
                 path: settings_path,
-                error: error.to_string(),
+                reason: AuditFailureReason::Diagnostic(error.to_string()),
             };
         }
     };
     if let Err(error) = validate_registrar_settings(&settings.registrar) {
         return AuditSettingsLoad::Failed {
             path: settings_path,
-            error: error.to_string(),
+            reason: AuditFailureReason::Diagnostic(error.to_string()),
         };
     }
     AuditSettingsLoad::Ready(AuditScanSettings {
@@ -423,8 +457,17 @@ fn audit_section_lines(messages: &Messages, audit_status: &AuditStatus) -> Vec<S
                 );
             }
         }
-        AuditStatus::Failed { path, error } => lines
-            .push(messages.status_warning_audit_scan_failed(&path.display().to_string(), error)),
+        AuditStatus::Failed { path, reason } => {
+            let reason = match reason {
+                AuditFailureReason::ExplicitConfigNotRegularFile => {
+                    messages.status_warning_audit_config_not_regular_file()
+                }
+                AuditFailureReason::Diagnostic(error) => error,
+            };
+            lines.push(
+                messages.status_warning_audit_scan_failed(&path.display().to_string(), reason),
+            );
+        }
     }
     lines
 }
@@ -664,7 +707,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unreadable_agent_config_path_is_a_failed_scan() {
+    async fn supplied_directory_agent_config_is_a_failed_scan() {
         let dir = tempfile::tempdir().expect("create test directory");
         let config = dir.path().join("agent-config-directory");
         std::fs::create_dir(&config).expect("create config directory");
@@ -674,12 +717,83 @@ mod tests {
             &test_messages(),
         )
         .await
+        .expect("a directory config must not abort status");
+        let AuditStatus::Failed { path, reason } = status else {
+            panic!("a directory config must report a failed scan");
+        };
+        assert_eq!(path, config);
+        assert!(matches!(
+            reason,
+            AuditFailureReason::ExplicitConfigNotRegularFile
+        ));
+    }
+
+    #[tokio::test]
+    async fn supplied_unsupported_agent_config_is_a_failed_scan() {
+        let dir = tempfile::tempdir().expect("create test directory");
+        let config = dir.path().join("agent.unsupported");
+        std::fs::write(&config, "[registrar]\n").expect("write unsupported config");
+
+        let status = load_audit_status(
+            &status_args_with_agent_config(config.clone()),
+            &test_messages(),
+        )
+        .await
+        .expect("an unsupported config must not abort status");
+        let AuditStatus::Failed { path, reason } = status else {
+            panic!("an unsupported config must report a failed scan");
+        };
+        assert_eq!(path, config);
+        assert!(matches!(reason, AuditFailureReason::Diagnostic(_)));
+    }
+
+    #[tokio::test]
+    async fn supplied_agent_config_metadata_error_is_a_failed_scan() {
+        let dir = tempfile::tempdir().expect("create test directory");
+        let blocker = dir.path().join("not-a-directory");
+        std::fs::write(&blocker, "blocker").expect("write metadata blocker");
+        let config = blocker.join("agent.toml");
+
+        let status = load_audit_status(
+            &status_args_with_agent_config(config.clone()),
+            &test_messages(),
+        )
+        .await
+        .expect("a metadata error must not abort status");
+        let AuditStatus::Failed { path, reason } = status else {
+            panic!("a metadata error must report a failed scan");
+        };
+        assert_eq!(path, config);
+        assert!(matches!(reason, AuditFailureReason::Diagnostic(_)));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unreadable_regular_agent_config_is_a_failed_scan() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // SAFETY: geteuid only reads the process identity and has no preconditions.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+
+        let dir = tempfile::tempdir().expect("create test directory");
+        let config = dir.path().join("agent.toml");
+        std::fs::write(&config, "[registrar]\n").expect("write agent config");
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o000))
+            .expect("remove config read permission");
+
+        let status = load_audit_status(
+            &status_args_with_agent_config(config.clone()),
+            &test_messages(),
+        )
+        .await
         .expect("an unreadable config must not abort status");
-        let AuditStatus::Failed { path, error } = status else {
+        let AuditStatus::Failed { path, reason } = status else {
             panic!("an unreadable config must report a failed scan");
         };
         assert_eq!(path, config);
-        assert!(!error.is_empty());
+        assert!(matches!(reason, AuditFailureReason::Diagnostic(_)));
     }
 
     #[tokio::test]
@@ -694,11 +808,11 @@ mod tests {
         )
         .await
         .expect("a malformed config does not abort status");
-        let AuditStatus::Failed { path, error } = status else {
+        let AuditStatus::Failed { path, reason } = status else {
             panic!("a malformed config must report a failed scan");
         };
         assert_eq!(path, config);
-        assert!(!error.is_empty());
+        assert!(matches!(reason, AuditFailureReason::Diagnostic(_)));
     }
 
     #[tokio::test]
@@ -711,8 +825,11 @@ mod tests {
         let status = load_audit_status(&status_args_with_agent_config(config), &test_messages())
             .await
             .expect("invalid settings must not abort status");
-        let AuditStatus::Failed { error, .. } = status else {
+        let AuditStatus::Failed { reason, .. } = status else {
             panic!("invalid registrar settings must report a failed scan");
+        };
+        let AuditFailureReason::Diagnostic(error) = reason else {
+            panic!("invalid registrar settings are diagnostic failures");
         };
         assert!(error.contains("audit_max_retained_files"));
     }
@@ -739,10 +856,13 @@ mod tests {
             )
             .await
             .expect("invalid registrar settings do not abort status");
-            let AuditStatus::Failed { path, error } = status else {
+            let AuditStatus::Failed { path, reason } = status else {
                 panic!("{name} must report a failed scan");
             };
             assert_eq!(path, config);
+            let AuditFailureReason::Diagnostic(error) = reason else {
+                panic!("{name} must be a diagnostic failure");
+            };
             assert!(error.contains("audit_"), "{name}: {error}");
         }
         assert!(
@@ -773,6 +893,30 @@ mod tests {
         assert!(matches!(status, AuditStatus::Scan(_)));
     }
 
+    #[tokio::test]
+    async fn settings_task_join_failure_is_a_failed_audit_status() {
+        let join_result = tokio::task::spawn_blocking(|| panic!("deliberate settings panic")).await;
+        let join_error = join_result
+            .as_ref()
+            .err()
+            .expect("the blocking task must panic")
+            .to_string();
+        let path = PathBuf::from("selected-agent.toml");
+
+        let Err(AuditStatus::Failed {
+            path: failed_path,
+            reason,
+        }) = map_audit_settings_join_result(path.clone(), join_result)
+        else {
+            panic!("the join failure must return failed audit status");
+        };
+        assert_eq!(failed_path, path);
+        let AuditFailureReason::Diagnostic(reason) = reason else {
+            panic!("a join error is diagnostic text");
+        };
+        assert_eq!(reason, join_error);
+    }
+
     #[test]
     fn audit_section_renders_each_state_in_both_locales() {
         let scan = AuditStatus::Scan(AuditScan {
@@ -782,7 +926,11 @@ mod tests {
         });
         let failure = AuditStatus::Failed {
             path: PathBuf::from("/var/lib/bootroot/registrar-audit"),
-            error: "permission denied".to_string(),
+            reason: AuditFailureReason::Diagnostic("permission denied".to_string()),
+        };
+        let non_regular_file_failure = AuditStatus::Failed {
+            path: PathBuf::from("/etc/bootroot/agent.toml"),
+            reason: AuditFailureReason::ExplicitConfigNotRegularFile,
         };
 
         for locale in ["en", "ko"] {
@@ -805,6 +953,18 @@ mod tests {
             let warning = failed.get(1).expect("failed audit section has a warning");
             assert!(warning.contains("/var/lib/bootroot/registrar-audit"));
             assert!(warning.contains("permission denied"));
+
+            let non_regular_file = audit_section_lines(&messages, &non_regular_file_failure);
+            let warning = non_regular_file
+                .get(1)
+                .expect("non-regular-file failure has a warning");
+            assert!(warning.contains("/etc/bootroot/agent.toml"));
+            let explanation = match locale {
+                "en" => "agent configuration path is not a regular file",
+                "ko" => "agent 구성 경로가 일반 파일이 아닙니다",
+                _ => unreachable!("the test provides only known locales"),
+            };
+            assert!(warning.contains(explanation), "{locale}: {warning}");
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -488,8 +488,8 @@ impl Settings {
     /// Creates settings from one required configuration file without an
     /// environment overlay.
     ///
-    /// Unlike [`Settings::from_file`], this refuses an absent or unreadable
-    /// file instead of silently deserializing the defaults.
+    /// Unlike [`Settings::from_file`], this refuses an absent, unreadable,
+    /// or unsupported-format file instead of silently deserializing defaults.
     ///
     /// # Errors
     /// Returns an error if the file cannot be read, its format is unsupported,
@@ -501,7 +501,8 @@ impl Settings {
             .try_deserialize()
     }
 
-    /// Builds the defaults-plus-file layers both constructors share.
+    /// Builds the defaults-plus-optional-file layers used by [`Settings::new`]
+    /// and [`Settings::from_file`].
     fn file_builder(
         config_path: Option<PathBuf>,
     ) -> Result<ConfigBuilder<DefaultState>, ConfigError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -485,6 +485,22 @@ impl Settings {
         Self::file_builder(config_path)?.build()?.try_deserialize()
     }
 
+    /// Creates settings from one required configuration file without an
+    /// environment overlay.
+    ///
+    /// Unlike [`Settings::from_file`], this refuses an absent or unreadable
+    /// file instead of silently deserializing the defaults.
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be read, its format is unsupported,
+    /// or its configuration cannot be deserialized.
+    pub fn from_required_file(config_path: PathBuf) -> Result<Self, ConfigError> {
+        defaults::apply_defaults(Config::builder())?
+            .add_source(File::from(config_path).required(true))
+            .build()?
+            .try_deserialize()
+    }
+
     /// Builds the defaults-plus-file layers both constructors share.
     fn file_builder(
         config_path: Option<PathBuf>,
@@ -595,6 +611,26 @@ mod tests {
         assert_eq!(profile.daemon.check_jitter, Duration::from_secs(0));
         assert!(profile.hooks.post_renew.success.is_empty());
         assert!(profile.hooks.post_renew.failure.is_empty());
+    }
+
+    #[test]
+    fn optional_file_loading_accepts_a_missing_path_but_required_loading_rejects_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing-agent.toml");
+
+        let optional = Settings::from_file(Some(missing.clone())).unwrap();
+        assert_eq!(optional.email, "admin@example.com");
+        assert!(Settings::from_required_file(missing).is_err());
+    }
+
+    #[test]
+    fn required_file_loading_rejects_an_unsupported_existing_file() {
+        let file = tempfile::Builder::new()
+            .suffix(".unsupported")
+            .tempfile()
+            .unwrap();
+
+        assert!(Settings::from_required_file(file.path().to_path_buf()).is_err());
     }
 
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -317,6 +317,7 @@ pub(crate) struct Strings {
     pub(crate) status_warning_audit_malformed_records: &'static str,
     pub(crate) status_warning_audit_retention_shortfall: &'static str,
     pub(crate) status_warning_audit_scan_failed: &'static str,
+    pub(crate) status_warning_audit_config_not_regular_file: &'static str,
     pub(crate) status_error_agent_config_missing: &'static str,
     pub(crate) summary_title: &'static str,
     pub(crate) summary_openbao_url: &'static str,

--- a/src/i18n/en.rs
+++ b/src/i18n/en.rs
@@ -305,6 +305,7 @@ pub(super) static STRINGS: Strings = Strings {
     status_warning_audit_malformed_records: "WARNING: registrar audit contains malformed records.",
     status_warning_audit_retention_shortfall: "WARNING: registrar audit retention is shorter than configured.",
     status_warning_audit_scan_failed: "WARNING: registrar audit scan failed for {path}: {reason}",
+    status_warning_audit_config_not_regular_file: "agent configuration path is not a regular file",
     status_error_agent_config_missing: "Agent config path does not exist: {path}",
     summary_title: "bootroot init: summary",
     summary_openbao_url: "- OpenBao URL: {value}",

--- a/src/i18n/ko.rs
+++ b/src/i18n/ko.rs
@@ -305,6 +305,7 @@ pub(super) static STRINGS: Strings = Strings {
     status_warning_audit_malformed_records: "경고: 레지스트라 감사에 잘못된 레코드가 있습니다.",
     status_warning_audit_retention_shortfall: "경고: 레지스트라 감사 보존 기간이 설정보다 짧습니다.",
     status_warning_audit_scan_failed: "경고: {path}의 레지스트라 감사 스캔에 실패했습니다: {reason}",
+    status_warning_audit_config_not_regular_file: "agent 구성 경로가 일반 파일이 아닙니다",
     status_error_agent_config_missing: "agent 구성 경로가 존재하지 않습니다: {path}",
     summary_title: "bootroot init: 요약",
     summary_openbao_url: "- OpenBao URL: {value}",

--- a/src/i18n/status.rs
+++ b/src/i18n/status.rs
@@ -277,6 +277,10 @@ impl Messages {
         )
     }
 
+    pub(crate) fn status_warning_audit_config_not_regular_file(&self) -> &'static str {
+        self.strings().status_warning_audit_config_not_regular_file
+    }
+
     pub(crate) fn status_error_agent_config_missing(&self, path: &str) -> String {
         format_template(
             self.strings().status_error_agent_config_missing,


### PR DESCRIPTION
## Summary

- Load an explicitly supplied agent configuration file strictly after its metadata gate, preventing fallback to default audit settings.
- Preserve status output by mapping settings task joins and configuration failures to failed audit scans.
- Localize the known non-regular configuration path condition in English and Korean.

Closes #892

## Test plan

- [x] Verify optional versus strict settings loading, including unsupported explicit files.
- [x] Verify explicit configuration metadata outcomes, malformed settings, registrar validation, absent stores, and scanner failures.
- [x] Verify settings task join failures and localized English/Korean non-regular-path warnings.
- [x] Run `cargo fmt -- --check --config group_imports=StdExternalCrate`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`, and `cargo test --bin bootroot`.
- [x] Run the completed CI-equivalent checks, core coverage, and non-hosts E2E lifecycle from `scripts/preflight/run-all.sh`.
- [ ] Complete the hosts-mode E2E lifecycle locally (blocked because it requires non-interactive `sudo -n` on this workstation).