### PR TITLE
Map audit-failure refusals onto the wire

### DIFF
--- a/docs/reference/registrar-wire-contract.md
+++ b/docs/reference/registrar-wire-contract.md
@@ -510,9 +510,10 @@ unclassified form, with no `error` member and class `retryable`.
 | `InvalidWrapTtl(Negative)` | none | `retryable` |
 | `InvalidWrapTtl(NotWholeSeconds)` | none | `retryable` |
 | `InvalidWrapTtl(ExceedsOpenBaoRange)` | none | `retryable` |
+| `AuditUnwritable { phase: Intent }` | `RegistrarUnavailable { reason: AuditUnwritable }` | `permanent` |
+| `AuditUnwritable { phase: Outcome }` | `RegistrarUnavailable { reason: AuditUnwritable }` | `permanent` |
+| `PostMintUnrecordable` | `RegistrarUnavailable { reason: PostMintUnrecordable }` | `permanent` |
 | `Unavailable` | none | `retryable` |
-| Future outcome-audit write failure | `RegistrarUnavailable { reason: PostMintUnrecordable }` | `permanent` |
-| Future intent-audit write failure (`AuditUnwritable` when introduced) | `RegistrarUnavailable { reason: AuditUnwritable }` | `permanent` |
 | Future registrar rate-limit refusal | `RegistrarBusy { retry_after }` | `retryable` |
 
 The two named collapses are deliberate: `ServiceSpecConflict` carries
@@ -524,8 +525,21 @@ a ten-digit instance with 63-octet service and host labels produces a 138-octet
 candidate, beyond the 131-octet registration-id limit. Its response omits both
 `registration_id` and `error`.
 
-The final three rows describe variants that do not exist yet. Their introducing
-changes must add explicit mapping arms; matching coincident internal and
+Both `AuditUnwritable` phases map onto the one transcribed `AuditUnwritable`
+reason. The §6.5 row transcribes the source's intent-phase condition and is
+not edited here; that this endpoint also produces the reason for an
+outcome-phase failure on an invocation that changed no `OpenBao` state is
+this repository's own expectation, not transcribed from the source. The
+caller-visible facts are the intent case's — nothing minted, no teardown
+owed, the audit store unwritable — where `PostMintUnrecordable` would
+falsely owe a teardown and the unclassified form would drop the audit-store
+signal. `PostMintUnrecordable` itself carries every outcome-write failure
+whose invocation did, or may have, changed `OpenBao` state — refusals and
+completed removals included — which is wider than the reason's name; the
+variant's own documentation records that width.
+
+The final row describes a refusal that does not exist yet. Its introducing
+change must add an explicit mapping arm; matching coincident internal and
 external names is not permitted. The rate-limit payload is whole seconds.
 
 ## 11. Counts

--- a/src/registrar/endpoint/protocol.rs
+++ b/src/registrar/endpoint/protocol.rs
@@ -20,6 +20,9 @@ use time::OffsetDateTime;
 
 use super::frame::Operation;
 use crate::kv_payload::{TrustPayload, parse_trust_payload};
+use crate::registrar::audit::AuditPhase;
+#[cfg(test)]
+use crate::registrar::audit::AuditStoreError;
 use crate::registrar::error::RegistrarError;
 #[cfg(test)]
 use crate::registrar::identity::{derive_registration_id, validate_request_labels};
@@ -491,19 +494,22 @@ fn validate_refusal_class(
 // Each internal variant has its own arm so additions cannot silently inherit
 // the unclassified wire form, even where two current arms return the same form.
 //
-// Three wire forms are already assigned to refusals no internal variant
-// produces yet, and the change that introduces each one adds its own arm here
-// rather than reaching this mapping through a wildcard:
+// One wire form is still assigned to a refusal no internal variant produces
+// yet, and the change that introduces it adds its own arm here rather than
+// reaching this mapping through a wildcard: the registrar's own rate-limit
+// refusal maps to retryable `RegistrarBusy { retry_after }`, in whole
+// seconds. No internal variant is added for it here: an arm without a
+// variant to match would be unreachable, and a variant without a producer
+// would be dead.
 //
-// - a post-mint outcome-audit write failure maps to permanent
-//   `RegistrarUnavailable { reason: PostMintUnrecordable }`;
-// - an intent-audit write failure maps to permanent
-//   `RegistrarUnavailable { reason: AuditUnwritable }`;
-// - the registrar's own rate-limit refusal maps to retryable
-//   `RegistrarBusy { retry_after }`, in whole seconds.
-//
-// No internal variant is added for them here: an arm without a variant to
-// match would be unreachable, and a variant without a producer would be dead.
+// Both `AuditUnwritable` phases map onto the one transcribed
+// `AuditUnwritable` reason. The reference's §6.5 row transcribes the
+// source's intent-phase condition; a non-mutating outcome-phase failure
+// presents the same caller-visible facts — nothing minted, no teardown
+// owed, the audit store unwritable — where `PostMintUnrecordable` would
+// falsely owe a teardown and the unclassified form would drop the
+// audit-store signal. The locally owned half of the reference records this
+// producer set.
 #[allow(clippy::match_same_arms)]
 #[allow(clippy::too_many_lines)]
 fn map_refusal(error: &VerbError) -> (RefusalClass, Option<EnrollError>) {
@@ -616,6 +622,30 @@ fn map_refusal(error: &VerbError) -> (RefusalClass, Option<EnrollError>) {
         VerbError::InvalidWrapTtl(WrapTtlRefusal::ExceedsOpenBaoRange) => {
             (RefusalClass::Retryable, None)
         }
+        VerbError::AuditUnwritable {
+            phase: AuditPhase::Intent,
+            ..
+        } => (
+            RefusalClass::Permanent,
+            Some(EnrollError::RegistrarUnavailable {
+                reason: RegistrarUnavailableReason::AuditUnwritable,
+            }),
+        ),
+        VerbError::AuditUnwritable {
+            phase: AuditPhase::Outcome,
+            ..
+        } => (
+            RefusalClass::Permanent,
+            Some(EnrollError::RegistrarUnavailable {
+                reason: RegistrarUnavailableReason::AuditUnwritable,
+            }),
+        ),
+        VerbError::PostMintUnrecordable { .. } => (
+            RefusalClass::Permanent,
+            Some(EnrollError::RegistrarUnavailable {
+                reason: RegistrarUnavailableReason::PostMintUnrecordable,
+            }),
+        ),
         VerbError::Unavailable { .. } => (RefusalClass::Retryable, None),
     }
 }
@@ -1536,10 +1566,37 @@ mod tests {
                 VerbError::InvalidWrapTtl(WrapTtlRefusal::ExceedsOpenBaoRange),
             ),
             (
+                "AuditUnwritable { phase: Intent }",
+                VerbError::AuditUnwritable {
+                    phase: AuditPhase::Intent,
+                    source: fixture_audit_store_error(),
+                },
+            ),
+            (
+                "AuditUnwritable { phase: Outcome }",
+                VerbError::AuditUnwritable {
+                    phase: AuditPhase::Outcome,
+                    source: fixture_audit_store_error(),
+                },
+            ),
+            (
+                "PostMintUnrecordable",
+                VerbError::PostMintUnrecordable {
+                    source: fixture_audit_store_error(),
+                },
+            ),
+            (
                 "Unavailable",
                 VerbError::unavailable("fixture", anyhow::anyhow!("unavailable")),
             ),
         ]
+    }
+
+    fn fixture_audit_store_error() -> AuditStoreError {
+        AuditStoreError::Append {
+            path: PathBuf::from("audit"),
+            source: std::io::Error::other("append failed"),
+        }
     }
 
     // The reference's mapping table, minus the rows describing refusals no
@@ -1636,31 +1693,19 @@ mod tests {
     }
 
     #[test]
-    fn the_reference_records_the_three_future_mapping_assignments() {
+    fn the_reference_records_the_future_rate_limit_assignment() {
         let future = reference_refusal_mapping_rows()
             .into_iter()
             .filter(|(label, _)| label.starts_with("Future "))
             .map(|(_, row)| row)
             .collect::<Vec<_>>();
-        assert_eq!(future.len(), 3);
+        assert_eq!(future.len(), 1);
         for (class, identifier) in &future {
             let identifier = identifier
                 .as_ref()
                 .expect("a future assignment names an identifier");
             assert!(validate_refusal_class(*class, Some(identifier)).is_ok());
         }
-        assert!(future.contains(&(
-            RefusalClass::Permanent,
-            Some(EnrollError::RegistrarUnavailable {
-                reason: RegistrarUnavailableReason::PostMintUnrecordable,
-            }),
-        )));
-        assert!(future.contains(&(
-            RefusalClass::Permanent,
-            Some(EnrollError::RegistrarUnavailable {
-                reason: RegistrarUnavailableReason::AuditUnwritable,
-            }),
-        )));
         assert!(
             future
                 .iter()

--- a/src/registrar/verbs/outcome.rs
+++ b/src/registrar/verbs/outcome.rs
@@ -414,14 +414,11 @@ pub(crate) enum VerbError {
     /// §6.5 records for the closed `RegistrarUnavailable` reason set, and
     /// is adopted rather than coined here. That set describes it as
     /// "intent phase only", which is narrower than the condition above;
-    /// the divergence is deliberate and is not resolved here, because
-    /// narrowing the condition to fit the name would leave a
-    /// non-mutating outcome-write failure unreported. This variant is
-    /// internal to the verb layer and nothing more — there is no
-    /// verb-to-wire mapping in this repository, and carrying the phase
-    /// is what lets a later endpoint map [`AuditPhase::Intent`] onto the
-    /// transcribed reason and decide on its own terms what an
-    /// [`AuditPhase::Outcome`] failure tells a caller.
+    /// the divergence is deliberate, because narrowing the condition to
+    /// fit the name would leave a non-mutating outcome-write failure
+    /// unreported. The endpoint's `map_refusal` maps both phases onto
+    /// the transcribed reason; the locally owned half of the wire
+    /// reference records that decision and why.
     #[error("the registrar could not write the {phase} audit record")]
     AuditUnwritable {
         /// The write that failed. Reused from the record format rather


### PR DESCRIPTION
## Problem

`main`'s `Quality Check` job has been red since merge commit `19b9a11` (#884): `map_refusal` in `src/registrar/endpoint/protocol.rs` matches `VerbError` exhaustively with no wildcard arm — by design — and #884 landed `VerbError::AuditUnwritable` and `VerbError::PostMintUnrecordable` without arms, because #777 explicitly placed the wire mapping out of its scope. Each branch was green in isolation; combined on `main`, `cargo clippy --all-targets -- -D warnings` fails with E0004. The endpoint module is Linux-gated, so macOS checkouts never saw it.

## Decision

Recorded in #901: the transcribed `RegistrarUnavailable` reason set is closed, so within it —

- `AuditUnwritable { phase: Intent }` and `AuditUnwritable { phase: Outcome }` both map to permanent `RegistrarUnavailable { reason: AuditUnwritable }`. A non-mutating outcome-phase failure presents the same caller-visible facts as the intent case (nothing minted, no teardown owed, audit store unwritable); `PostMintUnrecordable` would falsely owe a teardown and the unclassified retryable form would drop the audit-store signal. The transcribed §6.5 row keeps its intent-phase wording; the locally owned half of the reference records the wider producer set as this repository's own expectation.
- `PostMintUnrecordable` maps to permanent `RegistrarUnavailable { reason: PostMintUnrecordable }`, the reserved assignment.

Each phase gets its own arm, so a new `AuditPhase` member breaks this match too.

## Changes

- `src/registrar/endpoint/protocol.rs` — the three arms; the mapping comment rewritten (only the rate-limit `RegistrarBusy { retry_after }` assignment remains future); fixtures for the three new labels in `every_current_verb_error`, covered by the existing mapping and envelope round-trip tests; `the_reference_records_the_three_future_mapping_assignments` becomes `the_reference_records_the_future_rate_limit_assignment`.
- `docs/reference/registrar-wire-contract.md` — the locally owned mapping table replaces the two "Future … audit write failure" rows with the three current-variant rows and records the outcome-phase decision; the transcribed §6.5 table is untouched.
- `src/registrar/verbs/outcome.rs` — doc comment only: it claimed no verb-to-wire mapping exists in this repository, which the arms above make false.

This supersedes #900 (the comment it corrects is rewritten here); merging closes it.

## Verification

- `cargo fmt -- --check --config group_imports=StdExternalCrate` — pass.
- Linux (Docker, rust:latest stable): `cargo clippy --all-targets -- -D warnings` — pass; `cargo test` — lib 898/898 including the Linux-gated endpoint protocol tests. The only failures in the container were 8 `tests/bootroot_rotate.rs` cases that shell out to a `docker` CLI absent inside the container — unrelated to this diff and covered on CI runners.
- macOS: `cargo clippy --all-targets -- -D warnings`, `cargo test`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` — pass.
- `./scripts/check-docs.sh` and `markdownlint-cli2` on the changed reference — pass.
- `scripts/preflight/ci/e2e-matrix.sh` skipped: the endpoint codec is not yet served by the production handler (#886), so no E2E path exercises this mapping, and the Docker lifecycle and E2E scripts are untouched.

Closes #901. Closes #900. Supplies the missing delivery that reopened #897 (the all-current-refusals mapping and envelope coverage).
