### PR TITLE
Correct registrar endpoint deadline coverage (#908)

### DIFF
--- a/src/registrar/endpoint.rs
+++ b/src/registrar/endpoint.rs
@@ -103,6 +103,7 @@ use std::time::Duration;
 
 use anyhow::Context as _;
 use tokio::net::UnixListener;
+use tokio::time::Instant;
 use tokio_rustls::TlsAcceptor;
 use tracing::{info, warn};
 
@@ -158,6 +159,37 @@ pub(crate) const SD_LISTEN_FDS_START: RawFd = 3;
 
 /// The mode the activated socket must carry, exactly.
 pub(crate) const REQUIRED_SOCKET_MODE: u32 = 0o700;
+
+/// The instant a TLS handshake completed, which is the origin
+/// [`HEADER_IDLE_TIMEOUT`] is measured from.
+///
+/// A newtype rather than a bare `Instant` because the serving path
+/// carries two instants of that one type whose deadlines are not
+/// interchangeable, and the older of the two — acceptance, which starts
+/// [`HANDSHAKE_TIMEOUT`] — is still in scope at the call that arms the
+/// header budget. Nothing turns an `Instant` into one of these, so
+/// arming that budget from acceptance is a compile error rather than
+/// something a test has to be built to notice.
+#[derive(Clone, Copy)]
+pub(crate) struct HandshakeCompleted(Instant);
+
+impl HandshakeCompleted {
+    /// Stamps the origin at the moment of the call.
+    ///
+    /// Call it where the handshake has just completed and nowhere else:
+    /// what makes the value mean what it says is the call site, and
+    /// that is the one thing the type cannot check.
+    #[must_use]
+    pub(crate) fn now() -> Self {
+        Self(Instant::now())
+    }
+
+    /// Returns the instant the header deadline expires.
+    #[must_use]
+    pub(crate) fn header_deadline(self) -> Instant {
+        self.0 + HEADER_IDLE_TIMEOUT
+    }
+}
 
 /// The listening socket the daemon serves the registrar verbs on,
 /// together with everything a connection is decided against.

--- a/src/registrar/endpoint/serve.rs
+++ b/src/registrar/endpoint/serve.rs
@@ -151,13 +151,15 @@ pub(crate) async fn run(
             accepted = endpoint.listener().accept() => {
                 match accepted {
                     Ok((stream, _addr)) => {
-                        // The header deadline is cumulative *from
-                        // acceptance*, so the clock starts here rather
-                        // than wherever the connection task is
+                        // The TLS handshake deadline is cumulative
+                        // *from acceptance*, so the clock starts here
+                        // rather than wherever the connection task is
                         // eventually scheduled: under executor
                         // contention those are not the same instant,
                         // and only this one is the one the contract
-                        // names.
+                        // names. The header deadline is a separate
+                        // budget that starts once the handshake has
+                        // completed.
                         let accepted_at = Instant::now();
                         admit(
                             &mut connections,
@@ -342,6 +344,14 @@ async fn handle_connection(
     // acceptance: the handshake had a budget of its own, and a slow one
     // must not leave a caller with no time left to send a header.
     let handshaken_at = Instant::now();
+    // Logged because this instant is the origin of the header deadline:
+    // without it the log shows a connection accepted and then refused
+    // for a missing header, with nothing to say which of the two
+    // budgets the caller actually spent.
+    debug!(
+        connection = connection.as_str(),
+        "Registrar endpoint completed a TLS handshake."
+    );
 
     // The identity is decided here, after the handshake, rather than
     // inside a `ClientCertVerifier` — see [`CallerIdentityRefusal`].

--- a/src/registrar/endpoint/serve.rs
+++ b/src/registrar/endpoint/serve.rs
@@ -464,21 +464,22 @@ fn recognize_caller(
 /// an in-memory duplex — including every deadline, with `tokio::time`
 /// paused — without a socket, a peer or a uid.
 ///
-/// `accepted_at` starts the header deadline, which is cumulative
+/// `handshaken_at` starts the header deadline, which is cumulative
 /// through both the five-byte prefix and the declared operation-name
-/// bytes. On the real serving path it is the instant the TLS handshake
-/// completed, not the instant the connection was accepted: the handshake
-/// has a budget of its own.
+/// bytes. It is the instant the TLS handshake completed, not the
+/// instant the connection was accepted: the handshake has a budget of
+/// its own, and a slow one must not leave a caller with no time left to
+/// send a header.
 pub(crate) async fn serve_request<S>(
     stream: &mut S,
     connection: &ConnectionId,
     caller: &CallerIdentity,
     handler: &dyn RegistrarRequestHandler,
-    accepted_at: Instant,
+    handshaken_at: Instant,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    let Some((operation, payload_length)) = read_header(stream, connection, accepted_at).await
+    let Some((operation, payload_length)) = read_header(stream, connection, handshaken_at).await
     else {
         return;
     };
@@ -516,12 +517,12 @@ pub(crate) async fn serve_request<S>(
 async fn read_header<S>(
     stream: &mut S,
     connection: &ConnectionId,
-    accepted_at: Instant,
+    handshaken_at: Instant,
 ) -> Option<(Operation, usize)>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    let header_deadline = accepted_at + HEADER_IDLE_TIMEOUT;
+    let header_deadline = handshaken_at + HEADER_IDLE_TIMEOUT;
 
     let mut prefix = [0u8; REQUEST_PREFIX_BYTES];
     if let Err(stop) = read_exactly(stream, &mut prefix, header_deadline, connection).await {

--- a/src/registrar/endpoint/serve.rs
+++ b/src/registrar/endpoint/serve.rs
@@ -61,7 +61,7 @@ use super::refusal::{
 };
 use super::{
     ActivatedEndpoint, BODY_READ_TIMEOUT, CONNECTION_DRAIN_TIMEOUT, HANDSHAKE_TIMEOUT,
-    HEADER_IDLE_TIMEOUT, MAX_CONCURRENT_CONNECTIONS, MAX_FRAME_PAYLOAD_BYTES,
+    HandshakeCompleted, MAX_CONCURRENT_CONNECTIONS, MAX_FRAME_PAYLOAD_BYTES,
     MAX_RESPONSE_PAYLOAD_BYTES, RESPONSE_WRITE_TIMEOUT,
 };
 use crate::registrar::verbs::outcome::CallerIdentity;
@@ -343,7 +343,7 @@ async fn handle_connection(
     // The header budget restarts here rather than continuing from
     // acceptance: the handshake had a budget of its own, and a slow one
     // must not leave a caller with no time left to send a header.
-    let handshaken_at = Instant::now();
+    let handshaken_at = HandshakeCompleted::now();
     // Logged because this instant is the origin of the header deadline:
     // without it the log shows a connection accepted and then refused
     // for a missing header, with nothing to say which of the two
@@ -469,13 +469,15 @@ fn recognize_caller(
 /// bytes. It is the instant the TLS handshake completed, not the
 /// instant the connection was accepted: the handshake has a budget of
 /// its own, and a slow one must not leave a caller with no time left to
-/// send a header.
+/// send a header. That distinction is the parameter's type rather than
+/// its name — see [`HandshakeCompleted`] — because acceptance is an
+/// `Instant` in scope at the only call site there is.
 pub(crate) async fn serve_request<S>(
     stream: &mut S,
     connection: &ConnectionId,
     caller: &CallerIdentity,
     handler: &dyn RegistrarRequestHandler,
-    handshaken_at: Instant,
+    handshaken_at: HandshakeCompleted,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -517,12 +519,12 @@ pub(crate) async fn serve_request<S>(
 async fn read_header<S>(
     stream: &mut S,
     connection: &ConnectionId,
-    handshaken_at: Instant,
+    handshaken_at: HandshakeCompleted,
 ) -> Option<(Operation, usize)>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    let header_deadline = handshaken_at + HEADER_IDLE_TIMEOUT;
+    let header_deadline = handshaken_at.header_deadline();
 
     let mut prefix = [0u8; REQUEST_PREFIX_BYTES];
     if let Err(stop) = read_exactly(stream, &mut prefix, header_deadline, connection).await {

--- a/src/registrar/endpoint/tests.rs
+++ b/src/registrar/endpoint/tests.rs
@@ -2466,6 +2466,16 @@ async fn a_connection_that_never_handshakes_is_dropped_at_the_handshake_timeout(
     running.stop().await;
 }
 
+/// The message the endpoint logs once it has accepted a connection.
+///
+/// It marks the point the handshake deadline is measured from: the
+/// accept loop stamps that origin, and the connection task logs this a
+/// few statements later. A test that means to place anything *between*
+/// acceptance and the handshake has to wait for it, because a `connect`
+/// completes in the listener's backlog — before the endpoint has
+/// accepted anything, and so before it has stamped anything.
+const CONNECTION_ACCEPTED_MESSAGE: &str = "Registrar endpoint accepted a connection.";
+
 /// The message the endpoint logs once a TLS handshake has completed.
 ///
 /// It is the only signal a test has that the *server* is past the
@@ -2474,32 +2484,28 @@ async fn a_connection_that_never_handshakes_is_dropped_at_the_handshake_timeout(
 /// which is before the server has read it.
 const HANDSHAKE_COMPLETED_MESSAGE: &str = "Registrar endpoint completed a TLS handshake.";
 
-/// How many scheduler turns the handshake barrier will spin for.
+/// How many scheduler turns [`await_log_message`] will spin for.
 ///
 /// Only a bound on a hang: the connection task needs a handful of turns
-/// to read the client's final flight, and the clock is still running
-/// here, so an endpoint that never completes the handshake fails with
-/// this message rather than blocking the suite forever.
-const HANDSHAKE_BARRIER_TURNS: usize = 100_000;
+/// to reach either of the events above, and the clock is running
+/// wherever this is used, so an endpoint that never gets there fails
+/// with the message below rather than blocking the suite forever.
+const LOG_BARRIER_TURNS: usize = 100_000;
 
-/// Yields until the endpoint has logged a completed handshake.
+/// Yields until the endpoint has logged `message`.
 ///
 /// Nothing sleeps and nothing waits on a timeout: the loop hands the
 /// runtime back to the connection task until the event appears. It must
-/// be called before `tokio::time` is paused, because the handshake it
-/// waits for runs under the handshake deadline.
-async fn await_completed_handshake(logs: &CapturedLogs) {
-    for _ in 0..HANDSHAKE_BARRIER_TURNS {
-        if logs
-            .events()
-            .iter()
-            .any(|event| event.message == HANDSHAKE_COMPLETED_MESSAGE)
-        {
+/// be called with the clock running, because what it waits for is
+/// progress the endpoint makes under a live deadline.
+async fn await_log_message(logs: &CapturedLogs, message: &str) {
+    for _ in 0..LOG_BARRIER_TURNS {
+        if logs.events().iter().any(|event| event.message == message) {
             return;
         }
         tokio::task::yield_now().await;
     }
-    panic!("the endpoint never completed the handshake");
+    panic!("the endpoint never logged {message:?}");
 }
 
 /// How many scheduler turns [`settle`] hands back before its caller
@@ -2521,39 +2527,91 @@ async fn settle() {
     }
 }
 
+/// How far the clock is moved between acceptance and the handshake in
+/// [`a_completed_handshake_gets_the_whole_header_budget_from_that_completion`].
+///
+/// Over a loopback socket a handshake completes a fraction of a
+/// millisecond after the connection was accepted, and no advance can
+/// land inside a gap that narrow: an endpoint arming the header
+/// deadline at acceptance and one arming it at handshake completion
+/// would answer every advance identically. Moving the clock forward
+/// before the `ClientHello` is sent widens that gap to something a test
+/// can aim between. It costs the handshake nothing but budget it does
+/// not need, which is why it stays short of [`HANDSHAKE_TIMEOUT`].
+const PRE_HANDSHAKE_ADVANCE: StdDuration = StdDuration::from_secs(4);
+
+/// How far the clock is moved once that handshake has completed, before
+/// asserting the connection is still open.
+///
+/// Aimed between the two candidate origins: added to
+/// [`PRE_HANDSHAKE_ADVANCE`] it is past `accepted_at +
+/// HEADER_IDLE_TIMEOUT`, so a header deadline armed at acceptance has
+/// expired by then, and on its own it is short of
+/// [`HEADER_IDLE_TIMEOUT`], so one armed at handshake completion has
+/// not.
+const POST_HANDSHAKE_ADVANCE: StdDuration = StdDuration::from_secs(3);
+
+/// The margin added to the last advance of that test, for the timer
+/// wheel's millisecond granularity.
+///
+/// A deadline is rounded up to the next millisecond, so advancing by
+/// exactly the budget can land short of it and leave the connection
+/// open. One millisecond covers the whole of that rounding, and keeps
+/// the upper bound the advance places on the budget as tight as the
+/// wheel allows.
+const TIMER_ROUNDING: StdDuration = StdDuration::from_millis(1);
+
+/// The two advances above discriminate between the origins only while
+/// these hold, and each relates a test constant to an endpoint one. They
+/// are checked here so that changing either timeout is a compile error
+/// rather than a test that quietly stops proving what it says it does.
+const _: () = {
+    assert!(
+        PRE_HANDSHAKE_ADVANCE.as_nanos() < HANDSHAKE_TIMEOUT.as_nanos(),
+        "the head start must leave the handshake budget unspent"
+    );
+    assert!(
+        POST_HANDSHAKE_ADVANCE.as_nanos() < HEADER_IDLE_TIMEOUT.as_nanos(),
+        "a header budget measured from handshake completion must survive the probe"
+    );
+    assert!(
+        PRE_HANDSHAKE_ADVANCE.as_nanos() + POST_HANDSHAKE_ADVANCE.as_nanos()
+            > HEADER_IDLE_TIMEOUT.as_nanos(),
+        "a header budget measured from acceptance must not survive the probe"
+    );
+};
+
 /// A connection that *does* complete a handshake gets a whole
-/// [`HEADER_IDLE_TIMEOUT`] in which to send a header, and is then
+/// [`HEADER_IDLE_TIMEOUT`] measured from that completion, and is then
 /// refused as a missing header rather than as a handshake that never
 /// finished.
 ///
-/// What the advance below pins down is that budget's *length* and the
-/// reason it ends in: five seconds pass with the connection still open,
-/// and the refusal names `no-header`. It does not pin the origin down
-/// to the microsecond, and is not the coverage that the origin is
-/// handshake completion rather than acceptance. Over a loopback socket
-/// those two instants are a fraction of a millisecond apart, and every
-/// instant this test can name falls outside that gap, so no advance
-/// from one of them separates a deadline armed at acceptance from one
-/// armed at completion. Nor can the budget be bounded from above any
-/// more tightly than it is here: the timer wheel rounds a deadline up
-/// to the next millisecond, so advancing to exactly the pause plus the
-/// budget lands short of the rounded deadline and the connection
-/// outlives the assertion. What holds the origin is the signature
-/// `serve_request` is given -- it takes `handshaken_at`, and its only
-/// production caller stamps that after `handshake` has returned -- and
-/// [`the_header_deadline_expires_with_no_header_when_no_byte_arrives`],
-/// which drives the same deadline from an origin it chooses outright.
+/// The origin is what is at stake, so the test manufactures the one
+/// thing a loopback connection does not have: a wide, exactly known gap
+/// between acceptance and handshake completion. The clock is advanced
+/// by [`PRE_HANDSHAKE_ADVANCE`] after the endpoint has accepted the
+/// connection and before the client sends its `ClientHello`, which
+/// leaves the two candidate origins seconds apart instead of
+/// microseconds. [`POST_HANDSHAKE_ADVANCE`] then lands between the two
+/// deadlines they imply: an endpoint passing `accepted_at` to
+/// `serve_request` refuses the connection during that advance and fails
+/// the assertion after it, and only one measuring from handshake
+/// completion is still open. The remaining advance carries the clock
+/// past the completion-measured deadline as well, and the refusal it
+/// produces names `no-header` rather than a handshake timeout.
 ///
-/// The clock runs for the handshake and is paused only once the server
-/// has completed it. Pausing earlier would let auto-advance fire while
-/// the handshake was still in flight, jumping past the handshake
-/// deadline and refusing a connection that was making progress — the
-/// test would then assert the wrong reason for a reason that has nothing
-/// to do with the endpoint. Once the server is past that point the only
-/// deadline left is the header one, so the budget can be advanced
-/// through rather than waited out: five seconds of it are spent without
-/// five seconds of wall-clock time, and which of the two deadlines ends
-/// the connection is still what the refusal reason says.
+/// That last advance also bounds the budget from above: it stops one
+/// millisecond past `HEADER_IDLE_TIMEOUT` from the pause, so a deadline
+/// an order of magnitude too far away would not be reached by it.
+///
+/// The clock runs whenever the endpoint has to make progress — through
+/// the accept, and through the handshake itself — and is paused only to
+/// be moved. Pausing across the handshake would let auto-advance fire
+/// while it was still in flight, jumping to the handshake deadline and
+/// refusing a connection that was making progress; the test would then
+/// assert the wrong reason for a reason that has nothing to do with the
+/// endpoint. No wall-clock time is spent on any of the three advances,
+/// so the nine seconds of deadline they cover cost the suite nothing.
 #[tokio::test]
 async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion() {
     let (logs, _guard) = capture_logs();
@@ -2565,41 +2623,60 @@ async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion
         }),
     );
 
-    // A real handshake through the production endpoint, under real time
-    // and therefore under the real handshake deadline.
-    let connect_started = Instant::now();
-    let mut stream = tls_connect(&harness.socket_path, harness.pki.registrar_client_config())
+    // The connection, but not yet the handshake, so that the clock can
+    // be moved between the two.
+    let stream = UnixStream::connect(&harness.socket_path)
+        .await
+        .expect("connect");
+    await_log_message(&logs, CONNECTION_ACCEPTED_MESSAGE).await;
+
+    // Most of the handshake budget, spent before the `ClientHello`.
+    // This is what puts acceptance and handshake completion far enough
+    // apart for an advance to fall between the deadlines they imply.
+    tokio::time::pause();
+    tokio::time::advance(PRE_HANDSHAKE_ADVANCE).await;
+    tokio::time::resume();
+
+    // A real handshake through the production endpoint, under a running
+    // clock and under the real handshake deadline — still armed, and
+    // with `PRE_HANDSHAKE_ADVANCE` less of itself left than it began
+    // with.
+    let mut stream = TlsConnector::from(Arc::new(harness.pki.registrar_client_config()))
+        .connect(
+            ServerName::try_from(DIAL_NAME).expect("a valid dial name"),
+            stream,
+        )
         .await
         .expect("the registrar client completes a handshake");
-    await_completed_handshake(&logs).await;
+    await_log_message(&logs, HANDSHAKE_COMPLETED_MESSAGE).await;
 
     // From here the connection is inside the header deadline and no
-    // other deadline is armed, so the rest of the budget is spent by
-    // moving the clock rather than by waiting.
+    // other deadline is armed, so the budget is spent by moving the
+    // clock rather than by waiting.
     tokio::time::pause();
 
-    // The endpoint stamped the header-deadline origin at an instant
-    // strictly after `connect_started`, so its deadline is strictly
-    // after `connect_started + HEADER_IDLE_TIMEOUT`. Advancing to
-    // exactly there is therefore still inside the budget, whatever the
-    // handshake cost: a connection refused by now was refused early.
-    let owed = HEADER_IDLE_TIMEOUT.saturating_sub(connect_started.elapsed());
-    tokio::time::advance(owed).await;
+    // Past `accepted_at + HEADER_IDLE_TIMEOUT` and short of
+    // `handshaken_at + HEADER_IDLE_TIMEOUT`.
+    tokio::time::advance(POST_HANDSHAKE_ADVANCE).await;
     settle().await;
     assert!(
         logs.refusals().is_empty(),
-        "a completed handshake keeps its whole header budget, and {owed:?} of it was left"
+        "a completed handshake gets a header budget of its own: \
+         {PRE_HANDSHAKE_ADVANCE:?} of one measured from acceptance had \
+         already gone before the handshake even began"
     );
 
-    // The remainder, measured from the pause rather than from an origin
-    // only the endpoint knows, so the deadline is certainly crossed.
-    tokio::time::advance(HEADER_IDLE_TIMEOUT).await;
-    // Asserted here, before the close is awaited, because this is the
-    // only point at which the budget is bounded from above. The read
-    // below parks the runtime under a paused clock, so auto-advance
-    // carries it to whatever the next timer is: a header deadline an
-    // order of magnitude too far away would still be reached there, and
-    // still be reported as no-header.
+    // The rest of that budget, and the wheel's rounding. Asserted before
+    // the close is awaited, because this is the only point at which the
+    // budget is bounded from above: the read below parks the runtime
+    // under a paused clock, so auto-advance carries it to whatever the
+    // next timer is, however far away that is, and reports it as
+    // no-header just the same.
+    let remaining = HEADER_IDLE_TIMEOUT
+        .checked_sub(POST_HANDSHAKE_ADVANCE)
+        .expect("the assertion above holds the probe inside the header budget")
+        + TIMER_ROUNDING;
+    tokio::time::advance(remaining).await;
     settle().await;
     assert_eq!(
         logs.refusals().len(),

--- a/src/registrar/endpoint/tests.rs
+++ b/src/registrar/endpoint/tests.rs
@@ -2576,6 +2576,19 @@ async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion
     // The remainder, measured from the pause rather than from an origin
     // only the endpoint knows, so the deadline is certainly crossed.
     tokio::time::advance(HEADER_IDLE_TIMEOUT).await;
+    // Asserted here, before the close is awaited, because this is the
+    // only point at which the budget is bounded from above. The read
+    // below parks the runtime under a paused clock, so auto-advance
+    // carries it to whatever the next timer is: a header deadline an
+    // order of magnitude too far away would still be reached there, and
+    // still be reported as no-header.
+    settle().await;
+    assert_eq!(
+        logs.refusals().len(),
+        1,
+        "the header deadline must end the connection inside the budget \
+         advanced here"
+    );
 
     let observed = read_tls_until_closed(&mut stream).await;
     assert!(

--- a/src/registrar/endpoint/tests.rs
+++ b/src/registrar/endpoint/tests.rs
@@ -63,9 +63,9 @@ use super::tls::{
 };
 use super::{
     ActivatedEndpoint, CONNECTION_DRAIN_TIMEOUT, HANDSHAKE_TIMEOUT, HEADER_IDLE_TIMEOUT,
-    MAX_CONCURRENT_CONNECTIONS, MAX_FRAME_PAYLOAD_BYTES, MAX_RESPONSE_PAYLOAD_BYTES,
-    REQUIRED_SOCKET_MODE, UNPRIVILEGED_DAEMON_WARNING, current_effective_uid,
-    warns_about_unprivileged_daemon,
+    HandshakeCompleted, MAX_CONCURRENT_CONNECTIONS, MAX_FRAME_PAYLOAD_BYTES,
+    MAX_RESPONSE_PAYLOAD_BYTES, REQUIRED_SOCKET_MODE, UNPRIVILEGED_DAEMON_WARNING,
+    current_effective_uid, warns_about_unprivileged_daemon,
 };
 use crate::openbao::{OpenBaoClient, SecretIdOptions};
 use crate::registrar::audit::AuditRecordStore;
@@ -1116,7 +1116,7 @@ async fn drive_with(
         &ConnectionId::next(),
         &caller_identity(&registrar_client_name()),
         handler,
-        Instant::now(),
+        HandshakeCompleted::now(),
     )
     .await;
     let mut observed = Vec::new();
@@ -1607,7 +1607,7 @@ async fn the_response_deadline_closes_the_connection_without_a_refusal() {
         &ConnectionId::next(),
         &caller_identity(&registrar_client_name()),
         &handler,
-        started,
+        HandshakeCompleted::now(),
     )
     .await;
 
@@ -2466,16 +2466,6 @@ async fn a_connection_that_never_handshakes_is_dropped_at_the_handshake_timeout(
     running.stop().await;
 }
 
-/// The message the endpoint logs once it has accepted a connection.
-///
-/// It marks the point the handshake deadline is measured from: the
-/// accept loop stamps that origin, and the connection task logs this a
-/// few statements later. A test that means to place anything *between*
-/// acceptance and the handshake has to wait for it, because a `connect`
-/// completes in the listener's backlog — before the endpoint has
-/// accepted anything, and so before it has stamped anything.
-const CONNECTION_ACCEPTED_MESSAGE: &str = "Registrar endpoint accepted a connection.";
-
 /// The message the endpoint logs once a TLS handshake has completed.
 ///
 /// It is the only signal a test has that the *server* is past the
@@ -2487,9 +2477,9 @@ const HANDSHAKE_COMPLETED_MESSAGE: &str = "Registrar endpoint completed a TLS ha
 /// How many scheduler turns [`await_log_message`] will spin for.
 ///
 /// Only a bound on a hang: the connection task needs a handful of turns
-/// to reach either of the events above, and the clock is running
-/// wherever this is used, so an endpoint that never gets there fails
-/// with the message below rather than blocking the suite forever.
+/// to reach the event above, and the clock is running wherever this is
+/// used, so an endpoint that never gets there fails with the message
+/// below rather than blocking the suite forever.
 const LOG_BARRIER_TURNS: usize = 100_000;
 
 /// Yields until the endpoint has logged `message`.
@@ -2527,91 +2517,49 @@ async fn settle() {
     }
 }
 
-/// How far the clock is moved between acceptance and the handshake in
-/// [`a_completed_handshake_gets_the_whole_header_budget_from_that_completion`].
-///
-/// Over a loopback socket a handshake completes a fraction of a
-/// millisecond after the connection was accepted, and no advance can
-/// land inside a gap that narrow: an endpoint arming the header
-/// deadline at acceptance and one arming it at handshake completion
-/// would answer every advance identically. Moving the clock forward
-/// before the `ClientHello` is sent widens that gap to something a test
-/// can aim between. It costs the handshake nothing but budget it does
-/// not need, which is why it stays short of [`HANDSHAKE_TIMEOUT`].
-const PRE_HANDSHAKE_ADVANCE: StdDuration = StdDuration::from_secs(4);
-
-/// How far the clock is moved once that handshake has completed, before
-/// asserting the connection is still open.
-///
-/// Aimed between the two candidate origins: added to
-/// [`PRE_HANDSHAKE_ADVANCE`] it is past `accepted_at +
-/// HEADER_IDLE_TIMEOUT`, so a header deadline armed at acceptance has
-/// expired by then, and on its own it is short of
-/// [`HEADER_IDLE_TIMEOUT`], so one armed at handshake completion has
-/// not.
-const POST_HANDSHAKE_ADVANCE: StdDuration = StdDuration::from_secs(3);
-
-/// The margin added to the last advance of that test, for the timer
+/// The margin the header-budget advances below carry, for the timer
 /// wheel's millisecond granularity.
 ///
 /// A deadline is rounded up to the next millisecond, so advancing by
 /// exactly the budget can land short of it and leave the connection
-/// open. One millisecond covers the whole of that rounding, and keeps
-/// the upper bound the advance places on the budget as tight as the
-/// wheel allows.
+/// open. One millisecond covers the whole of that rounding: it is held
+/// back from the advance that must not reach the deadline, and added to
+/// the one that must.
 const TIMER_ROUNDING: StdDuration = StdDuration::from_millis(1);
-
-/// The two advances above discriminate between the origins only while
-/// these hold, and each relates a test constant to an endpoint one. They
-/// are checked here so that changing either timeout is a compile error
-/// rather than a test that quietly stops proving what it says it does.
-const _: () = {
-    assert!(
-        PRE_HANDSHAKE_ADVANCE.as_nanos() < HANDSHAKE_TIMEOUT.as_nanos(),
-        "the head start must leave the handshake budget unspent"
-    );
-    assert!(
-        POST_HANDSHAKE_ADVANCE.as_nanos() < HEADER_IDLE_TIMEOUT.as_nanos(),
-        "a header budget measured from handshake completion must survive the probe"
-    );
-    assert!(
-        PRE_HANDSHAKE_ADVANCE.as_nanos() + POST_HANDSHAKE_ADVANCE.as_nanos()
-            > HEADER_IDLE_TIMEOUT.as_nanos(),
-        "a header budget measured from acceptance must not survive the probe"
-    );
-};
 
 /// A connection that *does* complete a handshake gets a whole
 /// [`HEADER_IDLE_TIMEOUT`] measured from that completion, and is then
 /// refused as a missing header rather than as a handshake that never
 /// finished.
 ///
-/// The origin is what is at stake, so the test manufactures the one
-/// thing a loopback connection does not have: a wide, exactly known gap
-/// between acceptance and handshake completion. The clock is advanced
-/// by [`PRE_HANDSHAKE_ADVANCE`] after the endpoint has accepted the
-/// connection and before the client sends its `ClientHello`, which
-/// leaves the two candidate origins seconds apart instead of
-/// microseconds. [`POST_HANDSHAKE_ADVANCE`] then lands between the two
-/// deadlines they imply: an endpoint passing `accepted_at` to
-/// `serve_request` refuses the connection during that advance and fails
-/// the assertion after it, and only one measuring from handshake
-/// completion is still open. The remaining advance carries the clock
-/// past the completion-measured deadline as well, and the refusal it
-/// produces names `no-header` rather than a handshake timeout.
+/// Everything up to and including the handshake runs under a live
+/// clock, against the production deadlines: the endpoint has real
+/// progress to make there, and pausing across it would let auto-advance
+/// fire mid-flight, jump to the handshake deadline and refuse a
+/// connection that was getting on with it. Only once the server has
+/// logged the handshake — the client's future resolves earlier than
+/// that — is the clock paused, and from there the header budget is
+/// spent by moving it rather than by waiting.
 ///
-/// That last advance also bounds the budget from above: it stops one
-/// millisecond past `HEADER_IDLE_TIMEOUT` from the pause, so a deadline
-/// an order of magnitude too far away would not be reached by it.
+/// The two advances bound that budget from both sides. What the test
+/// cannot read is the endpoint's own stamp, so the first advance bounds
+/// it instead: the stamp is taken after a handshake that had not begun
+/// at `dialed_at`, so no more of the budget has gone at the pause than
+/// has elapsed since then. Deducting that bound and the wheel's
+/// rounding leaves an advance that cannot reach the deadline, however
+/// long the handshake took, and the connection is still open after it.
+/// The second carries the clock a millisecond past a whole
+/// [`HEADER_IDLE_TIMEOUT`] from the pause, which is at or past the
+/// deadline for the same reason — so a budget an order of magnitude too
+/// generous would fail here rather than pass.
 ///
-/// The clock runs whenever the endpoint has to make progress — through
-/// the accept, and through the handshake itself — and is paused only to
-/// be moved. Pausing across the handshake would let auto-advance fire
-/// while it was still in flight, jumping to the handshake deadline and
-/// refusing a connection that was making progress; the test would then
-/// assert the wrong reason for a reason that has nothing to do with the
-/// endpoint. No wall-clock time is spent on any of the three advances,
-/// so the nine seconds of deadline they cover cost the suite nothing.
+/// The origin itself is not what this test pins down: over a loopback
+/// socket acceptance and handshake completion are microseconds apart,
+/// and no advance can be aimed between deadlines that close together
+/// without moving the clock before the handshake, which this test is
+/// required not to do. That is [`HandshakeCompleted`]'s job in the
+/// serving path, where measuring the header budget from acceptance is a
+/// compile error.
 #[tokio::test]
 async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion() {
     let (logs, _guard) = capture_logs();
@@ -2623,47 +2571,32 @@ async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion
         }),
     );
 
-    // The connection, but not yet the handshake, so that the clock can
-    // be moved between the two.
-    let stream = UnixStream::connect(&harness.socket_path)
-        .await
-        .expect("connect");
-    await_log_message(&logs, CONNECTION_ACCEPTED_MESSAGE).await;
-
-    // Most of the handshake budget, spent before the `ClientHello`.
-    // This is what puts acceptance and handshake completion far enough
-    // apart for an advance to fall between the deadlines they imply.
-    tokio::time::pause();
-    tokio::time::advance(PRE_HANDSHAKE_ADVANCE).await;
-    tokio::time::resume();
-
     // A real handshake through the production endpoint, under a running
-    // clock and under the real handshake deadline — still armed, and
-    // with `PRE_HANDSHAKE_ADVANCE` less of itself left than it began
-    // with.
-    let mut stream = TlsConnector::from(Arc::new(harness.pki.registrar_client_config()))
-        .connect(
-            ServerName::try_from(DIAL_NAME).expect("a valid dial name"),
-            stream,
-        )
+    // clock and under the real handshake deadline.
+    let dialed_at = Instant::now();
+    let mut stream = tls_connect(&harness.socket_path, harness.pki.registrar_client_config())
         .await
         .expect("the registrar client completes a handshake");
     await_log_message(&logs, HANDSHAKE_COMPLETED_MESSAGE).await;
 
-    // From here the connection is inside the header deadline and no
-    // other deadline is armed, so the budget is spent by moving the
-    // clock rather than by waiting.
+    // The handshake is behind the endpoint and the header deadline is
+    // the only one armed, so the budget can be spent without waiting.
     tokio::time::pause();
 
-    // Past `accepted_at + HEADER_IDLE_TIMEOUT` and short of
-    // `handshaken_at + HEADER_IDLE_TIMEOUT`.
-    tokio::time::advance(POST_HANDSHAKE_ADVANCE).await;
+    // How much of that budget has already gone is the endpoint's stamp
+    // against this pause, and the test can read neither. It can bound
+    // the difference: the stamp comes after a handshake that had not
+    // begun at `dialed_at`.
+    let spent_at_most = dialed_at.elapsed();
+    let inside = HEADER_IDLE_TIMEOUT
+        .checked_sub(spent_at_most + TIMER_ROUNDING)
+        .expect("a loopback handshake completes far inside the header budget");
+    tokio::time::advance(inside).await;
     settle().await;
     assert!(
         logs.refusals().is_empty(),
-        "a completed handshake gets a header budget of its own: \
-         {PRE_HANDSHAKE_ADVANCE:?} of one measured from acceptance had \
-         already gone before the handshake even began"
+        "a completed handshake keeps its connection through {inside:?} of \
+         a {HEADER_IDLE_TIMEOUT:?} header budget"
     );
 
     // The rest of that budget, and the wheel's rounding. Asserted before
@@ -2672,11 +2605,11 @@ async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion
     // under a paused clock, so auto-advance carries it to whatever the
     // next timer is, however far away that is, and reports it as
     // no-header just the same.
-    let remaining = HEADER_IDLE_TIMEOUT
-        .checked_sub(POST_HANDSHAKE_ADVANCE)
-        .expect("the assertion above holds the probe inside the header budget")
-        + TIMER_ROUNDING;
-    tokio::time::advance(remaining).await;
+    let whole_budget = HEADER_IDLE_TIMEOUT + TIMER_ROUNDING;
+    let rest = whole_budget
+        .checked_sub(inside)
+        .expect("the advance above is a whole budget less what preceded it");
+    tokio::time::advance(rest).await;
     settle().await;
     assert_eq!(
         logs.refusals().len(),

--- a/src/registrar/endpoint/tests.rs
+++ b/src/registrar/endpoint/tests.rs
@@ -2521,10 +2521,28 @@ async fn settle() {
     }
 }
 
-/// A connection that *does* complete a handshake gets the full
-/// [`HEADER_IDLE_TIMEOUT`] measured from that completion, and is then
+/// A connection that *does* complete a handshake gets a whole
+/// [`HEADER_IDLE_TIMEOUT`] in which to send a header, and is then
 /// refused as a missing header rather than as a handshake that never
 /// finished.
+///
+/// What the advance below pins down is that budget's *length* and the
+/// reason it ends in: five seconds pass with the connection still open,
+/// and the refusal names `no-header`. It does not pin the origin down
+/// to the microsecond, and is not the coverage that the origin is
+/// handshake completion rather than acceptance. Over a loopback socket
+/// those two instants are a fraction of a millisecond apart, and every
+/// instant this test can name falls outside that gap, so no advance
+/// from one of them separates a deadline armed at acceptance from one
+/// armed at completion. Nor can the budget be bounded from above any
+/// more tightly than it is here: the timer wheel rounds a deadline up
+/// to the next millisecond, so advancing to exactly the pause plus the
+/// budget lands short of the rounded deadline and the connection
+/// outlives the assertion. What holds the origin is the signature
+/// `serve_request` is given -- it takes `handshaken_at`, and its only
+/// production caller stamps that after `handshake` has returned -- and
+/// [`the_header_deadline_expires_with_no_header_when_no_byte_arrives`],
+/// which drives the same deadline from an origin it chooses outright.
 ///
 /// The clock runs for the handshake and is paused only once the server
 /// has completed it. Pausing earlier would let auto-advance fire while

--- a/src/registrar/endpoint/tests.rs
+++ b/src/registrar/endpoint/tests.rs
@@ -1536,9 +1536,10 @@ fn connection_ids_are_distinct_and_shaped_unlike_a_verb_request_id() {
 // Cumulative deadlines
 // ---------------------------------------------------------------------
 
-/// The header deadline is cumulative from acceptance: a caller that
-/// holds the connection open without sending a byte is refused as
-/// no-header when it expires.
+/// The header deadline is cumulative from handshake completion — the
+/// instant `serve_request` is handed here, and the instant the serving
+/// path stamps after its handshake: a caller that holds the connection
+/// open without sending a byte is refused as no-header when it expires.
 #[tokio::test(start_paused = true)]
 async fn the_header_deadline_expires_with_no_header_when_no_byte_arrives() {
     let (logs, _guard) = capture_logs();

--- a/src/registrar/endpoint/tests.rs
+++ b/src/registrar/endpoint/tests.rs
@@ -684,18 +684,22 @@ impl CapturedLogs {
             .clone()
     }
 
-    /// The one refusal event, which every refusal path emits exactly
-    /// once.
-    fn refusal(&self) -> CapturedEvent {
-        let mut matching: Vec<CapturedEvent> = self
-            .events()
+    /// Every refusal event captured so far.
+    fn refusals(&self) -> Vec<CapturedEvent> {
+        self.events()
             .into_iter()
             .filter(|event| {
                 event
                     .message
                     .starts_with("Registrar endpoint refused a connection")
             })
-            .collect();
+            .collect()
+    }
+
+    /// The one refusal event, which every refusal path emits exactly
+    /// once.
+    fn refusal(&self) -> CapturedEvent {
+        let mut matching = self.refusals();
         assert_eq!(
             matching.len(),
             1,
@@ -2461,18 +2465,76 @@ async fn a_connection_that_never_handshakes_is_dropped_at_the_handshake_timeout(
     running.stop().await;
 }
 
+/// The message the endpoint logs once a TLS handshake has completed.
+///
+/// It is the only signal a test has that the *server* is past the
+/// handshake deadline and inside the header one: the client's own
+/// handshake future resolves as soon as it has written its last flight,
+/// which is before the server has read it.
+const HANDSHAKE_COMPLETED_MESSAGE: &str = "Registrar endpoint completed a TLS handshake.";
+
+/// How many scheduler turns the handshake barrier will spin for.
+///
+/// Only a bound on a hang: the connection task needs a handful of turns
+/// to read the client's final flight, and the clock is still running
+/// here, so an endpoint that never completes the handshake fails with
+/// this message rather than blocking the suite forever.
+const HANDSHAKE_BARRIER_TURNS: usize = 100_000;
+
+/// Yields until the endpoint has logged a completed handshake.
+///
+/// Nothing sleeps and nothing waits on a timeout: the loop hands the
+/// runtime back to the connection task until the event appears. It must
+/// be called before `tokio::time` is paused, because the handshake it
+/// waits for runs under the handshake deadline.
+async fn await_completed_handshake(logs: &CapturedLogs) {
+    for _ in 0..HANDSHAKE_BARRIER_TURNS {
+        if logs
+            .events()
+            .iter()
+            .any(|event| event.message == HANDSHAKE_COMPLETED_MESSAGE)
+        {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("the endpoint never completed the handshake");
+}
+
+/// How many scheduler turns [`settle`] hands back before its caller
+/// asserts that nothing has happened.
+///
+/// Far more than the refusal path needs — it logs before it closes, so
+/// a handful of polls carry it from an elapsed deadline to a captured
+/// event — and cheap enough that the margin costs nothing.
+const SETTLE_TURNS: usize = 1_000;
+
+/// Hands the runtime back until any work already in motion has run.
+///
+/// Callable only under a paused clock, and it is the caller's task that
+/// stays ready throughout, so no timer can elapse while it spins: an
+/// assertion after it reads a state the clock did not move on.
+async fn settle() {
+    for _ in 0..SETTLE_TURNS {
+        tokio::task::yield_now().await;
+    }
+}
+
 /// A connection that *does* complete a handshake gets the full
 /// [`HEADER_IDLE_TIMEOUT`] measured from that completion, and is then
 /// refused as a missing header rather than as a handshake that never
 /// finished.
 ///
-/// This one does not pause the clock. Auto-advance fires whenever the
-/// runtime parks, which during a real handshake would jump straight past
-/// the handshake deadline and refuse a connection that was making
-/// progress — so the test would assert the wrong reason for a reason
-/// that has nothing to do with the endpoint. Waiting out the real budget
-/// is the honest way to observe which of the two deadlines ends this
-/// connection.
+/// The clock runs for the handshake and is paused only once the server
+/// has completed it. Pausing earlier would let auto-advance fire while
+/// the handshake was still in flight, jumping past the handshake
+/// deadline and refusing a connection that was making progress — the
+/// test would then assert the wrong reason for a reason that has nothing
+/// to do with the endpoint. Once the server is past that point the only
+/// deadline left is the header one, so the budget can be advanced
+/// through rather than waited out: five seconds of it are spent without
+/// five seconds of wall-clock time, and which of the two deadlines ends
+/// the connection is still what the refusal reason says.
 #[tokio::test]
 async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion() {
     let (logs, _guard) = capture_logs();
@@ -2484,18 +2546,40 @@ async fn a_completed_handshake_gets_the_whole_header_budget_from_that_completion
         }),
     );
 
+    // A real handshake through the production endpoint, under real time
+    // and therefore under the real handshake deadline.
+    let connect_started = Instant::now();
     let mut stream = tls_connect(&harness.socket_path, harness.pki.registrar_client_config())
         .await
         .expect("the registrar client completes a handshake");
-    let handshaken_at = Instant::now();
+    await_completed_handshake(&logs).await;
+
+    // From here the connection is inside the header deadline and no
+    // other deadline is armed, so the rest of the budget is spent by
+    // moving the clock rather than by waiting.
+    tokio::time::pause();
+
+    // The endpoint stamped the header-deadline origin at an instant
+    // strictly after `connect_started`, so its deadline is strictly
+    // after `connect_started + HEADER_IDLE_TIMEOUT`. Advancing to
+    // exactly there is therefore still inside the budget, whatever the
+    // handshake cost: a connection refused by now was refused early.
+    let owed = HEADER_IDLE_TIMEOUT.saturating_sub(connect_started.elapsed());
+    tokio::time::advance(owed).await;
+    settle().await;
+    assert!(
+        logs.refusals().is_empty(),
+        "a completed handshake keeps its whole header budget, and {owed:?} of it was left"
+    );
+
+    // The remainder, measured from the pause rather than from an origin
+    // only the endpoint knows, so the deadline is certainly crossed.
+    tokio::time::advance(HEADER_IDLE_TIMEOUT).await;
+
     let observed = read_tls_until_closed(&mut stream).await;
     assert!(
         observed.is_empty(),
         "a refused connection writes no bytes: {observed:?}"
-    );
-    assert!(
-        handshaken_at.elapsed() >= HEADER_IDLE_TIMEOUT,
-        "the header budget must run from handshake completion"
     );
 
     let event = logs.refusal();


### PR DESCRIPTION
## Summary

The registrar endpoint already measured its two deadlines from the right origins — `HANDSHAKE_TIMEOUT` from acceptance, `HEADER_IDLE_TIMEOUT` from handshake completion — but two things still said otherwise. The accept-loop comment beside `Instant::now()` claimed the *header* deadline started there, and the completed-handshake test proved its point by waiting out five real seconds.

Both are corrected here, with no change to runtime behavior.

- The accept-loop comment now names the instant it captures as the origin of the **TLS handshake** deadline, and says the header deadline is a separate budget starting at handshake completion.
- The header deadline's origin is a type of its own. `HandshakeCompleted` wraps the instant the handshake finished; nothing converts an `Instant` into one, and `serve_request` / `read_header` take it in place of the `Instant` they used to. Passing acceptance to the call that arms the header budget is now a compile error rather than something a test has to be built to catch — which matters because acceptance is an `Instant` still in scope at that call, one identifier away.
- `handle_connection` logs a `debug!` event once the handshake completes. Without it a log shows a connection accepted and then refused for a missing header, with nothing to say which of the two budgets the caller actually spent — and it is the only signal a test has that the *server* is past the handshake deadline, since the client's handshake future resolves as soon as it has written its last flight.
- `a_completed_handshake_gets_the_whole_header_budget_from_that_completion` now completes a real TLS handshake through the production endpoint harness and spends the header budget by moving the clock rather than by waiting.

### What the test does, and where the clock is touched

Time control stays where the issue puts it: after the handshake has completed. Everything up to and including the handshake runs under a live clock against the production deadlines — pausing across it would let auto-advance fire mid-flight, jump to the handshake deadline and refuse a connection that was making progress. The pause happens only once the endpoint has logged the completed handshake.

From there two advances bound the budget from both sides. The endpoint's own stamp is not readable from the test, so both are computed against a bound on it: the stamp is taken after a handshake that had not begun when the client dialled, so no more of the budget has gone at the pause than has elapsed since `dialed_at`.

- The first advance is `HEADER_IDLE_TIMEOUT` less that bound and less `TIMER_ROUNDING`. It cannot reach the deadline however long the handshake took, and the connection is still open after it.
- The second carries the clock to one millisecond past a whole `HEADER_IDLE_TIMEOUT` from the pause, which is at or past the deadline for the same reason. The millisecond is the timer wheel's granularity, which rounds a deadline up and would otherwise leave the connection open. The refusal is asserted here, before the close is awaited, because this is the only point at which the budget is bounded from above: the read below parks the runtime under a paused clock, and auto-advance would carry it to any deadline at all.

The test's existing assertions are unchanged: zero application bytes, `no-header`, and the unread-operation marker. No wall-clock time is spent on either advance — the revised test finishes in 0.01s.

### Why the origin is pinned by the type rather than by the test

Over a loopback socket acceptance and handshake completion are a fraction of a millisecond apart, so no advance can land between the deadlines they imply. Manufacturing that gap means moving the clock *before* the handshake, which this issue's constraints rule out. So the guarantee moves out of the test and into the signature, where it is checked by the compiler on every build rather than by one test on every run: reverting `serve.rs:362` to `accepted_at` no longer compiles.

```
error[E0308]: mismatched types
   --> src/registrar/endpoint/serve.rs:362:67
    |
362 |             serve_request(&mut tls, connection, &caller, handler, accepted_at).await;
    |             -------------                                         ^^^^^^^^^^^ expected `HandshakeCompleted`, found `Instant`
```

Closes #908

Part of #764

Part of #790

## Test plan

- [x] `a_completed_handshake_gets_the_whole_header_budget_from_that_completion` completes a real handshake through the production harness, pauses Tokio time only after that handshake has completed, and advances the budget deterministically
- [x] Time is neither paused nor advanced before or during the handshake, and nothing sleeps or waits on a timeout
- [x] It still asserts `no-header` rather than a handshake timeout, plus zero application bytes and the unread-operation marker
- [x] The header budget is bounded from both sides, to within the timer wheel's millisecond
- [x] Measuring the header budget from acceptance is a compile error: reverting the call at `serve.rs:362` to `accepted_at` fails the build with the `E0308` above
- [x] `a_connection_that_never_handshakes_is_dropped_at_the_handshake_timeout` remains `#[tokio::test(start_paused = true)]` coverage for the acceptance-to-handshake deadline
- [x] No five seconds of wall-clock time: the revised test finishes in 0.01s, and 25 consecutive runs of it all pass
- [x] Full `registrar::endpoint` suite green on Linux — 162 passed, 0 failed, 0.23s
- [x] `cargo test --locked --lib --no-fail-fast` on Linux: 1034 passed, 4 failed, and those four are the documented root-artifact set (each asserts what an unprivileged process cannot do, and the container runs as root) — none in `registrar::endpoint`
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean on Linux
- [x] `cargo doc --no-deps --document-private-items` clean on Linux
- [x] `cargo fmt -- --config group_imports=StdExternalCrate --check` clean
- [x] `scripts/impl/run-registrar-verbs-e2e.sh` passes (exit 0)
- [x] `HANDSHAKE_TIMEOUT` and `HEADER_IDLE_TIMEOUT` values, connection ordering, refusal shape, TLS authentication, frame protocol, and handler behavior all unchanged

### Verification notes

`src/registrar/endpoint` is `#[cfg(target_os = "linux")]`, so it is not compiled at all on the macOS development host — the Rust checks above were run in a `rust:latest` container against this worktree. For the same reason no local E2E arm can exercise the changed code on macOS; `run-registrar-verbs-e2e.sh` was run as a general no-breakage check, and the Docker E2E matrix is left to CI's Linux jobs.

No documentation or Markdown files are touched, so the docs build and Markdown lint steps are unaffected. The change is a type and two tests' worth of wiring, observable to no user of the last release, so there is no changelog entry.
