### PR TITLE
Keep reinit preflight phase-one-only (#935)

### DIFF
--- a/scripts/impl/run-registrar-internal-init-e2e.sh
+++ b/scripts/impl/run-registrar-internal-init-e2e.sh
@@ -695,6 +695,86 @@ remove_rendered_audit_override() {
   sudo_to_log rm -f "$WORK_DIR/secrets/openbao/docker-compose.openbao-audit.yml" || true
 }
 
+# A reinit whose configured reserve has not yet been activated must get
+# past the destructive boundary, enter the ordinary init pass, and stop
+# with precisely the same phase-two guidance as direct init. The first
+# filesystem-mode assertion above covers the direct invocation; this one
+# covers the recovery sequence between the wipe and that invocation.
+assert_reinit_defers_a_fresh_filesystem_reserve_to_init() {
+  local store config log direct_log before_container after_container direct_commands reinit_commands
+  store="$AUDIT_STORE_BASE/reinit-reserve-store"
+  config="$WORK_DIR/operator-agent-reinit-filesystem.toml"
+  log="$ARTIFACT_DIR/reinit-filesystem-mode.log"
+  direct_log="$ARTIFACT_DIR/init-reinit-filesystem-mode.log"
+
+  # The existing directory-mode override belongs to the deployment we
+  # have just exercised. Removing it makes this reserve fixture fresh:
+  # reinit's pre-wipe `infra up` has no override to read, and its ordinary
+  # init pass must render the one for `store` after the wipe.
+  remove_rendered_audit_override
+  if [ -e "$WORK_DIR/secrets/openbao/docker-compose.openbao-audit.yml" ]; then
+    fail "could not remove the audit override before fresh-reserve reinit"
+  fi
+  write_reserve_agent_config "$config" "$store" 16777216
+
+  # Establish the direct-init baseline with the identical configuration,
+  # then return the reserve to its fresh state before asking reinit to
+  # traverse the same init path.
+  if run_bootroot_as_root init \
+    --no-eab \
+    --skip responder-check \
+    --compose-file "$WORK_DIR/$COMPOSE_FILE_NAME" \
+    --secrets-dir "$SECRETS_DIR" \
+    --agent-config "$config" \
+    </dev/null >"$direct_log" 2>&1; then
+    fail "direct init reported success on an unactivated filesystem reserve; see $direct_log"
+  fi
+  grep -q "provisioned, not activated" "$direct_log" ||
+    fail "direct init did not reach the unactivated-reserve outcome; see $direct_log"
+  direct_commands="$(sed -n '/Run these as root, in order, then run the command in the last step:/,/ownership is not verified/p' "$direct_log" | sed -n 's/^       //p')"
+  [ -n "$direct_commands" ] ||
+    fail "direct init rendered no phase-two commands; see $direct_log"
+  sudo -n rm -rf "$WORK_DIR/audit-store" "$store"
+  remove_rendered_audit_override
+  [ ! -e "$WORK_DIR/secrets/openbao/docker-compose.openbao-audit.yml" ] ||
+    fail "could not reset the direct-init reserve fixture before reinit"
+
+  before_container="$(docker inspect --format '{{.Id}}' "${INSTANCE}-openbao")"
+
+  if run_bootroot_as_root reinit \
+    --yes \
+    --no-eab \
+    --skip responder-check \
+    --compose-file "$WORK_DIR/$COMPOSE_FILE_NAME" \
+    --secrets-dir "$SECRETS_DIR" \
+    --agent-config "$config" \
+    </dev/null >"$log" 2>&1; then
+    fail "reinit reported success on an unactivated filesystem reserve; see $log"
+  fi
+
+  # Reaching a different container proves reinit crossed its wipe and
+  # used the ordinary infra-up handoff; reaching this outcome proves the
+  # following init pass, rather than the preflight, rendered the reserve.
+  after_container="$(docker inspect --format '{{.Id}}' "${INSTANCE}-openbao")"
+  [ "$before_container" != "$after_container" ] ||
+    fail "reinit did not replace OpenBao before the filesystem outcome; see $log"
+  grep -q "provisioned, not activated" "$log" ||
+    fail "reinit did not reach init's unactivated-reserve outcome; see $log"
+  [ -f "$WORK_DIR/secrets/openbao/docker-compose.openbao-audit.yml" ] ||
+    fail "ordinary init did not render the audit override after reinit"
+  [ -d "$WORK_DIR/audit-store" ] ||
+    fail "ordinary init did not render the reserve artifacts after reinit"
+
+  # The outcome is not merely similar: the complete ordered command
+  # sequence must exactly match direct init with the same inputs.
+  reinit_commands="$(sed -n '/Run these as root, in order, then run the command in the last step:/,/ownership is not verified/p' "$log" | sed -n 's/^       //p')"
+  [ "$reinit_commands" = "$direct_commands" ] ||
+    fail "reinit's phase-two commands differ from direct init; see $direct_log and $log"
+  assert_equal "reinit restores the enabled endpoint predicate before init" \
+    "true" "$(jq -r '.registrar_endpoint.enabled' "$WORK_DIR/state.json")"
+  pass "fresh filesystem reinit reaches ordinary init with direct-init phase-two guidance"
+}
+
 # One elevated command, with its output appended to this run's log.
 #
 # The redirect is the invoking user's, not `sudo`'s, which is the
@@ -2219,6 +2299,12 @@ main() {
   # above would still hold once it has run.
   log_phase "assert-filesystem-deployment"
   assert_the_deployment_runs_on_a_mounted_reserve
+
+  # This intentionally leaves the deployment at the ordinary init
+  # phase-two boundary, so it follows every assertion that needs the
+  # activated reserve above.
+  log_phase "assert-reinit-filesystem-boundary"
+  assert_reinit_defers_a_fresh_filesystem_reserve_to_init
 
   log_phase "done"
   log "endpoint-enabled init checks passed"

--- a/src/commands/audit_store.rs
+++ b/src/commands/audit_store.rs
@@ -32,7 +32,7 @@ use bootroot::config::AuditStoreEnforcement;
 use bootroot::fs_util;
 use bootroot::registrar::audit_store::{
     AuditStoreLayoutError, OPENBAO_CONTAINER_AUDIT_DIR, PRODUCTION_UID, STORE_DIR_MODE,
-    check_ancestors, check_store_directory, create_layout, create_mount_point,
+    check_store_directory, create_layout, create_mount_point,
 };
 use serde::Deserialize;
 
@@ -475,24 +475,20 @@ pub(crate) enum AuditStorePlan {
     Provision(Box<AgentConfigView>),
 }
 
-/// Decides what this run does about the audit store, creating,
-/// rendering and deleting nothing.
+/// Decides how endpoint and explicit-enforcement configuration gates
+/// the audit store, creating, rendering and deleting nothing.
 ///
-/// Every refusal `bootroot init` makes before it touches the filesystem
-/// lives here — the required flag, the four load failures, the
-/// enablement cross-check, the caller's own uid and the stale override
-/// — so a caller with a destructive step of its own can raise them
-/// ahead of that step rather than after it. [`apply_audit_store`] is
-/// this plus the acting.
+/// These gates do not inspect a prospective store layout. Reinit uses
+/// them before its wipe, then separately evaluates the filesystem
+/// reserve's phase-one facts. [`plan_audit_store`] adds the provisioning
+/// checks that ordinary init needs before it acts.
 ///
 /// # Errors
 ///
 /// Returns an error when `--agent-config` is required and absent, when
-/// the file cannot be loaded, when the two recorded enablement values
-/// disagree, when a run that would provision is not running as
-/// `expected_uid`, or when a rendered override names a different store
-/// than the configuration now resolves.
-fn plan_audit_store(
+/// the file cannot be loaded, or when the two recorded enablement values
+/// disagree.
+fn select_audit_store_plan(
     inputs: &AuditStoreInitInputs<'_>,
     messages: &Messages,
 ) -> Result<AuditStorePlan> {
@@ -528,6 +524,26 @@ fn plan_audit_store(
         });
     }
 
+    Ok(AuditStorePlan::Provision(Box::new(view)))
+}
+
+/// Decides what ordinary init does about the audit store, creating,
+/// rendering and deleting nothing.
+///
+/// This is [`select_audit_store_plan`] plus the validation that matters
+/// only to a provisioning init pass. Reinit deliberately does not run
+/// these checks before its wipe: a fresh host needs init to create and
+/// render its first store, while reserve phase one remains the sole
+/// filesystem preflight boundary.
+fn plan_audit_store(
+    inputs: &AuditStoreInitInputs<'_>,
+    messages: &Messages,
+) -> Result<AuditStorePlan> {
+    let plan = select_audit_store_plan(inputs, messages)?;
+    let AuditStorePlan::Provision(view) = plan else {
+        return Ok(plan);
+    };
+
     // Refuse an unprivileged provisioning run *before* `create_layout`
     // has a chance to create anything. The layout is created owned by
     // whichever process creates it, so a non-root run would build
@@ -547,7 +563,8 @@ fn plan_audit_store(
         ));
     }
 
-    if rendered_present {
+    let override_path = audit_override_path(inputs.compose_dir);
+    if override_path.exists() {
         let rendered_store = read_audit_override_store_dir(&override_path, messages)?;
         // `Path`'s own equality compares components, so the rendered
         // spelling and the configured one agree wherever they name
@@ -562,53 +579,28 @@ fn plan_audit_store(
         }
     }
 
-    Ok(AuditStorePlan::Provision(Box::new(view)))
+    Ok(AuditStorePlan::Provision(view))
 }
 
-/// Raises every refusal an `init` would raise about the audit store,
+/// Raises the audit-store refusals that must precede a reinit wipe,
 /// without creating, rendering or deleting anything.
 ///
 /// `bootroot reinit` re-runs `init`, but only after it has removed the
-/// `OpenBao` container and its volumes. A refusal raised for the first
-/// time by that second pass would land after the wipe — the partial-init
-/// trap reinit exists to recover from — so reinit raises them here
-/// instead, beside its other pre-wipe preflights. Every check below is
-/// a read, so running it twice costs nothing and decides nothing.
+/// `OpenBao` container and its volumes. The endpoint/configuration gates
+/// and filesystem reserve phase-one refusals therefore run here, before
+/// that wipe. Phase-two work and normal init concerns remain on the init
+/// path. Every check below is a read, so running it twice costs nothing
+/// and decides nothing.
 ///
 /// # Errors
 ///
-/// Returns the same errors as [`apply_audit_store`], except those that
-/// only a write can produce, plus the missing-override refusal the
-/// bring-up between the wipe and the init pass would raise.
+/// Returns the endpoint/configuration gate errors and filesystem reserve
+/// phase-one refusals that apply before reinit wipes `OpenBao`.
 pub(crate) fn preflight_audit_store(
     inputs: &AuditStoreInitInputs<'_>,
     messages: &Messages,
 ) -> Result<()> {
-    if let AuditStorePlan::Provision(view) = plan_audit_store(inputs, messages)? {
-        // The ancestor chain is the one remaining refusal `create_layout`
-        // makes before it creates anything, and it is a pure read too.
-        //
-        // The configured spelling is the right input here even in
-        // `filesystem` mode, where everything *derived* comes from the
-        // simplified path instead. An ancestor chain is spelling-
-        // invariant: `Path::ancestors` walks `parent()`, which is
-        // defined over components, and components normalise away
-        // repeated separators, a trailing separator and every `.` —
-        // exactly what simplification removes. A configured
-        // `…/audit-store/.` therefore yields `…/bootroot`, `…/lib`,
-        // `/var`, `/` — the same chain the simplified path yields, and
-        // one that never contains the store directory itself. Checking
-        // it before `evaluate` keeps a missing or untraversable
-        // ancestor ahead of the reserve verdicts, which is the order
-        // `create_layout` establishes on the init path.
-        check_ancestors(&view.audit_store_dir).map_err(|err| {
-            anyhow::anyhow!(layout_error_message(
-                &err,
-                StoreCheckCaller::Init,
-                inputs.expected_uid,
-                messages
-            ))
-        })?;
+    if let AuditStorePlan::Provision(view) = select_audit_store_plan(inputs, messages)? {
         // Phase-1 refusals only, and every one of them a pure read: a
         // sub-minimum reserve, a store path the artifacts cannot carry,
         // an image of the wrong type or the wrong size, a filesystem
@@ -633,17 +625,6 @@ pub(crate) fn preflight_audit_store(
                     &view.audit_store_dir.display().to_string()
                 ));
             }
-        }
-        // Reinit brings the stack back up *before* it re-runs `init`,
-        // and that bring-up gates on the recorded predicate alone: with
-        // it enabled it requires the rendered override, which the init
-        // pass has not written yet on a host that has never provisioned
-        // one. Saying so here costs a read; leaving it to the bring-up
-        // costs the wipe. Rendering it instead is not the answer — the
-        // store it names has to be created by the root-run init pass,
-        // and this preflight writes nothing.
-        if !audit_override_path(inputs.compose_dir).exists() {
-            anyhow::bail!(messages.error_audit_store_override_missing());
         }
     }
     Ok(())
@@ -1522,12 +1503,12 @@ mod tests {
     // ---------------------------------------------------------------
 
     /// `bootroot reinit` removes the `OpenBao` container and its volumes
-    /// before it re-runs `init`, so every refusal the init pass would
-    /// make has to be reachable ahead of that wipe. This asserts the
-    /// preflight raises each of them and, for the runs it accepts,
-    /// leaves the filesystem exactly as it found it.
+    /// before it re-runs `init`, so the endpoint/configuration gates and
+    /// filesystem reserve phase-one refusals must be reachable ahead of
+    /// that wipe. This asserts they are, and that accepted runs leave the
+    /// filesystem exactly as they found it.
     #[test]
-    fn the_preflight_raises_every_init_refusal_without_touching_anything() {
+    fn the_preflight_raises_endpoint_configuration_gates_without_touching_anything() {
         // The required flag, on the two runs that require it.
         let fixture = Fixture::new();
         let compose_dir = fixture.compose_dir();
@@ -1580,43 +1561,45 @@ mod tests {
         assert_eq!(fs::read(&rendered).expect("read"), before);
     }
 
-    /// The bring-up reinit runs between the wipe and the init pass gates
-    /// on the recorded predicate alone, so it demands the rendered
-    /// override the init pass has not written yet. On a host whose
-    /// predicate was recorded by hand and never provisioned, that
-    /// refusal has to land here rather than after `OpenBao` has been
-    /// removed.
+    /// A fresh filesystem-mode host has no rendered override for the
+    /// pre-wipe preflight to read. Once it clears phase one, it must
+    /// proceed to the ordinary init path, which renders the override,
+    /// reports the not-activated outcome, and gives the operator the
+    /// phase-two commands exactly as a direct init would.
     #[test]
-    fn the_preflight_refuses_a_provisioning_run_with_no_override_yet() {
+    fn the_preflight_leaves_fresh_filesystem_provisioning_to_init() {
         let fixture = Fixture::new();
         let compose_dir = fixture.compose_dir();
         let state = fixture.state(Some(true));
-        let agreeing = fixture.agent_config(true);
+        let agreeing = fixture.filesystem_agent_config(true);
+        let inputs = Fixture::inputs(Some(&agreeing), &state, true, &compose_dir);
 
-        let err = preflight_audit_store(
-            &Fixture::inputs(Some(&agreeing), &state, true, &compose_dir),
-            &test_messages(),
-        )
-        .expect_err("refused before the wipe");
-        assert!(err.to_string().contains("bootroot init"), "{err}");
+        preflight_audit_store(&inputs, &test_messages()).expect("phase one clears");
         assert!(!fixture.store_dir().exists());
         assert!(!audit_override_path(&compose_dir).exists());
+        assert!(!fixture.artifact_dir().exists());
 
-        // The same refusal the bring-up would have raised afterwards,
-        // which is what makes raising it here the whole point.
-        let bring_up = resolve_audit_override(
-            &state,
-            &compose_dir,
-            current_process_euid(),
-            &test_messages(),
-        )
-        .expect_err("the bring-up refuses the same host");
-        assert_eq!(bring_up.to_string(), err.to_string());
+        let outcome = apply_audit_store(&inputs, &test_messages())
+            .expect_err("ordinary init reports the phase-two outcome");
+        let text = outcome.to_string();
+        assert!(text.contains("provisioned, not activated"), "{text}");
+        let rerun = test_messages().audit_reserve_step_rerun(RESERVE_RERUN_COMMAND);
+        for step in [
+            test_messages().audit_reserve_step_image(),
+            test_messages().audit_reserve_step_install(),
+            test_messages().audit_reserve_step_subdirectories(),
+            rerun.as_str(),
+        ] {
+            assert!(text.contains(step), "missing {step:?} from {text}");
+        }
+        assert!(audit_override_path(&compose_dir).exists());
+        assert!(fixture.artifact_dir().is_dir());
     }
 
     #[test]
-    fn the_preflight_raises_the_stale_override_and_the_ancestor_refusals() {
-        // A stale override, with the rendered file left byte-identical.
+    fn the_preflight_defers_stale_override_and_ancestor_checks_to_init() {
+        // A stale override is an ordinary init concern. The preflight
+        // leaves it byte-identical and does not stop the wipe.
         let fixture = Fixture::new();
         let compose_dir = fixture.compose_dir();
         let state = fixture.state(Some(true));
@@ -1632,11 +1615,11 @@ mod tests {
             &Fixture::inputs(Some(&agreeing), &state, true, &compose_dir),
             &test_messages(),
         )
-        .expect_err("refused as stale");
+        .expect("the stale override is deferred to init");
         assert_eq!(fs::read(&rendered).expect("read"), before);
 
-        // An ancestor without `o+x`, on a fixture with no rendered
-        // override to get past first.
+        // An ancestor without `o+x` is likewise a layout check for the
+        // ordinary init pass, not a filesystem reserve phase-one fact.
         let fixture = Fixture::new();
         let compose_dir = fixture.compose_dir();
         let state = fixture.state(Some(true));
@@ -1644,16 +1627,13 @@ mod tests {
         fs::create_dir(&tight).expect("ancestor");
         fs::set_permissions(&tight, fs::Permissions::from_mode(0o700)).expect("chmod");
         let store = tight.join("audit-store");
-        let agent_config = fixture.agent_config_for(&store, true);
-        let err = preflight_audit_store(
+        let agent_config =
+            fixture.filesystem_agent_config_at(&store, true, RESERVE_FLOOR_FOR_TESTS);
+        preflight_audit_store(
             &Fixture::inputs(Some(&agent_config), &state, true, &compose_dir),
             &test_messages(),
         )
-        .expect_err("refused");
-        assert!(
-            err.to_string().contains(&tight.display().to_string()),
-            "{err}"
-        );
+        .expect("the ancestor check is deferred to init");
         assert!(!store.exists());
     }
 
@@ -1737,22 +1717,20 @@ mod tests {
         );
     }
 
-    /// The same refusal reaches `reinit` through the shared preflight,
-    /// so an unprivileged reinit is refused while `OpenBao` is still
-    /// intact rather than after the wipe.
+    /// Reinit's preflight is deliberately phase-one-only. An ordinary
+    /// init still rejects an unprivileged provisioning process, but
+    /// reinit leaves that post-wipe/init concern to its init pass.
     #[test]
-    fn the_preflight_raises_the_unprivileged_refusal_before_the_wipe() {
+    fn the_preflight_defers_the_unprivileged_refusal_to_init() {
         let fixture = Fixture::new();
         let compose_dir = fixture.compose_dir();
         let store_dir = fixture.store_dir();
         let agent_config = fixture.agent_config(true);
         let state = fixture.state(Some(true));
-        // Rendered, so the missing-override refusal cannot be what
-        // fires here.
         write_audit_override(&compose_dir, &store_dir, &test_messages()).expect("render");
 
         let foreign_uid = current_process_euid().wrapping_add(1);
-        let err = preflight_audit_store(
+        preflight_audit_store(
             &AuditStoreInitInputs {
                 compose_dir: &compose_dir,
                 agent_config: Some(&agent_config),
@@ -1762,8 +1740,7 @@ mod tests {
             },
             &test_messages(),
         )
-        .expect_err("refused");
-        assert!(err.to_string().contains(&foreign_uid.to_string()), "{err}");
+        .expect("the uid check is deferred to init");
         assert!(!store_dir.exists(), "the preflight created a store");
     }
 
@@ -2588,17 +2565,11 @@ mod tests {
         );
     }
 
-    /// A store path that is not simplified reinits, and the ancestor
-    /// chain is why.
+    /// A store path that is not simplified survives the phase-one-only
+    /// reinit preflight.
     ///
-    /// `reinit`'s pre-wipe preflight checks the ancestors of the
-    /// *configured* spelling while everything else in `filesystem`
-    /// mode is derived from the simplified one. That is safe because
-    /// an ancestor chain is spelling-invariant: `Path::ancestors`
-    /// walks `parent()`, which normalises away the trailing `.`, so
-    /// the store directory is never itself walked as one of its own
-    /// ancestors and its required `0700` — which has no `o+x` — is
-    /// never held against the traversability rule.
+    /// `filesystem` mode derives its reserve facts from the simplified
+    /// path. The ordinary init pass alone owns directory layout checks.
     #[test]
     fn the_reinit_preflight_clears_a_store_path_that_is_not_simplified() {
         let messages = test_messages();
@@ -2626,9 +2597,8 @@ mod tests {
         // would refuse.
         assert_eq!(mode & 0o001, 0, "the store directory has no o+x");
 
-        // The pre-wipe preflight now clears: no ancestor refusal, and
-        // no phase-1 refusal either, so a valid deployment spelled
-        // this way can reinit.
+        // The pre-wipe preflight only evaluates reserve phase one, so
+        // this valid deployment spelling can reinit.
         preflight_audit_store(&inputs, &messages).expect("the pre-wipe preflight clears");
 
         // It still creates nothing beneath the store and installs

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -221,7 +221,15 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
         services: vec![OPENBAO_COMPOSE_SERVICE.to_string()],
         image_archive_dir: None,
         restart_policy: "always".to_string(),
-        openbao_url: openbao.openbao_url.clone(),
+        // A registrar endpoint leaves OpenBao's preserved HCL serving
+        // TLS on loopback. The transient state below omits its predicate
+        // so infra up does not require an audit override that ordinary
+        // init has yet to render, but that must not also make infra up
+        // probe the TLS listener over HTTP.
+        openbao_url: reinit_runtime_openbao_url(
+            &openbao.openbao_url,
+            snapshot.registrar_endpoint.as_ref(),
+        ),
         openbao_unseal_from_file: None,
     };
     let infra_result = run_infra_up(&infra_args, messages).await;
@@ -1134,6 +1142,8 @@ fn init_args_for_reinit(
                 openbao_host_port_env,
             ),
         };
+        openbao.openbao_url =
+            reinit_runtime_openbao_url(&openbao.openbao_url, snapshot.registrar_endpoint.as_ref());
     }
     let db_dsn = preserved_db_dsn_from_ca_json(effective_secrets_dir);
     let stepca_provisioner = preserved_stepca_provisioner_from_ca_json(effective_secrets_dir)
@@ -1188,6 +1198,24 @@ fn init_args_for_reinit(
         reinit_mode: true,
         root_token_output: args.root_token_output.clone(),
     })
+}
+
+/// Returns the URL for recovery work against a preserved `OpenBao` listener.
+///
+/// A recorded registrar endpoint enables TLS even when `OpenBao` stays on
+/// loopback. Reinit starts that already-configured listener before its
+/// follow-up init pass can restore the endpoint predicate to `state.json`,
+/// so both operations must retain the HTTPS scheme independently of that
+/// transient state.
+fn reinit_runtime_openbao_url(
+    openbao_url: &str,
+    registrar_endpoint: Option<&crate::state::RegistrarEndpointState>,
+) -> String {
+    if registrar_endpoint.is_some_and(|endpoint| endpoint.enabled) {
+        openbao_url.replacen("http://", "https://", 1)
+    } else {
+        openbao_url.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -2580,6 +2608,26 @@ mod tests {
         assert_eq!(
             init_args.openbao.openbao_url, "https://192.168.1.10:8200",
             "non-loopback bind intent must drive the init client URL"
+        );
+    }
+
+    /// A loopback registrar endpoint still leaves the preserved `OpenBao`
+    /// listener on TLS, although it has no non-loopback bind override.
+    #[test]
+    fn reinit_runtime_url_uses_https_for_a_registrar_endpoint() {
+        let endpoint = crate::state::RegistrarEndpointState {
+            enabled: true,
+            domain: "example.internal".to_string(),
+            host: "bootroot-01".to_string(),
+        };
+
+        assert_eq!(
+            reinit_runtime_openbao_url("http://localhost:18200", Some(&endpoint)),
+            "https://localhost:18200"
+        );
+        assert_eq!(
+            reinit_runtime_openbao_url("http://localhost:18200", None),
+            "http://localhost:18200"
         );
     }
 

--- a/src/commands/reinit.rs
+++ b/src/commands/reinit.rs
@@ -132,16 +132,11 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
         validate_summary_json_output_path(out, messages)?;
     }
 
-    // 4.5. Same preflight for the audit store.  The init pass below
-    //      requires `--agent-config` on a host whose `state.json`
-    //      records an enabled registrar endpoint, or which carries a
-    //      rendered audit compose override, and refuses when that
-    //      file's `[registrar_endpoint] enabled` disagrees with the
-    //      recorded predicate.  `write_minimal_state` preserves that
-    //      predicate, so the answer here is the answer the init pass
-    //      gets — and raising it there would land after the OpenBao
-    //      wipe, recreating the partial-init trap.  Every check is a
-    //      read: nothing is created, rendered or deleted by it.
+    // 4.5. Preflight the audit-store endpoint/configuration gates and
+    //      filesystem reserve phase-one refusals. Every check is a
+    //      read: nothing is created, rendered or deleted by it. The
+    //      normal init pass below handles rendering, verification,
+    //      outcome reporting and phase-two instructions after the wipe.
     preflight_audit_store(
         &AuditStoreInitInputs {
             compose_dir: &compose_dir,
@@ -203,10 +198,13 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
     // 9. Remove OpenBao runtime/bootstrap artifacts (narrow).
     remove_openbao_runtime_state(&effective_secrets_dir, messages)?;
 
-    // 10. Rewrite state.json with intent-only fields BEFORE infra up so
-    //     the infra-up path layers the correct compose overrides for
-    //     any recorded non-loopback bind.
-    write_minimal_state(
+    // 10. Rewrite state.json with intent-only fields before infra up.
+    //     Keep the registrar predicate out of this transient state:
+    //     infra up consumes it by requiring an existing audit override,
+    //     while a fresh filesystem-mode host has not reached ordinary
+    //     init yet to render one. Non-loopback OpenBao bind intent stays
+    //     present so infra up restores its required port override.
+    write_minimal_state_for_infra(
         &state_path,
         &snapshot,
         &openbao,
@@ -226,9 +224,25 @@ pub(crate) async fn run_reinit(args: &ReinitArgs, messages: &Messages) -> Result
         openbao_url: openbao.openbao_url.clone(),
         openbao_unseal_from_file: None,
     };
-    run_infra_up(&infra_args, messages).await?;
+    let infra_result = run_infra_up(&infra_args, messages).await;
 
-    // 12. Re-run init in reinit mode.  Reinit-mode behavior is enforced
+    // 12. Restore the preserved endpoint predicate before handling the
+    //     bring-up result. A failed infra up must not strand recovery
+    //     with its registrar intent erased. On success, ordinary init
+    //     consumes the restored predicate and therefore uses the same
+    //     audit-store path, outcome, and phase-two instructions as
+    //     direct init.
+    write_minimal_state(
+        &state_path,
+        &snapshot,
+        &openbao,
+        &effective_secrets_dir,
+        messages,
+    )
+    .await?;
+    infra_result?;
+
+    // 13. Re-run init in reinit mode.  Reinit-mode behavior is enforced
     //     inside the init flow: overwrite prompts for preserved files
     //     are skipped, and an existing `password.txt` short-circuits
     //     the auto-gen path so the step-ca password is not rotated.
@@ -497,6 +511,51 @@ pub(crate) async fn write_minimal_state(
     effective_secrets_dir: &Path,
     messages: &Messages,
 ) -> Result<()> {
+    write_minimal_state_with_registrar_endpoint(
+        state_path,
+        snapshot,
+        openbao,
+        effective_secrets_dir,
+        snapshot.registrar_endpoint.clone(),
+        messages,
+    )
+    .await
+}
+
+/// Writes the transient minimal state `infra up` needs during reinit.
+///
+/// A fresh filesystem-mode audit store does not have a rendered compose
+/// override until the ordinary init pass that follows `infra up`. Omitting
+/// the predicate for this one invocation prevents its override reader from
+/// treating that normal init concern as a pre-init failure. The caller
+/// restores the predicate with [`write_minimal_state`] before invoking init.
+async fn write_minimal_state_for_infra(
+    state_path: &Path,
+    snapshot: &DeploymentIntent,
+    openbao: &OpenBaoArgs,
+    effective_secrets_dir: &Path,
+    messages: &Messages,
+) -> Result<()> {
+    write_minimal_state_with_registrar_endpoint(
+        state_path,
+        snapshot,
+        openbao,
+        effective_secrets_dir,
+        None,
+        messages,
+    )
+    .await
+}
+
+/// Serializes a reinit state carrying the selected registrar predicate.
+async fn write_minimal_state_with_registrar_endpoint(
+    state_path: &Path,
+    snapshot: &DeploymentIntent,
+    openbao: &OpenBaoArgs,
+    effective_secrets_dir: &Path,
+    registrar_endpoint: Option<crate::state::RegistrarEndpointState>,
+    messages: &Messages,
+) -> Result<()> {
     let state = StateFile {
         openbao_url: openbao.openbao_url.clone(),
         kv_mount: openbao.kv_mount.clone(),
@@ -511,7 +570,7 @@ pub(crate) async fn write_minimal_state(
         stepca_bind_addr: snapshot.stepca_bind_addr.clone(),
         stepca_advertise_addr: snapshot.stepca_advertise_addr.clone(),
         infra_certs: snapshot.infra_certs.clone(),
-        registrar_endpoint: snapshot.registrar_endpoint.clone(),
+        registrar_endpoint,
         ..Default::default()
     };
     state
@@ -3301,6 +3360,61 @@ mod tests {
 
         let rewritten = StateFile::load(&state_path).unwrap();
         assert_eq!(rewritten.registrar_endpoint, original.registrar_endpoint);
+    }
+
+    /// Reinit starts `OpenBao` before the ordinary init pass can render a
+    /// fresh audit override. Its transient state must therefore omit the
+    /// endpoint predicate for `infra up`, then restore it for init.
+    #[tokio::test]
+    async fn transient_infra_state_omits_then_restores_registrar_endpoint() {
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut original = state_with_intent();
+        original.registrar_endpoint = Some(crate::state::RegistrarEndpointState {
+            enabled: true,
+            domain: "example.internal".to_string(),
+            host: "bootroot-01".to_string(),
+        });
+        original.save(&state_path).unwrap();
+        let snapshot = snapshot_deployment_intent(&state_path).expect("snapshot");
+        let openbao = OpenBaoArgs {
+            openbao_url: "http://localhost:8200".to_string(),
+            kv_mount: "secret".to_string(),
+        };
+        let messages = test_messages();
+
+        write_minimal_state_for_infra(
+            &state_path,
+            &snapshot,
+            &openbao,
+            Path::new("secrets"),
+            &messages,
+        )
+        .await
+        .expect("write transient state");
+        assert!(
+            StateFile::load(&state_path)
+                .expect("transient state")
+                .registrar_endpoint
+                .is_none(),
+            "infra up must not require an override that init has not rendered"
+        );
+
+        write_minimal_state(
+            &state_path,
+            &snapshot,
+            &openbao,
+            Path::new("secrets"),
+            &messages,
+        )
+        .await
+        .expect("restore state");
+        assert_eq!(
+            StateFile::load(&state_path)
+                .expect("restored state")
+                .registrar_endpoint,
+            original.registrar_endpoint
+        );
     }
 
     /// A host that never recorded the predicate still records none: the


### PR DESCRIPTION
## Summary

- Restrict reinit’s pre-wipe audit-store validation to endpoint/configuration gates and filesystem reserve phase-one refusals.
- Omit the endpoint predicate only during reinit’s transient infra-up state, then restore it for ordinary init so a fresh host renders its audit override after the wipe.
- Keep HTTPS for the preserved loopback OpenBao listener while that transient state is active.
- Add unit and lifecycle coverage that compares fresh reinit’s phase-two reserve guidance with direct init.

Closes #935

Part of #923

## Test plan

- [x] Verify a fresh endpoint-enabled filesystem host with no staged audit override reaches ordinary init after reinit.
- [x] Verify reinit’s reserve outcome and phase-two commands match direct init.
- [x] Verify sub-minimum reserve, unrenderable path, wrong-size image, and non-empty store refuse before wiping.
- [x] Run all bootroot unit tests.
- [x] Run Clippy with warnings denied.
- [x] Run the full Docker E2E matrix (verified in CI; local `sudo -n` requires a password).
- [x] Verify the endpoint-enabled Docker scenario in CI.