### PR TITLE
Correct limited audit record verification (#944)

### DIFF
--- a/src/registrar/audit/scan.rs
+++ b/src/registrar/audit/scan.rs
@@ -468,6 +468,11 @@ fn classify_line(line: &[u8], data: &mut FileData, scan_state: Option<&mut ScanS
             (record.phase, record.outcome.is_some()),
             (AuditPhase::Intent | AuditPhase::Limited, true) | (AuditPhase::Outcome, false)
         )
+        || (matches!(record.phase, AuditPhase::Intent | AuditPhase::Outcome)
+            && (record.limited_bucket.is_some()
+                || record.count.is_some()
+                || record.window_start.is_some()
+                || record.window_end.is_some()))
         || (record.phase == AuditPhase::Limited
             && (!record.request_id.is_empty()
                 || !record.requested.service_name.is_empty()
@@ -790,6 +795,79 @@ mod tests {
             .expect("scan limited record");
         assert_eq!(scan.malformed_records, 0);
         assert_eq!(scan.intent_without_outcome, 1);
+    }
+
+    #[test]
+    fn rejects_limited_only_fields_on_intents_and_outcomes_without_pairing_side_effects() {
+        let dir = audit_store();
+        let now = OffsetDateTime::now_utc();
+        let request_id = "paired".to_string();
+        append_record(
+            dir.path(),
+            &AuditRecord::intent(
+                now - Duration::minutes(2),
+                request_id.clone(),
+                AuditVerb::Mint,
+                "caller".to_string(),
+                identity(),
+            ),
+        );
+        append_record(
+            dir.path(),
+            &AuditRecord::outcome(
+                now - Duration::minutes(1),
+                request_id,
+                AuditVerb::Mint,
+                "caller".to_string(),
+                identity(),
+                None,
+                AuditOutcome::FirstMint,
+            ),
+        );
+
+        macro_rules! append_records_with_limited_field {
+            ($field:ident, $value:expr, $request_id:literal) => {{
+                let mut intent = AuditRecord::intent(
+                    now - Duration::minutes(2),
+                    $request_id.to_string(),
+                    AuditVerb::Mint,
+                    "caller".to_string(),
+                    identity(),
+                );
+                intent.$field = Some($value);
+                append_record(dir.path(), &intent);
+
+                let mut outcome = AuditRecord::outcome(
+                    now - Duration::minutes(1),
+                    "paired".to_string(),
+                    AuditVerb::Mint,
+                    "caller".to_string(),
+                    identity(),
+                    None,
+                    AuditOutcome::FirstMint,
+                );
+                outcome.$field = Some($value);
+                append_record(dir.path(), &outcome);
+            }};
+        }
+
+        append_records_with_limited_field!(
+            limited_bucket,
+            super::super::LimitedBucket::Admission,
+            "limited-bucket-intent"
+        );
+        append_records_with_limited_field!(count, 1, "count-intent");
+        append_records_with_limited_field!(
+            window_start,
+            now - Duration::seconds(60),
+            "window-start-intent"
+        );
+        append_records_with_limited_field!(window_end, now, "window-end-intent");
+
+        let scan = scan_audit_store(dir.path(), now, AUDIT_SCAN_WINDOW, 16, 90)
+            .expect("scan mixed-phase limited fields");
+        assert_eq!(scan.malformed_records, 8);
+        assert_eq!(scan.intent_without_outcome, 0);
     }
 
     #[test]

--- a/src/registrar/verbs/coalescing/tests.rs
+++ b/src/registrar/verbs/coalescing/tests.rs
@@ -62,6 +62,23 @@ fn expire(
     verb: AuditVerb,
     bucket: LimiterBucket,
 ) {
+    expire_at(
+        sink,
+        caller,
+        verb,
+        bucket,
+        OffsetDateTime::now_utc()
+            - WallDuration::seconds(i64::try_from(WINDOW_SECONDS).expect("fits i64")),
+    );
+}
+
+fn expire_at(
+    sink: &CoalescingLimitedInvocationSink,
+    caller: &str,
+    verb: AuditVerb,
+    bucket: LimiterBucket,
+    wall_start: OffsetDateTime,
+) {
     let key = WindowKey {
         caller: CallerIdentity::new(caller),
         verb,
@@ -75,8 +92,7 @@ fn expire(
     // Tokio's monotonic test clock is not advanced here. Make the wall-clock
     // projection agree with the forced deadline, as it would after a real
     // configured window had elapsed.
-    window.wall_start = OffsetDateTime::now_utc()
-        - WallDuration::seconds(i64::try_from(WINDOW_SECONDS).expect("fits i64"));
+    window.wall_start = wall_start;
 }
 
 fn assert_window_span(record: &AuditRecord) {
@@ -362,6 +378,8 @@ async fn one_key_keeps_one_open_window_across_three_rollovers() {
     let sink = Arc::new(sink());
     let limiter = limiter(Arc::clone(&sink));
     let caller = CallerIdentity::new("rollover-caller");
+    let window_seconds = i64::try_from(WINDOW_SECONDS).expect("fits i64");
+    let first_window_start = OffsetDateTime::now_utc() - WallDuration::seconds(window_seconds * 3);
 
     emit_limited(
         &limiter,
@@ -370,14 +388,15 @@ async fn one_key_keeps_one_open_window_across_three_rollovers() {
         LimiterBucket::Admission,
     );
     assert_eq!(sink.windows.lock().expect("map lock").len(), 1);
-    expire(
+    expire_at(
         &sink,
         caller.as_str(),
         AuditVerb::Mint,
         LimiterBucket::Admission,
+        first_window_start,
     );
 
-    for _ in 0..2 {
+    for rollover in 1_i64..=2 {
         assert!(matches!(
             limiter.charge(&caller, AuditVerb::Mint, LimiterBucket::Admission),
             ChargeOutcome::Limited { .. }
@@ -387,11 +406,12 @@ async fn one_key_keeps_one_open_window_across_three_rollovers() {
             1,
             "a successor replaces its predecessor instead of creating a second open window"
         );
-        expire(
+        expire_at(
             &sink,
             caller.as_str(),
             AuditVerb::Mint,
             LimiterBucket::Admission,
+            first_window_start + WallDuration::seconds(window_seconds * rollover),
         );
     }
 
@@ -401,6 +421,25 @@ async fn one_key_keeps_one_open_window_across_three_rollovers() {
     assert!(records.iter().all(|record| record.count == Some(1)));
     for record in &records {
         assert_window_span(record);
+    }
+    for records in records.windows(2) {
+        let predecessor = records
+            .first()
+            .expect("adjacent records have a predecessor");
+        let successor = records.get(1).expect("adjacent records have a successor");
+        let predecessor_start = predecessor
+            .window_start
+            .expect("limited record has a start");
+        let predecessor_end = predecessor.window_end.expect("limited record has an end");
+        let successor_start = successor.window_start.expect("limited record has a start");
+        assert!(
+            predecessor_start <= successor_start,
+            "records are emitted in window order"
+        );
+        assert!(
+            predecessor_end <= successor_start,
+            "adjacent limited windows do not overlap"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Reject persisted intent and outcome records that carry limited-only fields before scanner pairing or duplicate detection.
- Add mixed-phase scanner coverage for every limited-only field and retain the valid limited-record regression.
- Strengthen the three-rollover coalescing regression with ordered, adjacent, count, and span assertions.

Closes #944

Part of #787

## Test plan

- [x] Run the focused audit scanner tests, including mixed-phase intent and outcome cases.
- [x] Run the focused coalescing-sink tests, including the three-rollover case.
- [x] Run repository formatting, all-feature Clippy, and registrar tests.
- [x] Run documentation checks and the non-Docker preflight checks.
- [x] Verify the complete Docker E2E matrix through the successful CI run; all matrix arms passed.