### PR TITLE
Prevent audit config path substitution (#894)

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -265,7 +265,13 @@ async fn load_audit_status(args: &StatusArgs, messages: &Messages) -> Result<Aud
         })
         .await,
     );
+    load_audit_status_from_settings_load(settings, messages).await
+}
 
+async fn load_audit_status_from_settings_load(
+    settings: AuditSettingsLoad,
+    messages: &Messages,
+) -> Result<AuditStatus> {
     let settings = match settings {
         AuditSettingsLoad::Ready(settings) => settings,
         AuditSettingsLoad::Failed { path, reason } => {
@@ -331,11 +337,30 @@ fn load_audit_settings(agent_config: Option<PathBuf>) -> AuditSettingsLoad {
             }
         }
     }
-    let settings_path = audit_settings_path(agent_config.as_ref());
-    let settings_result = match agent_config {
-        Some(path) => Settings::from_required_file(path),
-        None => Settings::from_file(None),
-    };
+
+    match agent_config {
+        Some(path) => load_explicit_audit_settings_after_metadata_gate(path),
+        None => {
+            load_audit_settings_from_result(audit_settings_path(None), Settings::from_file(None))
+        }
+    }
+}
+
+/// Loads one explicit configuration after its caller has confirmed it is a
+/// regular file.
+///
+/// Keeping this step separate from the metadata gate ensures a file that
+/// disappears in between is reported as an audit failure instead of falling
+/// back to a discovered sibling configuration file.
+fn load_explicit_audit_settings_after_metadata_gate(path: PathBuf) -> AuditSettingsLoad {
+    let settings_result = Settings::from_required_file(&path);
+    load_audit_settings_from_result(path, settings_result)
+}
+
+fn load_audit_settings_from_result(
+    settings_path: PathBuf,
+    settings_result: Result<Settings, config::ConfigError>,
+) -> AuditSettingsLoad {
     let settings = match settings_result {
         Ok(settings) => settings,
         Err(error) => {
@@ -686,6 +711,45 @@ mod tests {
         .await
         .expect("a missing default store does not abort status");
         assert!(matches!(status, AuditStatus::Absent));
+    }
+
+    #[tokio::test]
+    async fn vanished_extensionless_agent_config_does_not_load_a_toml_sibling() {
+        let dir = tempfile::tempdir().expect("create test directory");
+        let supplied = dir.path().join("agent");
+        let audit_dir = dir.path().join("sibling-registrar-audit");
+        let sibling = dir.path().join("agent.toml");
+        std::fs::create_dir(&audit_dir).expect("create sibling audit directory");
+        std::fs::write(&supplied, "[registrar]\n").expect("write supplied config");
+        std::fs::write(
+            &sibling,
+            format!(
+                "[registrar]\naudit_store_dir = \"{}\"\naudit_record_dir = \"{}\"\n",
+                dir.path().display(),
+                audit_dir.display()
+            ),
+        )
+        .expect("write sibling config");
+
+        assert!(
+            std::fs::metadata(&supplied)
+                .expect("inspect supplied config")
+                .is_file(),
+            "the explicit metadata gate must pass before the file disappears"
+        );
+        std::fs::remove_file(&supplied).expect("remove supplied config after metadata gate");
+
+        let status = load_audit_status_from_settings_load(
+            load_explicit_audit_settings_after_metadata_gate(supplied.clone()),
+            &test_messages(),
+        )
+        .await
+        .expect("a strict-load failure must not abort status");
+        let AuditStatus::Failed { path, reason } = status else {
+            panic!("the vanished supplied config must not load its TOML sibling");
+        };
+        assert_eq!(path, supplied);
+        assert!(matches!(reason, AuditFailureReason::Diagnostic(_)));
     }
 
     #[tokio::test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -349,9 +349,9 @@ fn load_audit_settings(agent_config: Option<PathBuf>) -> AuditSettingsLoad {
 /// Loads one explicit configuration after its caller has confirmed it is a
 /// regular file.
 ///
-/// Keeping this step separate from the metadata gate ensures a file that
-/// disappears in between is reported as an audit failure instead of falling
-/// back to a discovered sibling configuration file.
+/// This seam lets tests drive the load-after-gate step without constructing
+/// [`StatusArgs`]. [`Settings::from_required_file`] provides the exact-path
+/// guarantee that prevents fallback to a discovered sibling configuration.
 fn load_explicit_audit_settings_after_metadata_gate(path: PathBuf) -> AuditSettingsLoad {
     let settings_result = Settings::from_required_file(&path);
     load_audit_settings_from_result(path, settings_result)
@@ -747,6 +747,33 @@ mod tests {
         .expect("a strict-load failure must not abort status");
         let AuditStatus::Failed { path, reason } = status else {
             panic!("the vanished supplied config must not load its TOML sibling");
+        };
+        assert_eq!(path, supplied);
+        assert!(matches!(reason, AuditFailureReason::Diagnostic(_)));
+    }
+
+    #[tokio::test]
+    async fn vanished_toml_agent_config_is_a_failed_scan_after_metadata_gate() {
+        let dir = tempfile::tempdir().expect("create test directory");
+        let supplied = dir.path().join("agent.toml");
+        std::fs::write(&supplied, "[registrar]\n").expect("write supplied config");
+
+        assert!(
+            std::fs::metadata(&supplied)
+                .expect("inspect supplied config")
+                .is_file(),
+            "the explicit metadata gate must pass before the file disappears"
+        );
+        std::fs::remove_file(&supplied).expect("remove supplied config after metadata gate");
+
+        let status = load_audit_status_from_settings_load(
+            load_explicit_audit_settings_after_metadata_gate(supplied.clone()),
+            &test_messages(),
+        )
+        .await
+        .expect("a strict-load failure must not abort status");
+        let AuditStatus::Failed { path, reason } = status else {
+            panic!("a supplied config that vanishes after the gate must fail the audit status");
         };
         assert_eq!(path, supplied);
         assert!(matches!(reason, AuditFailureReason::Diagnostic(_)));

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use config::builder::DefaultState;
-use config::{Config, ConfigBuilder, ConfigError, Environment, File, FileFormat};
+use config::{Config, ConfigBuilder, ConfigError, Environment, File, FileFormat, FileStoredFormat};
 use serde::Deserialize;
 
 use crate::secret::HmacSecret;
@@ -498,6 +498,8 @@ impl Settings {
         let format = required_file_format(config_path)?;
         let contents =
             std::fs::read(config_path).map_err(|error| ConfigError::Foreign(Box::new(error)))?;
+        // Match `config::File`'s lossy decoding so invalid UTF-8 retains its
+        // previous behavior instead of becoming a new load failure.
         let contents = String::from_utf8_lossy(strip_utf8_bom(&contents));
 
         defaults::apply_defaults(Config::builder())?
@@ -554,17 +556,22 @@ impl Settings {
     }
 }
 
-/// Returns the only configuration format compiled into this application.
+/// Returns the supported format for one strict configuration path.
 ///
 /// This deliberately examines only the exact supplied path. `config::File`
 /// performs filename discovery when its source path is absent, which is useful
 /// for optional configuration but unsafe for an explicitly selected file.
 fn required_file_format(config_path: &Path) -> Result<FileFormat, ConfigError> {
+    // `Cargo.toml` enables only config's `toml` feature. Add a branch for
+    // each subsequently enabled file format so strict and optional sources
+    // continue to accept the same extensions.
+    let format = FileFormat::Toml;
     if config_path
         .extension()
-        .is_some_and(|extension| extension == "toml")
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| format.file_extensions().contains(&extension))
     {
-        Ok(FileFormat::Toml)
+        Ok(format)
     } else {
         Err(ConfigError::Message(format!(
             "configuration file \"{}\" is not of a supported file format",
@@ -573,7 +580,10 @@ fn required_file_format(config_path: &Path) -> Result<FileFormat, ConfigError> {
     }
 }
 
-/// Removes the UTF-8 byte-order mark accepted by `config::File` sources.
+/// Removes a UTF-8 byte-order mark before parsing.
+///
+/// This retains `config::File` source behavior should a future supported
+/// format not tolerate a byte-order mark itself.
 fn strip_utf8_bom(contents: &[u8]) -> &[u8] {
     const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
 
@@ -666,7 +676,14 @@ mod tests {
         let sibling = dir.path().join("agent.toml");
         std::fs::write(&sibling, "email = \"sibling@example.com\"\n").unwrap();
 
-        assert!(Settings::from_required_file(&supplied).is_err());
+        let error = Settings::from_required_file(&supplied).expect_err(
+            "an extension-less supplied path must be rejected before reading a sibling",
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("is not of a supported file format")
+        );
     }
 
     #[test]
@@ -679,6 +696,18 @@ mod tests {
 
         assert!(Settings::from_required_file(&unsupported).is_err());
         assert!(Settings::from_required_file(&extensionless).is_err());
+    }
+
+    #[test]
+    fn strip_utf8_bom_removes_only_a_leading_marker() {
+        assert_eq!(
+            strip_utf8_bom(b"\xEF\xBB\xBFemail = \"admin@example.com\""),
+            b"email = \"admin@example.com\""
+        );
+        assert_eq!(
+            strip_utf8_bom(b"email = \"admin@example.com\""),
+            b"email = \"admin@example.com\""
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::Result;
 use config::builder::DefaultState;
-use config::{Config, ConfigBuilder, ConfigError, Environment, File};
+use config::{Config, ConfigBuilder, ConfigError, Environment, File, FileFormat};
 use serde::Deserialize;
 
 use crate::secret::HmacSecret;
@@ -494,9 +494,14 @@ impl Settings {
     /// # Errors
     /// Returns an error if the file cannot be read, its format is unsupported,
     /// or its configuration cannot be deserialized.
-    pub fn from_required_file(config_path: PathBuf) -> Result<Self, ConfigError> {
+    pub fn from_required_file(config_path: &Path) -> Result<Self, ConfigError> {
+        let format = required_file_format(config_path)?;
+        let contents =
+            std::fs::read(config_path).map_err(|error| ConfigError::Foreign(Box::new(error)))?;
+        let contents = String::from_utf8_lossy(strip_utf8_bom(&contents));
+
         defaults::apply_defaults(Config::builder())?
-            .add_source(File::from(config_path).required(true))
+            .add_source(File::from_str(&contents, format))
             .build()?
             .try_deserialize()
     }
@@ -546,6 +551,36 @@ impl Settings {
     /// Returns error if any setting is invalid or out of range.
     pub fn validate(&self) -> Result<()> {
         validation::validate_settings(self)
+    }
+}
+
+/// Returns the only configuration format compiled into this application.
+///
+/// This deliberately examines only the exact supplied path. `config::File`
+/// performs filename discovery when its source path is absent, which is useful
+/// for optional configuration but unsafe for an explicitly selected file.
+fn required_file_format(config_path: &Path) -> Result<FileFormat, ConfigError> {
+    if config_path
+        .extension()
+        .is_some_and(|extension| extension == "toml")
+    {
+        Ok(FileFormat::Toml)
+    } else {
+        Err(ConfigError::Message(format!(
+            "configuration file \"{}\" is not of a supported file format",
+            config_path.display()
+        )))
+    }
+}
+
+/// Removes the UTF-8 byte-order mark accepted by `config::File` sources.
+fn strip_utf8_bom(contents: &[u8]) -> &[u8] {
+    const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
+
+    if contents.starts_with(UTF8_BOM) {
+        &contents[UTF8_BOM.len()..]
+    } else {
+        contents
     }
 }
 
@@ -621,17 +656,29 @@ mod tests {
 
         let optional = Settings::from_file(Some(missing.clone())).unwrap();
         assert_eq!(optional.email, "admin@example.com");
-        assert!(Settings::from_required_file(missing).is_err());
+        assert!(Settings::from_required_file(&missing).is_err());
     }
 
     #[test]
-    fn required_file_loading_rejects_an_unsupported_existing_file() {
-        let file = tempfile::Builder::new()
-            .suffix(".unsupported")
-            .tempfile()
-            .unwrap();
+    fn required_file_loading_never_discovers_a_toml_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let supplied = dir.path().join("agent");
+        let sibling = dir.path().join("agent.toml");
+        std::fs::write(&sibling, "email = \"sibling@example.com\"\n").unwrap();
 
-        assert!(Settings::from_required_file(file.path().to_path_buf()).is_err());
+        assert!(Settings::from_required_file(&supplied).is_err());
+    }
+
+    #[test]
+    fn required_file_loading_rejects_unsupported_and_extensionless_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let unsupported = dir.path().join("agent.unsupported");
+        let extensionless = dir.path().join("agent-config");
+        std::fs::write(&unsupported, "[registrar]\n").unwrap();
+        std::fs::write(&extensionless, "[registrar]\n").unwrap();
+
+        assert!(Settings::from_required_file(&unsupported).is_err());
+        assert!(Settings::from_required_file(&extensionless).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Read an explicit audit configuration directly from its supplied pathname, deriving only the supported TOML format.
- Keep all post-metadata-gate configuration failures in the failed audit status, preventing sibling configuration discovery.
- Cover extension-less, unsupported, missing, and post-gate-disappearance paths.

Closes #894. Part of #892. Part of #780.

## Test plan

- [x] Confirm a vanished extension-less explicit path cannot load a sibling `agent.toml`.
- [x] Confirm strict loading rejects missing, unsupported, and extension-less supplied paths.
- [x] Verify explicit-path audit failure mappings and the optional default configuration path.
- [x] Run `cargo fmt -- --check --config group_imports=StdExternalCrate`.
- [x] Run `cargo clippy --all-targets -- -D warnings`.
- [x] Run `cargo test --lib` and `cargo test --bin bootroot`.
- [x] Run the CI-equivalent checks and core lifecycle portions of `scripts/preflight/run-all.sh`.
- [x] Verify E2E matrix hosts-mode coverage in green branch CI.