### PR TITLE
Complete the audit scanner contract and coverage (#896)

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -674,6 +674,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn supplied_agent_config_reports_a_populated_store_scan() {
+        use bootroot::registrar::audit::{
+            ACTIVE_FILE_NAME, AuditRecord, AuditVerb, RequestedIdentity,
+        };
+
+        let dir = tempfile::tempdir().expect("create test directory");
+        let audit_dir = dir.path().join("registrar-audit");
+        std::fs::create_dir(&audit_dir).expect("create audit directory");
+        let intent = AuditRecord::intent(
+            OffsetDateTime::now_utc() - TimeDuration::minutes(2),
+            "populated-store".to_string(),
+            AuditVerb::Mint,
+            "caller".to_string(),
+            RequestedIdentity {
+                service_name: "api".to_string(),
+                host: "host".to_string(),
+                instance: None,
+            },
+        );
+        let mut active = intent.to_line().expect("serialize audit record");
+        active.extend_from_slice(b"not JSON\n");
+        std::fs::write(audit_dir.join(ACTIVE_FILE_NAME), active).expect("write active file");
+
+        let config = dir.path().join("agent.toml");
+        std::fs::write(
+            &config,
+            format!(
+                "[registrar]\naudit_store_dir = \"{}\"\naudit_record_dir = \"{}\"\n",
+                dir.path().display(),
+                audit_dir.display()
+            ),
+        )
+        .expect("write agent config");
+
+        let status = load_audit_status(&status_args_with_agent_config(config), &test_messages())
+            .await
+            .expect("load audit status");
+        let AuditStatus::Scan(scan) = status else {
+            panic!("a populated configured store must be scanned");
+        };
+        assert_eq!(
+            scan,
+            AuditScan {
+                intent_without_outcome: 1,
+                malformed_records: 1,
+                retention_short: false,
+            }
+        );
+    }
+
+    /// A symlinked `audit_record_dir` is the one store defect that
+    /// reaches the scanner: `validate_registrar_settings` compares paths
+    /// lexically and accepts it, and the scanner then refuses it with
+    /// `PathCondition::Symlink`. A mode-based refusal would not do —
+    /// mode bits do not stop a root process, so it would invert between
+    /// a root and a non-root run.
+    #[tokio::test]
+    async fn a_symlinked_store_directory_is_a_failed_audit_status() {
+        let dir = tempfile::tempdir().expect("create test directory");
+        let target = dir.path().join("audit-target");
+        std::fs::create_dir(&target).expect("create audit target directory");
+        let audit_dir = dir.path().join("registrar-audit");
+        std::os::unix::fs::symlink(&target, &audit_dir).expect("create audit directory symlink");
+        let config = dir.path().join("agent.toml");
+        std::fs::write(
+            &config,
+            format!(
+                "[registrar]\naudit_store_dir = \"{}\"\naudit_record_dir = \"{}\"\n",
+                dir.path().display(),
+                audit_dir.display()
+            ),
+        )
+        .expect("write agent config");
+
+        let messages = test_messages();
+        let status = load_audit_status(&status_args_with_agent_config(config), &messages)
+            .await
+            .expect("a refused audit store does not abort status");
+        let AuditStatus::Failed { path, reason } = &status else {
+            panic!("a symlinked store directory must fail the audit status");
+        };
+        assert_eq!(path, &audit_dir);
+        let AuditFailureReason::Diagnostic(diagnostic) = reason else {
+            panic!("a scanner refusal is diagnostic text");
+        };
+        assert!(
+            diagnostic.contains("symbolic link"),
+            "the scanner refusal names its condition: {diagnostic}"
+        );
+
+        let lines = audit_section_lines(&messages, &status);
+        assert_eq!(lines.len(), 2, "a failed scan renders one warning");
+        let warning = lines.get(1).expect("failed audit section has a warning");
+        assert_eq!(
+            warning,
+            &messages
+                .status_warning_audit_scan_failed(&audit_dir.display().to_string(), diagnostic)
+        );
+        assert_ne!(warning, messages.status_audit_not_configured());
+        for count_line in [
+            messages.status_audit_unpaired_intents(0),
+            messages.status_audit_malformed_records(0),
+            messages.status_audit_retention_shortfall(false),
+        ] {
+            assert!(
+                !lines.contains(&count_line),
+                "a failed scan renders no count line: {count_line}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn supplied_agent_config_maps_a_missing_store_to_absent() {
         let dir = tempfile::tempdir().expect("create test directory");
         let audit_dir = dir.path().join("missing-registrar-audit");
@@ -1002,6 +1114,36 @@ mod tests {
             panic!("a join error is diagnostic text");
         };
         assert_eq!(reason, join_error);
+    }
+
+    #[test]
+    fn audit_section_renders_a_clean_scan_without_warnings() {
+        let clean = AuditStatus::Scan(AuditScan {
+            intent_without_outcome: 0,
+            malformed_records: 0,
+            retention_short: false,
+        });
+
+        for locale in ["en", "ko"] {
+            let messages = Messages::new(locale).expect("load test locale");
+            let lines = audit_section_lines(&messages, &clean);
+            assert_eq!(
+                lines,
+                vec![
+                    messages.status_section_registrar_audit().to_string(),
+                    messages.status_audit_unpaired_intents(0),
+                    messages.status_audit_malformed_records(0),
+                    messages.status_audit_retention_shortfall(false),
+                ],
+                "{locale} clean scan renders the heading and three counts only"
+            );
+            assert!(
+                !lines
+                    .iter()
+                    .any(|line| line.contains("WARNING") || line.contains("경고")),
+                "{locale} clean scan renders no warning"
+            );
+        }
     }
 
     #[test]

--- a/src/registrar/audit/scan.rs
+++ b/src/registrar/audit/scan.rs
@@ -131,10 +131,10 @@ pub fn scan_audit_store(
     let mut files = HashMap::new();
     let mut state = ScanState::default();
     for path in &scan_paths {
-        let data = read_file(path, Some(&mut state))?;
+        let data = read_file(path, Some(&mut state), euid)?;
         files.insert(path.clone(), data);
     }
-    let data = read_file(&active, Some(&mut state))?;
+    let data = read_file(&active, Some(&mut state), euid)?;
     files.insert(active.clone(), data);
 
     let mut malformed = state.duplicate_lines;
@@ -153,7 +153,7 @@ pub fn scan_audit_store(
         let mut oldest = None;
         for (path, _) in retained {
             if !files.contains_key(path) {
-                let data = read_file(path, None)?;
+                let data = read_file(path, None, euid)?;
                 files.insert(path.clone(), data);
             }
             if let Some(timestamp) = files
@@ -304,6 +304,7 @@ fn rotated_generations(dir: &Path) -> Result<Vec<(PathBuf, OffsetDateTime)>, Aud
 fn read_file(
     path: &Path,
     scan_state: Option<&mut ScanState>,
+    euid: u32,
 ) -> Result<Option<FileData>, AuditScanError> {
     #[cfg(test)]
     observe_open(path);
@@ -340,15 +341,34 @@ fn read_file(
             path: path.to_path_buf(),
             source,
         })?;
-    if !metadata.is_file() {
+    // The descriptor decides the kind, so a path swapped between the
+    // check above and the open is judged as what was actually opened.
+    // That does not make either symlink refusal above redundant: this
+    // one runs on a descriptor `O_NOFOLLOW` already refused to open a
+    // symlink through, so it can never report `Symlink` itself, and only
+    // the pre-open guard and the `ELOOP` mapping name that condition.
+    if let Some(condition) = path_condition(
+        metadata.file_type().is_symlink(),
+        metadata.is_file(),
+        metadata.uid(),
+        metadata.mode(),
+        false,
+        euid,
+    ) {
         return Err(AuditScanError::UnsafePath {
             path: path.to_path_buf(),
-            condition: PathCondition::NotARegularFile,
+            condition,
         });
     }
     read_lines(&mut file, path, scan_state).map(Some)
 }
 
+/// Classifies one path's metadata against the store's trust contract.
+///
+/// `directory` selects the arm: the store directory and its immediate
+/// parent are judged on kind, owner and mode, while an entry inside the
+/// store is judged on kind alone. `euid` is passed as a value so the
+/// classification is testable without the invoking process's identity.
 fn path_condition(
     is_symlink: bool,
     has_expected_kind: bool,
@@ -367,16 +387,25 @@ fn path_condition(
             PathCondition::NotARegularFile
         });
     }
-    if uid != 0 && uid != euid {
-        return Some(PathCondition::Owner {
-            expected: euid,
-            found: uid,
-        });
-    }
-    if directory && mode & 0o022 != 0 {
-        return Some(PathCondition::GroupOrWorldWritable {
-            mode: mode & 0o7777,
-        });
+    // Both remaining rules are directory-only. The store's trust
+    // contract places them on the store directory and its immediate
+    // parent, and deliberately not on the entries inside: a directory
+    // owned by root or the invoking user and writable by nobody else
+    // already bounds who can create an entry in it, so a per-file owner
+    // or mode check would refuse stores the contract accepts without
+    // narrowing what can reach them.
+    if directory {
+        if uid != 0 && uid != euid {
+            return Some(PathCondition::Owner {
+                expected: euid,
+                found: uid,
+            });
+        }
+        if mode & 0o022 != 0 {
+            return Some(PathCondition::GroupOrWorldWritable {
+                mode: mode & 0o7777,
+            });
+        }
     }
     None
 }
@@ -712,8 +741,8 @@ mod tests {
         bytes.extend(b"not json\n");
         fs::write(&active, bytes).expect("add malformed line");
 
-        let scan = scan_audit_store(dir.path(), now, Duration::days(30), 16, 90)
-            .expect("scan audit store");
+        let scan =
+            scan_audit_store(dir.path(), now, AUDIT_SCAN_WINDOW, 16, 90).expect("scan audit store");
         assert_eq!(scan.intent_without_outcome, 1);
         assert_eq!(scan.malformed_records, 1);
         assert!(!scan.retention_short);
@@ -822,7 +851,7 @@ mod tests {
         let scan = scan_audit_store(
             dir.path(),
             OffsetDateTime::now_utc(),
-            Duration::days(30),
+            AUDIT_SCAN_WINDOW,
             16,
             90,
         )
@@ -1133,10 +1162,15 @@ mod tests {
 
     #[test]
     fn refuses_invalid_arguments_before_opening_the_store() {
+        // A relative store path is its own rejected argument, so it
+        // cannot name a populated store the way the value table in
+        // `rejects_public_arguments_that_cannot_define_a_scan` does.
+        let relative = Path::new("relative");
+        let observer = observe_opens(relative, None);
         let error = scan_audit_store(
-            Path::new("relative"),
+            relative,
             OffsetDateTime::now_utc(),
-            Duration::days(30),
+            AUDIT_SCAN_WINDOW,
             16,
             90,
         )
@@ -1148,6 +1182,14 @@ mod tests {
                 ..
             }
         ));
+        assert!(
+            observer.counts().is_empty(),
+            "a relative store path must fail before any audit file is opened"
+        );
+        assert!(
+            observer.directory_checks().is_empty(),
+            "a relative store path must fail before the directory is inspected"
+        );
     }
 
     #[test]
@@ -1338,6 +1380,43 @@ mod tests {
         let scan = scan_audit_store(dir.path(), now, AUDIT_SCAN_WINDOW, 16, 90)
             .expect("scan paired records");
         assert_eq!(scan.intent_without_outcome, 0);
+        assert_eq!(scan.malformed_records, 0);
+    }
+
+    #[test]
+    fn outcome_after_now_pairs_an_in_window_intent() {
+        let dir = audit_store();
+        let now = OffsetDateTime::now_utc();
+        let request_id = "outcome-after-now".to_string();
+        append_record(
+            dir.path(),
+            &AuditRecord::intent(
+                now - Duration::minutes(2),
+                request_id.clone(),
+                AuditVerb::Mint,
+                "caller".to_string(),
+                identity(),
+            ),
+        );
+        append_record(
+            dir.path(),
+            &AuditRecord::outcome(
+                now + Duration::minutes(5),
+                request_id,
+                AuditVerb::Mint,
+                "caller".to_string(),
+                identity(),
+                None,
+                AuditOutcome::FirstMint,
+            ),
+        );
+
+        let scan = scan_audit_store(dir.path(), now, AUDIT_SCAN_WINDOW, 16, 90)
+            .expect("scan an outcome dated after now");
+        assert_eq!(
+            scan.intent_without_outcome, 0,
+            "an outcome dated after now still pairs its in-window intent"
+        );
         assert_eq!(scan.malformed_records, 0);
     }
 
@@ -1566,6 +1645,19 @@ mod tests {
                 ..
             }
         ));
+
+        let directory_dir = audit_store();
+        let directory_path = directory_dir.path().join(ACTIVE_FILE_NAME);
+        fs::create_dir(&directory_path).expect("create active-file directory entry");
+        let error = scan_audit_store(directory_dir.path(), now, AUDIT_SCAN_WINDOW, 16, 90)
+            .expect_err("directory must be refused");
+        assert!(matches!(
+            error,
+            AuditScanError::UnsafePath {
+                condition: PathCondition::NotARegularFile,
+                path,
+            } if path == directory_path
+        ));
     }
 
     #[test]
@@ -1585,6 +1677,28 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Pins the deliberate limit of the store's trust contract at the
+    /// scanner's own surface: the entries inside a safe store are judged
+    /// on kind alone, so a permissive mode on one of them is not a
+    /// refusal. The classifier's file arm is asserted directly by
+    /// [`path_trust_accepts_root_or_the_invoking_user_only`]; this is
+    /// the end-to-end half, so re-gating that rule on the entries could
+    /// not pass unnoticed.
+    #[test]
+    fn reads_a_group_or_world_writable_entry_inside_a_safe_store() {
+        let dir = audit_store();
+        let now = OffsetDateTime::now_utc();
+        append_record(dir.path(), &old_intent(now, "permissive-mode"));
+        let active = dir.path().join(ACTIVE_FILE_NAME);
+        fs::set_permissions(&active, fs::Permissions::from_mode(0o666))
+            .expect("make the active file group- and world-writable");
+
+        let scan = scan_audit_store(dir.path(), now, AUDIT_SCAN_WINDOW, 16, 90)
+            .expect("a permissive mode on an entry is not a refusal");
+        assert_eq!(scan.intent_without_outcome, 1);
+        assert_eq!(scan.malformed_records, 0);
     }
 
     #[test]
@@ -1820,6 +1934,9 @@ mod tests {
         }
     }
 
+    /// Drives the classifier as a value table, so every trust condition
+    /// the scanner can refuse — the foreign owner included — is asserted
+    /// whatever effective UID the run happens to have.
     #[test]
     fn path_trust_accepts_root_or_the_invoking_user_only() {
         let euid = 41;
@@ -1846,8 +1963,61 @@ mod tests {
             path_condition(false, true, euid, 0o770, true, euid),
             Some(PathCondition::GroupOrWorldWritable { mode: 0o770 })
         );
+        assert_eq!(
+            path_condition(false, true, foreign_uid, 0o777, true, euid),
+            Some(PathCondition::Owner {
+                expected: euid,
+                found: foreign_uid,
+            }),
+            "a foreign owner outranks the writable mode it is also refused for"
+        );
+
+        // The file arm, which `read_file` reaches for every entry it
+        // opens. A symlink and a non-regular kind are refused; nothing
+        // else is.
+        assert_eq!(
+            path_condition(true, true, 0, 0o600, false, euid),
+            Some(PathCondition::Symlink)
+        );
+        assert_eq!(
+            path_condition(true, false, foreign_uid, 0o777, false, euid),
+            Some(PathCondition::Symlink),
+            "a symlink outranks the non-regular kind it is also refused for"
+        );
+        assert_eq!(
+            path_condition(false, false, 0, 0o600, false, euid),
+            Some(PathCondition::NotARegularFile)
+        );
+        assert_eq!(path_condition(false, true, 0, 0o600, false, euid), None);
+        assert_eq!(path_condition(false, true, euid, 0o600, false, euid), None);
+        // The store's trust contract bounds who may create an entry by
+        // the directory's owner and mode, so neither a foreign owner nor
+        // a group- or world-writable mode refuses an entry inside it.
+        // These are deliberate limits, not missing checks.
+        assert_eq!(
+            path_condition(false, true, foreign_uid, 0o600, false, euid),
+            None,
+            "the file arm carries no ownership check"
+        );
+        for mode in [0o620, 0o602, 0o666, 0o777] {
+            assert_eq!(
+                path_condition(false, true, euid, mode, false, euid),
+                None,
+                "the file arm carries no mode check ({mode:o})"
+            );
+        }
+        assert_eq!(
+            path_condition(false, false, foreign_uid, 0o777, false, euid),
+            Some(PathCondition::NotARegularFile),
+            "a non-regular kind outranks the conditions the file arm ignores"
+        );
     }
 
+    /// Exercises the foreign-owner refusal end to end, which needs the
+    /// privilege to `chown` away from the invoking user. The refusal
+    /// itself is asserted unconditionally by
+    /// [`path_trust_accepts_root_or_the_invoking_user_only`], so the
+    /// coverage does not depend on this test running.
     #[test]
     fn refuses_foreign_owned_directories_when_running_as_root() {
         if crate::fs_util::current_process_euid() != 0 {
@@ -1887,37 +2057,27 @@ mod tests {
 
     #[test]
     fn rejects_public_arguments_that_cannot_define_a_scan() {
-        let absent = tempfile::tempdir()
-            .expect("create absent-store parent")
-            .path()
-            .join("must-not-be-opened");
-        let now = OffsetDateTime::UNIX_EPOCH;
-        for (window, retained, days, setting) in [
-            (Duration::ZERO, 16, 90, "window"),
-            (Duration::seconds(-1), 16, 90, "window"),
-            (AUDIT_SCAN_WINDOW, 0, 90, "audit_max_retained_files"),
-            (AUDIT_SCAN_WINDOW, 16, 0, "audit_min_retain_days"),
-            (Duration::MAX, 16, 90, "window"),
-            (AUDIT_SCAN_WINDOW, 16, u32::MAX, "audit_min_retain_days"),
-        ] {
-            let error = scan_audit_store(&absent, now, window, retained, days)
-                .expect_err("invalid scanner arguments must fail");
-            assert!(matches!(
-                error,
-                AuditScanError::InvalidSetting {
-                    setting: found,
-                    ..
-                } if found == setting
-            ));
-        }
+        // The store is real and holds a record, so a rejection that
+        // precedes any filesystem work is distinguishable from one that
+        // merely coincides with a store the scanner could not have read.
+        let populated = audit_store();
+        append_record(
+            populated.path(),
+            &old_intent(OffsetDateTime::now_utc(), "must-not-be-read"),
+        );
 
+        let observer = observe_opens(populated.path(), None);
         for now in [OffsetDateTime::UNIX_EPOCH, OffsetDateTime::now_utc()] {
-            for (window, days, setting) in [
-                (Duration::MAX, 90, "window"),
-                (AUDIT_SCAN_WINDOW, u32::MAX, "audit_min_retain_days"),
+            for (window, retained, days, setting) in [
+                (Duration::ZERO, 16, 90, "window"),
+                (Duration::seconds(-1), 16, 90, "window"),
+                (AUDIT_SCAN_WINDOW, 0, 90, "audit_max_retained_files"),
+                (AUDIT_SCAN_WINDOW, 16, 0, "audit_min_retain_days"),
+                (Duration::MAX, 16, 90, "window"),
+                (AUDIT_SCAN_WINDOW, 16, u32::MAX, "audit_min_retain_days"),
             ] {
-                let error = scan_audit_store(&absent, now, window, 16, days)
-                    .expect_err("an out-of-range lookback must fail before opening the store");
+                let error = scan_audit_store(populated.path(), now, window, retained, days)
+                    .expect_err("invalid scanner arguments must fail");
                 assert!(matches!(
                     error,
                     AuditScanError::InvalidSetting {
@@ -1925,9 +2085,30 @@ mod tests {
                         ..
                     } if found == setting
                 ));
+                assert!(
+                    observer.counts().is_empty(),
+                    "{setting} must be rejected before any audit file is opened"
+                );
+                assert!(
+                    observer.directory_checks().is_empty(),
+                    "{setting} must be rejected before the store directory is inspected"
+                );
             }
         }
+        drop(observer);
 
+        let scan = scan_audit_store(
+            populated.path(),
+            OffsetDateTime::now_utc(),
+            AUDIT_SCAN_WINDOW,
+            16,
+            90,
+        )
+        .expect("the same store scans cleanly once its arguments are valid");
+        assert_eq!(scan.intent_without_outcome, 1);
+
+        // The parentless root is its own rejected argument, so like the
+        // relative path it cannot name the populated store.
         let root = Path::new("/");
         let observer = observe_opens(root, None);
         let error = scan_audit_store(root, OffsetDateTime::now_utc(), AUDIT_SCAN_WINDOW, 16, 90)
@@ -1939,6 +2120,10 @@ mod tests {
                 ..
             }
         ));
+        assert!(
+            observer.counts().is_empty(),
+            "invalid root configuration must fail before opening any audit file"
+        );
         assert!(
             observer.directory_checks().is_empty(),
             "invalid root configuration must fail before inspecting the filesystem"


### PR DESCRIPTION
## Summary

`src/registrar/audit/scan.rs` had two places deciding what a path may be: the shared `path_condition` classifier, reached only from `check_directory`, and an inline `!metadata.is_file()` test inside `read_file`. Nothing reached the classifier's file arm, so what it returned for a file formed no part of the scanner's behavior.

This routes `read_file`'s post-open kind check through `path_condition` with `directory = false`, passing the opened descriptor's `is_symlink()`, `is_file()`, `uid()`, `mode()` and the invoking effective UID. The pre-open `symlink_metadata` refusal and the `O_NOFOLLOW`/`ELOOP` mapping to `PathCondition::Symlink` stay exactly where they are — they close a check-to-open race that no post-open classification can, so neither is made redundant.

Reaching that arm makes its ownership rule observable for the first time, and applying it to an entry would begin refusing stores the trust contract accepts, so the ownership branch is now gated on `directory` as the group-or-world-writable branch already was. A comment at that branch records why both rules are directory-only: the contract places them on the store directory and its immediate parent and deliberately not on the entries inside, because a directory owned by root or the invoking user and writable by nobody else already bounds who can create an entry in it. No per-file owner or mode check was added.

Scanner-observable behavior is unchanged. The single helper result that does change — a foreign-owned file on the file arm, from `PathCondition::Owner` to `None` — was unreachable before this commit and is what makes that preservation possible.

The rest is coverage:

- **Scanner** — the classifier's file arm in the value table (symlink, non-regular kind, and a foreign owner and permissive mode each yielding `None`), plus the added directory-arm precedence assertion; the deliberate per-entry limit pinned end to end by scanning a store whose active file is group- and world-writable; a directory in the active path alongside the existing symlink and FIFO cases; an outcome timestamped after `now` pairing an in-window intent; the invalid-argument value table retargeted at a populated store with the open observer installed across it, proving every rejection precedes any file open and any directory check; `AUDIT_SCAN_WINDOW` replacing the three literal `Duration::days(30)` lookbacks (the rotation stamp in `retention_shortfall_uses_the_oldest_parseable_record` is untouched); and a doc comment on the root-gated foreign-owner test naming the value table that carries that coverage unconditionally.
- **Status** — a supplied `--agent-config` naming a populated store reporting the counts that store produces; `audit_section_lines` rendering a clean scan as the heading plus three count lines and nothing else in both `en` and `ko`; and a genuine `AuditScanError` reaching the surface, driven by a symlinked `audit_record_dir` that `validate_registrar_settings` accepts lexically and the scanner then refuses with `PathCondition::Symlink`, asserted to render a scan-failed warning with no counts and no not-configured line.

No audit record format, window semantics, pairing rule, retention derivation, configuration key or status output line changed, and no `unsafe`, dependency or `Settings::validate()` call was added.

The branch carries a single commit and touches only `src/registrar/audit/scan.rs` and `src/commands/status.rs`. A test-only `commands::infra` fix that briefly rode along here has been withdrawn again at Round 2's request, and `src/commands/infra.rs` is byte-identical to `main`.

That fix closed a pre-existing race on the compose-declared default host port 8200: `preflight_compose_published_ports_checks_openbao_localhost_during_install` probes the port, releases it, and then expects the preflight's own bind to succeed, while a sibling test deliberately holds that port for the length of its own check. The race is `main`'s — both tests are byte-identical there — and it failed the `Unit & CLI Smoke` job on this branch at `cf1e44c` with that file already matching `main`. It fires on roughly one full-suite run in eight, so a CI run on this branch may still go red on it through nothing this branch did; re-run the job if it does. Its own issue and pull request against `main` remain the right home for it, and that seed is a human's to write.

Closes #896

## Test plan

- [x] `cargo test` passes over the library and the binary (804 library tests, 1137 binary tests, all integration targets, 0 failures), including every test named or added above
- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` is clean
- [x] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `scripts/preflight/ci/check.sh` passes end to end, including the strict docs build and `cargo audit`
- [x] The scanner suite passes with no existing assertion relaxed, deleted or retargeted to accommodate the refactor — the only edits to existing tests are the three lookback constants and the invalid-argument table's move onto a populated store, both required by the issue
- [x] The FIFO cases for the active file and for a rotated generation each complete inside their bounded elapsed assertion, confirming the non-blocking open still holds once classification is rerouted
- [x] `scripts/impl/run-reinit-recovery.sh` and `scripts/impl/run-two-instance-isolation.sh` — the two E2E scenarios that invoke `bootroot status` — both pass locally against Docker (reinit: all three scenarios plus `done`; two-instance: 41 PASS assertions). Both render the registrar audit section, and they render it as not-configured: no E2E scenario sets `audit_record_dir`, so what the suite exercises is the section's rendering and the `StoreAbsent` path, not the classification path the production edit sits on. That path is covered by the scanner unit tests, which is where the `read_file` rerouting is asserted.
- [x] `scripts/preflight/ci/e2e-matrix.sh` passes on CI — all twelve `Docker E2E` matrix arms were green on an earlier run of this branch, and nothing since has touched a path the matrix exercises (it cannot complete on the author's macOS host: it aborts at `run-rotation-recovery.sh`, which fails identically at the branch's merge-base, and the later arms need non-interactive `sudo`)







