### PR TITLE
Restrict registrar issuance option visibility (#922)

### DIFF
--- a/src/acme/flow.rs
+++ b/src/acme/flow.rs
@@ -28,7 +28,7 @@ fn contact_from_email(email: &str) -> String {
 /// behaviour and the variant is the opt-in, rather than each caller
 /// restating what it wants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum CsrShape {
+pub(crate) enum CsrShape {
     /// The ordinary service leaf: the profile's composed name as the
     /// single DNS SAN, mirrored into the common name, requesting no
     /// extended key usage at all.
@@ -54,7 +54,7 @@ pub enum CsrShape {
 /// and is then refused by the endpoint's own loader and by every
 /// correctly pinned caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum LeafPublication {
+pub(crate) enum LeafPublication {
     /// The leaf alone, exactly as every service issuance has always
     /// written it.
     #[default]
@@ -73,11 +73,11 @@ pub enum LeafPublication {
 /// [`issue_certificate`] is this struct's default and every existing
 /// caller is unaffected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct IssuanceOptions {
+pub(crate) struct IssuanceOptions {
     /// Which CSR shape to ask the CA for.
-    pub csr_shape: CsrShape,
+    pub(crate) csr_shape: CsrShape,
     /// What to write at `profile.paths.cert`.
-    pub leaf_publication: LeafPublication,
+    pub(crate) leaf_publication: LeafPublication,
 }
 
 fn build_csr_params(


### PR DESCRIPTION
`CsrShape`, `LeafPublication`, `IssuanceOptions` and its two fields were declared `pub` in `src/acme/flow.rs`, even though `flow` and the re-export in `src/acme.rs` are both crate-private. The `pub` spelling bought no external reachability and only misstated the intended audience, against the repository's rule that visibility is widened only when a compiler error requires it. All five declarations are now `pub(crate)`.

Nothing else moves: `src/acme.rs` keeps `pub use flow::{build_registrar_client_csr_params, issue_certificate}` for the ordinary public API and the `pub(crate) use` of the option types plus `issue_certificate_with_bootstrap` for registrar surface issuance. The crate-internal caller at `src/registrar_certs.rs:791` is untouched, so registrar client CSR selection (`CsrShape::RegistrarClient` for the client leaf, `CsrShape::Service` for the endpoint server leaf) and leaf publication (`LeafPublication::LeafWithChain` for surface leaves) behave exactly as before. No issuance behaviour, publication ordering or CSR content changes, and the effective external public API is unchanged.

Closes #922

Part of #913

Part of #767

## Test plan

- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] The crate compiles with no visibility error forcing a wider spelling for any of the five declarations
- [x] `cargo test --lib csr_shape` passes — `only_the_client_leaf_selects_the_client_auth_csr_shape`
- [x] `cargo test --lib registrar_certs` passes — 52 tests, covering surface issuance through the crate-internal option types
- [x] `cargo test --lib acme::` passes — 67 tests, covering the CSR builders and leaf/chain publication
