### PR TITLE
Prove the audit bind guard mid-migration (#960)

### DIFF
--- a/scripts/impl/run-registrar-internal-init-e2e.sh
+++ b/scripts/impl/run-registrar-internal-init-e2e.sh
@@ -1273,6 +1273,27 @@ assert_the_rendered_steps_migrate_an_existing_store() {
   RESERVE_IMAGE="$image"
   RESERVE_UNIT_NAME="$unit"
 
+  # The rendered step 1 is the maintenance window itself: stop both
+  # writers before the store moves aside.  `rendered_migration_commands`
+  # drops those two lines -- one would stop this scenario's whole
+  # Compose stack rather than the writer, and the other names a unit no
+  # CI host has installed -- so the OpenBao writer is stopped here, by
+  # service, through the same Compose surface.  It stays down for the
+  # whole window and comes back only on the closing path at the end of
+  # this section, which is the shape of the window an operator opens.
+  instance_compose stop openbao >>"$RUN_LOG" 2>&1 ||
+    fail "could not stop the OpenBao writer for the migration window"
+  instance_compose rm -f openbao >>"$RUN_LOG" 2>&1 ||
+    fail "could not remove the OpenBao writer for the migration window"
+  # The other writer is `bootroot-registrar.service`, and this is an
+  # assertion rather than a stop: no CI host has that unit installed,
+  # and stopping one this scenario did not install would be a
+  # host-changing step it has no way to undo.
+  if systemctl is-active --quiet bootroot-registrar.service 2>/dev/null; then
+    fail "the registrar writer is running; the migration window needs both writers stopped"
+  fi
+  pass "both writers are stopped before the store moves aside"
+
   run_rendered_migration_commands "$first" "$store"
   sudo -n test -d "${store}.pre-mount" ||
     fail "the aside rename did not create ${store}.pre-mount"
@@ -1308,6 +1329,8 @@ assert_the_rendered_steps_migrate_an_existing_store() {
     fail "records/ was created on the mounted reserve before the copy"
   fi
   pass "the reserve is mounted and the store on it is still empty"
+
+  assert_the_audit_bind_refuses_to_create_its_source_mid_migration "$store" "$unit"
 
   # Pass 3: migration incomplete, now with the capacity verdict, the
   # copy, the verification and the closing rename.
@@ -1418,6 +1441,96 @@ assert_the_rendered_steps_migrate_an_existing_store() {
   sudo_to_log rm -rf "${store}.migrated" || true
   sudo -n rm -rf "$WORK_DIR/audit-store"
   remove_rendered_audit_override
+
+  # The window closes here, and only here.  The OpenBao writer went down
+  # before the store moved aside and stayed down across every pass; it
+  # comes back on its ordinary audit volume, which is what the base
+  # compose file declares now that the override naming this section's
+  # store -- and the store itself -- are gone.
+  instance_compose up -d openbao >>"$RUN_LOG" 2>&1 ||
+    fail "could not restart the OpenBao writer after the migration window"
+  wait_for_openbao_listening
+  pass "the writers come back only once the migration has closed"
+}
+
+# The bind guard, inside the migration window rather than beside it.
+#
+# `assert_the_audit_bind_guard_boundaries` proves the same
+# `create_host_path: false` declaration against an unmounted store,
+# which is the state a host reaches by never having activated a
+# reserve.  This window is the other one, and it is the state the guard
+# exists for: the records are aside under `.pre-mount`, the reserve is
+# mounted and still empty, and `<audit_store_dir>/openbao` is the
+# directory the copy has not yet made.  A bring-up here that
+# manufactured it would leave a bind source on the destination side of a
+# copy that has not run -- one the migration did not put there, on a
+# filesystem whose only record of the operator's content is still the
+# holding directory.
+#
+# `bootroot infra up` refuses this state, and that refusal is covered in
+# `src/commands/audit_store.rs`.  It is a different assertion: it says
+# bootroot declines to start containers, not that Docker itself refuses
+# the bind.  The guarantee has to hold for whoever else brings the stack
+# up, so this drives the ordinary Compose surface over the override the
+# operator has on disk at this moment, rather than driving bootroot.
+assert_the_audit_bind_refuses_to_create_its_source_mid_migration() {
+  local store="$1" unit="$2" override log status before after
+  override="$WORK_DIR/secrets/openbao/docker-compose.openbao-audit.yml"
+  log="$ARTIFACT_DIR/compose-up-mid-migration.log"
+
+  # The window itself, restated rather than assumed: a change that
+  # closed it earlier would otherwise turn this into a bring-up against
+  # some other state that happens to pass for the wrong reason.
+  sudo -n test -d "${store}.pre-mount" ||
+    fail "the holding directory is absent, so this is not the migration window"
+  assert_equal "the reserve is mounted for the mid-window bring-up" \
+    "ActiveState=active" "$(sudo -n systemctl show -p ActiveState "$unit")"
+  if sudo -n test -e "$store/openbao"; then
+    fail "the bind source is already on the mounted reserve before the bring-up"
+  fi
+  # What the mounted reserve carries going in, so the assertion after
+  # the bring-up is that it gained nothing rather than that it holds one
+  # particular name.  A fresh `mkfs.ext4` filesystem carries its own
+  # `lost+found` and this window has put nothing beside it.
+  before="$(sudo -n find "$store" -mindepth 1 -maxdepth 1 -printf '[%f]')"
+  log "the mounted store holds ${before} before the mid-migration bring-up"
+
+  # The override the refusal pass rendered is still the one on disk --
+  # a migration-open pass writes none -- and it names the store this
+  # window is open over.
+  grep -qF "source: '$store/openbao'" "$override" ||
+    fail "the rendered override does not bind $store/openbao; see $override"
+  grep -q "create_host_path: false" "$override" ||
+    fail "the rendered override lets Docker create an absent audit bind source"
+
+  # The bring-up's own non-zero exit is the assertion.  One that
+  # returned success having quietly done nothing would satisfy the
+  # absent-source checks below on its own, so the failure is read from
+  # the command and from the error naming the bind source, and only
+  # then from what the reserve does not carry.
+  if instance_compose -f "$override" up -d --no-deps openbao >"$log" 2>&1; then
+    fail "OpenBao started mid-migration over an absent audit bind source; see $log"
+  fi
+  grep -qF "$store/openbao" "$log" ||
+    fail "the bring-up did not fail on the absent audit bind source; see $log"
+  status="$(docker inspect "${INSTANCE}-openbao" --format '{{.State.Status}}' 2>>"$RUN_LOG" || true)"
+  [ "$status" != "running" ] ||
+    fail "OpenBao is running mid-migration despite its absent audit bind source"
+  pass "the mid-migration bring-up fails on the guarded audit bind source"
+
+  # And nothing of the destination was manufactured: no bind source, and
+  # the mounted reserve still carries exactly what `mkfs.ext4` put on it.
+  sudo -n test ! -e "$store/openbao" ||
+    fail "Docker created $store/openbao inside the migration window"
+  after="$(sudo -n find "$store" -mindepth 1 -maxdepth 1 -printf '[%f]')"
+  assert_equal "the refused bring-up added no entry beneath the mounted store" \
+    "$before" "$after"
+
+  # Leave the writers where the window found them.  The refused bring-up
+  # created a container that never started, and it would otherwise be
+  # what the next Compose call over this project adopts.
+  instance_compose rm -f openbao >>"$RUN_LOG" 2>&1 ||
+    fail "could not remove the refused OpenBao container"
 }
 
 # Takes the activation back off the host, in the order the manual's


### PR DESCRIPTION
## Summary

The audit bind is declared `create_host_path: false` so Docker refuses to manufacture the bind source when the reserve mount is not there. The migration window is where that guarantee matters most — the store is aside under `.pre-mount`, the reserve is mounted but still carries no `openbao/`, and a bring-up that created that directory would leave a bind source on the destination side of a copy that has not run.

`bootroot infra up` already refuses that state (`src/commands/audit_store.rs`), but that is a different assertion: it proves bootroot declines to start containers, not that Docker itself refuses the bind when something else brings the stack up. The migration E2E scenario never attempted a Compose bring-up inside the window, so the guarantee was asserted nowhere against the state the window actually produces.

Closes #960

Part of #926

## Changes

All of it is in `scripts/impl/run-registrar-internal-init-e2e.sh`, inside the existing `assert_the_rendered_steps_migrate_an_existing_store` lifecycle path. No Rust changed.

- **`assert_the_audit_bind_refuses_to_create_its_source_mid_migration`** — a focused sibling called between pass 2 (the activation) and pass 3 (the copy), which is exactly the window. It restates its preconditions rather than assuming them (`.pre-mount` present, the mount unit `active`, `<audit_store_dir>/openbao` absent), checks that the override the refusal pass rendered still names that store and still carries `create_host_path: false`, then runs the ordinary `docker compose up -d --no-deps openbao` over it.
- **The failure is read from the bring-up itself** — its non-zero exit, the error naming the bind source, and the container not running — so a bring-up that returned success having quietly done nothing cannot pass on the absent source alone. Only then does it assert the destination was not manufactured: `openbao/` still absent, and the mounted store's entry list identical to the one taken before the attempt.
- **Both writers are stopped for the window.** Rendered step 1 stops them, and `rendered_migration_commands` drops those two lines — one would stop this scenario's whole Compose stack, the other names a unit no CI host has installed. The OpenBao writer is now stopped by service through the same Compose surface just before the aside rename, stays down across every pass, and is brought back only on the closing path at the end of the section. The registrar writer is asserted not running rather than stopped: stopping a unit this scenario did not install would be a host-changing step it has no way to undo.

The fixture starts from an existing audit store, so the aside rename and the full window are exercised rather than simulated. Nothing is created, removed, mounted or unmounted to stand in for Docker's result, and no rendered command list, outcome, or `withholds_activation` behaviour is touched.

## Test plan

- [x] `docker compose up` is attempted while `.pre-mount` exists, the reserve mount is active, and `<audit_store_dir>/openbao` is absent.
- [x] The OpenBao container's failure is asserted by its own non-zero exit and by the error naming the bind source, not by the absence of a side effect alone, and no entry is created beneath the mounted store.
- [x] The scenario runs through the existing `registrar-internal-init` lifecycle harness rather than a new one, starting from an existing audit store and leaving both writers stopped until the normal closing path.
- [x] The existing `infra up` refusal coverage is kept and unchanged — `cargo test --bin bootroot commands::audit_store::` passes 136 tests, including `infra_up_refuses_the_bring_up_while_a_migration_is_open`.
- [x] `cargo clippy --all-targets -- -D warnings` passes.
- [x] `cargo fmt -- --config group_imports=StdExternalCrate --check` passes.
- [x] `./scripts/check-docs.sh` passes.
- [x] `shellcheck -x` and `bash -n` on the changed script are clean.
- [x] `./scripts/validate-e2e-run-scope.sh` and `./scripts/validate-e2e-leftover-check.sh` pass.
- [x] The Linux `Docker E2E` `registrar-internal-init` job passes — it ran green on this commit ([job 99074231742](https://github.com/aicers/bootroot/actions/runs/33242493022/job/99074231742)), and its log shows the new assertions actually executing inside the `reserve_activation_is_possible` guard rather than being skipped: `PASS both writers are stopped before the store moves aside`, `PASS the reserve is mounted for the mid-window bring-up`, `the mounted store holds [lost+found] before the mid-migration bring-up`, `PASS the mid-migration bring-up fails on the guarded audit bind source`, `PASS the refused bring-up added no entry beneath the mounted store`, and `PASS the writers come back only once the migration has closed`. It could not run on the development host — macOS with no passwordless sudo, no systemd, no loop device and no `mkfs.ext4` — so that CI job is the only arm that exercises it.
