### PR TITLE
Add the in-repo client for the registrar endpoint (#765)

### DIFF
--- a/docs/reference/registrar-endpoint-client.md
+++ b/docs/reference/registrar-endpoint-client.md
@@ -65,7 +65,15 @@ key, and holds no second copy of either rule.
 Both halves are rebuilt **on every dial**, so the pin file and the client pair
 are re-read every time. A pin file that is missing, unreadable or malformed is
 a typed failure of the dial — never a fallback to trusting whatever the peer
-presents.
+presents. So is a certificate file holding a PEM block the parser refuses: a
+refused block is never skipped over, because a file whose valid leaf is
+followed by a corrupt one would otherwise dial with the leaf alone and report
+nothing.
+
+Those three reads sit outside both timeouts below — the connect budget starts
+once the configuration is in hand — so they run on the runtime's blocking pool
+rather than on a worker thread, where a filesystem answering slowly could hold
+one for as long as it liked.
 
 The name handed to the TLS connector is inert: a handshake over `AF_UNIX` has
 no hostname to match against, so the verifier ignores the dialed name and
@@ -76,6 +84,15 @@ a SAN other than the expected name — fails the dial before a request byte is
 written, with its own error variant naming the **expected** name. The client
 does not parse the peer's certificate, so it does not report the name the
 server actually presented.
+
+That variant is selected by asking whether the recovered `rustls::Error` is one
+the endpoint's verifier could itself have produced, and not by the
+`InvalidCertificate` wrapper alone. The wrapper does not separate the two: the
+peer's `CertificateVerify` signature is checked *after* the verifier has
+already accepted the chain, and a bad one is reported as
+`InvalidCertificate(BadSignature)`. That is a handshake failure the pin did not
+cause, so it reaches the generic handshake variant. The predicate lives beside
+the rejection mapping in `endpoint_pin`, so the two move together.
 
 ## 4. The two timeouts and the response bound
 

--- a/docs/reference/registrar-endpoint-client.md
+++ b/docs/reference/registrar-endpoint-client.md
@@ -1,0 +1,157 @@
+<!-- markdownlint-configure-file {
+  "MD013": { "tables": false }
+} -->
+
+# Registrar endpoint client (reference implementation)
+
+This file describes `src/registrar/endpoint/client.rs`, the in-repository
+caller of the registrar endpoint. It is the **reference behaviour** this
+repository expects of a registrar that dials the endpoint, written as running
+code and covered by tests; it is **not** the deployed caller, which is roxyd in
+another repository and dials the socket itself.
+
+It is checked in outside the mirrored `docs/en/` + `docs/ko/` operator pair, on
+the precedent of `docs/reference/registrar-client-identity.md` and
+`docs/reference/registrar-wire-contract.md`: it is cross-repository reference
+material rather than operator documentation, so `mkdocs.yml` lists it in
+neither locale's nav and there is no `docs/ko/` counterpart.
+
+## 1. How it is constructed
+
+The client is built from four paths and one name, and from nothing else:
+
+| Argument | What it names |
+| --- | --- |
+| socket path | The host-local `AF_UNIX` socket the endpoint is activated on. |
+| pin file path | The trust-anchor pin file described in `docs/reference/registrar-client-identity.md`. |
+| certificate path | The registrar client leaf, and whatever chain follows it, as PEM. |
+| key path | That leaf's private key, as PEM. |
+| expected endpoint name | The endpoint server identity the presented leaf must carry. |
+
+It reads no configuration file and introduces no `agent.toml` key. Every value
+arrives as an argument, which keeps configuration ownership where it already is
+and makes the client directly constructible from a temporary directory in a
+test.
+
+The expected endpoint name is the one `registrar_endpoint_identity` composes,
+`<instance>.bootroot-registrar-endpoint.<host>.<domain>`, where `<domain>` is
+the configured `network.domain` appended as a **suffix of whatever label count
+it was configured with** rather than as a single label. The composed name is
+therefore three labels in front of that suffix and its total label count is not
+fixed — a one-, two- or three-label domain all compose validly. The client
+stores the name and asserts nothing about its shape.
+
+## 2. One request per connection
+
+The endpoint's contract is exactly one request and one response per connection,
+after which it closes. The client dials, hands over one encoded request, reads
+one response to the end of the stream, and closes. It does not pool, reuse or
+pipeline connections, and it never writes a second request on a connection that
+has carried one.
+
+A request payload longer than the envelope's `MAX_FRAME_PAYLOAD_BYTES` is
+refused locally, with a typed error and before the socket is dialed. The
+endpoint would refuse such a frame with a bare close, and there is no reason to
+make a caller learn that over the wire.
+
+## 3. What it verifies
+
+Every trust decision belongs to `endpoint_server_verifier`: the trust anchors
+are exactly the SHA-256 digests listed in the pin file, and the presented
+end-entity certificate must carry one DNS SAN equal to the expected endpoint
+name. The client composes that verifier with its own client certificate and
+key, and holds no second copy of either rule.
+
+Both halves are rebuilt **on every dial**, so the pin file and the client pair
+are re-read every time. A pin file that is missing, unreadable or malformed is
+a typed failure of the dial — never a fallback to trusting whatever the peer
+presents.
+
+The name handed to the TLS connector is inert: a handshake over `AF_UNIX` has
+no hostname to match against, so the verifier ignores the dialed name and
+applies the pinned expected name instead.
+
+A server refused by the pin — one chaining to no pinned anchor, or one carrying
+a SAN other than the expected name — fails the dial before a request byte is
+written, with its own error variant naming the **expected** name. The client
+does not parse the peer's certificate, so it does not report the name the
+server actually presented.
+
+## 4. The two timeouts and the response bound
+
+| Bound | Value | What it covers |
+| --- | --- | --- |
+| Connect timeout | 5 s | The dial alone. A host-local `AF_UNIX` connect, at the same scale as the endpoint's own handshake deadline. |
+| Read timeout | 30 s | The TLS handshake, the request write and the response read together. It spans the endpoint's verb execution, which has no server-side deadline of its own, with clear headroom over every server-side deadline. |
+| Response bound | 65,540 bytes | The response prefix plus the largest payload the endpoint will write, defined by referencing the endpoint's own constants so the two cannot drift. |
+
+The two timeouts are separately observable: a caller can tell which one
+elapsed. A response whose prefix declares more than the bound allows fails
+before the payload is read, and the read buffer never grows past the bound.
+
+## 5. When the response is complete
+
+The response is complete once the four-byte prefix and exactly the declared
+number of payload bytes have arrived. The client then reads **once more**, and
+that read decides the exchange:
+
+- a **clean end of stream** completes it, and the payload is decoded only after
+  that. This is what the endpoint does: it finishes the frame and shuts the
+  connection down, which sends `close_notify`;
+- **any byte after the declared payload** fails the exchange with its own error
+  variant. The payload is not decoded and no outcome is returned, so a peer
+  cannot append a second frame behind a well-formed one and have the first
+  honoured;
+- an **error** — including the `UnexpectedEof` that `rustls` reports for a peer
+  that vanished without `close_notify` — is a transport failure carrying the
+  phase it happened in. A response that arrived in full behind an unclean close
+  is reported that way rather than returned.
+
+A connection the endpoint ends cleanly after zero application bytes has its own
+variant, distinct from a decode failure and from a truncation. That is the
+endpoint's designed shape for a caller it will not serve.
+
+One limitation the wire cannot carry: a connection the endpoint refuses
+*before* the handshake completes — for capacity, or for peer credentials — has
+no application stream to close, so it reaches the client as a connect- or
+handshake-level failure and is not distinguishable there from an ordinary one.
+
+## 6. Success or refusal
+
+The endpoint answers a mint with a mint response, a deregister with a
+deregister response, and either verb with a refusal response, and the envelope
+carries no status field to choose between them. The client fixes one rule, and
+it is a rule about the **membership** of the `class` key rather than about that
+key's value:
+
+> A response payload that is a JSON object carrying a top-level `class` member
+> — whatever that member's value — is a refusal. A JSON object carrying no
+> top-level `class` member is the success shape for the operation that was
+> sent.
+
+`class` is required and non-nullable on the refusal shape and appears in
+neither success shape, while `outcome` is required on both success shapes and
+appears in no refusal. The rule rests on `class` never being added to a success
+shape, which would be a change to the wire contract in
+`docs/reference/registrar-wire-contract.md` rather than something an
+implementation may do.
+
+Three consequences follow:
+
+- `{"class": null, …}`, `{"class": 7, …}` and any other wrongly typed `class`
+  is a **malformed refusal**, not a success. It reaches the refusal decoder,
+  which rejects it, and the client reports a decode failure;
+- a payload that is not a JSON object at all — an array, a string, a number, a
+  bare `null`, or bytes that are not JSON — fails the discrimination itself,
+  and **no** decoder runs;
+- exactly one decoder runs for every payload that is a JSON object, and none
+  falls back to a second. A decode failure therefore names one shape rather
+  than being the residue of two attempts.
+
+**A decoded refusal is a successful exchange.** It is returned in the `Ok`
+position, in the refusal arm of the verb's reply, carrying the wire error
+identifier and its transient-versus-permanent class exactly as they arrived.
+The client does not retry it, reclassify it, collapse two identifiers into one,
+or promote it to an error. It implements no retry policy of any kind — not on
+connect, not on handshake, not on a transient refusal — because retry semantics
+belong with the code that owns the reasons for retrying.

--- a/docs/reference/registrar-endpoint-client.md
+++ b/docs/reference/registrar-endpoint-client.md
@@ -73,7 +73,11 @@ nothing.
 Those three reads sit outside both timeouts below — the connect budget starts
 once the configuration is in hand — so they run on the runtime's blocking pool
 rather than on a worker thread, where a filesystem answering slowly could hold
-one for as long as it liked.
+one for as long as it liked. The hand-off has a failure of its own, distinct
+from anything the load decided: the runtime shutting down with the load still
+queued, or the load panicking. It has its own variant, no connection is opened
+when it fires, and a load that did report back keeps whichever failure it
+decided.
 
 The name handed to the TLS connector is inert: a handshake over `AF_UNIX` has
 no hostname to match against, so the verifier ignores the dialed name and

--- a/src/registrar/endpoint.rs
+++ b/src/registrar/endpoint.rs
@@ -38,6 +38,13 @@
 //!   resolver a renewal swaps new material through.
 //! - [`serve`] is the accept loop, the bounded connection fleet and the
 //!   drain-then-abort shutdown.
+//! - [`client`] is the other end of all of it: this repository's
+//!   reference caller, which dials the socket, completes the pinned
+//!   handshake and drives one request over one connection. It has no
+//!   production consumer here — the deployed caller lives in another
+//!   repository — and exists so that the caller behaviour this endpoint
+//!   expects is written down as running code rather than reinvented
+//!   inline by whichever test needs it next.
 //!
 //! # What authenticates a caller
 //!
@@ -84,6 +91,7 @@
 //! while the socket inode stays exactly as it was.
 
 pub(crate) mod activation;
+pub(crate) mod client;
 pub(crate) mod frame;
 pub(crate) mod handler;
 pub(crate) mod policy;
@@ -93,6 +101,8 @@ pub(crate) mod refusal;
 pub(crate) mod serve;
 pub(crate) mod tls;
 
+#[cfg(test)]
+mod test_support;
 #[cfg(test)]
 mod tests;
 

--- a/src/registrar/endpoint/client.rs
+++ b/src/registrar/endpoint/client.rs
@@ -173,6 +173,16 @@ pub(crate) enum ClientMaterialError {
         /// The path that was handed to the client.
         path: PathBuf,
     },
+    /// The certificate file holds a PEM block the parser refused.
+    ///
+    /// Distinct from [`ClientMaterialError::NoCertificate`] because the
+    /// file is not empty of certificates — it is wrong — and distinct
+    /// from silence because a refused block is never skipped over.
+    #[error("registrar client certificate {} holds a malformed PEM block", .path.display())]
+    MalformedCertificate {
+        /// The path that was handed to the client.
+        path: PathBuf,
+    },
     /// The key file holds no PEM private key.
     #[error("registrar client key {} holds no PEM private key", .path.display())]
     NoPrivateKey {
@@ -232,6 +242,18 @@ pub(crate) enum ExchangeError {
         /// Which half of the pair, and how.
         #[source]
         source: ClientMaterialError,
+    },
+    /// The per-dial load never reported back.
+    ///
+    /// It runs on Tokio's blocking pool, so this is the hand-off itself
+    /// failing rather than any file being wrong: the runtime shut down
+    /// with the load still queued, or the load panicked. Neither is a
+    /// statement about the endpoint, and no connection was opened.
+    #[error("the registrar endpoint dial configuration was never loaded: {source}")]
+    LoadAbandoned {
+        /// Why the blocking task produced no result.
+        #[source]
+        source: tokio::task::JoinError,
     },
     /// The encoded request is longer than the envelope admits. Refused
     /// locally, before the dial.
@@ -507,7 +529,7 @@ impl RegistrarEndpointClient {
         let payload = protocol::encode_request(request).map_err(codec)?;
         let request_frame = frame::encode_request_frame(operation, &payload)
             .map_err(|source| ExchangeError::RequestTooLarge { source })?;
-        let config = self.dial_config()?;
+        let config = self.dial_config().await?;
 
         debug!(
             operation = operation.as_str(),
@@ -548,28 +570,45 @@ impl RegistrarEndpointClient {
     /// unreadable or malformed is a typed failure of the dial rather
     /// than a panic or a fallback, and a renewed pair is picked up
     /// without a restart.
-    fn dial_config(&self) -> Result<ClientConfig, ExchangeError> {
-        let (chain, key) =
-            load_client_material(&self.certificate_path, &self.key_path).map_err(|source| {
-                warn!(
-                    certificate = %self.certificate_path.display(),
-                    key = %self.key_path.display(),
-                    "Registrar client material could not be loaded: {source}"
-                );
-                ExchangeError::Material { source }
-            })?;
-        build_client_config(&self.pin_file, &self.expected_endpoint_name, chain, key).map_err(
-            |err| match err {
-                ClientConfigError::Pin(source) => ExchangeError::Pin { source },
-                ClientConfigError::ClientAuth(source) => ExchangeError::Material {
-                    source: ClientMaterialError::Unusable {
-                        certificate_path: self.certificate_path.clone(),
-                        key_path: self.key_path.clone(),
-                        source,
-                    },
-                },
-            },
-        )
+    ///
+    /// Those three reads are the only blocking syscalls on the dial
+    /// path, and they are outside both exchange timeouts — the connect
+    /// budget starts after this returns — so a filesystem that answers
+    /// slowly, or a path that turns out to be a FIFO, would otherwise
+    /// hold a runtime worker for as long as it liked. They run on the
+    /// blocking pool for that reason, together with the key parsing
+    /// `with_client_auth_cert` does, rather than each read being made
+    /// async separately: the pin file is read inside
+    /// [`endpoint_pin::endpoint_server_verifier`], whose signature this
+    /// issue leaves alone.
+    async fn dial_config(&self) -> Result<ClientConfig, ExchangeError> {
+        let pin_file = self.pin_file.clone();
+        let expected_endpoint_name = self.expected_endpoint_name.clone();
+        let certificate_path = self.certificate_path.clone();
+        let key_path = self.key_path.clone();
+        let loaded = tokio::task::spawn_blocking(move || {
+            load_dial_config(
+                &pin_file,
+                &expected_endpoint_name,
+                &certificate_path,
+                &key_path,
+            )
+        })
+        .await
+        .map_err(|source| ExchangeError::LoadAbandoned { source })?;
+        if let Err(ExchangeError::Material { source }) = &loaded {
+            // Emitted here rather than inside the closure: a
+            // `tracing` subscriber installed for one thread — which is
+            // what `tracing::subscriber::set_default` gives, and what
+            // this module's tests capture with — does not see an event
+            // a blocking-pool thread records.
+            warn!(
+                certificate = %self.certificate_path.display(),
+                key = %self.key_path.display(),
+                "Registrar client material could not be loaded: {source}"
+            );
+        }
+        loaded
     }
 
     /// Completes the handshake, writes the one request and reads the one
@@ -607,22 +646,61 @@ impl RegistrarEndpointClient {
     /// `tokio_rustls` wraps the `rustls::Error` the verifier produced in
     /// an [`io::Error`]; recovering it is the same downcast
     /// `serve::handshake_failure_label` performs on the server side, so
-    /// one rule decides both directions. Every
-    /// [`endpoint_pin::EndpointVerifyRejection`] maps onto an
-    /// `InvalidCertificate(_)`, and nothing else the handshake can fail
-    /// with does.
+    /// one rule decides both directions.
+    ///
+    /// What the recovered error is then asked is
+    /// [`endpoint_pin::is_endpoint_verify_rejection`] rather than the
+    /// bare `InvalidCertificate(_)` the server side asks. The two
+    /// questions are not the same one: the server's verifier is
+    /// `WebPkiClientVerifier`, whose decision is the whole of the
+    /// caller's chain check, while this client verifies the peer and
+    /// then goes on to check its `CertificateVerify` signature — and
+    /// `rustls` reports a bad one as `InvalidCertificate(BadSignature)`,
+    /// after the pin has already passed. That is a handshake failure the
+    /// pin did not cause, which is exactly what the generic variant is
+    /// for, so the predicate that owns the rejection mapping decides it
+    /// instead of the wrapper.
     fn classify_handshake(&self, err: io::Error) -> ExchangeError {
         match err
             .get_ref()
             .and_then(|inner| inner.downcast_ref::<rustls::Error>())
         {
-            Some(source @ rustls::Error::InvalidCertificate(_)) => ExchangeError::PinRefused {
-                expected_name: self.expected_endpoint_name.clone(),
-                source: source.clone(),
-            },
+            Some(source) if endpoint_pin::is_endpoint_verify_rejection(source) => {
+                ExchangeError::PinRefused {
+                    expected_name: self.expected_endpoint_name.clone(),
+                    source: source.clone(),
+                }
+            }
             _ => ExchangeError::Handshake { source: err },
         }
     }
+}
+
+/// The whole per-dial load, in one blocking call.
+///
+/// [`RegistrarEndpointClient::dial_config`] hands this to the blocking
+/// pool. Kept as a free function taking owned paths so that it can be
+/// moved into the closure, and so the three reads it performs — the
+/// certificate, the key and, inside the verifier, the pin file — stay in
+/// one place.
+fn load_dial_config(
+    pin_file: &Path,
+    expected_endpoint_name: &str,
+    certificate_path: &Path,
+    key_path: &Path,
+) -> Result<ClientConfig, ExchangeError> {
+    let (chain, key) = load_client_material(certificate_path, key_path)
+        .map_err(|source| ExchangeError::Material { source })?;
+    build_client_config(pin_file, expected_endpoint_name, chain, key).map_err(|err| match err {
+        ClientConfigError::Pin(source) => ExchangeError::Pin { source },
+        ClientConfigError::ClientAuth(source) => ExchangeError::Material {
+            source: ClientMaterialError::Unusable {
+                certificate_path: certificate_path.to_path_buf(),
+                key_path: key_path.to_path_buf(),
+                source,
+            },
+        },
+    })
 }
 
 /// Builds the pinned, authenticating client configuration.
@@ -698,10 +776,19 @@ fn load_client_material(
         }
     })?;
 
+    // Collected as a `Result` rather than flattened: a block this
+    // parser refuses is a fault in the file, and dropping it would
+    // authenticate with whatever else the file happened to hold — a
+    // valid leaf followed by a corrupt block would dial with the leaf
+    // alone and report nothing. The parser's own complaint is not
+    // carried: a certificate path can be misconfigured onto a key file,
+    // and `rustls_pemfile` quotes the offending line.
     let chain: Vec<CertificateDer<'static>> =
         rustls_pemfile::certs(&mut io::BufReader::new(certificate_bytes.as_slice()))
-            .flatten()
-            .collect();
+            .collect::<Result<_, io::Error>>()
+            .map_err(|_source| ClientMaterialError::MalformedCertificate {
+                path: certificate_path.to_path_buf(),
+            })?;
     if chain.is_empty() {
         return Err(ClientMaterialError::NoCertificate {
             path: certificate_path.to_path_buf(),

--- a/src/registrar/endpoint/client.rs
+++ b/src/registrar/endpoint/client.rs
@@ -1,0 +1,896 @@
+//! The in-repo client for the registrar endpoint.
+//!
+//! One dial, one request, one response, then close. The client opens the
+//! host-local `AF_UNIX` socket, completes a pinned mTLS handshake
+//! presenting the registrar client leaf, writes exactly one
+//! [`frame`]-encoded request, reads exactly one response to a clean end
+//! of stream, and turns what came back into a typed outcome.
+//!
+//! # What it decides, and what it deliberately does not
+//!
+//! Every *verification* decision belongs to
+//! [`crate::registrar::endpoint_pin`]: the anchor set comes from the pin
+//! file and the presented leaf's single DNS SAN has to equal the
+//! expected endpoint name. This module composes that verifier with its
+//! own per-dial identity and holds no second copy of either rule. It
+//! never parses the peer's certificate — not to extract a SAN, not to
+//! enrich an error — and it never reads `notAfter` on either leaf.
+//!
+//! It implements no retry of any kind. A refusal the endpoint encoded is
+//! a *successful exchange* here and is returned in the `Ok` position,
+//! carrying [`protocol::EnrollError`] and [`protocol::RefusalClass`]
+//! exactly as they arrived; deciding what to do about one belongs to a
+//! caller that owns the reasons.
+//!
+//! # One limitation the wire cannot carry
+//!
+//! A connection the endpoint refuses *before* the handshake completes —
+//! for capacity, or for peer credentials — has no application stream to
+//! close, so it reaches this client as a connect- or handshake-level
+//! failure and is not distinguishable there from an ordinary one. The
+//! endpoint answers a refused caller with a bare close by design, and
+//! this client does not guess at a reason the wire does not carry.
+
+// This module has no production consumer in this crate, and that is the
+// same fact `protocol.rs` and `verbs.rs` already record about their own
+// halves: the deployed caller of this endpoint is roxyd, the co-located
+// registrar, which lives in another repository and dials the socket
+// itself. What lives here is this repository's reference implementation
+// of that caller — the running record of the caller behaviour the
+// endpoint expects — and the vehicle the registrar acceptance suite
+// drives. Publishing it to escape the lint is not an option: it speaks
+// `frame` and `protocol`, both `pub(crate)`, so a `pub` client would
+// widen every payload type onto the library's public surface.
+#![allow(dead_code)]
+
+#[cfg(test)]
+mod tests;
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use rustls::ClientConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::UnixStream;
+use tokio::time::timeout;
+use tokio_rustls::TlsConnector;
+use tracing::{debug, warn};
+
+use super::frame::{self, Operation};
+use super::protocol::{self, CodecError};
+use crate::registrar::endpoint;
+use crate::registrar::endpoint_pin::{self, EndpointPinError};
+
+/// Largest response this client will read off the wire, prefix
+/// included — 65,540 bytes as the endpoint's constants stand.
+///
+/// Defined by referencing those constants rather than by restating a
+/// literal, so the caller's bound cannot drift from the server's when
+/// either moves.
+const MAX_RESPONSE_BYTES: usize =
+    frame::RESPONSE_PREFIX_BYTES + endpoint::MAX_RESPONSE_PAYLOAD_BYTES;
+
+/// The declared payload length [`MAX_RESPONSE_BYTES`] leaves room for,
+/// which is the only length this client ever allocates a buffer for. A
+/// larger declaration fails before a payload byte is read.
+const MAX_DECLARED_PAYLOAD_BYTES: usize = MAX_RESPONSE_BYTES - frame::RESPONSE_PREFIX_BYTES;
+
+/// Deadline on the dial alone.
+///
+/// The dial is a host-local `AF_UNIX` connect, so this matches the scale
+/// the endpoint already uses for its own [`endpoint::HANDSHAKE_TIMEOUT`].
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Deadline covering the TLS handshake, the request write and the
+/// response read together.
+///
+/// It has to span the client-side handshake, the endpoint's verb
+/// execution — a mint reaches `OpenBao` on the same host and has no
+/// server-side execution deadline — and the response read. The server
+/// budgets [`endpoint::HANDSHAKE_TIMEOUT`] (5 s) for the handshake and
+/// [`endpoint::RESPONSE_WRITE_TIMEOUT`] (10 s) for the write, so this
+/// bounds a stalled endpoint with clear headroom over every server-side
+/// deadline.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The name handed to [`TlsConnector::connect`].
+///
+/// Inert. [`endpoint_pin::RegistrarEndpointVerifier`] deliberately
+/// ignores the dialed name and applies the pinned expected name instead,
+/// because a handshake over `AF_UNIX` has no hostname to match against.
+/// Only its syntax matters, and only because `ServerName` insists on it.
+const DIAL_NAME: &str = "registrar-endpoint.invalid";
+
+/// The one response member success and refusal are told apart by.
+const REFUSAL_DISCRIMINATOR: &str = "class";
+
+/// Which half of the exchange an I/O failure interrupted.
+///
+/// The one thing an [`io::Error`] cannot say by itself: whether the
+/// request could have reached the endpoint at all. A caller that knows
+/// the write never completed knows a retry elsewhere cannot duplicate a
+/// mint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExchangePhase {
+    /// The request was still being written.
+    Request,
+    /// The response was being read.
+    Response,
+}
+
+impl std::fmt::Display for ExchangePhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Request => f.write_str("writing the request"),
+            Self::Response => f.write_str("reading the response"),
+        }
+    }
+}
+
+/// Why the registrar client's own certificate and key are not usable.
+///
+/// Every variant names a path and nothing else. The bytes these
+/// failures were reading are key material, and an error that quoted them
+/// would put them in a log.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ClientMaterialError {
+    /// The certificate file does not exist.
+    #[error("registrar client certificate {} does not exist", .path.display())]
+    MissingCertificate {
+        /// The path that was handed to the client.
+        path: PathBuf,
+    },
+    /// The key file does not exist.
+    #[error("registrar client key {} does not exist", .path.display())]
+    MissingKey {
+        /// The path that was handed to the client.
+        path: PathBuf,
+    },
+    /// The certificate file exists but could not be read.
+    #[error("registrar client certificate {} could not be read", .path.display())]
+    UnreadableCertificate {
+        /// The path that was handed to the client.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The key file exists but could not be read.
+    #[error("registrar client key {} could not be read", .path.display())]
+    UnreadableKey {
+        /// The path that was handed to the client.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The certificate file holds no PEM certificate.
+    #[error("registrar client certificate {} holds no PEM certificate", .path.display())]
+    NoCertificate {
+        /// The path that was handed to the client.
+        path: PathBuf,
+    },
+    /// The key file holds no PEM private key.
+    #[error("registrar client key {} holds no PEM private key", .path.display())]
+    NoPrivateKey {
+        /// The path that was handed to the client.
+        path: PathBuf,
+    },
+    /// The pair parsed but `rustls` will not authenticate with it.
+    #[error(
+        "registrar client certificate {} and key {} are not usable client authentication \
+         material: {source}",
+        .certificate_path.display(),
+        .key_path.display()
+    )]
+    Unusable {
+        /// The certificate path that was handed to the client.
+        certificate_path: PathBuf,
+        /// The key path that was handed to the client.
+        key_path: PathBuf,
+        /// What `rustls` said about the pair.
+        #[source]
+        source: rustls::Error,
+    },
+}
+
+/// Why a pinned, authenticating client configuration could not be built.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ClientConfigError {
+    /// The pin file or the expected endpoint name was unusable.
+    #[error(transparent)]
+    Pin(#[from] EndpointPinError),
+    /// `rustls` refused the presented pair as authentication material.
+    #[error("the registrar client pair was refused as client authentication material: {0}")]
+    ClientAuth(#[source] rustls::Error),
+}
+
+/// Why one exchange with the registrar endpoint did not produce an
+/// answer.
+///
+/// Covers the exchange itself failing and nothing else. A refusal the
+/// endpoint encoded is a *successful* exchange and has no variant here:
+/// it arrives in the `Ok` position, in the `Refused` arm of the verb's
+/// reply.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ExchangeError {
+    /// The pin file could not be read or parsed, or the expected
+    /// endpoint name is not a usable DNS name. Never a fallback to
+    /// trusting whatever the peer presents.
+    #[error("the registrar endpoint trust decision could not be made: {source}")]
+    Pin {
+        /// Which pin rule the deployment broke.
+        #[source]
+        source: EndpointPinError,
+    },
+    /// The registrar client certificate or key could not be loaded.
+    #[error("{source}")]
+    Material {
+        /// Which half of the pair, and how.
+        #[source]
+        source: ClientMaterialError,
+    },
+    /// The encoded request is longer than the envelope admits. Refused
+    /// locally, before the dial.
+    #[error("the registrar endpoint request could not be framed: {source}")]
+    RequestTooLarge {
+        /// The envelope's own complaint, carrying the length and limit.
+        #[source]
+        source: frame::OverLongRequestPayload,
+    },
+    /// The socket could not be connected.
+    #[error("the registrar endpoint socket {} could not be connected", .path.display())]
+    Connect {
+        /// The socket path that was handed to the client.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The dial did not finish inside [`CONNECT_TIMEOUT`].
+    #[error(
+        "connecting the registrar endpoint socket {} did not finish within {timeout:?}",
+        .path.display()
+    )]
+    ConnectTimeout {
+        /// The socket path that was handed to the client.
+        path: PathBuf,
+        /// The budget that elapsed.
+        timeout: Duration,
+    },
+    /// The handshake, write and read together did not finish inside
+    /// [`READ_TIMEOUT`].
+    #[error("the registrar endpoint exchange did not finish within {timeout:?}")]
+    ReadTimeout {
+        /// The budget that elapsed.
+        timeout: Duration,
+    },
+    /// The handshake failed for a reason the pin did not cause.
+    #[error("the registrar endpoint TLS handshake failed: {source}")]
+    Handshake {
+        /// What `tokio_rustls` reported.
+        #[source]
+        source: io::Error,
+    },
+    /// The server was refused by the pin: it chained to no pinned
+    /// anchor, or it carried a SAN other than the expected one.
+    ///
+    /// The two arrive as different [`rustls::CertificateError`]s and are
+    /// deliberately one variant here, because both mean the same thing
+    /// to a caller — the peer is not the endpoint this client pinned.
+    #[error(
+        "the registrar endpoint certificate was refused by the pin for {expected_name}: {source}"
+    )]
+    PinRefused {
+        /// The endpoint name this client was constructed with. Not the
+        /// name the server presented: recovering that would mean
+        /// parsing the peer's certificate, which is a second copy of
+        /// logic `endpoint_pin` owns.
+        expected_name: String,
+        /// The `rustls::Error` recovered from the wrapping
+        /// [`io::Error`], verbatim.
+        #[source]
+        source: rustls::Error,
+    },
+    /// The response prefix declared more than [`MAX_RESPONSE_BYTES`]
+    /// leaves room for. Refused before the payload is read.
+    #[error(
+        "the registrar endpoint declared a {declared}-byte response payload, over the \
+         {limit}-byte maximum"
+    )]
+    ResponseTooLarge {
+        /// The length the prefix declared.
+        declared: u32,
+        /// The bound it broke.
+        limit: usize,
+    },
+    /// Fewer bytes arrived than the response frame needed, and then the
+    /// stream ended *cleanly*.
+    ///
+    /// Both counts are over the whole frame, prefix included, so a
+    /// prefix that itself arrived short is described the same way as a
+    /// payload that did.
+    #[error("the registrar endpoint response stopped cleanly after {received} of {expected} bytes")]
+    Truncated {
+        /// Bytes the frame needed.
+        expected: usize,
+        /// Bytes that arrived.
+        received: usize,
+    },
+    /// Bytes arrived after the declared response payload.
+    ///
+    /// Its own variant rather than a decode failure: the frame was
+    /// complete and something followed it, so the payload is not decoded
+    /// and no outcome is returned.
+    #[error("the registrar endpoint wrote {observed} byte(s) after a complete response frame")]
+    TrailingBytes {
+        /// How many bytes the one-byte probe saw. It neither drains nor
+        /// buffers whatever else is pending.
+        observed: usize,
+    },
+    /// The connection ended cleanly with zero application bytes read —
+    /// the endpoint's bare-close refusal shape for a caller it will not
+    /// serve.
+    #[error("the registrar endpoint closed the connection cleanly without answering")]
+    EmptyResponse,
+    /// The exchange failed on an I/O error after the handshake
+    /// completed.
+    ///
+    /// Includes the `UnexpectedEof` `rustls` reports for a peer that
+    /// vanished without `close_notify`, which is an `Err` and not an
+    /// orderly end. A response that arrived in full behind an unclean
+    /// close is reported here rather than returned.
+    #[error("the registrar endpoint exchange failed while {phase}: {source}")]
+    Transport {
+        /// Whether the request could have reached the endpoint at all.
+        phase: ExchangePhase,
+        /// The underlying I/O failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The payload codec failed.
+    ///
+    /// In practice only the response direction is reachable: every
+    /// request shape this client encodes is plain JSON that
+    /// `serde_json` cannot fail on, so what lands here is a response the
+    /// selected decoder rejected — or a payload that is not a JSON
+    /// object at all, which the discriminator rejects before any
+    /// decoder runs.
+    #[error("the registrar endpoint payload codec failed: {source}")]
+    Codec {
+        /// The protocol's own complaint.
+        #[source]
+        source: CodecError,
+    },
+}
+
+/// What a mint exchange produced.
+///
+/// Two arms because [`protocol`] models the success shape and the
+/// refusal shape as separate types and the envelope carries no status
+/// field to choose between them. The enum adds no field the protocol
+/// does not already define.
+#[derive(Debug)]
+pub(crate) enum MintReply {
+    /// The endpoint minted, or idempotently re-minted, the identity.
+    Success(protocol::MintResponse),
+    /// The endpoint refused the invocation, and said why.
+    Refused(protocol::RefusalResponse),
+}
+
+/// What a deregister exchange produced.
+#[derive(Debug)]
+pub(crate) enum DeregisterReply {
+    /// The endpoint removed the identity, or found it already absent.
+    Success(protocol::DeregisterResponse),
+    /// The endpoint refused the invocation, and said why.
+    Refused(protocol::RefusalResponse),
+}
+
+/// A caller of the host-local registrar endpoint.
+///
+/// Constructed from four paths and one expected endpoint name and from
+/// nothing else: it reads no configuration and introduces no
+/// configuration key, which keeps configuration ownership where it
+/// already is and makes the client directly constructible from a
+/// `tempfile::tempdir()` in a test.
+///
+/// The expected name is the one
+/// [`crate::registrar::registrar_endpoint_identity`] composes,
+/// `<instance>.bootroot-registrar-endpoint.<host>.<domain>`, where
+/// `<domain>` is a *suffix* of whatever label count it was configured
+/// with rather than a single label. The client stores it and asserts
+/// nothing about its shape.
+#[derive(Debug)]
+pub(crate) struct RegistrarEndpointClient {
+    socket_path: PathBuf,
+    pin_file: PathBuf,
+    certificate_path: PathBuf,
+    key_path: PathBuf,
+    expected_endpoint_name: String,
+}
+
+impl RegistrarEndpointClient {
+    /// Builds a client over explicit paths and one expected endpoint
+    /// name.
+    pub(crate) fn new(
+        socket_path: impl Into<PathBuf>,
+        pin_file: impl Into<PathBuf>,
+        certificate_path: impl Into<PathBuf>,
+        key_path: impl Into<PathBuf>,
+        expected_endpoint_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            pin_file: pin_file.into(),
+            certificate_path: certificate_path.into(),
+            key_path: key_path.into(),
+            expected_endpoint_name: expected_endpoint_name.into(),
+        }
+    }
+
+    /// The endpoint name every dial pins the presented leaf against.
+    pub(crate) fn expected_endpoint_name(&self) -> &str {
+        &self.expected_endpoint_name
+    }
+
+    /// Mints, or idempotently re-mints, one service identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExchangeError`] when the exchange itself failed. An
+    /// endpoint refusal is not one: it arrives as
+    /// [`MintReply::Refused`].
+    pub(crate) async fn mint(
+        &self,
+        request: protocol::RegisterRequest,
+    ) -> Result<MintReply, ExchangeError> {
+        let payload = self
+            .exchange(Operation::Mint, &protocol::Request::Register(request))
+            .await?;
+        if is_refusal(&payload).map_err(codec)? {
+            protocol::decode_refusal_response(&payload)
+                .map(MintReply::Refused)
+                .map_err(codec)
+        } else {
+            protocol::decode_mint_response(&payload)
+                .map(MintReply::Success)
+                .map_err(codec)
+        }
+    }
+
+    /// Tears one service identity down.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExchangeError`] when the exchange itself failed. An
+    /// endpoint refusal is not one: it arrives as
+    /// [`DeregisterReply::Refused`].
+    pub(crate) async fn deregister(
+        &self,
+        request: protocol::DeregisterRequest,
+    ) -> Result<DeregisterReply, ExchangeError> {
+        let payload = self
+            .exchange(
+                Operation::Deregister,
+                &protocol::Request::Deregister(request),
+            )
+            .await?;
+        if is_refusal(&payload).map_err(codec)? {
+            protocol::decode_refusal_response(&payload)
+                .map(DeregisterReply::Refused)
+                .map_err(codec)
+        } else {
+            protocol::decode_deregister_response(&payload)
+                .map(DeregisterReply::Success)
+                .map_err(codec)
+        }
+    }
+
+    /// Runs one whole exchange and returns the response payload.
+    ///
+    /// Everything that can fail before a byte reaches the socket — the
+    /// codec, the envelope bound, the client material and the pin
+    /// decision — fails here and in that order, so a misconfigured
+    /// caller never opens a connection it cannot use.
+    async fn exchange(
+        &self,
+        operation: Operation,
+        request: &protocol::Request,
+    ) -> Result<Vec<u8>, ExchangeError> {
+        crate::tls::install_crypto_provider();
+
+        let payload = protocol::encode_request(request).map_err(codec)?;
+        let request_frame = frame::encode_request_frame(operation, &payload)
+            .map_err(|source| ExchangeError::RequestTooLarge { source })?;
+        let config = self.dial_config()?;
+
+        debug!(
+            operation = operation.as_str(),
+            socket = %self.socket_path.display(),
+            request_bytes = request_frame.len(),
+            "Dialing the registrar endpoint."
+        );
+
+        let stream = connect_within(
+            &self.socket_path,
+            UnixStream::connect(&self.socket_path),
+            CONNECT_TIMEOUT,
+        )
+        .await?;
+
+        let response =
+            match timeout(READ_TIMEOUT, self.converse(stream, config, &request_frame)).await {
+                Ok(result) => result?,
+                Err(_elapsed) => {
+                    return Err(ExchangeError::ReadTimeout {
+                        timeout: READ_TIMEOUT,
+                    });
+                }
+            };
+
+        debug!(
+            operation = operation.as_str(),
+            response_bytes = response.len(),
+            "The registrar endpoint answered."
+        );
+        Ok(response)
+    }
+
+    /// Builds this dial's TLS configuration.
+    ///
+    /// Called on every dial, so the pin file and the client material are
+    /// re-read every time. That is intended: a pin file that is missing,
+    /// unreadable or malformed is a typed failure of the dial rather
+    /// than a panic or a fallback, and a renewed pair is picked up
+    /// without a restart.
+    fn dial_config(&self) -> Result<ClientConfig, ExchangeError> {
+        let (chain, key) =
+            load_client_material(&self.certificate_path, &self.key_path).map_err(|source| {
+                warn!(
+                    certificate = %self.certificate_path.display(),
+                    key = %self.key_path.display(),
+                    "Registrar client material could not be loaded: {source}"
+                );
+                ExchangeError::Material { source }
+            })?;
+        build_client_config(&self.pin_file, &self.expected_endpoint_name, chain, key).map_err(
+            |err| match err {
+                ClientConfigError::Pin(source) => ExchangeError::Pin { source },
+                ClientConfigError::ClientAuth(source) => ExchangeError::Material {
+                    source: ClientMaterialError::Unusable {
+                        certificate_path: self.certificate_path.clone(),
+                        key_path: self.key_path.clone(),
+                        source,
+                    },
+                },
+            },
+        )
+    }
+
+    /// Completes the handshake, writes the one request and reads the one
+    /// response.
+    async fn converse(
+        &self,
+        stream: UnixStream,
+        config: ClientConfig,
+        request_frame: &[u8],
+    ) -> Result<Vec<u8>, ExchangeError> {
+        let server_name = ServerName::try_from(DIAL_NAME)
+            .expect("DIAL_NAME is a literal that is a syntactically valid DNS name");
+        let mut tls = TlsConnector::from(Arc::new(config))
+            .connect(server_name, stream)
+            .await
+            .map_err(|err| self.classify_handshake(err))?;
+
+        tls.write_all(request_frame).await.map_err(write_failed)?;
+        tls.flush().await.map_err(write_failed)?;
+
+        let response = read_response(&mut tls).await?;
+
+        // The exchange is over and this connection carries nothing
+        // else, so it is closed the way the endpoint closes its own:
+        // with a `close_notify` rather than a disappearance. The peer
+        // has already ended its side, so a write failure here says
+        // nothing a caller could act on.
+        let _ = tls.shutdown().await;
+        Ok(response)
+    }
+
+    /// Selects between the pin-refusal variant and the generic handshake
+    /// variant.
+    ///
+    /// `tokio_rustls` wraps the `rustls::Error` the verifier produced in
+    /// an [`io::Error`]; recovering it is the same downcast
+    /// `serve::handshake_failure_label` performs on the server side, so
+    /// one rule decides both directions. Every
+    /// [`endpoint_pin::EndpointVerifyRejection`] maps onto an
+    /// `InvalidCertificate(_)`, and nothing else the handshake can fail
+    /// with does.
+    fn classify_handshake(&self, err: io::Error) -> ExchangeError {
+        match err
+            .get_ref()
+            .and_then(|inner| inner.downcast_ref::<rustls::Error>())
+        {
+            Some(source @ rustls::Error::InvalidCertificate(_)) => ExchangeError::PinRefused {
+                expected_name: self.expected_endpoint_name.clone(),
+                source: source.clone(),
+            },
+            _ => ExchangeError::Handshake { source: err },
+        }
+    }
+}
+
+/// Builds the pinned, authenticating client configuration.
+///
+/// The one place in this tree where the registrar caller's TLS
+/// configuration is composed. It is exactly
+/// [`endpoint_pin::endpoint_server_verifier`] finished with
+/// [`rustls::ConfigBuilder::with_client_auth_cert`], which is what
+/// [`endpoint_pin::build_endpoint_client_config`]'s own rustdoc directs
+/// an authenticating caller to do — that helper is a convenience for a
+/// caller presenting no client certificate and is deliberately not used
+/// here. Every verification decision stays inside the verifier; this
+/// function only attaches the caller's identity.
+///
+/// # Errors
+///
+/// Returns [`ClientConfigError::Pin`] when the pin file is missing,
+/// unreadable or malformed, or when `expected_endpoint_name` is not a
+/// usable DNS name, and [`ClientConfigError::ClientAuth`] when `rustls`
+/// refuses the presented pair.
+pub(crate) fn build_client_config(
+    pin_file: &Path,
+    expected_endpoint_name: &str,
+    chain: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+) -> Result<ClientConfig, ClientConfigError> {
+    let verifier = endpoint_pin::endpoint_server_verifier(pin_file, expected_endpoint_name)?;
+    ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_client_auth_cert(chain, key)
+        .map_err(ClientConfigError::ClientAuth)
+}
+
+/// Loads the registrar client leaf and its key from disk.
+///
+/// The single seam every dial's material comes through. It does the
+/// plain load and nothing more: it does not verify that the key matches
+/// the leaf, does not retry a pair that is momentarily torn by a
+/// renewal, and does not inspect `notAfter`. Later work that owns those
+/// reasons adds them here rather than restructuring the dial path.
+///
+/// # Errors
+///
+/// Returns [`ClientMaterialError`] naming the offending path. It names
+/// no byte of either file.
+fn load_client_material(
+    certificate_path: &Path,
+    key_path: &Path,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), ClientMaterialError> {
+    let certificate_bytes = std::fs::read(certificate_path).map_err(|source| {
+        if source.kind() == io::ErrorKind::NotFound {
+            ClientMaterialError::MissingCertificate {
+                path: certificate_path.to_path_buf(),
+            }
+        } else {
+            ClientMaterialError::UnreadableCertificate {
+                path: certificate_path.to_path_buf(),
+                source,
+            }
+        }
+    })?;
+    let key_bytes = std::fs::read(key_path).map_err(|source| {
+        if source.kind() == io::ErrorKind::NotFound {
+            ClientMaterialError::MissingKey {
+                path: key_path.to_path_buf(),
+            }
+        } else {
+            ClientMaterialError::UnreadableKey {
+                path: key_path.to_path_buf(),
+                source,
+            }
+        }
+    })?;
+
+    let chain: Vec<CertificateDer<'static>> =
+        rustls_pemfile::certs(&mut io::BufReader::new(certificate_bytes.as_slice()))
+            .flatten()
+            .collect();
+    if chain.is_empty() {
+        return Err(ClientMaterialError::NoCertificate {
+            path: certificate_path.to_path_buf(),
+        });
+    }
+
+    // The error deliberately quotes none of the bytes it failed on:
+    // this input is key material, and a parse failure that named it
+    // would put it in a log.
+    let key = rustls_pemfile::private_key(&mut io::BufReader::new(key_bytes.as_slice()))
+        .ok()
+        .flatten()
+        .ok_or_else(|| ClientMaterialError::NoPrivateKey {
+            path: key_path.to_path_buf(),
+        })?;
+
+    Ok((chain, key))
+}
+
+/// Wraps a dial in [`CONNECT_TIMEOUT`].
+///
+/// The future is a parameter so the wrapper itself is drivable under a
+/// paused clock: a stalled `AF_UNIX` `connect(2)` is not portably
+/// constructible, and an accept-and-stall listener would exercise the
+/// handshake instead.
+async fn connect_within<F>(
+    path: &Path,
+    dial: F,
+    budget: Duration,
+) -> Result<UnixStream, ExchangeError>
+where
+    F: std::future::Future<Output = io::Result<UnixStream>>,
+{
+    match timeout(budget, dial).await {
+        Ok(Ok(stream)) => Ok(stream),
+        Ok(Err(source)) => Err(ExchangeError::Connect {
+            path: path.to_path_buf(),
+            source,
+        }),
+        Err(_elapsed) => Err(ExchangeError::ConnectTimeout {
+            path: path.to_path_buf(),
+            timeout: budget,
+        }),
+    }
+}
+
+/// How a bounded read ended.
+enum FillOutcome {
+    /// The buffer was filled.
+    Filled,
+    /// The peer ended the stream cleanly, `received` bytes in.
+    EndOfStream {
+        /// Bytes of this buffer that had arrived.
+        received: usize,
+    },
+}
+
+/// Reads until `buffer` is full or the peer ends the stream cleanly.
+///
+/// An `Err` — including the `UnexpectedEof` `rustls` reports for a peer
+/// that vanished without `close_notify` — is propagated rather than
+/// folded into an end of stream. That is what keeps a truncation, a
+/// reset and a broken pipe out of the orderly-close variants.
+async fn fill<S>(stream: &mut S, buffer: &mut [u8]) -> io::Result<FillOutcome>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut received = 0;
+    while received < buffer.len() {
+        let read = stream.read(&mut buffer[received..]).await?;
+        if read == 0 {
+            return Ok(FillOutcome::EndOfStream { received });
+        }
+        received += read;
+    }
+    Ok(FillOutcome::Filled)
+}
+
+/// Reads exactly one response frame and the clean end of stream that has
+/// to follow it.
+///
+/// Three outcomes decide the post-payload read, and only the first
+/// completes the exchange: a clean end of stream, any byte at all, or an
+/// `Err`. The payload is decoded only after the first of them, so a peer
+/// cannot append a second frame — or anything else — behind a
+/// well-formed one and still have the first honoured.
+async fn read_response<S>(stream: &mut S) -> Result<Vec<u8>, ExchangeError>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut prefix = [0_u8; frame::RESPONSE_PREFIX_BYTES];
+    match fill(stream, &mut prefix).await.map_err(read_failed)? {
+        FillOutcome::Filled => {}
+        FillOutcome::EndOfStream { received: 0 } => return Err(ExchangeError::EmptyResponse),
+        FillOutcome::EndOfStream { received } => {
+            return Err(ExchangeError::Truncated {
+                expected: frame::RESPONSE_PREFIX_BYTES,
+                received,
+            });
+        }
+    }
+
+    // The declared length is checked before a payload byte is read and
+    // before anything is allocated for one, so the buffer never grows
+    // past the bound.
+    let declared = u32::from_be_bytes(prefix);
+    let payload_length = match usize::try_from(declared) {
+        Ok(length) if length <= MAX_DECLARED_PAYLOAD_BYTES => length,
+        _ => {
+            return Err(ExchangeError::ResponseTooLarge {
+                declared,
+                limit: MAX_DECLARED_PAYLOAD_BYTES,
+            });
+        }
+    };
+
+    let mut payload = vec![0_u8; payload_length];
+    match fill(stream, &mut payload).await.map_err(read_failed)? {
+        FillOutcome::Filled => {}
+        FillOutcome::EndOfStream { received } => {
+            return Err(ExchangeError::Truncated {
+                expected: frame::RESPONSE_PREFIX_BYTES + payload_length,
+                received: frame::RESPONSE_PREFIX_BYTES + received,
+            });
+        }
+    }
+
+    // One byte settles it, so the probe reads into a small fixed buffer
+    // and neither drains nor buffers whatever else is pending. It does
+    // not read a second frame in order to describe it.
+    let mut probe = [0_u8; 1];
+    match stream.read(&mut probe).await.map_err(read_failed)? {
+        0 => Ok(payload),
+        observed => Err(ExchangeError::TrailingBytes { observed }),
+    }
+}
+
+/// Decides whether a response payload is a refusal.
+///
+/// The rule is about the *membership* of the top-level `class` member
+/// and not about that member's value: `class` is required and
+/// non-nullable on [`protocol::RefusalResponse`] and appears in neither
+/// success shape, so a payload carrying it is a refusal — a malformed
+/// one when its value is not a class, which the refusal decoder is left
+/// to say.
+///
+/// The probe is written structurally rather than derived because both
+/// obvious derived probes are wrong. A `#[serde(default)] class:
+/// Option<T>` field deserializes an explicit `null` to `None`, making
+/// `{"class": null, ...}` indistinguishable from a payload with no
+/// `class` at all; a `#[serde(default)] class: IgnoredAny` field keeps no
+/// presence bit beside a zero-sized value that accepts anything, so an
+/// absent member and a present one produce the identical value. Asking
+/// a parsed [`serde_json::Map`] for the key answers exactly the question
+/// asked: it rejects a payload that is not a JSON object by itself, and
+/// it counts `null` as the present member it is.
+///
+/// It matters because no response type sets `deny_unknown_fields`, so
+/// the success decoders ignore a `class` member entirely — routing a
+/// present-`class` payload to a success decoder would let a malformed
+/// refusal decode as a success whenever it happened to carry the success
+/// members too.
+///
+/// # Errors
+///
+/// Returns [`CodecError::Json`] when the payload is not a JSON object —
+/// an array, a string, a number, a bare `null`, or bytes that are not
+/// JSON. No protocol decoder runs for one.
+fn is_refusal(payload: &[u8]) -> Result<bool, CodecError> {
+    let members = serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(payload)?;
+    Ok(members.contains_key(REFUSAL_DISCRIMINATOR))
+}
+
+/// Wraps a codec failure, in either direction.
+fn codec(source: CodecError) -> ExchangeError {
+    ExchangeError::Codec { source }
+}
+
+/// Wraps an I/O failure that interrupted the request write.
+fn write_failed(source: io::Error) -> ExchangeError {
+    ExchangeError::Transport {
+        phase: ExchangePhase::Request,
+        source,
+    }
+}
+
+/// Wraps an I/O failure that interrupted the response read.
+fn read_failed(source: io::Error) -> ExchangeError {
+    ExchangeError::Transport {
+        phase: ExchangePhase::Response,
+        source,
+    }
+}

--- a/src/registrar/endpoint/client.rs
+++ b/src/registrar/endpoint/client.rs
@@ -432,7 +432,8 @@ impl RegistrarEndpointClient {
         }
     }
 
-    /// The endpoint name every dial pins the presented leaf against.
+    /// Returns the endpoint name every dial pins the presented leaf
+    /// against.
     pub(crate) fn expected_endpoint_name(&self) -> &str {
         &self.expected_endpoint_name
     }

--- a/src/registrar/endpoint/client.rs
+++ b/src/registrar/endpoint/client.rs
@@ -586,16 +586,17 @@ impl RegistrarEndpointClient {
         let expected_endpoint_name = self.expected_endpoint_name.clone();
         let certificate_path = self.certificate_path.clone();
         let key_path = self.key_path.clone();
-        let loaded = tokio::task::spawn_blocking(move || {
-            load_dial_config(
-                &pin_file,
-                &expected_endpoint_name,
-                &certificate_path,
-                &key_path,
-            )
-        })
-        .await
-        .map_err(|source| ExchangeError::LoadAbandoned { source })?;
+        let loaded = finish_dial_load(
+            tokio::task::spawn_blocking(move || {
+                load_dial_config(
+                    &pin_file,
+                    &expected_endpoint_name,
+                    &certificate_path,
+                    &key_path,
+                )
+            })
+            .await,
+        );
         if let Err(ExchangeError::Material { source }) = &loaded {
             // Emitted here rather than inside the closure: a
             // `tracing` subscriber installed for one thread — which is
@@ -673,6 +674,28 @@ impl RegistrarEndpointClient {
             }
             _ => ExchangeError::Handshake { source: err },
         }
+    }
+}
+
+/// Turns the blocking load's join result into this dial's outcome.
+///
+/// The one place [`ExchangeError::LoadAbandoned`] is built. Everything
+/// the load itself decided is already an `ExchangeError` and passes
+/// through untouched; the only failure this adds is the hand-off's own —
+/// the runtime shutting down with the load still queued, or the load
+/// panicking.
+///
+/// Kept as a function rather than an inline `map_err` so that a test can
+/// hand it a real [`tokio::task::JoinError`], taken from a blocking task
+/// that really panicked, and assert the variant it selects. No dial can
+/// be made to produce one: a test that killed its own runtime to force
+/// the hand-off to fail would have nothing left to await the verb with.
+fn finish_dial_load(
+    joined: Result<Result<ClientConfig, ExchangeError>, tokio::task::JoinError>,
+) -> Result<ClientConfig, ExchangeError> {
+    match joined {
+        Ok(loaded) => loaded,
+        Err(source) => Err(ExchangeError::LoadAbandoned { source }),
     }
 }
 

--- a/src/registrar/endpoint/client/tests.rs
+++ b/src/registrar/endpoint/client/tests.rs
@@ -46,6 +46,7 @@ use crate::registrar::endpoint::test_support::{
     CapturedEvent, Pki, TestCa, capture_logs, dns_san, endpoint_name, issue_leaf, key_der,
     registrar_client_name, valid_ca, write_leaf_material,
 };
+use crate::registrar::endpoint_pin::EndpointVerifyRejection;
 
 /// The canned success and refusal payloads, taken from the golden
 /// fixtures the protocol module already round-trips, so a case that
@@ -656,6 +657,42 @@ async fn a_certificate_that_is_not_pem_fails_before_the_dial() {
 }
 
 #[tokio::test]
+async fn a_malformed_block_behind_a_valid_leaf_fails_before_the_dial() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    // The file opens with the leaf the client would otherwise dial
+    // with, so nothing here is missing: a load that skipped the block
+    // it could not parse would authenticate with that leaf and report
+    // no fault at all.
+    let mut bytes = std::fs::read(&deployment.certificate_path).expect("read the good leaf");
+    bytes.extend_from_slice(
+        b"-----BEGIN CERTIFICATE-----\nthis is not base64 at all !!!\n-----END CERTIFICATE-----\n",
+    );
+    std::fs::write(&deployment.certificate_path, &bytes).expect("write the mixed chain");
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a block the parser refuses is a fault in the file");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Material {
+                source: ClientMaterialError::MalformedCertificate { .. }
+            }
+        ),
+        "{err:?}"
+    );
+    assert_eq!(
+        double.observed().connections,
+        0,
+        "a chain with a refused block reached the socket"
+    );
+}
+
+#[tokio::test]
 async fn a_key_that_is_not_a_private_key_fails_before_the_dial() {
     let deployment = Deployment::new();
     let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
@@ -962,6 +999,65 @@ async fn bytes_that_are_not_a_tls_record_produce_the_generic_handshake_variant()
         ),
         "{source:?}"
     );
+}
+
+#[test]
+fn a_signature_failure_after_the_pin_passed_is_not_a_pin_refusal() {
+    let deployment = Deployment::new();
+    // `rustls` checks the peer's `CertificateVerify` signature after
+    // the verifier has already accepted the chain, and reports a bad
+    // one as `InvalidCertificate(BadSignature)`. The pin made no such
+    // decision, so the wrapper alone must not select the pin-refusal
+    // variant — and this case is not reachable from the double, which
+    // signs correctly with the key its own leaf carries.
+    let err = deployment
+        .client()
+        .classify_handshake(io::Error::other(rustls::Error::from(
+            rustls::CertificateError::BadSignature,
+        )));
+
+    let ExchangeError::Handshake { source } = err else {
+        panic!("expected the generic handshake failure, saw {err:?}");
+    };
+    assert!(
+        matches!(
+            recovered(&source),
+            Some(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::BadSignature
+            ))
+        ),
+        "the recovered error is carried verbatim: {source:?}"
+    );
+}
+
+#[test]
+fn a_verifier_rejection_selects_the_pin_refusal_variant() {
+    let deployment = Deployment::new();
+    // The other half of the rule above, asserted through the same
+    // seam: every rejection `endpoint_pin`'s verifier can reach is a
+    // pin refusal here, whichever `CertificateError` it maps onto.
+    for rejection in [
+        EndpointVerifyRejection::SanMismatch,
+        EndpointVerifyRejection::AnchorMismatch,
+        EndpointVerifyRejection::AnchorNotCa,
+        EndpointVerifyRejection::AnchorExpired,
+        EndpointVerifyRejection::AnchorNotYetValid,
+        EndpointVerifyRejection::AnchorMalformed,
+        EndpointVerifyRejection::ChainVerificationFailed,
+    ] {
+        let err = deployment
+            .client()
+            .classify_handshake(io::Error::other(rustls::Error::from(rejection)));
+        let ExchangeError::PinRefused {
+            expected_name,
+            source,
+        } = err
+        else {
+            panic!("expected the pin refusal for {rejection:?}, saw {err:?}");
+        };
+        assert_eq!(expected_name, endpoint_name());
+        assert_eq!(source, rustls::Error::from(rejection));
+    }
 }
 
 #[tokio::test(start_paused = true)]

--- a/src/registrar/endpoint/client/tests.rs
+++ b/src/registrar/endpoint/client/tests.rs
@@ -1516,6 +1516,64 @@ async fn a_second_dial_re_reads_the_client_material() {
 }
 
 // ---------------------------------------------------------------------
+// The blocking load's hand-off
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_panicking_dial_load_gives_the_load_abandoned_variant() {
+    // The hand-off is exercised at its seam rather than through a verb.
+    // A dial cannot be made to abandon its load on demand: the two ways
+    // it happens are the runtime shutting down with the load still
+    // queued and the load panicking, and a test that shut its own
+    // runtime down would have nothing left to await the verb with. What
+    // it can do is produce the real `JoinError` — from a blocking task
+    // on this runtime's own pool, panicking for real — and hand it to
+    // the function that owns the variant.
+    let joined = tokio::task::spawn_blocking(|| -> Result<ClientConfig, ExchangeError> {
+        panic!("the per-dial load panicked");
+    })
+    .await;
+
+    let err = finish_dial_load(joined).expect_err("an abandoned load is not a configuration");
+
+    let ExchangeError::LoadAbandoned { source } = &err else {
+        panic!("expected the abandoned-load variant, got {err:?}");
+    };
+    assert!(source.is_panic(), "{source:?}");
+    assert!(
+        err.to_string()
+            .starts_with("the registrar endpoint dial configuration was never loaded"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn a_load_that_reported_back_keeps_its_own_variant() {
+    // The other half of the seam: a load that ran to completion owns
+    // its outcome, and a failure it decided is not re-labelled as the
+    // hand-off failing.
+    let path = PathBuf::from("/nonexistent/registrar-client.pem");
+    let joined = tokio::task::spawn_blocking(move || {
+        Err(ExchangeError::Material {
+            source: ClientMaterialError::MissingCertificate { path },
+        })
+    })
+    .await;
+
+    let err = finish_dial_load(joined).expect_err("the load reported a failure");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Material {
+                source: ClientMaterialError::MissingCertificate { .. }
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
 // The one variant with no portable test
 // ---------------------------------------------------------------------
 

--- a/src/registrar/endpoint/client/tests.rs
+++ b/src/registrar/endpoint/client/tests.rs
@@ -1195,6 +1195,36 @@ async fn a_refusal_is_a_successful_exchange() {
 }
 
 #[tokio::test]
+async fn a_deregister_refusal_is_a_successful_exchange() {
+    // The discrimination is written once per verb, so the deregister
+    // arm gets its own refusal case rather than resting on the mint
+    // one having exercised the shared rule.
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(REFUSAL_PERMANENT)));
+
+    let reply = deployment
+        .client()
+        .deregister(deregister_request())
+        .await
+        .expect("a refusal is not an exchange failure");
+
+    let refusal = match reply {
+        DeregisterReply::Refused(refusal) => refusal,
+        DeregisterReply::Success(response) => panic!("expected the refusal arm, saw {response:?}"),
+    };
+    assert_eq!(refusal.class, protocol::RefusalClass::Permanent);
+    assert_eq!(
+        refusal.error,
+        Some(protocol::EnrollError::ServiceHostMismatch)
+    );
+    assert_eq!(
+        double.observed().connections,
+        1,
+        "the client retried a refusal"
+    );
+}
+
+#[tokio::test]
 async fn a_success_payload_is_not_misdecoded_as_a_refusal() {
     let deployment = Deployment::new();
     let _double = deployment.double(answered(response_frame(DEREGISTER_SUCCESS)));

--- a/src/registrar/endpoint/client/tests.rs
+++ b/src/registrar/endpoint/client/tests.rs
@@ -1,0 +1,1531 @@
+//! Tests for the registrar endpoint client.
+//!
+//! **None of these starts the endpoint's own listener.** Every property
+//! this module owns is a property of the *caller*: what it presents at
+//! the handshake, how many messages it puts on a connection, how much it
+//! is willing to read, how long it is willing to wait, and how it
+//! classifies what came back. All of it is observable against a **server
+//! double** standing entirely inside this file — a `UnixListener` bound
+//! to a socket in a `tempfile::tempdir()`, whose behaviour each case
+//! chooses.
+//!
+//! Most cases run the double TLS-wrapped. Two must run it **raw**, with
+//! no `TlsAcceptor` at all, because what they exercise happens below or
+//! during the handshake and a completed handshake would make the case
+//! untestable: the read-timeout case needs a peer that accepts and then
+//! never completes a handshake, and the non-pin handshake case needs a
+//! peer that answers the `ClientHello` with bytes that are not a TLS
+//! record. Being raw is the point of each rather than a shortcut. The
+//! connect-failure case has no listener at all, which is likewise the
+//! point.
+//!
+//! The double is required regardless of convenience: the degenerate and
+//! hostile behaviours this client's error taxonomy is defined against —
+//! a stall, a clean bare close, an unclean disappearance, an oversized
+//! frame, an unpinned or wrong-SAN certificate — are precisely the ones
+//! the real listener will not produce.
+//!
+//! The whole file therefore runs under plain, unprivileged `cargo test`:
+//! no root, no Docker, no `OpenBao`, no dispatcher and no real verb
+//! execution. "Returns the mint success shape" means the double wrote
+//! the encoded mint success response and the client handed it back
+//! unchanged; nothing is minted and no privileged credential is reached.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use rustls::server::WebPkiClientVerifier;
+use rustls::{RootCertStore, ServerConfig};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_rustls::TlsAcceptor;
+
+use super::*;
+use crate::registrar::endpoint::test_support::{
+    CapturedEvent, Pki, TestCa, capture_logs, dns_san, endpoint_name, issue_leaf, key_der,
+    registrar_client_name, valid_ca, write_leaf_material,
+};
+
+/// The canned success and refusal payloads, taken from the golden
+/// fixtures the protocol module already round-trips, so a case that
+/// hand-writes a payload is only ever hand-writing the deviation it is
+/// about.
+const MINT_SUCCESS: &[u8] = include_bytes!("../fixtures/mint-success.json");
+const DEREGISTER_SUCCESS: &[u8] = include_bytes!("../fixtures/deregister-success.json");
+const REFUSAL_PERMANENT: &[u8] = include_bytes!("../fixtures/refusal-permanent.json");
+
+/// Bytes that are not a TLS record, for the raw handshake-failure case.
+const NOT_A_TLS_RECORD: &[u8] = b"this is not a TLS record, not even slightly\n";
+
+/// A distinctive string a secret-leak assertion looks for. It appears in
+/// no path, so finding it anywhere means it came from the material or
+/// the payload it was planted in.
+const SECRET_MARKER: &str = "z9Q-marker-that-must-never-be-logged";
+
+// ---------------------------------------------------------------------
+// The server double
+// ---------------------------------------------------------------------
+
+/// What the double writes once it has read one request frame.
+#[derive(Clone)]
+struct Reply {
+    /// The exact bytes to write, response prefix included. Empty means
+    /// the double answers with nothing at all.
+    bytes: Vec<u8>,
+    /// Whether the double ends the stream cleanly. Several cases below
+    /// come in pairs that differ by exactly this flag, which is what
+    /// pins the clean-versus-unclean rule to a test rather than to a
+    /// comment.
+    shutdown: bool,
+}
+
+/// A clean answer: these bytes, then `close_notify`.
+fn answered(bytes: Vec<u8>) -> Reply {
+    Reply {
+        bytes,
+        shutdown: true,
+    }
+}
+
+/// These bytes, then a disappearance with no `close_notify`.
+fn abandoned(bytes: Vec<u8>) -> Reply {
+    Reply {
+        bytes,
+        shutdown: false,
+    }
+}
+
+/// What the double does with each connection it accepts.
+enum Script {
+    /// Complete a TLS handshake, read one request frame, then reply.
+    Tls { acceptor: TlsAcceptor, reply: Reply },
+    /// No `TlsAcceptor` at all: accept and hold the connection open
+    /// forever, completing no handshake and writing no bytes.
+    RawStall,
+    /// No `TlsAcceptor` at all: answer the `ClientHello` with bytes
+    /// that are not a TLS record.
+    RawGarbage,
+}
+
+/// Everything the double saw, which is what a case asserts the client
+/// did.
+#[derive(Debug, Clone, Default)]
+struct Observed {
+    /// Connections accepted, whether or not they handshook.
+    connections: usize,
+    /// Application bytes read across every connection. Zero is what
+    /// "the double observes no request byte" means.
+    request_bytes: usize,
+    /// Complete request frames read, in order.
+    requests: Vec<Vec<u8>>,
+    /// DER of each connection's client leaf, in order.
+    peer_leaves: Vec<Vec<u8>>,
+    /// Application bytes that arrived *after* a connection's one
+    /// request frame.
+    trailing_request_bytes: usize,
+    /// Whether a connection's stream ended after its one request frame.
+    ended_after_one_request: bool,
+    /// Handshakes the double itself could not complete.
+    handshake_failures: usize,
+}
+
+/// A listener bound in a `tempfile::tempdir()` and driven by this
+/// harness.
+struct Double {
+    observed: Arc<StdMutex<Observed>>,
+    /// Connections the double has finished with. The client returns as
+    /// soon as it has read its answer, which is before the double has
+    /// seen the `close_notify` that follows, so anything asserted about
+    /// how a connection *ended* waits on this rather than racing it.
+    completed: watch::Receiver<usize>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for Double {
+    fn drop(&mut self) {
+        // The double outlives no test: whichever connection it is
+        // parked on, the harness owns the handle and ends the task
+        // here rather than leaving it detached.
+        self.task.abort();
+    }
+}
+
+impl Double {
+    fn start(socket_path: &Path, script: Script) -> Self {
+        let listener = UnixListener::bind(socket_path).expect("bind the double's socket");
+        let observed = Arc::new(StdMutex::new(Observed::default()));
+        let (progress, completed) = watch::channel(0);
+        let task = tokio::spawn(run_double(
+            listener,
+            script,
+            Arc::clone(&observed),
+            progress,
+        ));
+        Self {
+            observed,
+            completed,
+            task,
+        }
+    }
+
+    fn observed(&self) -> Observed {
+        self.observed
+            .lock()
+            .expect("the observation mutex is only held to record and read")
+            .clone()
+    }
+
+    /// Waits until the double has finished with `count` connections.
+    async fn settled(&self, count: usize) {
+        let mut completed = self.completed.clone();
+        while *completed.borrow_and_update() < count {
+            completed
+                .changed()
+                .await
+                .expect("the double outlives the assertion");
+        }
+    }
+}
+
+async fn run_double(
+    listener: UnixListener,
+    script: Script,
+    observed: Arc<StdMutex<Observed>>,
+    progress: watch::Sender<usize>,
+) {
+    // Held so a stalled peer stays a stalled peer: dropping the stream
+    // would close it and turn the case into a disappearance.
+    let mut stalled = Vec::new();
+    loop {
+        let Ok((stream, _)) = listener.accept().await else {
+            return;
+        };
+        record(&observed, |seen| seen.connections += 1);
+        match &script {
+            Script::Tls { acceptor, reply } => {
+                serve_tls(acceptor.clone(), stream, reply.clone(), &observed).await;
+            }
+            Script::RawStall => stalled.push(stream),
+            Script::RawGarbage => serve_garbage(stream).await,
+        }
+        progress.send_modify(|finished| *finished += 1);
+    }
+}
+
+async fn serve_tls(
+    acceptor: TlsAcceptor,
+    stream: UnixStream,
+    reply: Reply,
+    observed: &Arc<StdMutex<Observed>>,
+) {
+    let Ok(mut tls) = acceptor.accept(stream).await else {
+        record(observed, |seen| seen.handshake_failures += 1);
+        return;
+    };
+    let leaf = {
+        let (_, session) = tls.get_ref();
+        session
+            .peer_certificates()
+            .and_then(<[CertificateDer<'_>]>::first)
+            .map(|leaf| leaf.as_ref().to_vec())
+    };
+    if let Some(leaf) = leaf {
+        record(observed, |seen| seen.peer_leaves.push(leaf));
+    }
+
+    let Some(request) = read_request_frame(&mut tls, observed).await else {
+        return;
+    };
+    record(observed, |seen| seen.requests.push(request));
+
+    if !reply.bytes.is_empty() {
+        if tls.write_all(&reply.bytes).await.is_err() {
+            return;
+        }
+        if tls.flush().await.is_err() {
+            return;
+        }
+    }
+    if !reply.shutdown {
+        // Dropping without `shutdown()` is the whole point of the
+        // cases that ask for it: the client must see an
+        // `UnexpectedEof` and not an orderly end.
+        return;
+    }
+    let _ = tls.shutdown().await;
+
+    // Whatever else the client had to say on this connection. A client
+    // that honours one-request-per-connection says nothing.
+    let mut extra = Vec::new();
+    if tls.read_to_end(&mut extra).await.is_ok() {
+        record(observed, |seen| {
+            seen.trailing_request_bytes += extra.len();
+            seen.ended_after_one_request = true;
+        });
+    }
+}
+
+async fn serve_garbage(mut stream: UnixStream) {
+    let mut buffer = [0_u8; 512];
+    let _ = stream.read(&mut buffer).await;
+    let _ = stream.write_all(NOT_A_TLS_RECORD).await;
+    let _ = stream.flush().await;
+}
+
+fn record(observed: &Arc<StdMutex<Observed>>, edit: impl FnOnce(&mut Observed)) {
+    let mut seen = observed
+        .lock()
+        .expect("the observation mutex is only held to record and read");
+    edit(&mut seen);
+}
+
+async fn read_request_frame<S>(
+    stream: &mut S,
+    observed: &Arc<StdMutex<Observed>>,
+) -> Option<Vec<u8>>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut prefix = [0_u8; frame::REQUEST_PREFIX_BYTES];
+    read_exactly(stream, &mut prefix, observed).await?;
+    let payload_length = usize::try_from(frame::declared_payload_length(prefix)).ok()?;
+    let name_length = usize::from(frame::declared_name_length(prefix));
+    let mut rest = vec![0_u8; name_length + payload_length];
+    read_exactly(stream, &mut rest, observed).await?;
+    let mut whole = prefix.to_vec();
+    whole.extend_from_slice(&rest);
+    Some(whole)
+}
+
+async fn read_exactly<S>(
+    stream: &mut S,
+    buffer: &mut [u8],
+    observed: &Arc<StdMutex<Observed>>,
+) -> Option<()>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut received = 0;
+    while received < buffer.len() {
+        let read = stream.read(&mut buffer[received..]).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        received += read;
+        record(observed, |seen| seen.request_bytes += read);
+    }
+    Some(())
+}
+
+// ---------------------------------------------------------------------
+// The deployment every case is built from
+// ---------------------------------------------------------------------
+
+/// One CA, one pin file, one registrar client pair on disk, and a socket
+/// path — all under one `tempfile::tempdir()`.
+struct Deployment {
+    pki: Pki,
+    certificate_path: PathBuf,
+    key_path: PathBuf,
+}
+
+impl Deployment {
+    fn new() -> Self {
+        crate::tls::install_crypto_provider();
+        let pki = Pki::new();
+        let certificate_path = pki.path("registrar-client.crt");
+        let key_path = pki.path("registrar-client.key");
+        write_leaf_material(
+            &pki.ca,
+            vec![dns_san(&registrar_client_name())],
+            &certificate_path,
+            &key_path,
+            true,
+        );
+        Self {
+            pki,
+            certificate_path,
+            key_path,
+        }
+    }
+
+    fn socket_path(&self) -> PathBuf {
+        self.pki.path("registrar.sock")
+    }
+
+    /// A client wired to this deployment, constructed from paths under
+    /// the temporary directory and from nothing else.
+    fn client(&self) -> RegistrarEndpointClient {
+        RegistrarEndpointClient::new(
+            self.socket_path(),
+            self.pki.pin_file_path(),
+            &self.certificate_path,
+            &self.key_path,
+            endpoint_name(),
+        )
+    }
+
+    /// An acceptor presenting a leaf carrying `san`, issued by `issuer`
+    /// and chained to it, and requiring a client certificate this
+    /// deployment's CA issued.
+    fn acceptor(&self, issuer: &TestCa, san: &str) -> TlsAcceptor {
+        let (certificate, key) = issue_leaf(issuer, vec![dns_san(san)]);
+        let chain = vec![
+            CertificateDer::from(certificate.der().to_vec()),
+            CertificateDer::from(issuer.der().to_vec()),
+        ];
+        let mut roots = RootCertStore::empty();
+        roots
+            .add(CertificateDer::from(self.pki.ca.der().to_vec()))
+            .expect("the deployment CA is a usable anchor");
+        let verifier = WebPkiClientVerifier::builder(Arc::new(roots))
+            .build()
+            .expect("a client verifier over the deployment CA");
+        let config = ServerConfig::builder()
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(chain, key_der(&key))
+            .expect("the double's own server material");
+        TlsAcceptor::from(Arc::new(config))
+    }
+
+    /// The conforming double: the pinned CA, the expected endpoint SAN.
+    fn double(&self, reply: Reply) -> Double {
+        self.double_presenting(&self.pki.ca, &endpoint_name(), reply)
+    }
+
+    fn double_presenting(&self, issuer: &TestCa, san: &str, reply: Reply) -> Double {
+        Double::start(
+            &self.socket_path(),
+            Script::Tls {
+                acceptor: self.acceptor(issuer, san),
+                reply,
+            },
+        )
+    }
+
+    fn raw_double(&self, script: Script) -> Double {
+        Double::start(&self.socket_path(), script)
+    }
+}
+
+// ---------------------------------------------------------------------
+// Payload and frame helpers
+// ---------------------------------------------------------------------
+
+fn response_frame(payload: &[u8]) -> Vec<u8> {
+    let length = u32::try_from(payload.len()).expect("a test payload shorter than 4 GiB");
+    let mut frame = length.to_be_bytes().to_vec();
+    frame.extend_from_slice(payload);
+    frame
+}
+
+/// A response prefix declaring `declared` bytes and nothing behind it.
+fn response_prefix(declared: u32) -> Vec<u8> {
+    declared.to_be_bytes().to_vec()
+}
+
+/// A fixture payload with one edit applied, so a case hand-writes only
+/// the deviation it is about.
+fn payload_with(
+    base: &[u8],
+    edit: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>),
+) -> Vec<u8> {
+    let mut members = serde_json::from_slice::<serde_json::Map<String, serde_json::Value>>(base)
+        .expect("every fixture is a JSON object");
+    edit(&mut members);
+    serde_json::to_vec(&members).expect("a JSON object re-encodes")
+}
+
+fn register_request() -> protocol::RegisterRequest {
+    protocol::RegisterRequest {
+        protocol_version: protocol::ProtocolVersion::current(),
+        service_name: "api".to_string(),
+        delivery_mode: protocol::WireDeliveryMode::RemoteBootstrap,
+        host: "node".to_string(),
+        instance: Some(7),
+        spec: protocol::WireServiceSpec {
+            component: "api".to_string(),
+            service_name: "api".to_string(),
+            reload: "opaque reload".to_string(),
+            cert_group: None,
+        },
+        wrap_ttl: 60,
+        idempotency_key: "opaque-key".to_string(),
+    }
+}
+
+fn deregister_request() -> protocol::DeregisterRequest {
+    protocol::DeregisterRequest {
+        protocol_version: protocol::ProtocolVersion::current(),
+        service_name: "api".to_string(),
+        host: "node".to_string(),
+        instance: Some(7),
+        idempotency_key: "opaque-key".to_string(),
+    }
+}
+
+fn mint_success(reply: MintReply) -> protocol::MintResponse {
+    match reply {
+        MintReply::Success(response) => response,
+        MintReply::Refused(refusal) => panic!("expected the success arm, saw {refusal:?}"),
+    }
+}
+
+fn mint_refusal(reply: MintReply) -> protocol::RefusalResponse {
+    match reply {
+        MintReply::Refused(refusal) => refusal,
+        MintReply::Success(response) => panic!("expected the refusal arm, saw {response:?}"),
+    }
+}
+
+/// The `rustls::Error` `tokio_rustls` wrapped in an `io::Error`, which
+/// is what selects between the two handshake variants.
+fn recovered(err: &io::Error) -> Option<&rustls::Error> {
+    err.get_ref()
+        .and_then(|inner| inner.downcast_ref::<rustls::Error>())
+}
+
+// ---------------------------------------------------------------------
+// Round trip
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_mint_returns_the_success_shape_the_double_encoded() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+
+    let reply = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect("the exchange completes");
+
+    let response = mint_success(reply);
+    assert_eq!(response.request_id, "request-0001");
+    assert_eq!(response.registration_id, "registration-1");
+    assert_eq!(response.outcome, protocol::MintWireOutcome::FirstMint);
+    assert_eq!(response.material.role_id, "role-id");
+
+    let seen = double.observed();
+    assert_eq!(seen.connections, 1);
+    assert_eq!(seen.requests.len(), 1);
+}
+
+#[tokio::test]
+async fn a_deregister_returns_the_success_shape_the_double_encoded() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(DEREGISTER_SUCCESS)));
+
+    let reply = deployment
+        .client()
+        .deregister(deregister_request())
+        .await
+        .expect("the exchange completes");
+
+    let response = match reply {
+        DeregisterReply::Success(response) => response,
+        DeregisterReply::Refused(refusal) => panic!("expected the success arm, saw {refusal:?}"),
+    };
+    assert_eq!(response.request_id, "request-0001");
+    assert_eq!(
+        response.outcome,
+        protocol::DeregisterWireOutcome::AlreadyAbsent
+    );
+    assert_eq!(double.observed().requests.len(), 1);
+}
+
+#[tokio::test]
+async fn exactly_one_request_and_one_response_cross_a_connection() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+
+    deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect("the exchange completes");
+
+    double.settled(1).await;
+    let seen = double.observed();
+    assert_eq!(seen.connections, 1, "the client dialed more than once");
+    assert_eq!(seen.requests.len(), 1, "the client wrote a second request");
+    assert_eq!(
+        seen.trailing_request_bytes, 0,
+        "the client wrote something after its one request"
+    );
+    assert!(
+        seen.ended_after_one_request,
+        "the client left the connection open after the exchange"
+    );
+
+    // The one frame the double read is exactly the one the envelope
+    // writer composes for this request.
+    let payload = protocol::encode_request(&protocol::Request::Register(register_request()))
+        .expect("the request encodes");
+    let expected =
+        frame::encode_request_frame(Operation::Mint, &payload).expect("the request frames");
+    assert_eq!(seen.requests.first(), Some(&expected));
+}
+
+// ---------------------------------------------------------------------
+// Everything that fails before a byte reaches the socket
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_missing_client_certificate_fails_before_the_dial() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    let client = RegistrarEndpointClient::new(
+        deployment.socket_path(),
+        deployment.pki.pin_file_path(),
+        deployment.pki.path("absent.crt"),
+        &deployment.key_path,
+        endpoint_name(),
+    );
+
+    let err = client
+        .mint(register_request())
+        .await
+        .expect_err("a certificate that is not there cannot be presented");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Material {
+                source: ClientMaterialError::MissingCertificate { .. }
+            }
+        ),
+        "{err:?}"
+    );
+    assert_eq!(double.observed().connections, 0);
+}
+
+#[tokio::test]
+async fn a_missing_client_key_fails_before_the_dial() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    let client = RegistrarEndpointClient::new(
+        deployment.socket_path(),
+        deployment.pki.pin_file_path(),
+        &deployment.certificate_path,
+        deployment.pki.path("absent.key"),
+        endpoint_name(),
+    );
+
+    let err = client
+        .mint(register_request())
+        .await
+        .expect_err("a key that is not there cannot sign");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Material {
+                source: ClientMaterialError::MissingKey { .. }
+            }
+        ),
+        "{err:?}"
+    );
+    assert_eq!(double.observed().connections, 0);
+}
+
+#[tokio::test]
+async fn a_certificate_that_is_not_pem_fails_before_the_dial() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    std::fs::write(&deployment.certificate_path, b"these bytes are not PEM\n")
+        .expect("write the malformed certificate");
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("bytes that are not PEM carry no certificate");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Material {
+                source: ClientMaterialError::NoCertificate { .. }
+            }
+        ),
+        "{err:?}"
+    );
+    assert_eq!(double.observed().connections, 0);
+}
+
+#[tokio::test]
+async fn a_key_that_is_not_a_private_key_fails_before_the_dial() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    std::fs::write(&deployment.key_path, b"these bytes are not a private key\n")
+        .expect("write the malformed key");
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("bytes that are not PEM carry no key");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Material {
+                source: ClientMaterialError::NoPrivateKey { .. }
+            }
+        ),
+        "{err:?}"
+    );
+    assert_eq!(double.observed().connections, 0);
+}
+
+#[tokio::test]
+async fn a_pem_key_rustls_will_not_load_fails_before_the_dial() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    // Well-formed PEM framing around base64 that is not a key: the
+    // parse succeeds and `rustls` refuses the result.
+    std::fs::write(
+        &deployment.key_path,
+        "-----BEGIN PRIVATE KEY-----\nbm90IGEga2V5IGF0IGFsbA==\n-----END PRIVATE KEY-----\n",
+    )
+    .expect("write the unusable key");
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("rustls refuses a key it cannot load");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Material {
+                source: ClientMaterialError::Unusable { .. }
+            }
+        ),
+        "{err:?}"
+    );
+    assert_eq!(double.observed().connections, 0);
+}
+
+#[tokio::test]
+async fn a_request_over_the_frame_bound_is_refused_locally() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    let mut request = register_request();
+    request.idempotency_key = "k".repeat(endpoint::MAX_FRAME_PAYLOAD_BYTES + 1);
+
+    let err = deployment
+        .client()
+        .mint(request)
+        .await
+        .expect_err("the envelope will not carry it");
+
+    let ExchangeError::RequestTooLarge { source } = err else {
+        panic!("expected the local frame refusal, saw {err:?}");
+    };
+    assert_eq!(source.limit, endpoint::MAX_FRAME_PAYLOAD_BYTES);
+    assert!(source.length > endpoint::MAX_FRAME_PAYLOAD_BYTES);
+    assert_eq!(
+        double.observed().connections,
+        0,
+        "the client dialed for a request it had already refused"
+    );
+}
+
+#[tokio::test]
+async fn a_missing_pin_file_is_a_typed_refusal() {
+    let deployment = Deployment::new();
+    let client = RegistrarEndpointClient::new(
+        deployment.socket_path(),
+        deployment.pki.path("absent-pins.sha256"),
+        &deployment.certificate_path,
+        &deployment.key_path,
+        endpoint_name(),
+    );
+
+    let err = client
+        .mint(register_request())
+        .await
+        .expect_err("there is no trust decision to make");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Pin {
+                source: EndpointPinError::Missing { .. }
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_malformed_pin_file_is_a_typed_refusal() {
+    let deployment = Deployment::new();
+    let pin_file = deployment.pki.path("malformed-pins.sha256");
+    std::fs::write(&pin_file, "not-a-digest\n").expect("write the malformed pin file");
+    let client = RegistrarEndpointClient::new(
+        deployment.socket_path(),
+        pin_file,
+        &deployment.certificate_path,
+        &deployment.key_path,
+        endpoint_name(),
+    );
+
+    let err = client
+        .mint(register_request())
+        .await
+        .expect_err("a malformed pin file is not partially accepted");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Pin {
+                source: EndpointPinError::Content { .. }
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_expected_name_that_is_not_a_dns_name_is_a_typed_refusal() {
+    let deployment = Deployment::new();
+    let client = RegistrarEndpointClient::new(
+        deployment.socket_path(),
+        deployment.pki.pin_file_path(),
+        &deployment.certificate_path,
+        &deployment.key_path,
+        "not a dns name",
+    );
+
+    let err = client
+        .mint(register_request())
+        .await
+        .expect_err("there is no name to pin against");
+
+    assert!(
+        matches!(
+            err,
+            ExchangeError::Pin {
+                source: EndpointPinError::InvalidEndpointName { .. }
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Connect and handshake
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_socket_nothing_listens_on_produces_the_connect_variant() {
+    let deployment = Deployment::new();
+    let started = tokio::time::Instant::now();
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("nothing is listening");
+
+    assert!(matches!(err, ExchangeError::Connect { .. }), "{err:?}");
+    assert!(
+        started.elapsed() < CONNECT_TIMEOUT,
+        "a refused connect must not wait out the connect timeout"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn the_connect_timeout_wraps_the_dial() {
+    // A stalled `AF_UNIX` `connect(2)` is not portably constructible: a
+    // missing path fails immediately with `ENOENT`, and a live
+    // listener's backlog cannot be filled deterministically across
+    // Linux and macOS. The wrapper itself is what this asserts, driven
+    // over a future that never resolves.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("registrar.sock");
+    let started = tokio::time::Instant::now();
+
+    let err = connect_within(
+        &socket,
+        std::future::pending::<io::Result<UnixStream>>(),
+        CONNECT_TIMEOUT,
+    )
+    .await
+    .expect_err("a dial that never resolves must elapse");
+
+    let ExchangeError::ConnectTimeout { timeout, .. } = err else {
+        panic!("expected the connect timeout, saw {err:?}");
+    };
+    assert_eq!(timeout, CONNECT_TIMEOUT);
+    assert!(started.elapsed() >= CONNECT_TIMEOUT);
+}
+
+#[tokio::test]
+async fn a_server_chaining_to_an_unpinned_anchor_is_refused_by_the_pin() {
+    let deployment = Deployment::new();
+    let stranger = valid_ca();
+    let double = deployment.double_presenting(
+        &stranger,
+        &endpoint_name(),
+        answered(response_frame(MINT_SUCCESS)),
+    );
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("the anchor is not pinned");
+
+    let ExchangeError::PinRefused {
+        expected_name,
+        source,
+    } = err
+    else {
+        panic!("expected the pin refusal, saw {err:?}");
+    };
+    assert_eq!(expected_name, endpoint_name());
+    assert!(
+        matches!(source, rustls::Error::InvalidCertificate(_)),
+        "{source:?}"
+    );
+    assert_eq!(
+        double.observed().request_bytes,
+        0,
+        "a request byte was written to an unpinned server"
+    );
+}
+
+#[tokio::test]
+async fn a_server_carrying_the_wrong_san_is_refused_by_the_pin() {
+    let deployment = Deployment::new();
+    let double = deployment.double_presenting(
+        &deployment.pki.ca,
+        "somewhere.else.example.internal",
+        answered(response_frame(MINT_SUCCESS)),
+    );
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("the SAN is not the expected one");
+
+    let ExchangeError::PinRefused {
+        expected_name,
+        source,
+    } = err
+    else {
+        panic!("expected the pin refusal, saw {err:?}");
+    };
+    assert_eq!(
+        expected_name,
+        endpoint_name(),
+        "the variant names the expected SAN, which the client owns"
+    );
+    assert!(
+        matches!(source, rustls::Error::InvalidCertificate(_)),
+        "{source:?}"
+    );
+    assert_eq!(
+        double.observed().request_bytes,
+        0,
+        "a request byte was written to a server carrying the wrong name"
+    );
+}
+
+#[tokio::test]
+async fn bytes_that_are_not_a_tls_record_produce_the_generic_handshake_variant() {
+    let deployment = Deployment::new();
+    let _double = deployment.raw_double(Script::RawGarbage);
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("the peer does not speak TLS");
+
+    let ExchangeError::Handshake { source } = err else {
+        panic!("expected the generic handshake failure, saw {err:?}");
+    };
+    // The two handshake variants are selected by the recovery, not by
+    // which test wrote them.
+    assert!(
+        !matches!(
+            recovered(&source),
+            Some(rustls::Error::InvalidCertificate(_))
+        ),
+        "{source:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_peer_that_completes_no_handshake_elapses_the_read_timeout() {
+    let deployment = Deployment::new();
+    let _double = deployment.raw_double(Script::RawStall);
+    let started = tokio::time::Instant::now();
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a stalled peer answers nothing");
+
+    let ExchangeError::ReadTimeout { timeout } = err else {
+        panic!("expected the read timeout, saw {err:?}");
+    };
+    assert_eq!(timeout, READ_TIMEOUT);
+    assert!(
+        started.elapsed() >= READ_TIMEOUT,
+        "the connect timeout fired instead of the read timeout"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Reading the response
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_clean_close_after_zero_bytes_has_its_own_variant() {
+    let deployment = Deployment::new();
+    let _double = deployment.double(answered(Vec::new()));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a bare close is not an answer");
+
+    assert!(matches!(err, ExchangeError::EmptyResponse), "{err:?}");
+}
+
+#[tokio::test]
+async fn a_disappearance_before_the_prefix_is_a_transport_failure() {
+    let deployment = Deployment::new();
+    // The same double as above, minus one `shutdown()`.
+    let _double = deployment.double(abandoned(Vec::new()));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a peer that vanished answered nothing");
+
+    let ExchangeError::Transport { phase, source } = err else {
+        panic!("expected the transport variant, saw {err:?}");
+    };
+    assert_eq!(phase, ExchangePhase::Response);
+    assert_eq!(source.kind(), io::ErrorKind::UnexpectedEof);
+}
+
+#[tokio::test]
+async fn a_short_prefix_before_a_clean_close_is_a_truncation() {
+    let deployment = Deployment::new();
+    let _double = deployment.double(answered(vec![0x00, 0x00]));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("two bytes are not a response prefix");
+
+    let ExchangeError::Truncated { expected, received } = err else {
+        panic!("expected the truncation variant, saw {err:?}");
+    };
+    assert_eq!(expected, frame::RESPONSE_PREFIX_BYTES);
+    assert_eq!(received, 2);
+}
+
+#[tokio::test]
+async fn a_short_payload_before_a_clean_close_is_a_truncation() {
+    let deployment = Deployment::new();
+    let mut truncated = response_prefix(64);
+    truncated.extend_from_slice(&[b'x'; 10]);
+    let _double = deployment.double(answered(truncated));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("ten bytes are not sixty-four");
+
+    let ExchangeError::Truncated { expected, received } = err else {
+        panic!("expected the truncation variant, saw {err:?}");
+    };
+    assert_eq!(expected, frame::RESPONSE_PREFIX_BYTES + 64);
+    assert_eq!(received, frame::RESPONSE_PREFIX_BYTES + 10);
+}
+
+#[tokio::test]
+async fn a_disappearance_mid_payload_is_a_transport_failure() {
+    let deployment = Deployment::new();
+    let mut truncated = response_prefix(64);
+    truncated.extend_from_slice(&[b'x'; 10]);
+    // The same double as above, minus one `shutdown()`.
+    let _double = deployment.double(abandoned(truncated));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a peer that vanished mid-payload answered nothing");
+
+    let ExchangeError::Transport { phase, source } = err else {
+        panic!("expected the transport variant, saw {err:?}");
+    };
+    assert_eq!(phase, ExchangePhase::Response);
+    assert_eq!(source.kind(), io::ErrorKind::UnexpectedEof);
+}
+
+#[tokio::test]
+async fn a_complete_response_behind_an_unclean_close_is_a_transport_failure() {
+    let deployment = Deployment::new();
+    // The round-trip double, minus one `shutdown()`. A complete payload
+    // does not exempt a connection from the clean-close rule.
+    let _double = deployment.double(abandoned(response_frame(MINT_SUCCESS)));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("the connection did not end cleanly");
+
+    let ExchangeError::Transport { phase, source } = err else {
+        panic!("expected the transport variant, saw {err:?}");
+    };
+    assert_eq!(phase, ExchangePhase::Response);
+    assert_eq!(source.kind(), io::ErrorKind::UnexpectedEof);
+}
+
+#[tokio::test]
+async fn a_stray_byte_after_a_complete_response_is_refused() {
+    let deployment = Deployment::new();
+    let mut answer = response_frame(MINT_SUCCESS);
+    answer.push(b'!');
+    let _double = deployment.double(answered(answer));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("the first frame is not honoured behind trailing bytes");
+
+    assert!(
+        matches!(err, ExchangeError::TrailingBytes { observed: 1 }),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_second_frame_after_a_complete_response_is_refused() {
+    let deployment = Deployment::new();
+    let mut answer = response_frame(MINT_SUCCESS);
+    answer.extend_from_slice(&response_frame(DEREGISTER_SUCCESS));
+    let _double = deployment.double(answered(answer));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a second frame cannot ride behind the first");
+
+    assert!(
+        matches!(err, ExchangeError::TrailingBytes { .. }),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_response_declaring_more_than_the_bound_is_refused_before_the_payload() {
+    let deployment = Deployment::new();
+    let over = u32::try_from(MAX_DECLARED_PAYLOAD_BYTES + 1).expect("the bound fits a u32");
+    // Nothing but the prefix is ever written, so a client that read the
+    // payload before checking the declaration would hang instead.
+    let _double = deployment.double(answered(response_prefix(over)));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("the declaration is over the bound");
+
+    let ExchangeError::ResponseTooLarge { declared, limit } = err else {
+        panic!("expected the oversize variant, saw {err:?}");
+    };
+    assert_eq!(declared, over);
+    assert_eq!(limit, MAX_DECLARED_PAYLOAD_BYTES);
+    assert_eq!(
+        MAX_RESPONSE_BYTES,
+        frame::RESPONSE_PREFIX_BYTES + endpoint::MAX_RESPONSE_PAYLOAD_BYTES,
+        "the client's bound is the endpoint's, not a literal of its own"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Discrimination and decoding
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_refusal_is_a_successful_exchange() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(REFUSAL_PERMANENT)));
+
+    let reply = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect("a refusal is not an exchange failure");
+
+    let refusal = mint_refusal(reply);
+    assert_eq!(refusal.class, protocol::RefusalClass::Permanent);
+    assert_eq!(
+        refusal.error,
+        Some(protocol::EnrollError::ServiceHostMismatch)
+    );
+    assert_eq!(
+        double.observed().connections,
+        1,
+        "the client retried a refusal"
+    );
+}
+
+#[tokio::test]
+async fn a_success_payload_is_not_misdecoded_as_a_refusal() {
+    let deployment = Deployment::new();
+    let _double = deployment.double(answered(response_frame(DEREGISTER_SUCCESS)));
+
+    let reply = deployment
+        .client()
+        .deregister(deregister_request())
+        .await
+        .expect("the exchange completes");
+
+    assert!(matches!(reply, DeregisterReply::Success(_)), "{reply:?}");
+}
+
+#[tokio::test]
+async fn a_success_payload_missing_a_required_member_names_the_success_shape() {
+    let deployment = Deployment::new();
+    let payload = payload_with(MINT_SUCCESS, |members| {
+        members.remove("registration_id");
+    });
+    let _double = deployment.double(answered(response_frame(&payload)));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("the success shape requires registration_id");
+
+    let ExchangeError::Codec { source } = err else {
+        panic!("expected the decode variant, saw {err:?}");
+    };
+    assert!(matches!(source, CodecError::Json(_)), "{source:?}");
+    assert!(
+        source.to_string().contains("registration_id"),
+        "the failure must name the one shape it tried: {source}"
+    );
+}
+
+#[tokio::test]
+async fn a_refusal_whose_class_contradicts_its_error_is_a_decode_failure() {
+    let deployment = Deployment::new();
+    let payload = payload_with(REFUSAL_PERMANENT, |members| {
+        members.insert(
+            "class".to_string(),
+            serde_json::Value::String("retryable".to_string()),
+        );
+    });
+    let _double = deployment.double(answered(response_frame(&payload)));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("retryable does not match ServiceSpecConflict's family");
+
+    let ExchangeError::Codec { source } = err else {
+        panic!("expected the decode variant, saw {err:?}");
+    };
+    assert!(
+        matches!(source, CodecError::InvalidRefusalClass(_)),
+        "{source:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_null_class_beside_every_success_member_is_a_malformed_refusal() {
+    let deployment = Deployment::new();
+    // Every member `MintResponse` requires, plus a `class` that is not
+    // a class. A discrimination that looked at the value instead of the
+    // key would hand this to the success decoder and return it.
+    let payload = payload_with(MINT_SUCCESS, |members| {
+        members.insert("class".to_string(), serde_json::Value::Null);
+    });
+    let _double = deployment.double(answered(response_frame(&payload)));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a present class member is a refusal, whatever its value");
+
+    let ExchangeError::Codec { source } = err else {
+        panic!("expected the decode variant, saw {err:?}");
+    };
+    assert!(matches!(source, CodecError::Json(_)), "{source:?}");
+}
+
+#[tokio::test]
+async fn a_numeric_class_is_a_malformed_refusal() {
+    let deployment = Deployment::new();
+    let payload = payload_with(MINT_SUCCESS, |members| {
+        members.insert("class".to_string(), serde_json::Value::from(7));
+    });
+    let _double = deployment.double(answered(response_frame(&payload)));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("a present class member is a refusal, whatever its value");
+
+    assert!(matches!(err, ExchangeError::Codec { .. }), "{err:?}");
+}
+
+#[tokio::test]
+async fn a_json_array_payload_runs_no_protocol_decoder() {
+    let deployment = Deployment::new();
+    let _double = deployment.double(answered(response_frame(b"[1, 2, 3]")));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("an array is not a response shape");
+
+    let ExchangeError::Codec { source } = err else {
+        panic!("expected the decode variant, saw {err:?}");
+    };
+    assert!(matches!(source, CodecError::Json(_)), "{source:?}");
+}
+
+#[tokio::test]
+async fn a_payload_that_is_not_json_runs_no_protocol_decoder() {
+    let deployment = Deployment::new();
+    let _double = deployment.double(answered(response_frame(b"not json at all")));
+
+    let err = deployment
+        .client()
+        .mint(register_request())
+        .await
+        .expect_err("these bytes are not JSON");
+
+    let ExchangeError::Codec { source } = err else {
+        panic!("expected the decode variant, saw {err:?}");
+    };
+    assert!(matches!(source, CodecError::Json(_)), "{source:?}");
+}
+
+#[test]
+fn the_discriminator_reads_the_key_and_not_its_value() {
+    assert!(!is_refusal(MINT_SUCCESS).expect("the fixture is a JSON object"));
+    assert!(!is_refusal(DEREGISTER_SUCCESS).expect("the fixture is a JSON object"));
+    assert!(is_refusal(REFUSAL_PERMANENT).expect("the fixture is a JSON object"));
+    assert!(is_refusal(br#"{"class": null}"#).expect("an object with a null member"));
+    assert!(is_refusal(br#"{"class": 7}"#).expect("an object with a numeric member"));
+    assert!(is_refusal(br"{}").is_ok_and(|refusal| !refusal));
+    assert!(is_refusal(b"[]").is_err());
+    assert!(is_refusal(b"null").is_err());
+    assert!(is_refusal(b"\"class\"").is_err());
+}
+
+// ---------------------------------------------------------------------
+// The per-dial load seam
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_second_dial_re_reads_the_client_material() {
+    let deployment = Deployment::new();
+    let double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    let client = deployment.client();
+
+    client
+        .mint(register_request())
+        .await
+        .expect("the first exchange completes");
+
+    let replacement = write_leaf_material(
+        &deployment.pki.ca,
+        vec![dns_san(&registrar_client_name())],
+        &deployment.certificate_path,
+        &deployment.key_path,
+        true,
+    );
+
+    client
+        .mint(register_request())
+        .await
+        .expect("the second exchange completes");
+
+    double.settled(2).await;
+    let seen = double.observed();
+    assert_eq!(seen.connections, 2);
+    assert_eq!(seen.peer_leaves.len(), 2);
+    assert_ne!(
+        seen.peer_leaves.first(),
+        seen.peer_leaves.get(1),
+        "the second dial presented the first dial's cached leaf"
+    );
+    assert_eq!(
+        seen.peer_leaves.get(1),
+        Some(&replacement),
+        "the second dial did not present what is on disk"
+    );
+}
+
+// ---------------------------------------------------------------------
+// The one variant with no portable test
+// ---------------------------------------------------------------------
+
+#[test]
+fn the_two_transport_phases_are_distinguishable() {
+    // The write phase has no portable test and does not get a fake one.
+    // Forcing a real `EPIPE` on the request write means filling the
+    // peer's `AF_UNIX` send buffer, whose size differs between Linux
+    // and macOS; a double that drops before reading absorbs a small
+    // frame into that buffer and fails the *read* instead, exactly as
+    // the two disappearance cases above do. What a caller needs from
+    // the phase is that the two are distinguishable, and that is
+    // asserted here.
+    let writing = ExchangeError::Transport {
+        phase: ExchangePhase::Request,
+        source: io::Error::from(io::ErrorKind::BrokenPipe),
+    };
+    let reading = ExchangeError::Transport {
+        phase: ExchangePhase::Response,
+        source: io::Error::from(io::ErrorKind::UnexpectedEof),
+    };
+    let (
+        ExchangeError::Transport { phase: written, .. },
+        ExchangeError::Transport { phase: read, .. },
+    ) = (&writing, &reading)
+    else {
+        panic!("both are transport failures");
+    };
+    assert_ne!(written, read);
+    assert_eq!(written.to_string(), "writing the request");
+    assert_eq!(read.to_string(), "reading the response");
+    assert_ne!(writing.to_string(), reading.to_string());
+}
+
+// ---------------------------------------------------------------------
+// Nothing secret is logged or rendered
+// ---------------------------------------------------------------------
+
+/// Runs `attempt` under a capturing subscriber until it has emitted at
+/// least one event, and hands back the last attempt's outcome together
+/// with everything captured.
+///
+/// The retry is the price of `tracing`'s global callsite cache rather
+/// than a way of hiding a flake. A callsite's interest is cached
+/// process-wide and computed once, the first time any thread reaches it:
+/// a sibling test reaching one of the client's log lines first computes
+/// it against *its* thread's no-op subscriber and stores
+/// `Interest::never()`, which can land after this subscriber's own
+/// registration established otherwise. That first registration happens
+/// exactly once, so rebuilding the cache with this subscriber live and
+/// running again settles it for good. A capture still empty after every
+/// attempt fails the test rather than passing vacuously.
+async fn captured<T, Fut>(mut attempt: impl FnMut() -> Fut) -> (T, Vec<CapturedEvent>)
+where
+    Fut: Future<Output = T>,
+{
+    const ATTEMPTS: usize = 8;
+
+    let (logs, _guard) = capture_logs();
+    let mut outcome = attempt().await;
+    for _ in 1..ATTEMPTS {
+        if !logs.events().is_empty() {
+            break;
+        }
+        tracing::callsite::rebuild_interest_cache();
+        outcome = attempt().await;
+    }
+    let events = logs.events();
+    assert!(
+        !events.is_empty(),
+        "the client emitted nothing to check in {ATTEMPTS} attempts"
+    );
+    (outcome, events)
+}
+
+fn marker_free(events: &[CapturedEvent]) {
+    for event in events {
+        assert!(
+            !format!("{event:?}").contains(SECRET_MARKER),
+            "a captured event carried the marker: {event:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_key_load_failure_logs_and_renders_no_key_byte() {
+    let deployment = Deployment::new();
+    let _double = deployment.double(answered(response_frame(MINT_SUCCESS)));
+    // The raw file bytes are in hand on this path and a `source` error
+    // is the easiest thing to interpolate, which is why it is the one
+    // the marker is planted on.
+    std::fs::write(
+        &deployment.key_path,
+        format!("-----BEGIN NOTHING-----\n{SECRET_MARKER}\n"),
+    )
+    .expect("write the marked key");
+    let client = deployment.client();
+
+    let (outcome, events) = captured(|| client.mint(register_request())).await;
+
+    let err = outcome.expect_err("the marked bytes are not a private key");
+    assert!(matches!(err, ExchangeError::Material { .. }), "{err:?}");
+    assert!(
+        !err.to_string().contains(SECRET_MARKER),
+        "Display leaked the marker: {err}"
+    );
+    assert!(
+        !format!("{err:?}").contains(SECRET_MARKER),
+        "Debug leaked the marker: {err:?}"
+    );
+    marker_free(&events);
+}
+
+#[tokio::test]
+async fn a_successful_exchange_logs_no_response_payload() {
+    let deployment = Deployment::new();
+    let payload = payload_with(MINT_SUCCESS, |members| {
+        let material = members
+            .get_mut("material")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("the fixture carries material");
+        material.insert(
+            "wrapped_secret_id".to_string(),
+            serde_json::Value::String(SECRET_MARKER.to_string()),
+        );
+    });
+    let _double = deployment.double(answered(response_frame(&payload)));
+    let client = deployment.client();
+
+    let (outcome, events) = captured(|| client.mint(register_request())).await;
+
+    let reply = outcome.expect("the exchange completes");
+    assert!(matches!(reply, MintReply::Success(_)));
+    assert!(
+        !format!("{reply:?}").contains(SECRET_MARKER),
+        "the response Debug leaked the wrapped secret id"
+    );
+    marker_free(&events);
+}

--- a/src/registrar/endpoint/frame.rs
+++ b/src/registrar/endpoint/frame.rs
@@ -23,6 +23,8 @@
 //! refused and learns nothing it did not already know about the daemon's
 //! internals.
 
+use super::MAX_FRAME_PAYLOAD_BYTES;
+
 /// Bytes of the fixed request prefix: the four-byte payload length and
 /// the one-byte operation-name length.
 pub(crate) const REQUEST_PREFIX_BYTES: usize = 5;
@@ -175,4 +177,54 @@ pub(crate) fn declared_payload_length(prefix: [u8; REQUEST_PREFIX_BYTES]) -> u32
 /// Reads the one-byte operation-name length out of a request prefix.
 pub(crate) fn declared_name_length(prefix: [u8; REQUEST_PREFIX_BYTES]) -> u8 {
     prefix[4]
+}
+
+/// Why a request envelope could not be composed.
+///
+/// The caller's half of the envelope has exactly one way to fail that
+/// the layout above does not already rule out: a payload the four-byte
+/// length field could carry and this endpoint's bound will not accept.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("request payload is {length} bytes, over the {limit}-byte maximum")]
+pub(crate) struct OverLongRequestPayload {
+    /// Length of the payload that was offered.
+    pub(crate) length: usize,
+    /// The bound it broke, which is [`MAX_FRAME_PAYLOAD_BYTES`].
+    pub(crate) limit: usize,
+}
+
+/// Composes the request envelope around an already-encoded payload.
+///
+/// The caller's half of the layout this module owns, so a client writes
+/// the prefix through this function rather than restating the field
+/// order and the length arithmetic beside its socket.
+///
+/// # Errors
+///
+/// Returns [`OverLongRequestPayload`] when `payload` exceeds
+/// [`MAX_FRAME_PAYLOAD_BYTES`]. The endpoint would refuse such a frame
+/// with a bare close, so refusing it here costs a caller nothing and
+/// tells it why.
+pub(crate) fn encode_request_frame(
+    operation: Operation,
+    payload: &[u8],
+) -> Result<Vec<u8>, OverLongRequestPayload> {
+    if payload.len() > MAX_FRAME_PAYLOAD_BYTES {
+        return Err(OverLongRequestPayload {
+            length: payload.len(),
+            limit: MAX_FRAME_PAYLOAD_BYTES,
+        });
+    }
+    let payload_length = u32::try_from(payload.len())
+        .expect("the length was just checked against MAX_FRAME_PAYLOAD_BYTES, which fits a u32");
+    let name = operation.as_str().as_bytes();
+    let name_length = u8::try_from(name.len())
+        .expect("every Operation name is at most MAX_OPERATION_NAME_BYTES long, which fits a u8");
+
+    let mut frame = Vec::with_capacity(REQUEST_PREFIX_BYTES + name.len() + payload.len());
+    frame.extend_from_slice(&payload_length.to_be_bytes());
+    frame.push(name_length);
+    frame.extend_from_slice(name);
+    frame.extend_from_slice(payload);
+    Ok(frame)
 }

--- a/src/registrar/endpoint/protocol.rs
+++ b/src/registrar/endpoint/protocol.rs
@@ -10,11 +10,13 @@
 // caller's half — `encode_request`, the three response decoders and the
 // `ca_anchor` decode behind the mint one — has no production consumer
 // in this crate, because the enrolling agent that speaks this protocol
-// is separate work. Keeping both halves in one module is what lets a
-// test round-trip a payload through the exact bytes the endpoint
-// writes, so the caller's half is allowed to be unreached rather than
-// deleted and written again against the same reference when that agent
-// lands.
+// is separate work. `super::client` is this repository's reference
+// implementation of that caller and drives every one of them, but it is
+// itself unreached for the same reason, so the allow stays. Keeping both
+// halves in one module is what lets a test round-trip a payload through
+// the exact bytes the endpoint writes, so the caller's half is allowed
+// to be unreached rather than deleted and written again against the same
+// reference when that agent lands.
 #![allow(dead_code)]
 
 use std::fmt;

--- a/src/registrar/endpoint/test_support.rs
+++ b/src/registrar/endpoint/test_support.rs
@@ -1,0 +1,416 @@
+//! Certificate material and log capture shared by every test under
+//! `endpoint`.
+//!
+//! Both halves live here in exactly one copy, and that is the point. A
+//! second `rcgen` CA builder would let one module's tests keep passing
+//! against material the other module's tests no longer produce, and a
+//! second capturing subscriber would do the same for the events an
+//! assertion is written against. Nothing here is compiled into a
+//! shipped binary: the module is `#[cfg(test)]` and so is every use of
+//! it.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use rcgen::{
+    BasicConstraints, CertificateParams, CertifiedIssuer, DnType, KeyPair, KeyUsagePurpose,
+    SanType, date_time_ymd,
+};
+use rustls::ClientConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tempfile::TempDir;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, SubscriberExt as _};
+
+use super::client;
+use super::tls::{EndpointCertResolver, EndpointTlsError, build_server_config};
+use crate::registrar::endpoint_pin::{
+    REGISTRAR_ENDPOINT_ANCHORS_FILE, build_endpoint_client_config,
+};
+use crate::registrar::{registrar_client_identity, registrar_endpoint_identity};
+
+// ---------------------------------------------------------------------
+// Captured logging, so a refusal's diagnostic fields are assertable
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub(super) struct CapturedEvent {
+    pub(super) message: String,
+    pub(super) fields: BTreeMap<String, String>,
+}
+
+impl CapturedEvent {
+    pub(super) fn field(&self, name: &str) -> &str {
+        self.fields
+            .get(name)
+            .map_or("", std::string::String::as_str)
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct CapturedLogs(Arc<StdMutex<Vec<CapturedEvent>>>);
+
+impl CapturedLogs {
+    pub(super) fn events(&self) -> Vec<CapturedEvent> {
+        self.0
+            .lock()
+            .expect("the capture mutex is only held to push and read")
+            .clone()
+    }
+
+    /// Every refusal event captured so far.
+    pub(super) fn refusals(&self) -> Vec<CapturedEvent> {
+        self.events()
+            .into_iter()
+            .filter(|event| {
+                event
+                    .message
+                    .starts_with("Registrar endpoint refused a connection")
+            })
+            .collect()
+    }
+
+    /// The one refusal event, which every refusal path emits exactly
+    /// once.
+    pub(super) fn refusal(&self) -> CapturedEvent {
+        let mut matching = self.refusals();
+        assert_eq!(
+            matching.len(),
+            1,
+            "expected exactly one refusal event, saw {matching:?}"
+        );
+        matching.remove(0)
+    }
+}
+
+struct FieldCollector(BTreeMap<String, String>);
+
+impl Visit for FieldCollector {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedLogs {
+    fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
+        let mut collector = FieldCollector(BTreeMap::new());
+        event.record(&mut collector);
+        let message = collector
+            .0
+            .remove("message")
+            .unwrap_or_default()
+            .trim_matches('"')
+            .to_string();
+        self.0
+            .lock()
+            .expect("the capture mutex is only held to push and read")
+            .push(CapturedEvent {
+                message,
+                fields: collector.0,
+            });
+    }
+}
+
+/// Installs a capturing subscriber for the current thread.
+///
+/// Every test that uses it runs on a current-thread runtime, so the
+/// whole future stays on the thread the guard was taken on.
+///
+/// The interest cache is rebuilt afterwards, and that is load-bearing
+/// rather than defensive. `tracing` caches each callsite's interest
+/// globally, and a callsite first reached on a *parallel* test thread —
+/// where the default subscriber is the no-op one — is cached as
+/// `Interest::never()` and stays disabled for every thread, including
+/// this one. Rebuilding recomputes it over the live subscribers, this
+/// one now among them, so a capture cannot come back empty because some
+/// other test happened to reach the same log line first.
+pub(super) fn capture_logs() -> (CapturedLogs, tracing::subscriber::DefaultGuard) {
+    let logs = CapturedLogs::default();
+    let subscriber = tracing_subscriber::registry().with(logs.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    (logs, guard)
+}
+// ---------------------------------------------------------------------
+// Certificate material: a whole deployment's PKI under a tempdir
+// ---------------------------------------------------------------------
+
+/// The deployment domain every test identity is composed under.
+pub(super) const TEST_DOMAIN: &str = "example.internal";
+/// The host label the registrar and the endpoint both run on.
+pub(super) const TEST_HOST: &str = "h1";
+/// The instance label every test identity carries.
+pub(super) const TEST_INSTANCE: &str = "001";
+/// A domain that is a bare string suffix of [`TEST_DOMAIN`] without
+/// being a label-boundary suffix of it.
+pub(super) const NEAR_MISS_DOMAIN: &str = "evil-example.internal";
+/// Basename stem of the conforming server material.
+pub(super) const SERVER_STEM: &str = "endpoint";
+/// The name a client dials with. The endpoint verifier deliberately
+/// ignores it — over `AF_UNIX` there is no meaningful name — so it is a
+/// placeholder and never the pinned identity.
+pub(super) const DIAL_NAME: &str = "localhost";
+
+pub(super) type TestCa = CertifiedIssuer<'static, KeyPair>;
+
+/// The endpoint server identity every test endpoint presents.
+pub(super) fn endpoint_name() -> String {
+    registrar_endpoint_identity(TEST_INSTANCE, TEST_HOST, TEST_DOMAIN)
+}
+
+/// The one client identity the endpoint accepts.
+pub(super) fn registrar_client_name() -> String {
+    registrar_client_identity(TEST_INSTANCE, TEST_HOST, TEST_DOMAIN)
+}
+
+pub(super) fn dns_san(name: &str) -> SanType {
+    SanType::DnsName(name.to_string().try_into().expect("a valid DNS SAN"))
+}
+
+/// Self-signs a CA whose validity window is `(not_before, not_after)`.
+pub(super) fn generate_ca(not_before: (i32, u8, u8), not_after: (i32, u8, u8)) -> TestCa {
+    let key = KeyPair::generate().expect("generate key");
+    let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "Bootroot Endpoint Test CA");
+    params.is_ca = rcgen::IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+    ];
+    params.not_before = date_time_ymd(not_before.0, not_before.1, not_before.2);
+    params.not_after = date_time_ymd(not_after.0, not_after.1, not_after.2);
+    CertifiedIssuer::self_signed(params, key).expect("self-signed CA")
+}
+
+pub(super) fn valid_ca() -> TestCa {
+    generate_ca((2020, 1, 1), (2099, 1, 1))
+}
+
+/// Issues a leaf carrying exactly `sans`, signed by `ca`.
+///
+/// The validity window is wide open because these handshakes run against
+/// the real clock.
+pub(super) fn issue_leaf(ca: &TestCa, sans: Vec<SanType>) -> (rcgen::Certificate, KeyPair) {
+    let key = KeyPair::generate().expect("generate key");
+    let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
+    params.is_ca = rcgen::IsCa::NoCa;
+    params.not_before = date_time_ymd(2020, 1, 1);
+    params.not_after = date_time_ymd(2099, 1, 1);
+    params.subject_alt_names = sans;
+    let certificate = params.signed_by(&key, ca).expect("issued leaf");
+    (certificate, key)
+}
+
+pub(super) fn key_der(key: &KeyPair) -> PrivateKeyDer<'static> {
+    PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.serialize_der()))
+}
+
+/// Writes a leaf and its key as PEM at the given paths, optionally
+/// following the leaf with its issuer, and returns the leaf's DER.
+///
+/// The one PEM writer for leaf material in this tree's endpoint tests:
+/// [`Pki::server_material_from`] and the client's tests both go through
+/// it, so material a test writes is material the other side reads back
+/// the same way.
+pub(super) fn write_leaf_material(
+    issuer: &TestCa,
+    sans: Vec<SanType>,
+    certificate_path: &Path,
+    key_path: &Path,
+    with_chain: bool,
+) -> Vec<u8> {
+    let (certificate, key) = issue_leaf(issuer, sans);
+    let mut pem = certificate.pem();
+    if with_chain {
+        pem.push_str(&issuer.pem());
+    }
+    std::fs::write(certificate_path, pem).expect("write the leaf chain");
+    std::fs::write(key_path, key.serialize_pem()).expect("write the leaf key");
+    certificate.der().to_vec()
+}
+
+/// A deployment's certificate material, written under
+/// `tempfile::tempdir()`: one CA, the bundle file, the pin file, and
+/// whatever leaves a test asks for.
+///
+/// Nothing here binds a path: every file is under the temporary
+/// directory this value owns, and dropping it removes them.
+pub(super) struct Pki {
+    pub(super) dir: TempDir,
+    pub(super) ca: TestCa,
+    /// Every certificate written to the bundle file, as PEM, pinned or
+    /// not.
+    bundle: Vec<String>,
+    /// The subset of the bundle named in `trust.trusted_ca_sha256`.
+    pins: Vec<String>,
+}
+
+/// Issues a client leaf carrying `sans`, signed by `issuer`, and returns
+/// the chain and key a `ClientConfig` authenticates with.
+pub(super) fn client_material_from(
+    issuer: &TestCa,
+    sans: Vec<SanType>,
+) -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+    let (certificate, key) = issue_leaf(issuer, sans);
+    (
+        vec![
+            CertificateDer::from(certificate.der().to_vec()),
+            CertificateDer::from(issuer.der().to_vec()),
+        ],
+        key_der(&key),
+    )
+}
+
+/// A caller pinning whatever `pin_file` names, authenticating with
+/// `auth` or with nothing when it is `None`.
+///
+/// The authenticating arm composes nothing itself: it delegates to
+/// [`client::build_client_config`], which is the one place in the tree
+/// where the registrar caller's TLS configuration is built. The
+/// unauthenticated arm keeps calling
+/// [`build_endpoint_client_config`], the helper written for a caller
+/// that presents no client certificate.
+pub(super) fn client_config_pinning(
+    pin_file: &Path,
+    auth: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
+) -> ClientConfig {
+    match auth {
+        Some((chain, key)) => client::build_client_config(pin_file, &endpoint_name(), chain, key)
+            .expect("a pinned, authenticating client configuration"),
+        None => build_endpoint_client_config(pin_file, &endpoint_name())
+            .expect("a pinned client configuration"),
+    }
+}
+
+impl Pki {
+    /// The conforming deployment: one CA, in the bundle and pinned.
+    pub(super) fn new() -> Self {
+        Self::over(valid_ca())
+    }
+
+    pub(super) fn over(ca: TestCa) -> Self {
+        let pin = crate::tls::sha256_hex(ca.der().as_ref());
+        let pem = ca.pem();
+        Self {
+            dir: tempfile::tempdir().expect("tempdir"),
+            ca,
+            bundle: vec![pem],
+            pins: vec![pin],
+        }
+    }
+
+    /// Adds a CA to the bundle file without pinning it, so a leaf it
+    /// issued is in the operator's bundle and still not admitted.
+    pub(super) fn add_unpinned(&mut self, ca: &TestCa) {
+        self.bundle.push(ca.pem());
+    }
+
+    pub(super) fn pins(&self) -> Vec<String> {
+        self.pins.clone()
+    }
+
+    pub(super) fn path(&self, name: &str) -> PathBuf {
+        self.dir.path().join(name)
+    }
+
+    /// Writes the bundle file and returns its path.
+    pub(super) fn ca_bundle_path(&self) -> PathBuf {
+        let path = self.path("ca-bundle.pem");
+        let mut pem = String::new();
+        for certificate in &self.bundle {
+            pem.push_str(certificate);
+        }
+        std::fs::write(&path, pem).expect("write the CA bundle");
+        path
+    }
+
+    /// Writes the caller-side pin file and returns its path.
+    pub(super) fn pin_file_path(&self) -> PathBuf {
+        self.pin_file_over(&self.pins())
+    }
+
+    pub(super) fn pin_file_over(&self, pins: &[String]) -> PathBuf {
+        let path = self.path(REGISTRAR_ENDPOINT_ANCHORS_FILE);
+        let mut contents = String::new();
+        for pin in pins {
+            contents.push_str(pin);
+            contents.push('\n');
+        }
+        std::fs::write(&path, contents).expect("write the pin file");
+        path
+    }
+
+    /// Writes server material: the leaf carrying `sans`, optionally
+    /// followed by its issuer, plus the leaf's key.
+    pub(super) fn server_material_from(
+        &self,
+        issuer: &TestCa,
+        stem: &str,
+        sans: Vec<SanType>,
+        with_chain: bool,
+    ) -> (PathBuf, PathBuf) {
+        let cert_path = self.path(&format!("{stem}.crt"));
+        let key_path = self.path(&format!("{stem}.key"));
+        write_leaf_material(issuer, sans, &cert_path, &key_path, with_chain);
+        (cert_path, key_path)
+    }
+
+    /// The conforming server material: the endpoint identity, leaf plus
+    /// issuer chain, issued by the pinned CA.
+    pub(super) fn server_material(&self) -> (PathBuf, PathBuf) {
+        self.server_material_from(&self.ca, SERVER_STEM, vec![dns_san(&endpoint_name())], true)
+    }
+
+    /// The registrar's own client material, from the pinned CA.
+    pub(super) fn registrar_client_material(
+        &self,
+    ) -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+        client_material_from(&self.ca, vec![dns_san(&registrar_client_name())])
+    }
+
+    /// Runs the production configuration builder over this deployment's
+    /// material.
+    pub(super) fn build(
+        &self,
+        cert_path: &Path,
+        key_path: &Path,
+    ) -> Result<(Arc<rustls::ServerConfig>, Arc<EndpointCertResolver>), EndpointTlsError> {
+        build_server_config(
+            Some(cert_path),
+            Some(key_path),
+            Some(&self.ca_bundle_path()),
+            &self.pins(),
+            TEST_DOMAIN,
+        )
+    }
+
+    /// The configuration and resolver the conforming material produces.
+    pub(super) fn conforming(&self) -> (Arc<rustls::ServerConfig>, Arc<EndpointCertResolver>) {
+        let (cert_path, key_path) = self.server_material();
+        self.build(&cert_path, &key_path)
+            .expect("conforming material must build a configuration")
+    }
+
+    /// A caller that pins this deployment's anchor and authenticates
+    /// with `auth`, or with nothing when it is `None`.
+    pub(super) fn client_config(
+        &self,
+        auth: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
+    ) -> ClientConfig {
+        client_config_pinning(&self.pin_file_path(), auth)
+    }
+
+    /// The caller the endpoint is meant to serve.
+    pub(super) fn registrar_client_config(&self) -> ClientConfig {
+        self.client_config(Some(self.registrar_client_material()))
+    }
+}

--- a/src/registrar/endpoint/tests.rs
+++ b/src/registrar/endpoint/tests.rs
@@ -17,22 +17,25 @@
 //!   `tempfile::tempdir()`, and hands its descriptor through the very
 //!   activation seam production uses. Code under test never binds,
 //!   unlinks or chmods anything.
+//!
+//! The certificate material the last two tiers rest on, and the
+//! `tracing` capture the stream tier reads its diagnostics back out of,
+//! live in [`super::test_support`] rather than here. They are shared
+//! with the client's tests, so that neither module grows a second
+//! `rcgen` CA builder or a second capturing subscriber and keeps passing
+//! against material — or against a capture — the other no longer
+//! produces.
 
-use std::collections::BTreeMap;
 use std::future::Future;
 use std::os::fd::RawFd;
 use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
 use std::time::Duration as StdDuration;
 
-use rcgen::{
-    BasicConstraints, CertificateParams, CertifiedIssuer, DnType, KeyPair, KeyUsagePurpose,
-    SanType, date_time_ymd,
-};
 use rustls::ClientConfig;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+use rustls::pki_types::ServerName;
 use tempfile::TempDir;
 use time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
@@ -41,8 +44,6 @@ use tokio::sync::{Semaphore, mpsc, watch};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
 use tokio_rustls::TlsConnector;
-use tracing::field::{Field, Visit};
-use tracing_subscriber::layer::{Context, SubscriberExt as _};
 use wiremock::MockServer;
 
 use super::activation::{
@@ -57,6 +58,11 @@ use super::handler::{HANDLER_REJECTED_PAYLOAD, HandlerRefusal, RegistrarRequestH
 use super::policy::{self, SocketMetadata, SocketPolicyViolation};
 use super::refusal::{ConnectionId, UNREAD_OPERATION, refuse};
 use super::serve::{self, authorize_peer, caller_identity, serve_request};
+use super::test_support::{
+    CapturedEvent, CapturedLogs, DIAL_NAME, NEAR_MISS_DOMAIN, Pki, TEST_DOMAIN, TEST_HOST,
+    TEST_INSTANCE, capture_logs, client_config_pinning, client_material_from, dns_san,
+    endpoint_name, generate_ca, registrar_client_name, valid_ca,
+};
 use super::tls::{
     CA_BUNDLE_SETTING, EndpointCertResolver, EndpointTlsError, SERVER_CERT_SETTING,
     SERVER_KEY_SETTING, TRUSTED_CA_SETTING, build_server_config,
@@ -72,9 +78,7 @@ use crate::registrar::audit::AuditRecordStore;
 use crate::registrar::config::RegistrarConfig;
 use crate::registrar::endpoint::production::ProductionHandler;
 use crate::registrar::endpoint::protocol;
-use crate::registrar::endpoint_pin::{
-    EndpointVerifyRejection, REGISTRAR_ENDPOINT_ANCHORS_FILE, endpoint_server_verifier,
-};
+use crate::registrar::endpoint_pin::EndpointVerifyRejection;
 use crate::registrar::fixture::RegistrarConfigFixture;
 use crate::registrar::identity::RequestedSpec;
 use crate::registrar::internal::InternalCredential;
@@ -86,9 +90,7 @@ use crate::registrar::verbs::wrap_ttl::WrapTtlPolicy;
 use crate::registrar::verbs::{
     DeregisterRequest, MintRequest, RegistrarVerbs, RegistrarVerbsConfig,
 };
-use crate::registrar::{
-    RegistrarIdentityError, ReloadSpec, registrar_client_identity, registrar_endpoint_identity,
-};
+use crate::registrar::{RegistrarIdentityError, ReloadSpec, registrar_client_identity};
 
 /// A pid no test process can have, for the mismatch arm.
 const OTHER_PID: u32 = 424_242;
@@ -653,104 +655,6 @@ fn name_bytes_are_escaped_and_capped_for_logging() {
     let long = [b'a'; 40];
     let escaped = escape_name_bytes(&long);
     assert_eq!(escaped, format!("{}...", "a".repeat(32)));
-}
-
-// ---------------------------------------------------------------------
-// Captured logging, so a refusal's diagnostic fields are assertable
-// ---------------------------------------------------------------------
-
-#[derive(Debug, Clone)]
-struct CapturedEvent {
-    message: String,
-    fields: BTreeMap<String, String>,
-}
-
-impl CapturedEvent {
-    fn field(&self, name: &str) -> &str {
-        self.fields
-            .get(name)
-            .map_or("", std::string::String::as_str)
-    }
-}
-
-#[derive(Clone, Default)]
-struct CapturedLogs(Arc<StdMutex<Vec<CapturedEvent>>>);
-
-impl CapturedLogs {
-    fn events(&self) -> Vec<CapturedEvent> {
-        self.0
-            .lock()
-            .expect("the capture mutex is only held to push and read")
-            .clone()
-    }
-
-    /// Every refusal event captured so far.
-    fn refusals(&self) -> Vec<CapturedEvent> {
-        self.events()
-            .into_iter()
-            .filter(|event| {
-                event
-                    .message
-                    .starts_with("Registrar endpoint refused a connection")
-            })
-            .collect()
-    }
-
-    /// The one refusal event, which every refusal path emits exactly
-    /// once.
-    fn refusal(&self) -> CapturedEvent {
-        let mut matching = self.refusals();
-        assert_eq!(
-            matching.len(),
-            1,
-            "expected exactly one refusal event, saw {matching:?}"
-        );
-        matching.remove(0)
-    }
-}
-
-struct FieldCollector(BTreeMap<String, String>);
-
-impl Visit for FieldCollector {
-    fn record_str(&mut self, field: &Field, value: &str) {
-        self.0.insert(field.name().to_string(), value.to_string());
-    }
-
-    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        self.0
-            .insert(field.name().to_string(), format!("{value:?}"));
-    }
-}
-
-impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedLogs {
-    fn on_event(&self, event: &tracing::Event<'_>, _context: Context<'_, S>) {
-        let mut collector = FieldCollector(BTreeMap::new());
-        event.record(&mut collector);
-        let message = collector
-            .0
-            .remove("message")
-            .unwrap_or_default()
-            .trim_matches('"')
-            .to_string();
-        self.0
-            .lock()
-            .expect("the capture mutex is only held to push and read")
-            .push(CapturedEvent {
-                message,
-                fields: collector.0,
-            });
-    }
-}
-
-/// Installs a capturing subscriber for the current thread.
-///
-/// Every test that uses it runs on a current-thread runtime, so the
-/// whole future stays on the thread the guard was taken on.
-fn capture_logs() -> (CapturedLogs, tracing::subscriber::DefaultGuard) {
-    let logs = CapturedLogs::default();
-    let subscriber = tracing_subscriber::registry().with(logs.clone());
-    let guard = tracing::subscriber::set_default(subscriber);
-    (logs, guard)
 }
 
 // ---------------------------------------------------------------------
@@ -1657,262 +1561,6 @@ async fn drain_aborts_connections_that_outlast_the_window() {
         started.elapsed() >= CONNECTION_DRAIN_TIMEOUT,
         "the drain window must be honoured before the abort"
     );
-}
-
-// ---------------------------------------------------------------------
-// Certificate material: a whole deployment's PKI under a tempdir
-// ---------------------------------------------------------------------
-
-/// The deployment domain every test identity is composed under.
-const TEST_DOMAIN: &str = "example.internal";
-/// The host label the registrar and the endpoint both run on.
-const TEST_HOST: &str = "h1";
-/// The instance label every test identity carries.
-const TEST_INSTANCE: &str = "001";
-/// A domain that is a bare string suffix of [`TEST_DOMAIN`] without
-/// being a label-boundary suffix of it.
-const NEAR_MISS_DOMAIN: &str = "evil-example.internal";
-/// Basename stem of the conforming server material.
-const SERVER_STEM: &str = "endpoint";
-/// The name a client dials with. The endpoint verifier deliberately
-/// ignores it — over `AF_UNIX` there is no meaningful name — so it is a
-/// placeholder and never the pinned identity.
-const DIAL_NAME: &str = "localhost";
-
-type TestCa = CertifiedIssuer<'static, KeyPair>;
-
-/// The endpoint server identity every test endpoint presents.
-fn endpoint_name() -> String {
-    registrar_endpoint_identity(TEST_INSTANCE, TEST_HOST, TEST_DOMAIN)
-}
-
-/// The one client identity the endpoint accepts.
-fn registrar_client_name() -> String {
-    registrar_client_identity(TEST_INSTANCE, TEST_HOST, TEST_DOMAIN)
-}
-
-fn dns_san(name: &str) -> SanType {
-    SanType::DnsName(name.to_string().try_into().expect("a valid DNS SAN"))
-}
-
-/// Self-signs a CA whose validity window is `(not_before, not_after)`.
-fn generate_ca(not_before: (i32, u8, u8), not_after: (i32, u8, u8)) -> TestCa {
-    let key = KeyPair::generate().expect("generate key");
-    let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
-    params
-        .distinguished_name
-        .push(DnType::CommonName, "Bootroot Endpoint Test CA");
-    params.is_ca = rcgen::IsCa::Ca(BasicConstraints::Unconstrained);
-    params.key_usages = vec![
-        KeyUsagePurpose::DigitalSignature,
-        KeyUsagePurpose::KeyCertSign,
-        KeyUsagePurpose::CrlSign,
-    ];
-    params.not_before = date_time_ymd(not_before.0, not_before.1, not_before.2);
-    params.not_after = date_time_ymd(not_after.0, not_after.1, not_after.2);
-    CertifiedIssuer::self_signed(params, key).expect("self-signed CA")
-}
-
-fn valid_ca() -> TestCa {
-    generate_ca((2020, 1, 1), (2099, 1, 1))
-}
-
-/// Issues a leaf carrying exactly `sans`, signed by `ca`.
-///
-/// The validity window is wide open because these handshakes run against
-/// the real clock.
-fn issue_leaf(ca: &TestCa, sans: Vec<SanType>) -> (rcgen::Certificate, KeyPair) {
-    let key = KeyPair::generate().expect("generate key");
-    let mut params = CertificateParams::new(Vec::new()).expect("certificate params");
-    params.is_ca = rcgen::IsCa::NoCa;
-    params.not_before = date_time_ymd(2020, 1, 1);
-    params.not_after = date_time_ymd(2099, 1, 1);
-    params.subject_alt_names = sans;
-    let certificate = params.signed_by(&key, ca).expect("issued leaf");
-    (certificate, key)
-}
-
-fn key_der(key: &KeyPair) -> PrivateKeyDer<'static> {
-    PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key.serialize_der()))
-}
-
-/// A deployment's certificate material, written under
-/// `tempfile::tempdir()`: one CA, the bundle file, the pin file, and
-/// whatever leaves a test asks for.
-///
-/// Nothing here binds a path: every file is under the temporary
-/// directory this value owns, and dropping it removes them.
-struct Pki {
-    dir: TempDir,
-    ca: TestCa,
-    /// Every certificate written to the bundle file, as PEM, pinned or
-    /// not.
-    bundle: Vec<String>,
-    /// The subset of the bundle named in `trust.trusted_ca_sha256`.
-    pins: Vec<String>,
-}
-
-/// Issues a client leaf carrying `sans`, signed by `issuer`, and returns
-/// the chain and key a `ClientConfig` authenticates with.
-fn client_material_from(
-    issuer: &TestCa,
-    sans: Vec<SanType>,
-) -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
-    let (certificate, key) = issue_leaf(issuer, sans);
-    (
-        vec![
-            CertificateDer::from(certificate.der().to_vec()),
-            CertificateDer::from(issuer.der().to_vec()),
-        ],
-        key_der(&key),
-    )
-}
-
-/// A caller pinning whatever `pin_file` names, authenticating with
-/// `auth` or with nothing when it is `None`.
-fn client_config_pinning(
-    pin_file: &Path,
-    auth: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
-) -> ClientConfig {
-    let verifier =
-        endpoint_server_verifier(pin_file, &endpoint_name()).expect("an endpoint verifier");
-    let builder = ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(verifier);
-    match auth {
-        Some((chain, key)) => builder
-            .with_client_auth_cert(chain, key)
-            .expect("client authentication material"),
-        None => builder.with_no_client_auth(),
-    }
-}
-
-impl Pki {
-    /// The conforming deployment: one CA, in the bundle and pinned.
-    fn new() -> Self {
-        Self::over(valid_ca())
-    }
-
-    fn over(ca: TestCa) -> Self {
-        let pin = crate::tls::sha256_hex(ca.der().as_ref());
-        let pem = ca.pem();
-        Self {
-            dir: tempfile::tempdir().expect("tempdir"),
-            ca,
-            bundle: vec![pem],
-            pins: vec![pin],
-        }
-    }
-
-    /// Adds a CA to the bundle file without pinning it, so a leaf it
-    /// issued is in the operator's bundle and still not admitted.
-    fn add_unpinned(&mut self, ca: &TestCa) {
-        self.bundle.push(ca.pem());
-    }
-
-    fn pins(&self) -> Vec<String> {
-        self.pins.clone()
-    }
-
-    fn path(&self, name: &str) -> PathBuf {
-        self.dir.path().join(name)
-    }
-
-    /// Writes the bundle file and returns its path.
-    fn ca_bundle_path(&self) -> PathBuf {
-        let path = self.path("ca-bundle.pem");
-        let mut pem = String::new();
-        for certificate in &self.bundle {
-            pem.push_str(certificate);
-        }
-        std::fs::write(&path, pem).expect("write the CA bundle");
-        path
-    }
-
-    /// Writes the caller-side pin file and returns its path.
-    fn pin_file_path(&self) -> PathBuf {
-        self.pin_file_over(&self.pins())
-    }
-
-    fn pin_file_over(&self, pins: &[String]) -> PathBuf {
-        let path = self.path(REGISTRAR_ENDPOINT_ANCHORS_FILE);
-        let mut contents = String::new();
-        for pin in pins {
-            contents.push_str(pin);
-            contents.push('\n');
-        }
-        std::fs::write(&path, contents).expect("write the pin file");
-        path
-    }
-
-    /// Writes server material: the leaf carrying `sans`, optionally
-    /// followed by its issuer, plus the leaf's key.
-    fn server_material_from(
-        &self,
-        issuer: &TestCa,
-        stem: &str,
-        sans: Vec<SanType>,
-        with_chain: bool,
-    ) -> (PathBuf, PathBuf) {
-        let (certificate, key) = issue_leaf(issuer, sans);
-        let mut pem = certificate.pem();
-        if with_chain {
-            pem.push_str(&issuer.pem());
-        }
-        let cert_path = self.path(&format!("{stem}.crt"));
-        let key_path = self.path(&format!("{stem}.key"));
-        std::fs::write(&cert_path, pem).expect("write the server chain");
-        std::fs::write(&key_path, key.serialize_pem()).expect("write the server key");
-        (cert_path, key_path)
-    }
-
-    /// The conforming server material: the endpoint identity, leaf plus
-    /// issuer chain, issued by the pinned CA.
-    fn server_material(&self) -> (PathBuf, PathBuf) {
-        self.server_material_from(&self.ca, SERVER_STEM, vec![dns_san(&endpoint_name())], true)
-    }
-
-    /// The registrar's own client material, from the pinned CA.
-    fn registrar_client_material(&self) -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
-        client_material_from(&self.ca, vec![dns_san(&registrar_client_name())])
-    }
-
-    /// Runs the production configuration builder over this deployment's
-    /// material.
-    fn build(
-        &self,
-        cert_path: &Path,
-        key_path: &Path,
-    ) -> Result<(Arc<rustls::ServerConfig>, Arc<EndpointCertResolver>), EndpointTlsError> {
-        build_server_config(
-            Some(cert_path),
-            Some(key_path),
-            Some(&self.ca_bundle_path()),
-            &self.pins(),
-            TEST_DOMAIN,
-        )
-    }
-
-    /// The configuration and resolver the conforming material produces.
-    fn conforming(&self) -> (Arc<rustls::ServerConfig>, Arc<EndpointCertResolver>) {
-        let (cert_path, key_path) = self.server_material();
-        self.build(&cert_path, &key_path)
-            .expect("conforming material must build a configuration")
-    }
-
-    /// A caller that pins this deployment's anchor and authenticates
-    /// with `auth`, or with nothing when it is `None`.
-    fn client_config(
-        &self,
-        auth: Option<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)>,
-    ) -> ClientConfig {
-        client_config_pinning(&self.pin_file_path(), auth)
-    }
-
-    /// The caller the endpoint is meant to serve.
-    fn registrar_client_config(&self) -> ClientConfig {
-        self.client_config(Some(self.registrar_client_material()))
-    }
 }
 
 /// Opens one TLS connection to the endpoint, or reports why the

--- a/src/registrar/endpoint_pin.rs
+++ b/src/registrar/endpoint_pin.rs
@@ -169,6 +169,38 @@ impl From<EndpointVerifyRejection> for rustls::Error {
     }
 }
 
+/// Reports whether `error` is one [`RegistrarEndpointVerifier`] could
+/// itself have produced.
+///
+/// `tokio_rustls` hands a caller one `io::Error` for every way a
+/// handshake can fail, and the `rustls::Error` recovered from it is all
+/// there is to tell a *trust decision this verifier made* from a later
+/// failure that merely shares the `InvalidCertificate` wrapper. The
+/// wrapper alone does not separate them: `rustls` reports a bad
+/// `CertificateVerify` signature — checked after
+/// [`ServerCertVerifier::verify_server_cert`] has already accepted the
+/// chain — as `InvalidCertificate(BadSignature)`, which no rule here
+/// decided.
+///
+/// So the question is asked of the exact set
+/// `From<EndpointVerifyRejection>` above emits, and it is asked here,
+/// beside that impl, because the two have to move together.
+#[must_use]
+pub fn is_endpoint_verify_rejection(error: &rustls::Error) -> bool {
+    let rustls::Error::InvalidCertificate(certificate) = error else {
+        return false;
+    };
+    matches!(
+        certificate,
+        rustls::CertificateError::BadEncoding
+            | rustls::CertificateError::NotValidForName
+            | rustls::CertificateError::UnknownIssuer
+            | rustls::CertificateError::ApplicationVerificationFailure
+            | rustls::CertificateError::Expired
+            | rustls::CertificateError::NotValidYet
+    )
+}
+
 /// Derives the conventional pin-file path from a registrar client
 /// certificate path: that path's parent directory joined with
 /// [`REGISTRAR_ENDPOINT_ANCHORS_FILE`].
@@ -1100,5 +1132,66 @@ mod tests {
         std::fs::write(&path, format!("{}\n", tls::sha256_hex(anchor.as_ref())))
             .expect("write pin file");
         assert!(build_endpoint_client_config(&path, &endpoint_name()).is_ok());
+    }
+
+    #[test]
+    fn every_verifier_rejection_is_recognized_as_one() {
+        let rejections = [
+            EndpointVerifyRejection::San(SanShapeError::Malformed),
+            EndpointVerifyRejection::San(SanShapeError::Missing),
+            EndpointVerifyRejection::San(SanShapeError::Multiple),
+            EndpointVerifyRejection::San(SanShapeError::NotDns),
+            EndpointVerifyRejection::SanMismatch,
+            EndpointVerifyRejection::AnchorMismatch,
+            EndpointVerifyRejection::AnchorMalformed,
+            EndpointVerifyRejection::AnchorNotCa,
+            EndpointVerifyRejection::AnchorExpired,
+            EndpointVerifyRejection::AnchorNotYetValid,
+            EndpointVerifyRejection::ChainVerificationFailed,
+        ];
+        for rejection in rejections {
+            // Exhaustive on purpose. A variant added to either enum
+            // fails to compile here, which is the reminder that the
+            // list above and `is_endpoint_verify_rejection` both have
+            // to grow with it — a rejection missing from the predicate
+            // would reach a caller as a generic handshake failure.
+            match rejection {
+                EndpointVerifyRejection::San(shape) => match shape {
+                    SanShapeError::Malformed
+                    | SanShapeError::Missing
+                    | SanShapeError::Multiple
+                    | SanShapeError::NotDns => {}
+                },
+                EndpointVerifyRejection::SanMismatch
+                | EndpointVerifyRejection::AnchorMismatch
+                | EndpointVerifyRejection::AnchorMalformed
+                | EndpointVerifyRejection::AnchorNotCa
+                | EndpointVerifyRejection::AnchorExpired
+                | EndpointVerifyRejection::AnchorNotYetValid
+                | EndpointVerifyRejection::ChainVerificationFailed => {}
+            }
+            assert!(
+                is_endpoint_verify_rejection(&rustls::Error::from(rejection)),
+                "{rejection:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_handshake_signature_failure_is_not_a_verifier_rejection() {
+        // `rustls` checks the peer's `CertificateVerify` signature
+        // after `verify_server_cert` has already accepted the chain,
+        // and reports a bad one under the same `InvalidCertificate`
+        // wrapper every rejection above uses. No rule in this module
+        // produced it.
+        assert!(!is_endpoint_verify_rejection(&rustls::Error::from(
+            rustls::CertificateError::BadSignature
+        )));
+        assert!(!is_endpoint_verify_rejection(
+            &rustls::Error::NoCertificatesPresented
+        ));
+        assert!(!is_endpoint_verify_rejection(&rustls::Error::from(
+            rustls::CertificateError::Revoked
+        )));
     }
 }


### PR DESCRIPTION
## Summary

Adds `src/registrar/endpoint/client.rs`, this repository's reference implementation of the registrar endpoint's caller. It opens the `AF_UNIX` socket, completes a pinned mTLS handshake presenting the registrar client leaf, writes exactly one framed request, reads exactly one response to a clean end of stream, and turns the result into a typed outcome. The deployed caller remains roxyd in another repository; nothing here gains a production call site, so the module carries a module-level `#![allow(dead_code)]` explaining why, in the terms `protocol.rs` and `verbs.rs` already use.

- **Construction from explicit paths only** — socket, pin file, client certificate, client key and the expected endpoint SAN. No configuration is read and no `agent.toml` key is added, so a test builds one entirely under `tempfile::tempdir()`.
- **Trust stays in `endpoint_pin`.** The per-dial TLS configuration is `endpoint_server_verifier` finished with `with_client_auth_cert`. `build_endpoint_client_config` is not called, its signature and semantics are untouched, and the anchor-list and exact-SAN rules are not restated here. `client_config_pinning`'s authenticated arm now delegates to the client's builder, so exactly one place in the tree composes that configuration.
- **The pin-refusal variant is selected by what the verifier could have produced, not by the `InvalidCertificate` wrapper.** The wrapper does not separate the two: `rustls` checks the peer's `CertificateVerify` signature *after* the verifier has accepted the chain and reports a bad one as `InvalidCertificate(BadSignature)`, which no pin rule decided. `endpoint_pin` gains `is_endpoint_verify_rejection`, sited beside the `From<EndpointVerifyRejection>` impl whose exact output set it answers for, so the mapping and the question about it cannot drift; every existing helper signature and semantic is unchanged.
- **One request, one response, then close.** The request-envelope writer lands in `frame.rs` beside the readers it mirrors, rather than the layout being restated in the client. A payload over `MAX_FRAME_PAYLOAD_BYTES` is refused locally before the dial.
- **Bounds derived, not invented.** `MAX_RESPONSE_BYTES` is `frame::RESPONSE_PREFIX_BYTES + endpoint::MAX_RESPONSE_PAYLOAD_BYTES`, a 5-second connect timeout wraps the dial, and a 30-second read timeout covers the handshake, the write and the read together; each elapsed timeout has its own variant.
- **The clean-close rule is checked.** The exchange completes only on an orderly end of stream after the declared payload. Bytes after it, a truncation, a zero-byte clean close and an I/O error carrying its phase are four distinct variants, and pairs of tests differing by exactly one `shutdown()` on the double pin the clean-versus-unclean boundary.
- **Success and refusal are discriminated by the membership of the top-level `class` key**, through a `serde_json::Map` probe rather than a derived field — `null` and a wrongly typed `class` reach the refusal decoder, a non-object payload runs no protocol decoder at all, and exactly one decoder runs per JSON-object payload with no fallback to a second. A decoded refusal is a successful exchange and is returned in the `Ok` position with its `EnrollError` and `RefusalClass` unchanged; the client retries and reclassifies nothing.
- **A single per-dial load seam** for the certificate/key pair, so later renewal and lapse work changes one function rather than the dial path. This PR implements the plain load only. A PEM block the parser refuses fails the load rather than being skipped, so a file whose valid leaf is followed by a corrupt one cannot dial with the leaf alone; the variant names the path and quotes none of the file's bytes.
- **The per-dial load runs on the blocking pool.** The certificate, the key and — inside the verifier — the pin file are the only blocking syscalls on the dial path, and they sit outside both exchange timeouts, so a slow filesystem or a path that turns out to be a FIFO would otherwise hold a runtime worker indefinitely. The whole load moves rather than each read being made async separately, because the pin file is read inside `endpoint_server_verifier`, whose signature this issue leaves alone. The hand-off's own failure — the runtime shutting down with the load still queued, or the load panicking — is a variant of its own, built in one small seam that a test drives with a real `JoinError` from a really panicking blocking task; a load that did report back keeps whichever failure it decided.
- The `rcgen` PKI helpers and the `tracing` capture move into one `#[cfg(test)]` `test_support` module shared by the endpoint's tests and the client's, so no second CA builder or capturing subscriber exists under `src/registrar/endpoint/`.
- `docs/reference/registrar-endpoint-client.md` documents the contract, in neither locale's nav and with no `docs/ko/` counterpart, following `registrar-client-identity.md`'s precedent.

All of the client's tests run under plain unprivileged `cargo test` against a server double bound in a `tempfile::tempdir()` — the endpoint's own listener is never started.

Closes #765

Part of #790

## Test plan

- [x] Round-trip: mint and deregister return the protocol's own success shapes in the `Success` arm
- [x] Client material missing (certificate, then key) fails before the dial, with the double observing no connection
- [x] Client material malformed (non-PEM certificate, non-key key) fails before the dial
- [x] A malformed PEM block *behind* a valid leaf fails the load and never dials, rather than being skipped
- [x] Connect failure on a socket nothing listens on gives the connect variant, without waiting out the connect timeout
- [x] Pin failure, unlisted anchor: pin-refusal variant, zero request bytes observed
- [x] Pin failure, wrong SAN: same variant, same zero-request-bytes assertion
- [x] The pin-refusal variant names the expected SAN and carries a `rustls::Error::InvalidCertificate(_)`
- [x] Non-pin handshake failure (raw double): generic handshake variant, recovered error asserted not to be `InvalidCertificate(_)`
- [x] `InvalidCertificate(BadSignature)` — the signature failure `rustls` raises after the pin has already passed — gives the generic handshake variant, carrying the recovered error verbatim
- [x] Every `EndpointVerifyRejection` gives the pin-refusal variant, whichever `CertificateError` it maps onto, and `endpoint_pin`'s own tests hold the predicate and that mapping together under an exhaustive match
- [x] Refusal returns the `Refused` arm with `EnrollError` and `RefusalClass` preserved, on both verbs
- [x] Discrimination: a refusal is not misdecoded as a success, and a success is not misdecoded as a refusal
- [x] Decode failure on the success arm names the success shape
- [x] Decode failure on the refusal arm carries `CodecError::InvalidRefusalClass` and is not returned as a refusal
- [x] Zero-byte clean close has its own variant
- [x] Truncated response gives the truncation variant
- [x] Transport failure before the prefix gives the transport variant with the read phase, not the zero-byte variant
- [x] Transport failure mid-payload gives the transport variant, not the truncation variant
- [x] The transport variant's write phase has no portable test; the phase discriminant is asserted directly instead
- [x] The blocking-pool hand-off variant is produced by a test: a blocking task that really panics yields a real `JoinError`, which the seam that owns the variant turns into it — asserted `is_panic()`, alongside the paired case showing a load that reported back keeps its own variant rather than being re-labelled. The verb path cannot produce one on demand, since a test that shut its own runtime down would have nothing left to await the verb with
- [x] Trailing bytes after a complete response (a stray byte, and a whole second frame) give the trailing-bytes variant and no outcome
- [x] Complete response behind an unclean close gives the transport variant, not the `Success` arm
- [x] Hostile `class` (`null` beside every `MintResponse` member, and `7`) gives the decode variant in neither arm
- [x] Non-object payload (JSON array, and bytes that are not JSON) gives the decode variant carrying `CodecError::Json`
- [x] Oversized response fails before the payload is read
- [x] Oversized request fails locally with no connection attempted
- [x] Re-read: a second dial presents material replaced between the dials
- [x] Missing, malformed and non-DNS-name pin/expected-name inputs each give the typed `EndpointPinError`-bearing variant
- [x] One request per connection: the double reads exactly one complete request frame and then EOF
- [x] Read timeout (raw double) fires within a bound, and is shown to be the read timeout rather than the connect timeout
- [x] Connect timeout asserted at the wrapper level under `#[tokio::test(start_paused = true)]`
- [x] No marker from a key file or a wrapped secret id appears in any captured event or in either rendering of the error
- [x] The endpoint's own suite still passes after the helper move and the `client_config_pinning` rewrite — 210 `registrar::endpoint` tests pass on Linux
- [x] `./scripts/check-docs.sh` passes
- [x] `cargo fmt -- --config group_imports=StdExternalCrate` and `cargo clippy --all-targets -- -D warnings` clean, on Linux where this code compiles; production code uses no `unwrap()`
- [x] `scripts/preflight/ci/check.sh` exits 0 through all nine steps
- [x] Full `cargo test --lib` on Linux: 1083 passed, with only the four known root-artifact failures unrelated to this change

The Docker E2E matrix was not run: this change adds no production call site and touches no Docker lifecycle, E2E script or code path those scenarios exercise.


