### PR TITLE
Strengthen relocation-procedure regression coverage (#954)

### DIFF
--- a/src/commands/audit_store/reserve.rs
+++ b/src/commands/audit_store/reserve.rs
@@ -3796,12 +3796,19 @@ mod tests {
                 !passage.contains("\n```"),
                 "{manual}: the existing-records passage must not add a relocation procedure"
             );
-            for command in ["`mv ", "`cp ", "`rsync ", "`rm ", "`mount ", "`umount "] {
+            for command in [
+                "`mv ", "`cp ", "`rsync ", "`rm ", "`mount ", "`umount ", "`find ", "`cmp ",
+                "`diff ",
+            ] {
                 assert!(
                     !passage.contains(command),
                     "{manual}: the existing-records passage must not add a relocation command: {command}"
                 );
             }
+            assert!(
+                !passage.contains(".pre-mount"),
+                "{manual}: the existing-records passage must not name the relocation path .pre-mount"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- Extend the existing existing-records manual guard with `find`, `cmp`, and `diff` command prefixes.
- Reject the `.pre-mount` path fragment in either localized passage while retaining all existing positive checks and scope boundaries.

Closes #954. Part of #952. Part of #773.

## Test plan

- [x] Run `cargo test manual_existing_records_passages_name_the_live_refusal_without_a_procedure`.
- [x] Run `cargo fmt -- --config group_imports=StdExternalCrate --check` and `cargo clippy --all-targets -- -D warnings`.
- [x] Run `scripts/preflight/ci/check.sh`.
- [x] Run `scripts/preflight/ci/test-core.sh`.
- [x] Mutate a copy of each locale passage with every new literal and confirm the focused regression fails.
- [x] Confirm the current English and Korean passages contain none of the four newly forbidden literals.
