### PR TITLE
Verify a source root lost+found on both sides (#959)

### DIFF
--- a/docs/en/operations.md
+++ b/docs/en/operations.md
@@ -1336,8 +1336,8 @@ records:
      ! -type d ! -type f -exec false {} +
    find <audit_store_dir> -xdev -mindepth 1 ! -type d ! -type f -exec false {} +
    cd <audit_store_dir>.pre-mount
-   find . -xdev -mindepth 1 ! \( -path './lost+found' -type d \) \
-     -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.source.raw
+   find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\0' \
+     > "$SCRATCH"/meta.source.raw
    sort -z -o "$SCRATCH"/meta.source "$SCRATCH"/meta.source.raw
    find . -xdev -mindepth 1 -type f -printf '%s %P\0' > "$SCRATCH"/size.source.raw
    sort -z -o "$SCRATCH"/size.source "$SCRATCH"/size.source.raw
@@ -1345,8 +1345,14 @@ records:
    sort -z -o "$SCRATCH"/files.source "$SCRATCH"/files.source.raw
    xargs -0 -r sha256sum --binary --zero < "$SCRATCH"/files.source > "$SCRATCH"/content.source
    cd <audit_store_dir>
-   find . -xdev -mindepth 1 ! \( -path './lost+found' -type d \) \
-     -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.destination.raw
+   if [ -d <audit_store_dir>.pre-mount/lost+found ] \
+     && [ ! -L <audit_store_dir>.pre-mount/lost+found ]; then
+     find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\0' \
+       > "$SCRATCH"/meta.destination.raw
+   else
+     find . -xdev -mindepth 1 ! \( -path './lost+found' -type d \) \
+       -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.destination.raw
+   fi
    sort -z -o "$SCRATCH"/meta.destination "$SCRATCH"/meta.destination.raw
    find . -xdev -mindepth 1 -type f -printf '%s %P\0' > "$SCRATCH"/size.destination.raw
    sort -z -o "$SCRATCH"/size.destination "$SCRATCH"/size.destination.raw
@@ -1447,13 +1453,25 @@ afterwards. The metadata pass carries the **hard-link count**, so a copy
 that expanded one source inode into two destination files fails even
 though every path matches on type, mode, ownership, size and content.
 Directory sizes and modification times are excluded, both differing
-legitimately between two filesystems. So is `lost+found`, and only where
-it is a directory at a tree's own root: `mkfs.ext4` creates it in every
-reserve it makes, so it stands on a side the copy did not put it on and
-would fault every correct migration. Only that one entry is exempt —
-anything underneath it is still compared under its `lost+found/…` path,
-so nothing is smuggled past the verification by being put there. A
-mismatch is decided by exit status, never by reading output.
+legitimately between two filesystems. `lost+found` is dropped from the
+**destination** manifest alone, and only where it is a directory at that
+tree's own root **and** the source root holds no directory of that name:
+`mkfs.ext4` creates it in every reserve it makes, so a source without one
+would otherwise be faulted for a record the copy did not put there. Which
+of the two destination walks runs is decided by the shell at the moment
+it runs them, from the source it is about to be compared against — so a
+source that *does* carry one, as the live store of
+[the replacement procedure](#changing-the-reserve) does, being itself a
+mounted reserve, has that directory's type, mode, numeric uid and gid and
+link count compared like any other directory's, and a mismatch on it
+stops the sequence before the closing rename. The test is spelled `-d`
+**and not** `-L` because `test -d` answers for a symbolic link's target
+and nothing in this procedure follows one, which is what `find -type d`
+also does. Only ever that one entry, and only on that one side — anything
+underneath it is still compared under its `lost+found/…` path, so nothing
+is smuggled past the verification by being put there, and a regular file
+merely bearing the name is compared in full. A mismatch is decided by exit
+status, never by reading output.
 
 **Resume and rollback.** Both are rendered, both are idempotent, and
 bootroot performs neither.

--- a/docs/ko/operations.md
+++ b/docs/ko/operations.md
@@ -1264,8 +1264,8 @@ reinit의 사전 점검은 이 표면의 1단계 거부를 모두 순수 읽기�
      ! -type d ! -type f -exec false {} +
    find <audit_store_dir> -xdev -mindepth 1 ! -type d ! -type f -exec false {} +
    cd <audit_store_dir>.pre-mount
-   find . -xdev -mindepth 1 ! \( -path './lost+found' -type d \) \
-     -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.source.raw
+   find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\0' \
+     > "$SCRATCH"/meta.source.raw
    sort -z -o "$SCRATCH"/meta.source "$SCRATCH"/meta.source.raw
    find . -xdev -mindepth 1 -type f -printf '%s %P\0' > "$SCRATCH"/size.source.raw
    sort -z -o "$SCRATCH"/size.source "$SCRATCH"/size.source.raw
@@ -1273,8 +1273,14 @@ reinit의 사전 점검은 이 표면의 1단계 거부를 모두 순수 읽기�
    sort -z -o "$SCRATCH"/files.source "$SCRATCH"/files.source.raw
    xargs -0 -r sha256sum --binary --zero < "$SCRATCH"/files.source > "$SCRATCH"/content.source
    cd <audit_store_dir>
-   find . -xdev -mindepth 1 ! \( -path './lost+found' -type d \) \
-     -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.destination.raw
+   if [ -d <audit_store_dir>.pre-mount/lost+found ] \
+     && [ ! -L <audit_store_dir>.pre-mount/lost+found ]; then
+     find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\0' \
+       > "$SCRATCH"/meta.destination.raw
+   else
+     find . -xdev -mindepth 1 ! \( -path './lost+found' -type d \) \
+       -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.destination.raw
+   fi
    sort -z -o "$SCRATCH"/meta.destination "$SCRATCH"/meta.destination.raw
    find . -xdev -mindepth 1 -type f -printf '%s %P\0' > "$SCRATCH"/size.destination.raw
    sort -z -o "$SCRATCH"/size.destination "$SCRATCH"/size.destination.raw
@@ -1367,12 +1373,23 @@ incomplete**를 내고 복사를 렌더링하지 않습니다.
 담으므로, 원본의 한 아이노드를 대상에서 두 개의 독립 파일로 늘린 복사는
 종류·모드·소유권·크기·내용이 모두 일치해도 실패합니다. 디렉터리 크기와
 수정 시각은 제외됩니다. 둘 다 파일 시스템이 다르면 정당하게 달라지기
-때문입니다. `lost+found`도 트리 자신의 뿌리에 있는 디렉터리인 경우에 한해
-제외됩니다. `mkfs.ext4`는 예약량을 만들 때마다 그것을 만들므로, 복사가
-올려놓지 않은 쪽에 서서 올바른 이전마다 실패를 일으킵니다. 제외되는 것은
-그 항목 하나뿐입니다. 그 아래에 있는 것은 여전히 `lost+found/…` 경로로
-비교되므로, 그곳에 넣어 검증을 몰래 통과시킬 수는 없습니다. 불일치는
-출력을 읽어서가 아니라 종료 상태로 판정합니다.
+때문입니다. `lost+found`는 **대상** 목록에서만 빠지며, 그것도 그 트리
+자신의 뿌리에 있는 디렉터리이고 **또한** 원본 뿌리에 같은 이름의
+디렉터리가 없을 때뿐입니다. `mkfs.ext4`는 예약량을 만들 때마다 그것을
+만들므로, 그렇지 않으면 복사가 올려놓지 않은 레코드 때문에 그런 원본이
+실패로 판정되기 때문입니다. 두 대상 순회 중 어느 쪽을 실행할지는 셸이
+실행하는 그 시점에, 곧 비교될 원본을 보고 정합니다. 그래서 원본이
+`lost+found`를 실제로 가진 경우 — [예약량 교체 절차](#changing-the-reserve)의
+살아 있는 저장소가 그 자신 마운트된 예약량이므로 그렇습니다 — 그
+디렉터리의 종류·모드·숫자 uid·숫자 gid·링크 수는 다른 디렉터리와 똑같이
+비교되고, 거기서 어긋나면 마무리 이름 바꾸기 전에 절차가 멈춥니다. 검사를
+`-d`로 쓰되 `-L`이 **아님**까지 함께 쓰는 것은, `test -d`가 심볼릭 링크의
+대상을 두고 답하는데 이 절차는 어떤 링크도 따라가지 않기 때문입니다.
+`find -type d`도 따라가지 않으므로 둘은 같은 답을 냅니다. 빠지는 것은
+언제나 그 항목 하나뿐이고 그 한쪽에서만입니다. 그 아래에 있는 것은 여전히
+`lost+found/…` 경로로 비교되므로 그곳에 넣어 검증을 몰래 통과시킬 수는
+없고, 이름만 같은 일반 파일은 온전히 비교됩니다. 불일치는 출력을
+읽어서가 아니라 종료 상태로 판정합니다.
 
 **재개와 되돌리기.** 둘 다 렌더링되고 둘 다 멱등이며 bootroot는 어느
 것도 수행하지 않습니다.

--- a/scripts/impl/run-registrar-internal-init-e2e.sh
+++ b/scripts/impl/run-registrar-internal-init-e2e.sh
@@ -1325,6 +1325,11 @@ assert_the_rendered_steps_migrate_an_existing_store() {
     fail "the copy was not rendered; see $third"
   grep -q -- "xargs -0 -r sha256sum --binary --zero" "$third" ||
     fail "the content comparison was not rendered NUL-delimited; see $third"
+  # The `mkfs.ext4` exemption is on the destination side alone, and the
+  # rendered shell decides whether to apply it from what the holding
+  # root actually holds.
+  grep -qF "if [ -d '${store}.pre-mount/lost+found' ] && [ ! -L '${store}.pre-mount/lost+found' ]" "$third" ||
+    fail "the destination walk is not decided from the holding root; see $third"
   grep -qF "mv '${store}.pre-mount' '${store}.migrated'" "$third" ||
     fail "the closing rename was not rendered; see $third"
   # The way back out is offered too, while the holding directory still
@@ -1349,11 +1354,17 @@ assert_the_rendered_steps_migrate_an_existing_store() {
 
   # The verification just passed over a destination that is an ext4
   # filesystem root, and `mkfs.ext4` puts this directory in every one it
-  # makes.  The metadata comparison exempts exactly that entry; without
-  # the exemption the destination carries one record the holding
+  # makes.  The holding directory has none, so the rendered shell took
+  # the branch that drops exactly that one entry from the destination
+  # manifest; without it the destination carries one record the holding
   # directory never had, and no correct relocation could ever verify.
+  # Had the holding root carried a `lost+found` of its own, the other
+  # branch would have compared the two like any other pair.
   sudo -n test -d "$store/lost+found" ||
     fail "the reserve carries no lost+found, so the exemption was never exercised"
+  if sudo -n test -e "${store}.migrated/lost+found"; then
+    fail "the holding directory carried a lost+found, so the exemption branch was not the one taken"
+  fi
   pass "the verification passed over a reserve carrying mkfs.ext4's own lost+found"
 
   # The records are on the mounted reserve, with their content and

--- a/src/commands/audit_store/migration.rs
+++ b/src/commands/audit_store/migration.rs
@@ -1152,7 +1152,9 @@ mod rendered_sequence {
         if bootroot::fs_util::current_process_euid() != 0 {
             return;
         }
-        for (uid, gid) in [(Some(1), None), (None, Some(1))] {
+        // Named by the manifest field each case moves, so a failure
+        // says which one without the numeric ids reaching the message.
+        for (field, uid, gid) in [("%U", Some(1), None), ("%G", None, Some(1))] {
             let fixture = fixture();
             plant_lost_and_found(&fixture.source);
             plant_lost_and_found(&fixture.destination);
@@ -1160,10 +1162,7 @@ mod rendered_sequence {
             assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
             std::os::unix::fs::chown(fixture.destination.join("lost+found"), uid, gid)
                 .expect("re-own the copied directory");
-            assert!(
-                !run(&fixture.scratch, &[&verify]),
-                "uid {uid:?} gid {gid:?}"
-            );
+            assert!(!run(&fixture.scratch, &[&verify]), "{field}");
         }
     }
 

--- a/src/commands/audit_store/migration.rs
+++ b/src/commands/audit_store/migration.rs
@@ -85,24 +85,46 @@ const MOUNTINFO_MOUNT_POINT_FIELD: usize = 4;
 /// inside either, the manifests would describe themselves.
 const SCRATCH_VARIABLE: &str = "SCRATCH";
 
+/// The entry `mke2fs` creates in the root of every filesystem it makes.
+const LOST_AND_FOUND_NAME: &str = "lost+found";
+
 /// The `find` expression that keeps `mkfs.ext4`'s own directory out of
-/// the metadata manifests.
+/// the **destination** metadata manifest.
 ///
 /// Every reserve is a freshly made ext4 filesystem, and `mke2fs`
 /// creates `lost+found` in its root. That root is the *destination* of
-/// the relocation copy and both sides of the replacement one, so the
-/// entry stands on a side the copy did not put it on and the metadata
-/// comparison faults every correct migration — the destination
-/// carrying one record the source does not.
+/// the relocation copy, so the entry stands on a side the copy did not
+/// put it on and the metadata comparison would fault every correct
+/// migration — the destination carrying one record the source does not.
 ///
-/// Only the entry itself is exempt, and only where it is a directory at
-/// the tree's own root. Anything *underneath* it still appears in all
-/// three manifests under its `lost+found/…` path and is compared as
-/// usual, so nothing can be smuggled past the verification by being put
-/// there; and a regular file or a symbolic link that merely bears the
-/// name is matched by neither `-path` nor `-type d` together, so it is
-/// compared in full and, being a link, refused by the type guard.
+/// It is rendered **only on the destination side, and only where the
+/// source root carries no `lost+found` directory of its own**. A
+/// symmetric exemption would be the wider thing it looks like: a
+/// holding directory that does hold one — the whole source tree of the
+/// replacement procedure, whose source is itself a mounted reserve —
+/// would have that directory's type, mode, ownership and link count
+/// compared against nothing at all, and a mismatch on it would pass the
+/// gate. Where the source has one, both sides record it and it is
+/// compared like any other directory.
+///
+/// Only the entry itself is ever exempt, and only where it is a
+/// directory at the tree's own root. Anything *underneath* it still
+/// appears in all three manifests under its `lost+found/…` path and is
+/// compared as usual, so nothing can be smuggled past the verification
+/// by being put there; and a regular file or a symbolic link that
+/// merely bears the name is matched by neither `-path` nor `-type d`
+/// together, so it is compared in full and, being a link, refused by
+/// the type guard.
 const LOST_AND_FOUND_EXCLUSION: &str = "! \\( -path './lost+found' -type d \\)";
+
+/// What the metadata manifest records of every entry: type, octal mode,
+/// numeric uid and gid, hard-link count and the relative path.
+///
+/// The path is the only variable-length field and it is last, so the
+/// record's own NUL delimits it and no name the container wrote can be
+/// read as ending elsewhere. A second variable-length field after it
+/// would destroy that.
+const METADATA_PRINTF: &str = "-printf '%y %m %U %G %n %P\\0'";
 
 /// The two derived siblings of the store this procedure uses.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -583,11 +605,57 @@ pub(super) fn copy_step(store_dir: &Path, holding: &Path, messages: &Messages) -
 /// must never fail in.
 fn manifest_commands(name: &str, side: &str, find_arguments: &str) -> Vec<String> {
     let raw = scratch(&format!("{name}.{side}.raw"));
-    let sorted = scratch(&format!("{name}.{side}"));
-    vec![
-        format!("find . -xdev -mindepth 1 {find_arguments} > {raw}"),
-        format!("sort -z -o {sorted} {raw}"),
-    ]
+    vec![find_command(find_arguments, &raw), sort_command(name, side)]
+}
+
+/// One walk of the side already `cd`-ed into, into its own raw file.
+fn find_command(find_arguments: &str, raw: &str) -> String {
+    format!("find . -xdev -mindepth 1 {find_arguments} > {raw}")
+}
+
+/// The sort that turns one raw manifest into the file `cmp` reads.
+fn sort_command(name: &str, side: &str) -> String {
+    format!(
+        "sort -z -o {} {}",
+        scratch(&format!("{name}.{side}")),
+        scratch(&format!("{name}.{side}.raw")),
+    )
+}
+
+/// The metadata manifest for one side.
+///
+/// `source_root` is `Some` on the destination side alone, naming the
+/// tree the copy came *from*. The exemption for `mke2fs`'s own
+/// `lost+found` belongs to that side only — the source cannot carry a
+/// record the copy did not put there — and even there it applies only
+/// where the source root has no such directory. So the destination's
+/// walk is chosen by the shell, at the moment it runs, from the source
+/// it is about to be compared against: with a source `lost+found`
+/// directory the destination records its counterpart and the two are
+/// compared like any other pair; without one, the destination's
+/// `mke2fs`-seeded entry is the one record dropped.
+///
+/// The predicate is `-d` **and** not `-L` rather than `-d` alone
+/// because `test -d` answers for the target of a symbolic link, and
+/// nothing in this procedure follows one. `find -type d` does not
+/// either, so the two spellings agree on every entry — a link named
+/// `lost+found` at the source root is not a directory to either of
+/// them, whatever it points at.
+fn metadata_commands(side: &str, source_root: Option<&Path>) -> Vec<String> {
+    let raw = scratch(&format!("meta.{side}.raw"));
+    let whole = find_command(METADATA_PRINTF, &raw);
+    let find = match source_root {
+        None => whole,
+        Some(root) => {
+            let entry = sh_quote_path(&root.join(LOST_AND_FOUND_NAME));
+            let exempt = find_command(
+                &format!("{LOST_AND_FOUND_EXCLUSION} {METADATA_PRINTF}"),
+                &raw,
+            );
+            format!("if [ -d {entry} ] && [ ! -L {entry} ]; then {whole}; else {exempt}; fi")
+        }
+    };
+    vec![find, sort_command("meta", side)]
 }
 
 /// One path under the scratch directory, as the rendered shell spells
@@ -598,19 +666,9 @@ fn scratch(name: &str) -> String {
 
 /// Every manifest for one side, produced after a `cd` into that side so
 /// the recorded paths are relative and directly comparable.
-fn side_commands(tree: &Path, side: &str) -> Vec<String> {
+fn side_commands(tree: &Path, side: &str, source_root: Option<&Path>) -> Vec<String> {
     let mut commands = vec![format!("cd {}", sh_quote_path(tree))];
-    // Type, octal mode, numeric uid and gid, hard-link count and the
-    // relative path — over every entry, directories included except
-    // the one below. The path is the only variable-length field and it
-    // is last, so the record's own NUL delimits it and no name the
-    // container wrote can be read as ending elsewhere. A second
-    // variable-length field after it would destroy that.
-    commands.extend(manifest_commands(
-        "meta",
-        side,
-        &format!("{LOST_AND_FOUND_EXCLUSION} -printf '%y %m %U %G %n %P\\0'"),
-    ));
+    commands.extend(metadata_commands(side, source_root));
     // Sizes are their own pass because a *directory's* size legitimately
     // differs between two filesystems and would fail every correct
     // migration. Modification times are excluded for the same reason:
@@ -653,8 +711,8 @@ pub(super) fn verification_step(
     let mut commands = vec![format!("{SCRATCH_VARIABLE}=\"$(mktemp -d)\"")];
     commands.push(type_guard_command(holding));
     commands.push(type_guard_command(store_dir));
-    commands.extend(side_commands(holding, "source"));
-    commands.extend(side_commands(store_dir, "destination"));
+    commands.extend(side_commands(holding, "source", None));
+    commands.extend(side_commands(store_dir, "destination", Some(holding)));
     for name in ["meta", "size", "content"] {
         commands.push(format!(
             "cmp {} {}",
@@ -812,6 +870,48 @@ pub(super) fn verdict_findings(verdict: &CopyVerdict, messages: &Messages) -> Ve
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::i18n::test_messages;
+
+    /// The `mke2fs` exemption is asymmetric on purpose. The source walk
+    /// carries none of it — a record the copy did not put there cannot
+    /// arise on the side the copy came *from* — and the destination's
+    /// is decided by the shell, when it runs, from what the source root
+    /// actually holds.
+    #[test]
+    fn only_the_destination_metadata_walk_can_drop_the_seeded_directory() {
+        let store = Path::new("/var/lib/bootroot/audit-store");
+        let holding = Path::new("/var/lib/bootroot/audit-store.pre-mount");
+        let commands = verification_step(store, holding, &test_messages()).commands;
+        let walk = |side: &str| {
+            let raw = format!("> \"$SCRATCH\"/meta.{side}.raw");
+            commands
+                .iter()
+                .find(|command| command.contains(&raw))
+                .unwrap_or_else(|| panic!("the {side} metadata walk is rendered"))
+                .clone()
+        };
+        let source = walk("source");
+        let destination = walk("destination");
+
+        // Type, mode, numeric uid and gid and the hard-link count, on
+        // both sides and in that order.
+        for walk in [&source, &destination] {
+            assert!(walk.contains("-printf '%y %m %U %G %n %P\\0'"), "{walk}");
+        }
+        assert!(!source.contains("lost+found"), "{source}");
+        assert_eq!(
+            destination,
+            concat!(
+                "if [ -d '/var/lib/bootroot/audit-store.pre-mount/lost+found' ]",
+                " && [ ! -L '/var/lib/bootroot/audit-store.pre-mount/lost+found' ]",
+                "; then find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\\0'",
+                " > \"$SCRATCH\"/meta.destination.raw",
+                "; else find . -xdev -mindepth 1 ! \\( -path './lost+found' -type d \\)",
+                " -printf '%y %m %U %G %n %P\\0' > \"$SCRATCH\"/meta.destination.raw",
+                "; fi",
+            )
+        );
+    }
 
     #[test]
     fn the_two_paths_are_siblings_of_the_store_with_no_configuration_key() {
@@ -986,6 +1086,114 @@ mod rendered_sequence {
         assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
     }
 
+    /// A holding directory that carries a root `lost+found` of its own
+    /// — the whole source tree of the replacement procedure, whose
+    /// source is a mounted reserve — has that directory copied like any
+    /// other, so it is compared like any other. Nothing is exempt here:
+    /// the destination's entry is the source's counterpart rather than
+    /// a record only `mke2fs` put there.
+    #[test]
+    fn a_source_root_lost_and_found_is_verified_against_its_copy() {
+        let fixture = fixture();
+        plant_lost_and_found(&fixture.source);
+        plant_lost_and_found(&fixture.destination);
+        let (guard, copy, verify) = copy_and_verify(&fixture);
+        assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
+    }
+
+    /// Every metadata field the manifest carries for that directory,
+    /// each broken on its own over a copy that had already passed.
+    #[test]
+    fn a_mismatched_source_root_lost_and_found_fails_the_verification() {
+        // Type: the copied directory replaced by a regular file of the
+        // same name, which `%y` reports as `f` against the source's `d`.
+        let type_mismatch = |fixture: &Fixture| {
+            let entry = fixture.destination.join("lost+found");
+            fs::remove_dir(&entry).expect("the copied directory");
+            fs::write(&entry, b"not a directory\n").expect("a regular file in its place");
+        };
+        // Mode: `mke2fs` gives it 0700 and the copy preserves it.
+        let mode_mismatch = |fixture: &Fixture| {
+            fs::set_permissions(
+                fixture.destination.join("lost+found"),
+                fs::Permissions::from_mode(0o755),
+            )
+            .expect("change the mode on the destination");
+        };
+        // Link count: a directory's `%n` is two plus its subdirectory
+        // count, so nothing can move it without also changing what the
+        // manifest lists underneath. The comparison faults both, which
+        // is the point — the field is compared rather than skipped.
+        let link_count_mismatch = |fixture: &Fixture| {
+            fs::create_dir(fixture.destination.join("lost+found").join("recovered"))
+                .expect("a subdirectory the source does not have");
+        };
+        for break_it in [
+            &type_mismatch as &dyn Fn(&Fixture),
+            &mode_mismatch,
+            &link_count_mismatch,
+        ] {
+            let fixture = fixture();
+            plant_lost_and_found(&fixture.source);
+            plant_lost_and_found(&fixture.destination);
+            let (guard, copy, verify) = copy_and_verify(&fixture);
+            assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
+            break_it(&fixture);
+            assert!(!run(&fixture.scratch, &[&verify]));
+        }
+    }
+
+    /// `%U` and `%G` are the two fields no unprivileged process can
+    /// move, so this half of the same contract runs only where the
+    /// ownership can actually be changed. The rendered form is asserted
+    /// unconditionally beside it.
+    #[test]
+    fn a_reowned_source_root_lost_and_found_fails_the_verification() {
+        if bootroot::fs_util::current_process_euid() != 0 {
+            return;
+        }
+        for (uid, gid) in [(Some(1), None), (None, Some(1))] {
+            let fixture = fixture();
+            plant_lost_and_found(&fixture.source);
+            plant_lost_and_found(&fixture.destination);
+            let (guard, copy, verify) = copy_and_verify(&fixture);
+            assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
+            std::os::unix::fs::chown(fixture.destination.join("lost+found"), uid, gid)
+                .expect("re-own the copied directory");
+            assert!(
+                !run(&fixture.scratch, &[&verify]),
+                "uid {uid:?} gid {gid:?}"
+            );
+        }
+    }
+
+    /// The destination's metadata walk is the one stage rendered
+    /// inside a compound command, and a compound command is exactly
+    /// where a failed walk could be swallowed. An `if` reports the
+    /// status of the branch it ran, so the sequence still stops there —
+    /// the same fail-closed direction every other stage carries.
+    #[test]
+    fn a_failed_destination_walk_inside_the_conditional_still_fails_closed() {
+        // The permission bits do nothing for root, so the fixture would
+        // pass vacuously there.
+        if bootroot::fs_util::current_process_euid() == 0 {
+            return;
+        }
+        let fixture = fixture();
+        let (guard, copy, verify) = copy_and_verify(&fixture);
+        assert!(run(&fixture.scratch, &[&guard, &copy]));
+        // Listable but not `stat`able: the type guard answers `-type`
+        // from the directory entry's own `d_type` and still exits 0,
+        // and the restriction is on the destination alone, so every
+        // source stage completes and the conditional is reached.
+        let blocked = fixture.destination.join("records");
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o444))
+            .expect("restrict the destination subdirectory");
+        assert!(!run(&fixture.scratch, &[&verify]));
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700))
+            .expect("restore the subdirectory so the fixture can be removed");
+    }
+
     #[test]
     fn content_under_lost_and_found_is_still_compared() {
         let fixture = fixture();
@@ -994,9 +1202,10 @@ mod rendered_sequence {
         plant_lost_and_found(&fixture.destination);
         let (guard, copy, verify) = copy_and_verify(&fixture);
         assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
-        // Only the directory entry is exempt. What it holds carries its
-        // `lost+found/…` path into all three manifests, so a same-sized
-        // difference underneath it is caught exactly as anywhere else.
+        // What that directory holds carries its `lost+found/…` path
+        // into all three manifests, so a same-sized difference
+        // underneath it is caught exactly as anywhere else — and would
+        // be even where the directory entry itself were exempt.
         fs::write(
             fixture.destination.join("lost+found").join("stray.log"),
             b"other\n",
@@ -1012,8 +1221,10 @@ mod rendered_sequence {
         fs::write(fixture.source.join("lost+found"), b"not the filesystem's\n")
             .expect("a regular file bearing the name");
         assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
-        // The exemption is `-path` *and* `-type d` together, so this one
-        // is in the metadata manifest and a changed mode fails it.
+        // The exemption is `-path` *and* `-type d` together, and it is
+        // only reached where the source root holds no directory of that
+        // name — which this one does not. So this entry is in the
+        // metadata manifest and a changed mode fails it.
         fs::set_permissions(
             fixture.destination.join("lost+found"),
             fs::Permissions::from_mode(0o600),
@@ -1393,6 +1604,32 @@ mod manuals {
                 ".pre-mount-other",
             ] {
                 assert!(passage.contains(required), "{page}: missing {required:?}");
+            }
+        }
+    }
+
+    /// The `mke2fs` exemption is on the destination side alone, and
+    /// decided from the source root when the shell runs it. Both
+    /// manuals have to carry that form rather than the symmetric one
+    /// bootroot no longer renders, whose reading is that a holding
+    /// directory with a `lost+found` of its own has it compared
+    /// against nothing.
+    #[test]
+    fn both_manuals_pin_the_asymmetric_lost_and_found_exemption() {
+        for (page, heading, next, _) in PAGES {
+            let source = read(page);
+            let blocks = command_blocks(section(&source, heading, next));
+            assert_eq!(
+                blocks.matches("-path './lost+found' -type d").count(),
+                1,
+                "{page}: the exemption belongs to one side only"
+            );
+            for required in [
+                "if [ -d <audit_store_dir>.pre-mount/lost+found ] \\",
+                "&& [ ! -L <audit_store_dir>.pre-mount/lost+found ]; then",
+                "find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\\0'",
+            ] {
+                assert!(blocks.contains(required), "{page}: missing {required:?}");
             }
         }
     }

--- a/src/commands/audit_store/migration.rs
+++ b/src/commands/audit_store/migration.rs
@@ -1171,7 +1171,10 @@ mod rendered_sequence {
     /// inside a compound command, and a compound command is exactly
     /// where a failed walk could be swallowed. An `if` reports the
     /// status of the branch it ran, so the sequence still stops there —
-    /// the same fail-closed direction every other stage carries.
+    /// the same fail-closed direction every other stage carries. Both
+    /// branches carry it, so the source root is given a `lost+found`
+    /// once to reach the unfiltered walk and left without one to reach
+    /// the exempting one.
     #[test]
     fn a_failed_destination_walk_inside_the_conditional_still_fails_closed() {
         // The permission bits do nothing for root, so the fixture would
@@ -1179,38 +1182,83 @@ mod rendered_sequence {
         if bootroot::fs_util::current_process_euid() == 0 {
             return;
         }
-        let fixture = fixture();
-        let (guard, copy, verify) = copy_and_verify(&fixture);
-        assert!(run(&fixture.scratch, &[&guard, &copy]));
-        // Listable but not `stat`able: the type guard answers `-type`
-        // from the directory entry's own `d_type` and still exits 0,
-        // and the restriction is on the destination alone, so every
-        // source stage completes and the conditional is reached.
-        let blocked = fixture.destination.join("records");
-        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o444))
-            .expect("restrict the destination subdirectory");
-        assert!(!run(&fixture.scratch, &[&verify]));
-        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700))
-            .expect("restore the subdirectory so the fixture can be removed");
+        for source_lost_and_found in [false, true] {
+            let fixture = fixture();
+            if source_lost_and_found {
+                plant_lost_and_found(&fixture.source);
+            }
+            let (guard, copy, verify) = copy_and_verify(&fixture);
+            assert!(run(&fixture.scratch, &[&guard, &copy]));
+            // Listable but not `stat`able: the type guard answers
+            // `-type` from the directory entry's own `d_type` and still
+            // exits 0, and the restriction is on the destination alone,
+            // so every source stage completes and the conditional is
+            // reached.
+            let blocked = fixture.destination.join("records");
+            fs::set_permissions(&blocked, fs::Permissions::from_mode(0o444))
+                .expect("restrict the destination subdirectory");
+            assert!(
+                !run(&fixture.scratch, &[&verify]),
+                "source lost+found: {source_lost_and_found}"
+            );
+            fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700))
+                .expect("restore the subdirectory so the fixture can be removed");
+        }
     }
 
+    /// What that directory holds carries its `lost+found/…` path into
+    /// all three manifests, so a difference underneath it is caught
+    /// exactly as anywhere else — and would be even where the directory
+    /// entry itself were exempt. One breakage per pass, each over a
+    /// copy that had already passed.
     #[test]
-    fn content_under_lost_and_found_is_still_compared() {
+    fn everything_under_lost_and_found_is_still_compared() {
+        let stray = |fixture: &Fixture| fixture.destination.join("lost+found").join("stray.log");
+        // Metadata: the same bytes at a mode the source never had.
+        let mode_mismatch = |fixture: &Fixture| {
+            fs::set_permissions(stray(fixture), fs::Permissions::from_mode(0o600))
+                .expect("change the mode under lost+found");
+        };
+        // Size: the size pass is `-type f`, so it reaches here.
+        let size_mismatch = |fixture: &Fixture| {
+            fs::write(stray(fixture), b"stray and then some\n").expect("lengthen the entry");
+        };
+        // Content: a same-sized difference, which only the digests see.
+        let content_mismatch = |fixture: &Fixture| {
+            fs::write(stray(fixture), b"other\n").expect("rewrite the entry under lost+found");
+        };
+        for break_it in [
+            &mode_mismatch as &dyn Fn(&Fixture),
+            &size_mismatch,
+            &content_mismatch,
+        ] {
+            let fixture = fixture();
+            fs::write(
+                plant_lost_and_found(&fixture.source).join("stray.log"),
+                b"stray\n",
+            )
+            .expect("a file under lost+found");
+            plant_lost_and_found(&fixture.destination);
+            let (guard, copy, verify) = copy_and_verify(&fixture);
+            assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
+            break_it(&fixture);
+            assert!(!run(&fixture.scratch, &[&verify]));
+        }
+    }
+
+    /// The other side of the same rule. Where the source root holds no
+    /// directory of that name the destination walk does drop one — but
+    /// the exemption is `-path` *and* `-type d` together, so a
+    /// non-directory planted at the destination root under the
+    /// filesystem's own name is recorded and faulted like anything else
+    /// the copy did not put there.
+    #[test]
+    fn a_non_directory_bearing_the_name_at_the_destination_root_is_not_exempt() {
         let fixture = fixture();
-        let stray = plant_lost_and_found(&fixture.source).join("stray.log");
-        fs::write(&stray, b"stray\n").expect("a file under lost+found");
-        plant_lost_and_found(&fixture.destination);
         let (guard, copy, verify) = copy_and_verify(&fixture);
         assert!(run(&fixture.scratch, &[&guard, &copy, &verify]));
-        // What that directory holds carries its `lost+found/…` path
-        // into all three manifests, so a same-sized difference
-        // underneath it is caught exactly as anywhere else — and would
-        // be even where the directory entry itself were exempt.
-        fs::write(
-            fixture.destination.join("lost+found").join("stray.log"),
-            b"other\n",
-        )
-        .expect("rewrite the entry under lost+found");
+        fs::write(fixture.destination.join("lost+found"), b"planted\n")
+            .expect("a regular file the source never had");
         assert!(!run(&fixture.scratch, &[&verify]));
     }
 
@@ -1231,6 +1279,36 @@ mod rendered_sequence {
         )
         .expect("change the mode on the destination");
         assert!(!run(&fixture.scratch, &[&verify]));
+    }
+
+    /// The third shape the name can take. `test -d` answers for a
+    /// symbolic link's *target*, so a link to a directory would read as
+    /// one and send the destination down the unfiltered walk; the
+    /// predicate carries `! -L` beside `-d` so it does not. It never
+    /// gets that far in practice, because this procedure follows no
+    /// link and the type guard refuses one wherever it stands —
+    /// including at the root, under this name.
+    #[test]
+    fn a_symlink_bearing_the_name_at_the_source_root_is_refused_by_the_guard() {
+        let fixture = fixture();
+        // Pointing at a real directory, so the reading `! -L` exists to
+        // rule out is the one available.
+        symlink(
+            fixture.source.join("records"),
+            fixture.source.join("lost+found"),
+        )
+        .expect("a link bearing the name");
+        let messages = test_messages();
+        let refused = first_forbidden_entry(&fixture.source, &HostProbe, &messages)
+            .expect("walk the holding directory")
+            .expect("the link at the root is refused");
+        assert_eq!(
+            refused,
+            (fixture.source.join("lost+found"), FileKind::Symlink)
+        );
+        let (guard, copy, verify) = copy_and_verify(&fixture);
+        assert!(!run(&fixture.scratch, &[&guard]));
+        assert!(!run(&fixture.scratch, &[&guard, &copy, &verify]));
     }
 
     #[test]

--- a/src/commands/audit_store/reserve.rs
+++ b/src/commands/audit_store/reserve.rs
@@ -4990,7 +4990,7 @@ mod tests {
                     "find '{STORE}' -xdev -mindepth 1 ! -type d ! -type f -exec false {{}} +"
                 ),
                 format!("cd '{HOLDING}'"),
-                "find . -xdev -mindepth 1 ! \\( -path './lost+found' -type d \\) -printf '%y %m %U %G %n %P\\0' > \"$SCRATCH\"/meta.source.raw".to_string(),
+                "find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\\0' > \"$SCRATCH\"/meta.source.raw".to_string(),
                 "sort -z -o \"$SCRATCH\"/meta.source \"$SCRATCH\"/meta.source.raw".to_string(),
                 "find . -xdev -mindepth 1 -type f -printf '%s %P\\0' > \"$SCRATCH\"/size.source.raw".to_string(),
                 "sort -z -o \"$SCRATCH\"/size.source \"$SCRATCH\"/size.source.raw".to_string(),
@@ -4998,7 +4998,14 @@ mod tests {
                 "sort -z -o \"$SCRATCH\"/files.source \"$SCRATCH\"/files.source.raw".to_string(),
                 "xargs -0 -r sha256sum --binary --zero < \"$SCRATCH\"/files.source > \"$SCRATCH\"/content.source".to_string(),
                 format!("cd '{STORE}'"),
-                "find . -xdev -mindepth 1 ! \\( -path './lost+found' -type d \\) -printf '%y %m %U %G %n %P\\0' > \"$SCRATCH\"/meta.destination.raw".to_string(),
+                // The one asymmetry: `mke2fs`'s own directory is
+                // dropped from the destination manifest alone, and
+                // only where the source root holds no directory of
+                // that name — decided by the shell against the source
+                // it is about to be compared with.
+                format!(
+                    "if [ -d '{HOLDING}/lost+found' ] && [ ! -L '{HOLDING}/lost+found' ]; then find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\\0' > \"$SCRATCH\"/meta.destination.raw; else find . -xdev -mindepth 1 ! \\( -path './lost+found' -type d \\) -printf '%y %m %U %G %n %P\\0' > \"$SCRATCH\"/meta.destination.raw; fi"
+                ),
                 "sort -z -o \"$SCRATCH\"/meta.destination \"$SCRATCH\"/meta.destination.raw".to_string(),
                 "find . -xdev -mindepth 1 -type f -printf '%s %P\\0' > \"$SCRATCH\"/size.destination.raw".to_string(),
                 "sort -z -o \"$SCRATCH\"/size.destination \"$SCRATCH\"/size.destination.raw".to_string(),


### PR DESCRIPTION
## What this changes

The migration metadata manifests dropped `./lost+found` from **both** sides. That exemption exists because `mke2fs` seeds a `lost+found` directory in the root of every filesystem it makes, and that root is the *destination* of the relocation copy — without it, the destination carries one record the holding directory never had and no correct migration could ever verify.

Applied symmetrically, it also silenced the source side. A holding directory that legitimately holds a root `lost+found` — the whole source tree of the replacement procedure, whose source is itself a mounted reserve — had that directory's type, mode, numeric uid, numeric gid and link count compared against nothing at all, and a mismatch on it passed the gate that guards the closing rename.

The exemption now belongs to the destination side alone, and even there it is conditional. The rendered shell asks, at the moment it runs, whether the source root carries a `lost+found` directory:

```sh
if [ -d '<holding>/lost+found' ] && [ ! -L '<holding>/lost+found' ]; then find . -xdev -mindepth 1 -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.destination.raw; else find . -xdev -mindepth 1 ! \( -path './lost+found' -type d \) -printf '%y %m %U %G %n %P\0' > "$SCRATCH"/meta.destination.raw; fi
```

The source walk carries no filter at all — a record the copy did not put there cannot arise on the side the copy came *from*.

The predicate is `-d` **and not** `-L` rather than `-d` alone: `test -d` answers for a symbolic link's target, and nothing in this procedure follows one. `find -type d` does not either, so the two spellings agree on every entry.

Everything else stands: the walks are NUL-delimited, each stage is its own command over its own staged file, the three manifests are byte-compared with `cmp`, and no recursive delete is introduced. The branch is a plain `if`, not a pipeline, so a failed walk inside it still stops the sequence — `set -e` fires on the branch body, and there is a test for exactly that, driven down *both* branches.

Also here: a CodeQL `rust/cleartext-logging` alert. The ownership case labelled its assertion with the uid and gid it had just set, and the query reads any value bound to `uid` reaching a message as a leak — a red required check over two loop constants in a Linux-only test module. The message names the manifest field the case moves instead, which is what a failure needed to distinguish anyway.

## Acceptance criteria

- **A newly formatted ext4 destination whose holding source lacks a root `lost+found` verifies successfully** — the `else` branch, covered by `the_reserves_own_lost_and_found_does_not_fail_the_verification` and by the `registrar-internal-init` E2E scenario, which now also asserts the conditional is rendered and that the branch taken really was the exempting one.
- **A source-root `lost+found` mismatch fails the comparison** — `a_mismatched_source_root_lost_and_found_fails_the_verification` breaks type, mode and link count in turn over a copy that had already passed; `a_reowned_source_root_lost_and_found_fails_the_verification` does uid and gid where the run has the privilege to `chown`, and the rendered `%y %m %U %G %n %P` form is asserted unconditionally beside it.
- **Contents beneath a source root `lost+found` stay in every comparison** — `everything_under_lost_and_found_is_still_compared` now breaks the metadata, size and content passes separately, each over a copy that had already passed, rather than only the same-sized content case.
- **A non-directory named `lost+found` stays under the ordinary rules** — `a_regular_file_merely_bearing_the_name_is_not_exempt` at the source root, and `a_non_directory_bearing_the_name_at_the_destination_root_is_not_exempt` at the destination root, which is where the exemption is actually spelled and so where `-type d` has to be the thing doing the work. `a_symlink_bearing_the_name_at_the_source_root_is_refused_by_the_guard` covers the third shape the name can take: a link to a real directory, which `test -d` alone would read as a directory, and which the type guard refuses before the question is ever asked.
- **The rendered commands stay NUL-delimited, staged, pipeline-free and `cmp`-compared** — `the_rendered_migration_commands_are_pinned_exactly` pins the whole sequence verbatim and re-checks the pipe, `diff -r`, `rm -r` and trailing-field bans.
- **Both manuals stay aligned** — `both_manuals_pin_the_asymmetric_lost_and_found_exemption` asserts each page's relocation block carries the exclusion exactly *once* and carries the conditional, so a symmetric form cannot come back in either language.

## Test plan

The `rendered_sequence` module is Linux-only (GNU `find -printf`, `sort -z`, `sha256sum --zero`), so it was run in a `rust:latest` container; everything else was run on macOS as well.

- [x] A source with no root `lost+found` verifies, and the destination's seeded directory is not treated as audit data
- [x] A source-root `lost+found` whose type, mode, numeric uid, numeric gid or link count differs fails the metadata comparison and stops before the closing rename
- [x] Descendants beneath a source root `lost+found` still participate in the metadata, regular-file-size and content comparisons — each broken separately
- [x] A regular file and a symlink bearing the name are not exempt, at the source root and at the destination root
- [x] `cargo test --bin bootroot audit_store::migration` — 27 passed, in the container both as **root** (so the uid/gid case ran) and as an **unprivileged user** (so the fail-closed-inside-the-conditional case ran, down both of its branches)
- [x] `cargo test` — green on macOS, and green in the Linux container (lib 1269, bin 1303, plus the other bins and integration suites). The 8 `tests/bootroot_rotate.rs` cases that fail in that container fail on a missing `docker` CLI and pass locally on macOS where Docker is present: `46 passed; 0 failed`. The container's own `umask` matters: at the image default of `002` the `registrar::audit::scan` and `registrar::openbao_audit` suites refuse their own fixtures as group-writable, which is the safe-path check working rather than a failure of this branch
- [x] `cargo clippy --all-targets -- -D warnings` — clean on macOS and Linux
- [x] `cargo fmt -- --config group_imports=StdExternalCrate --check` — clean on macOS and Linux
- [x] `./scripts/check-docs.sh` — `mkdocs build --strict` passes and the theme verification passes
- [x] `markdownlint-cli2` over the repository — 0 issues
- [x] `shellcheck -x scripts/impl/run-registrar-internal-init-e2e.sh` — clean (only `SC1091` info for sourced libs, resolved when run from the script's directory)
- [x] All CI checks green on the pushed branch, including `Docker E2E (registrar-internal-init)`

## Local run notes

- **`scripts/preflight/ci/e2e-matrix.sh` did not run here.** Its step 13 — `run-registrar-internal-init-e2e.sh`, the one arm that exercises this rendering end to end — requires passwordless `sudo`, and `sudo -n true` on this machine reports "a password is required"; the matrix's own usage text states `--skip-hosts` does not stand in for it. Port 8200 is also held by an unrelated live process from another session, which the earlier steps' port preflight refuses to start over, and tearing that down is not mine to do. CI's `Docker E2E` jobs gate that arm, and `Docker E2E (registrar-internal-init)` is green. Nothing was weakened, skipped, marked `continue-on-error` or deleted to get a local run to pass. What did run locally is the `rendered_sequence` suite, which executes the rendered shell for real against fixture trees on Linux, including every `lost+found` shape on both sides.
- **No `CHANGELOG.md` entry.** The audit-store reserve, its relocation procedure and its verification are all announced under `[Unreleased]`; no user of the last release ever saw the symmetric exemption, so this is a rework of unreleased work rather than an observable change.
- A directory's `%n` is two plus its subdirectory count, so no fixture can move that field alone without also changing the entries the manifest lists underneath. The link-count case therefore faults on both, which still demonstrates the field is compared rather than skipped; it is not an isolated one-field test and the code comment says so.

Closes #959

Part of #926
