### PR TITLE
Document the preflight route without passwordless sudo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,6 +480,15 @@ Where the crate handles key material or secrets:
   It may be skipped only when your changes do not affect the Docker
   lifecycle, E2E scripts, or any code paths exercised by the E2E tests
   (rotation, service add/verify, daemon, config, etc.).
+- **When the matrix cannot run in your environment**: the matrix needs
+  passwordless `sudo` — its step 13 runs `bootroot init` as root through
+  `sudo -n`, and `--skip-hosts` does not stand in for it. On a machine
+  that cannot supply it, run the matrix as far as it goes and let CI's
+  `Docker E2E` jobs gate the arm that did not run. Say which was which
+  in the pull request body: the arm that ran and passed locally, the arm
+  that did not run, and why. This is not licence to weaken, skip,
+  `continue-on-error`, or delete a check to make a local run pass — and
+  a change exempt under the bullet above still needs no matrix at all.
 - The extended E2E suite is scheduled CI coverage in
   `e2e-extended.yml`, not a per-pull-request requirement. Run
   `scripts/preflight/ci/e2e-extended.sh` only for investigation or when


### PR DESCRIPTION
Adds one bullet to `AGENTS.md`'s `CI Requirements` section for the case the file did not cover: an environment that cannot run `scripts/preflight/ci/e2e-matrix.sh` at all.

The matrix requires passwordless `sudo` — its own usage text says step 13 runs `bootroot init` as root through `sudo -n`, and that `--skip-hosts` does not stand in for it. On a machine that does not grant it, the matrix cannot complete whatever the change is. The section's single exemption covers changes that touch no E2E-exercised path, which is a different situation, so a runtime change on such a machine had no documented route and each run stopped to ask.

The new bullet records the answer that was given every time: run the matrix as far as it goes, let CI's `Docker E2E` jobs gate the arm that did not run, and say in the pull request body which arm ran and passed and which did not and why. It also states what it is not — no weakening, skipping, `continue-on-error`, or deleting a check to make a local run pass, and a change already exempt under the preceding bullet still needs no matrix at all.

Nothing else in the section changes: the `check`-job rule, the all-jobs-pass rule, the existing exemption and the extended-suite bullet are untouched, and no script, workflow or Rust code is modified.

`markdownlint-cli2` passes under the repository configuration (32 files, 0 issues).

Closes #937
