### PR TITLE
Read the registrar defaults out of the manuals

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2106,45 +2106,193 @@ rate_limit_predecision_refusal_refill_interval_ms = 2000
         settings.validate().unwrap();
     }
 
-    /// The whole `[registrar]` table, exactly as the configuration
-    /// manual shows it, loads with every key reaching its own field.
+    /// The configuration manuals whose documented `[registrar]` table
+    /// the tests below read, relative to the crate root.
+    const CONFIGURATION_MANUALS: [&str; 2] =
+        ["docs/en/configuration.md", "docs/ko/configuration.md"];
+
+    /// The heading anchor of the manual section holding the audit-record
+    /// and rate-limit `[registrar]` block.
     ///
-    /// The manual prints all twelve keys in **one** TOML block, because
-    /// TOML refuses a table declared twice and a reader pastes what the
-    /// page shows. `deny_unknown_fields` is what makes that block a
-    /// promise rather than a hope: a key renamed here without the page
-    /// following fails this test rather than silently doing nothing in
-    /// an operator's file.
-    #[test]
-    fn the_documented_registrar_table_loads_as_one_block() {
+    /// Both manuals carry a second `[registrar]` block further down —
+    /// the verb-provisioning one, which sets `state_file` and the TTLs
+    /// and is deliberately not a statement of defaults. Selecting by
+    /// section rather than by a key inside the block is what keeps the
+    /// two apart without naming a key that a rename could move: the
+    /// English heading slugifies to this anchor, and the Korean heading
+    /// declares it explicitly.
+    const REGISTRAR_AUDIT_SECTION_ANCHOR: &str = "registrar-audit-records";
+
+    fn manual_path(relative: &str) -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+    }
+
+    /// Returns the anchor a Markdown heading line resolves to: the
+    /// explicit `{#anchor}` where one is written, and the slug `MkDocs`
+    /// derives from the heading text otherwise.
+    fn heading_anchor(line: &str) -> String {
+        let text = line.trim_start_matches('#').trim();
+        if let Some(rest) = text.strip_suffix('}')
+            && let Some((_, anchor)) = rest.rsplit_once("{#")
+        {
+            return anchor.to_string();
+        }
+        let mut anchor = String::new();
+        for character in text.chars() {
+            if character.is_alphanumeric() {
+                anchor.extend(character.to_lowercase());
+            } else if character.is_whitespace() && !anchor.ends_with('-') {
+                anchor.push('-');
+            }
+        }
+        anchor.trim_matches('-').to_string()
+    }
+
+    /// Reads the first fenced TOML block of the section `anchor` names
+    /// out of the manual at `path`, stripping the fence delimiters and
+    /// nothing else.
+    ///
+    /// Comments and blank lines are part of what an operator would
+    /// paste, so they stay in: what this returns is the page's bytes,
+    /// not a transcription of them.
+    fn documented_toml_block(path: &std::path::Path, anchor: &str) -> String {
+        let manual = std::fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("reading {}: {err}", path.display()));
+        let mut lines = manual.lines();
+        lines
+            .by_ref()
+            .find(|line| line.starts_with('#') && heading_anchor(line) == anchor)
+            .unwrap_or_else(|| panic!("{} has no section anchored #{anchor}", path.display()));
+
+        let mut block = String::new();
+        let mut inside = false;
+        for line in lines {
+            if inside {
+                if line.trim_end() == "```" {
+                    return block;
+                }
+                block.push_str(line);
+                block.push('\n');
+            } else if line.trim_end() == "```toml" {
+                inside = true;
+            } else {
+                assert!(
+                    !line.starts_with('#'),
+                    "{}: section #{anchor} ends before any TOML block",
+                    path.display()
+                );
+            }
+        }
+        panic!(
+            "{}: the TOML block under #{anchor} is unterminated",
+            path.display()
+        );
+    }
+
+    /// The keys a documented TOML block assigns, in the order the page
+    /// prints them, ignoring the commented-out ones.
+    fn assigned_keys(block: &str) -> Vec<&str> {
+        block
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                (!line.starts_with('#'))
+                    .then(|| line.split_once(" = "))
+                    .flatten()
+                    .map(|(key, _)| key)
+            })
+            .collect()
+    }
+
+    /// Writes `block` into a fresh configuration file beneath a minimal
+    /// profile and loads it.
+    fn load_with_registrar_block(block: &str) -> Result<Settings, ConfigError> {
         let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
         write_minimal_profile_config(&mut file);
-        writeln!(
-            file,
-            r#"
-[registrar]
-audit_store_dir = "/var/lib/bootroot/audit-store"
-audit_store_reserve_bytes = 2147483648
-audit_store_low_water_bytes = 536870912
-audit_store_enforcement = "filesystem"
-audit_record_dir = "/var/lib/bootroot/audit-store/records"
-audit_max_file_bytes = 8388608
-audit_max_retained_files = 16
-audit_min_retain_days = 90
-rate_limit_admission_burst = 512
-rate_limit_admission_refill_interval_ms = 500
-rate_limit_predecision_refusal_burst = 32
-rate_limit_predecision_refusal_refill_interval_ms = 1000
-"#
-        )
-        .unwrap();
+        writeln!(file, "\n{block}").unwrap();
         file.flush().unwrap();
-        let settings = Settings::from_file(Some(file.path().to_path_buf())).unwrap();
-        // The documented block is the shipped defaults written out, so
-        // stating it explicitly must land exactly where leaving the
-        // table out does.
-        assert_eq!(settings.registrar, RegistrarSettings::default());
-        settings.validate().unwrap();
+        Settings::from_file(Some(file.path().to_path_buf()))
+    }
+
+    /// The whole audit-record and rate-limit `[registrar]` table, read
+    /// out of each configuration manual rather than transcribed here,
+    /// loads with every key reaching its own field.
+    ///
+    /// Each manual prints all twelve keys in **one** TOML block, because
+    /// TOML refuses a table declared twice and a reader pastes what the
+    /// page shows. Parsing the page itself is what makes that block a
+    /// promise rather than a hope: with the block copied into this file,
+    /// a rename could leave either manual stale and nothing would notice.
+    #[test]
+    fn the_documented_registrar_table_loads_as_one_block() {
+        for manual in CONFIGURATION_MANUALS {
+            let block = documented_toml_block(&manual_path(manual), REGISTRAR_AUDIT_SECTION_ANCHOR);
+            assert!(
+                block.starts_with("[registrar]\n"),
+                "{manual}: the documented block must open the [registrar] table"
+            );
+            assert!(
+                !assigned_keys(&block).contains(&"state_file"),
+                "{manual}: this is the provisioning block, not the audit-record one"
+            );
+            let settings = load_with_registrar_block(&block)
+                .unwrap_or_else(|err| panic!("{manual}: the documented block must load: {err}"));
+            // The documented block is the shipped defaults written out,
+            // so stating it explicitly must land exactly where leaving
+            // the table out does.
+            assert_eq!(
+                settings.registrar,
+                RegistrarSettings::default(),
+                "{manual}: the documented values are the defaults"
+            );
+            settings.validate().unwrap();
+        }
+    }
+
+    /// The manual is the input, key by key: renaming one in a temporary
+    /// copy of the page changes what this test parses, and the load then
+    /// fails through the `deny_unknown_fields` handling naming the key
+    /// the page invented.
+    #[test]
+    fn a_key_renamed_in_a_documented_registrar_table_fails_the_load() {
+        const RENAMED_SUFFIX: &str = "_renamed";
+
+        for manual in CONFIGURATION_MANUALS {
+            let source = std::fs::read_to_string(manual_path(manual)).unwrap();
+            let published =
+                documented_toml_block(&manual_path(manual), REGISTRAR_AUDIT_SECTION_ANCHOR);
+            let keys = assigned_keys(&published);
+            assert_eq!(keys.len(), 12, "{manual}: the block prints all twelve keys");
+
+            for key in keys {
+                let edited_block = published.replace(
+                    &format!("\n{key} = "),
+                    &format!("\n{key}{RENAMED_SUFFIX} = "),
+                );
+                assert_ne!(edited_block, published, "{manual}: {key} must have moved");
+                let dir = tempfile::tempdir().unwrap();
+                let edited_manual = dir.path().join("configuration.md");
+                std::fs::write(&edited_manual, source.replace(&published, &edited_block)).unwrap();
+
+                // Reading the edited copy back proves the extraction is
+                // what feeds the load: the block this test parses is the
+                // one on the page in front of it.
+                let extracted =
+                    documented_toml_block(&edited_manual, REGISTRAR_AUDIT_SECTION_ANCHOR);
+                assert_eq!(
+                    extracted, edited_block,
+                    "{manual}: {key} edit must be read back"
+                );
+
+                let error = load_with_registrar_block(&extracted)
+                    .err()
+                    .unwrap_or_else(|| panic!("{manual}: a renamed {key} must not load"));
+                assert!(
+                    format!("{error}").contains(&format!("{key}{RENAMED_SUFFIX}")),
+                    "{manual}: the error must name the key the page invented: {error}"
+                );
+            }
+        }
     }
 
     /// Zero disables or inverts the limiter, so each of the four keys

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -2477,51 +2477,56 @@ fn identity_pre_decision_cases() -> Vec<PreDecisionCase> {
 
 /// One case per [`WrapTtlRefusal`] variant, because each is a distinct
 /// answer the caller earned and the limiter must hand back unchanged.
+///
+/// The set is built by matching over the variants rather than by
+/// listing four cases, so "one per variant" is what the compiler
+/// enforces rather than what this comment asserts: a fifth variant
+/// fails to build here until it is given the request that provokes it.
 fn wrap_ttl_pre_decision_cases() -> Vec<PreDecisionCase> {
-    let wrap_ttl_request = |requested: Duration| {
+    [
+        WrapTtlRefusal::Zero,
+        WrapTtlRefusal::Negative,
+        WrapTtlRefusal::NotWholeSeconds,
+        WrapTtlRefusal::ExceedsOpenBaoRange,
+    ]
+    .into_iter()
+    .map(|refusal| {
+        let (name, requested, expects): (_, _, fn(&VerbError) -> bool) = match refusal {
+            WrapTtlRefusal::Zero => ("a zero wrap_ttl", Duration::ZERO, |error| {
+                matches!(error, VerbError::InvalidWrapTtl(WrapTtlRefusal::Zero))
+            }),
+            WrapTtlRefusal::Negative => ("a negative wrap_ttl", Duration::seconds(-5), |error| {
+                matches!(error, VerbError::InvalidWrapTtl(WrapTtlRefusal::Negative))
+            }),
+            WrapTtlRefusal::NotWholeSeconds => (
+                "a sub-second wrap_ttl",
+                Duration::milliseconds(250),
+                |error| {
+                    matches!(
+                        error,
+                        VerbError::InvalidWrapTtl(WrapTtlRefusal::NotWholeSeconds)
+                    )
+                },
+            ),
+            WrapTtlRefusal::ExceedsOpenBaoRange => (
+                "a wrap_ttl past the OpenBao range",
+                // One second past the largest whole-second value an
+                // `OpenBao` duration string can carry, so it is refused
+                // rather than clamped.
+                Duration::seconds(9_223_372_037),
+                |error| {
+                    matches!(
+                        error,
+                        VerbError::InvalidWrapTtl(WrapTtlRefusal::ExceedsOpenBaoRange)
+                    )
+                },
+            ),
+        };
         let mut request = mint_request("roxyd", "h1", None);
         request.wrap_ttl = requested;
-        request
-    };
-    vec![
-        pre_decision_case(
-            "a zero wrap_ttl",
-            base_fixture(),
-            wrap_ttl_request(Duration::ZERO),
-            |error| matches!(error, VerbError::InvalidWrapTtl(WrapTtlRefusal::Zero)),
-        ),
-        pre_decision_case(
-            "a negative wrap_ttl",
-            base_fixture(),
-            wrap_ttl_request(Duration::seconds(-5)),
-            |error| matches!(error, VerbError::InvalidWrapTtl(WrapTtlRefusal::Negative)),
-        ),
-        pre_decision_case(
-            "a sub-second wrap_ttl",
-            base_fixture(),
-            wrap_ttl_request(Duration::milliseconds(250)),
-            |error| {
-                matches!(
-                    error,
-                    VerbError::InvalidWrapTtl(WrapTtlRefusal::NotWholeSeconds)
-                )
-            },
-        ),
-        pre_decision_case(
-            "a wrap_ttl past the OpenBao range",
-            base_fixture(),
-            // One second past the largest whole-second value an
-            // `OpenBao` duration string can carry, so it is refused
-            // rather than clamped.
-            wrap_ttl_request(Duration::seconds(9_223_372_037)),
-            |error| {
-                matches!(
-                    error,
-                    VerbError::InvalidWrapTtl(WrapTtlRefusal::ExceedsOpenBaoRange)
-                )
-            },
-        ),
-    ]
+        pre_decision_case(name, base_fixture(), request, expects)
+    })
+    .collect()
 }
 
 /// A flood of invocations the pure checks refuse is limited: past the

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -2478,10 +2478,14 @@ fn identity_pre_decision_cases() -> Vec<PreDecisionCase> {
 /// One case per [`WrapTtlRefusal`] variant, because each is a distinct
 /// answer the caller earned and the limiter must hand back unchanged.
 ///
-/// The set is built by matching over the variants rather than by
-/// listing four cases, so "one per variant" is what the compiler
-/// enforces rather than what this comment asserts: a fifth variant
-/// fails to build here until it is given the request that provokes it.
+/// The request each case sends is chosen by matching over the variants
+/// rather than written out beside them, so a fifth variant fails to
+/// build here until someone writes the request that provokes it.
+///
+/// The list below is the one part the compiler cannot hold: nothing in
+/// Rust enumerates an enum's variants without a derive, so a variant
+/// given a match arm and left out of this list would build and cover
+/// nothing. The arm is what sends whoever adds it here.
 fn wrap_ttl_pre_decision_cases() -> Vec<PreDecisionCase> {
     [
         WrapTtlRefusal::Zero,

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -2369,6 +2369,10 @@ fn assert_same_wire_answer(_name: &str, _limited: &VerbRefusal, _unlimited: &Ver
 /// identifier-carrying refusal, a reserved name and an out-of-range
 /// `wrap_ttl`, the last two of which are retryable with no identifier
 /// today. What limiting preserves is the answer, not its permanence.
+///
+/// Every [`WrapTtlRefusal`] variant appears here, because each is a
+/// distinct answer the caller earned and the limiter must hand back
+/// unchanged.
 fn pre_decision_cases() -> Vec<(&'static str, RegistrarConfigFixture, MintRequest)> {
     let unconfigured = base_fixture();
     let mut spec_conflict = mint_request("roxyd", "h1", None);
@@ -2377,6 +2381,12 @@ fn pre_decision_cases() -> Vec<(&'static str, RegistrarConfigFixture, MintReques
     zero_wrap_ttl.wrap_ttl = Duration::ZERO;
     let mut negative_wrap_ttl = mint_request("roxyd", "h1", None);
     negative_wrap_ttl.wrap_ttl = Duration::seconds(-5);
+    let mut fractional_wrap_ttl = mint_request("roxyd", "h1", None);
+    fractional_wrap_ttl.wrap_ttl = Duration::milliseconds(250);
+    let mut unrepresentable_wrap_ttl = mint_request("roxyd", "h1", None);
+    // One second past the largest whole-second value an `OpenBao`
+    // duration string can carry, so it is refused rather than clamped.
+    unrepresentable_wrap_ttl.wrap_ttl = Duration::seconds(9_223_372_037);
     vec![
         (
             "an invalid service_name label",
@@ -2410,6 +2420,12 @@ fn pre_decision_cases() -> Vec<(&'static str, RegistrarConfigFixture, MintReques
         ),
         ("a zero wrap_ttl", base_fixture(), zero_wrap_ttl),
         ("a negative wrap_ttl", base_fixture(), negative_wrap_ttl),
+        ("a sub-second wrap_ttl", base_fixture(), fractional_wrap_ttl),
+        (
+            "a wrap_ttl past the OpenBao range",
+            base_fixture(),
+            unrepresentable_wrap_ttl,
+        ),
     ]
 }
 

--- a/src/registrar/verbs/tests.rs
+++ b/src/registrar/verbs/tests.rs
@@ -2362,69 +2362,164 @@ fn assert_same_wire_answer(name: &str, limited: &VerbRefusal, unlimited: &VerbRe
 #[cfg(not(target_os = "linux"))]
 fn assert_same_wire_answer(_name: &str, _limited: &VerbRefusal, _unlimited: &VerbRefusal) {}
 
+/// One pre-decision refusal case: the request, the fixture it needs,
+/// and the [`VerbError`] the request exists to provoke.
+struct PreDecisionCase {
+    name: &'static str,
+    fixture: RegistrarConfigFixture,
+    request: MintRequest,
+    expects: fn(&VerbError) -> bool,
+}
+
+fn pre_decision_case(
+    name: &'static str,
+    fixture: RegistrarConfigFixture,
+    request: MintRequest,
+    expects: fn(&VerbError) -> bool,
+) -> PreDecisionCase {
+    PreDecisionCase {
+        name,
+        fixture,
+        request,
+        expects,
+    }
+}
+
 /// Every pre-decision refusal the verbs can produce, as a mint request
-/// paired with the fixture it needs.
+/// paired with the fixture it needs and the refusal it is here for.
 ///
 /// The set spans both wire classes deliberately: a permanent
 /// identifier-carrying refusal, a reserved name and an out-of-range
 /// `wrap_ttl`, the last two of which are retryable with no identifier
 /// today. What limiting preserves is the answer, not its permanence.
 ///
-/// Every [`WrapTtlRefusal`] variant appears here, because each is a
-/// distinct answer the caller earned and the limiter must hand back
-/// unchanged.
-fn pre_decision_cases() -> Vec<(&'static str, RegistrarConfigFixture, MintRequest)> {
+/// The expected error travels with each case so that a case cannot
+/// quietly stop covering the refusal it names. A request that began
+/// tripping some earlier check would still pair identically under
+/// limiting and would still satisfy every assertion below, leaving the
+/// refusal uncovered with nothing to say so.
+fn pre_decision_cases() -> Vec<PreDecisionCase> {
+    let mut cases = identity_pre_decision_cases();
+    cases.extend(wrap_ttl_pre_decision_cases());
+    cases
+}
+
+/// The refusals a request earns from its identity triple or its
+/// restated spec, before any wrap-TTL rule is consulted.
+fn identity_pre_decision_cases() -> Vec<PreDecisionCase> {
     let unconfigured = base_fixture();
     let mut spec_conflict = mint_request("roxyd", "h1", None);
     spec_conflict.spec = requested(&sample_spec()).with_service_name("roxyd-h1");
-    let mut zero_wrap_ttl = mint_request("roxyd", "h1", None);
-    zero_wrap_ttl.wrap_ttl = Duration::ZERO;
-    let mut negative_wrap_ttl = mint_request("roxyd", "h1", None);
-    negative_wrap_ttl.wrap_ttl = Duration::seconds(-5);
-    let mut fractional_wrap_ttl = mint_request("roxyd", "h1", None);
-    fractional_wrap_ttl.wrap_ttl = Duration::milliseconds(250);
-    let mut unrepresentable_wrap_ttl = mint_request("roxyd", "h1", None);
-    // One second past the largest whole-second value an `OpenBao`
-    // duration string can carry, so it is refused rather than clamped.
-    unrepresentable_wrap_ttl.wrap_ttl = Duration::seconds(9_223_372_037);
     vec![
-        (
+        pre_decision_case(
             "an invalid service_name label",
             base_fixture(),
             mint_request("bad_name", "h1", None),
+            |error| {
+                matches!(
+                    error,
+                    VerbError::Registrar(RegistrarError::InvalidServiceName { .. })
+                )
+            },
         ),
-        (
+        pre_decision_case(
             "an invalid host label",
             base_fixture(),
             mint_request("roxyd", "-h1", None),
+            |error| {
+                matches!(
+                    error,
+                    VerbError::Registrar(RegistrarError::InvalidHost { .. })
+                )
+            },
         ),
-        (
+        pre_decision_case(
             "a reserved service_name",
             base_fixture(),
             mint_request("bootroot-decoy", "h1", None),
+            |error| matches!(error, VerbError::ReservedServiceName { .. }),
         ),
-        (
+        pre_decision_case(
             "an unconfigured component",
             unconfigured,
             mint_request("absent", "h1", None),
+            |error| {
+                matches!(
+                    error,
+                    VerbError::Registrar(RegistrarError::ComponentNotConfigured { .. })
+                )
+            },
         ),
-        (
+        pre_decision_case(
             "an instance on a one-per-host component",
             base_fixture(),
             mint_request("roxyd", "h1", Some(1)),
+            |error| {
+                matches!(
+                    error,
+                    VerbError::Registrar(RegistrarError::ServiceInstanceMismatch { .. })
+                )
+            },
         ),
-        (
+        pre_decision_case(
             "a restated spec that disagrees",
             base_fixture(),
             spec_conflict,
+            |error| {
+                matches!(
+                    error,
+                    VerbError::Registrar(RegistrarError::SpecIdentityDisagreement { .. })
+                )
+            },
         ),
-        ("a zero wrap_ttl", base_fixture(), zero_wrap_ttl),
-        ("a negative wrap_ttl", base_fixture(), negative_wrap_ttl),
-        ("a sub-second wrap_ttl", base_fixture(), fractional_wrap_ttl),
-        (
+    ]
+}
+
+/// One case per [`WrapTtlRefusal`] variant, because each is a distinct
+/// answer the caller earned and the limiter must hand back unchanged.
+fn wrap_ttl_pre_decision_cases() -> Vec<PreDecisionCase> {
+    let wrap_ttl_request = |requested: Duration| {
+        let mut request = mint_request("roxyd", "h1", None);
+        request.wrap_ttl = requested;
+        request
+    };
+    vec![
+        pre_decision_case(
+            "a zero wrap_ttl",
+            base_fixture(),
+            wrap_ttl_request(Duration::ZERO),
+            |error| matches!(error, VerbError::InvalidWrapTtl(WrapTtlRefusal::Zero)),
+        ),
+        pre_decision_case(
+            "a negative wrap_ttl",
+            base_fixture(),
+            wrap_ttl_request(Duration::seconds(-5)),
+            |error| matches!(error, VerbError::InvalidWrapTtl(WrapTtlRefusal::Negative)),
+        ),
+        pre_decision_case(
+            "a sub-second wrap_ttl",
+            base_fixture(),
+            wrap_ttl_request(Duration::milliseconds(250)),
+            |error| {
+                matches!(
+                    error,
+                    VerbError::InvalidWrapTtl(WrapTtlRefusal::NotWholeSeconds)
+                )
+            },
+        ),
+        pre_decision_case(
             "a wrap_ttl past the OpenBao range",
             base_fixture(),
-            unrepresentable_wrap_ttl,
+            // One second past the largest whole-second value an
+            // `OpenBao` duration string can carry, so it is refused
+            // rather than clamped.
+            wrap_ttl_request(Duration::seconds(9_223_372_037)),
+            |error| {
+                matches!(
+                    error,
+                    VerbError::InvalidWrapTtl(WrapTtlRefusal::ExceedsOpenBaoRange)
+                )
+            },
         ),
     ]
 }
@@ -2507,7 +2602,13 @@ async fn a_pre_decision_flood_is_limited_without_writing_a_record() {
 /// already determined.
 #[tokio::test]
 async fn limiting_preserves_the_callers_answer_across_every_pre_decision_refusal() {
-    for (name, fixture, request) in pre_decision_cases() {
+    for PreDecisionCase {
+        name,
+        fixture,
+        request,
+        expects,
+    } in pre_decision_cases()
+    {
         // Unlimited: a wide refusal budget, so the first invocation finds
         // a token.
         let (unlimited_server, _unlimited_dir, unlimited, _) =
@@ -2535,6 +2636,14 @@ async fn limiting_preserves_the_callers_answer_across_every_pre_decision_refusal
             "{name} must have been limited on the pre-decision bucket"
         );
 
+        // The case still refuses for the reason it was written for, so
+        // the pairwise assertions below are comparing the answer this
+        // case exists to cover.
+        assert!(
+            expects(unlimited_refusal.error()),
+            "{name}: no longer produces the refusal it covers: {:?}",
+            unlimited_refusal.error()
+        );
         assert_eq!(
             format!("{:?}", limited_refusal.error()),
             format!("{:?}", unlimited_refusal.error()),


### PR DESCRIPTION
Closes #909. Part of #786.

## What changed

**The documented `[registrar]` table is now the test input.** `the_documented_registrar_table_loads_as_one_block` used to write a hand-copied TOML literal into `src/config.rs`, so a key renamed on either configuration page left the test green and the manual stale. It now reads the audit-record and rate-limit block out of `docs/en/configuration.md` and `docs/ko/configuration.md`, strips only the Markdown fence delimiters — comments and blank lines stay in — and feeds those bytes through `Settings::from_file` and `validate()`, asserting the result equals `RegistrarSettings::default()`.

Each manual carries a second `[registrar]` block further down: the verb-provisioning one that sets `state_file` and the TTL keys, which is deliberately not a defaults statement. The extraction selects by the section's heading anchor (`registrar-audit-records` — the English heading slugifies to it, the Korean heading declares it explicitly) rather than by any key inside the block, so nothing a key rename could move decides which block is read. The test additionally asserts the selected block opens `[registrar]` and does not assign `state_file`.

**A new test proves the page is the input, key by key.** `a_key_renamed_in_a_documented_registrar_table_fails_the_load` takes each of the twelve documented keys in turn, renames it in a temporary copy of the manual, re-runs the extraction against that copy, and asserts the load fails through the existing `deny_unknown_fields` handling naming the invented key.

**The pairwise refusal set now covers every `WrapTtlRefusal` variant.** `pre_decision_cases` declared `Zero` and `Negative` but omitted `NotWholeSeconds` and `ExceedsOpenBaoRange`. Both are added as mint requests (a 250 ms `wrap_ttl`, and one second past the largest whole-second value an OpenBao duration string can carry) and run through the same limited/unlimited harness as the existing cases: same `VerbError`, never `Throttled`, no audit record on the limited call, and — under the existing Linux gate — the same encoded `RefusalClass` and identifier-or-absence as their unlimited twins.

**Each case now names the refusal it exists to provoke.** The harness previously compared the limited and unlimited answers only to each other, so a case proved that limiting changed nothing but never that the request still earned the refusal it was written for; a request that began tripping some earlier check would pair identically, pass every assertion, and leave its variant uncovered silently. Each case carries its expected `VerbError`, asserted against the unlimited call before the pair is compared. The tuple became a named `PreDecisionCase` struct in the process, and the list split along the line it already had: the refusals a request earns from its identity triple, and one per `WrapTtlRefusal` variant.

**The variant match carries as much of the one-case-per-variant promise as the compiler can hold.** The wrap-TTL list said "one case per variant" in a doc comment and then listed four cases by hand — the same arrangement this issue exists to undo on the configuration side. The request each case sends is now chosen by matching over the variants, so a fifth variant fails to build until someone writes the request that provokes it. The list that match is driven from stays hand-written, because Rust enumerates no enum's variants without a derive and this crate carries none: a variant given an arm and then left out of the list would build clean and cover nothing. The doc comment now says so rather than claiming a guarantee that is not there.

No production code changed; the limiter, the `VerbError` taxonomy, the wire identifiers, the configuration keys and defaults, and the published manual values are all untouched.

## Test plan

- [x] The audit-record and rate-limit `[registrar]` table is read from both `docs/en/configuration.md` and `docs/ko/configuration.md`, selected by section anchor rather than by any key inside the block, and is not the provisioning block that sets `state_file`. Verified by breaking the provisioning block on both pages — renaming its `state_file` — and confirming both documentation-derived tests stay green, so the selection reaches the intended block and only it.
- [x] Each documented table parses unchanged as TOML after removing only the fences, loads through `Settings::from_file`, validates, and equals `RegistrarSettings::default()`.
- [x] Renaming any of the twelve documented keys in a temporary copy of either manual fails the load through the existing unknown-key handling (`a_key_renamed_in_a_documented_registrar_table_fails_the_load`).
- [x] The published pages themselves are load-bearing, not just temporary copies. Editing the real manuals and reverting each time: `audit_min_retain_days = 91` in `docs/en/configuration.md` and `rate_limit_admission_burst = 513` in `docs/ko/configuration.md` each fail the defaults comparison naming their page, and renaming `audit_store_enforcement` in `docs/ko/configuration.md` fails the load with `deny_unknown_fields` naming the invented key.
- [x] `pre_decision_cases` contains requests that produce `WrapTtlRefusal::NotWholeSeconds` and `WrapTtlRefusal::ExceedsOpenBaoRange`. Verified by mutation: retargeting the range case at a negative duration — still a pre-decision refusal, still pairing identically under limiting — fails on the case's own expected error, and widening the sub-second case to whole seconds fails the test at the preceding pre-decision assertion, because a whole-second request stops being a pre-decision refusal at all.
- [x] Adding a fifth `WrapTtlRefusal` variant fails the build in `wrap_ttl_pre_decision_cases`. Verified by adding one; also verified that writing only the match arm, without the list entry, builds clean and leaves the variant uncovered, which is what the doc comment now records.
- [x] For both new cases the limited and unlimited calls return the same verb-layer refusal, the limited call never becomes `VerbError::Throttled`, and it writes no audit record.
- [x] On Linux both new cases preserve the encoded refusal class and identifier-or-absence against their unlimited twins — run in a `rust:latest` container, where `src/registrar/endpoint` compiles and the wire assertions are not gated out. That the wire half really runs there was checked rather than assumed: a probe panic planted inside `assert_same_wire_answer` fires on each of the new cases under Linux, and the same single-test filter leaves 1060 tests filtered out there against 896 on macOS.
- [x] `cargo test --lib config::tests` — 74 passed.
- [x] `cargo test --lib registrar::verbs` — 76 passed (17 ignored, needing a live OpenBao).
- [x] `cargo test --lib` — 876 passed; `cargo test --bins` — clean.
- [x] `scripts/preflight/ci/check.sh` steps, run individually: `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items`, `ruff format --check`, `ruff check`, `biome ci --error-on-warnings`, `markdownlint-cli2`, `./scripts/check-docs.sh`, `cargo audit` (one allowed warning, RUSTSEC-2025-0134, the expected baseline) — all clean.
- [x] On Linux, `cargo clippy --locked --all-targets -- -D warnings` clean with the endpoint module compiled in.

`scripts/preflight/ci/e2e-matrix.sh` was not run. The change is confined to `#[cfg(test)]` code in `src/config.rs` and `src/registrar/verbs/tests.rs`; it touches no Docker lifecycle, no E2E script, and no code path those tests exercise.


